### PR TITLE
feat(auth): schema migration for auth and tenant isolation (PER-10)

### DIFF
--- a/prisma/migrations/20260502070838_init_auth_schema/migration.sql
+++ b/prisma/migrations/20260502070838_init_auth_schema/migration.sql
@@ -1,0 +1,52 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `password` on the `User` table. All the data in the column will be lost.
+  - Added the required column `familyId` to the `Transaction` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `passwordHash` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "Transaction_userId_idx";
+
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN     "familyId" TEXT;
+
+-- Backfill Transaction.familyId
+UPDATE "Transaction" SET "familyId" = "User"."familyId" FROM "User" WHERE "Transaction"."userId" = "User"."id";
+
+-- Alter column to NOT NULL
+ALTER TABLE "Transaction" ALTER COLUMN "familyId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" RENAME COLUMN "password" TO "passwordHash";
+ALTER TABLE "User" ADD COLUMN     "emailVerifiedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "userAgent" TEXT,
+    "ip" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Session_userId_idx" ON "Session"("userId");
+
+-- CreateIndex
+CREATE INDEX "Session_expiresAt_idx" ON "Session"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "Transaction_familyId_deletedAt_date_idx" ON "Transaction"("familyId", "deletedAt", "date" DESC);
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,22 +23,40 @@ model Family {
   users      User[]
   accounts   Account[]
   merchants  Merchant[]
-  categories Category[]
-  smartRules SmartRule[]
+  categories   Category[]
+  smartRules   SmartRule[]
+  transactions Transaction[]
 }
 
 model User {
-  id           String        @id @default(cuid())
-  email        String        @unique
-  name         String
-  password     String
+  id              String        @id @default(cuid())
+  email           String        @unique
+  name            String
+  emailVerifiedAt DateTime?
+  passwordHash    String
 
   // Fitur Enterprise: Preferensi tampilan user
-  theme        String        @default("system")
+  theme           String        @default("system")
 
-  familyId     String
-  family       Family        @relation(fields: [familyId], references: [id])
-  transactions Transaction[]
+  familyId        String
+  family          Family        @relation(fields: [familyId], references: [id])
+  transactions    Transaction[]
+  sessions        Session[]
+}
+
+model Session {
+  id           String    @id @default(cuid())
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expiresAt    DateTime
+  revokedAt    DateTime?
+  userAgent    String?
+  ip           String?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @default(now()) @updatedAt
+
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 model Account {
@@ -161,6 +179,9 @@ model Transaction {
   userId      String
   user        User      @relation(fields: [userId], references: [id])
 
+  familyId    String
+  family      Family    @relation(fields: [familyId], references: [id])
+
   // Relasi ke Transfer (Hanya terisi jika type == "transfer")
   transferOut Transfer? @relation("OutflowTransaction")
   transferIn  Transfer? @relation("InflowTransaction")
@@ -179,9 +200,8 @@ model Transaction {
   @@index([deletedAt, date(sort: Desc)])
   // Per-account history (account-detail drill-down planned post-ADR-0004).
   @@index([accountId, date(sort: Desc)])
-  // Current dev "borrow user" pattern. Will be redundant once ADR-0004
-  // adds `familyId` directly on Transaction; remove at that time.
-  @@index([userId])
+  // Primary list-page index for tenant-scoped queries
+  @@index([familyId, deletedAt, date(sort: Desc)])
   // Aggregations.
   @@index([categoryId])
   @@index([merchantId])


### PR DESCRIPTION
## M1-2 Schema Migration: Session, passwordHash, familyId NOT NULL on Transaction

This PR includes the database schema updates required for the authentication and tenant isolation strategy detailed in ADR-0004.

- `User` model now has `passwordHash` instead of `password`.
- `Session` model was added.
- `Transaction` model now correctly requires a `familyId` (NOT NULL).
- Backfilled existing `Transaction` rows with the correct `familyId` from the linked `User` during migration so that the `NOT NULL` constraint doesn't break existing data.