### PR TITLE
PER-92: Scope tenant RLS GUC to transactions

### DIFF
--- a/docs/adr/0006-idempotency-and-audit-log.md
+++ b/docs/adr/0006-idempotency-and-audit-log.md
@@ -202,6 +202,26 @@ M2-3 and M2-5 implement this ADR. They must preserve these invariants:
 - Bulk/import/onboarding paths must match the single-mutation semantics.
 - Audit entries are append-only from online application traffic.
 
+### RLS GUC Transaction Scope
+
+`app.family_id` is never request-global, session-global, or connection-global.
+Tenant-scoped reads and writes must run through `scopedTenantTransaction` or an
+explicitly equivalent interactive Prisma transaction that calls
+`set_config('app.family_id', familyId, true)` on the transaction client before
+the first RLS-protected query.
+
+The helper passes a `TenantTransactionClient` into the callback. Protected
+queries must use that client. Setting the GUC on one client and then querying
+through the root Prisma singleton is a security bug because pooled connections
+do not guarantee the later query runs on the same connection. `set_config(...,
+false)`, manual `RESET app.family_id`, and root-client tenant reads after GUC
+setup are rejected patterns for online application traffic.
+
+Paths that create the tenant inside the same transaction, such as onboarding,
+may call `setTenantGuc(tx, newFamilyId)` after the `Family` row exists and
+before touching any RLS-protected table. The same rule applies: every protected
+query stays on that transaction client until commit or rollback.
+
 ## Tests Required In Follow-Up Issues
 
 The ADR itself does not implement these tests. M2-3, M2-5, and the real-Postgres integration suite must cover:

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -25,166 +25,174 @@ const prisma = new PrismaClient({
 async function main() {
   console.log("🌱 Seeding the database via the Postgres adapter...")
 
-  // Create Family first (not RLS-protected) so we have a tenant ID.
-  // Upsert handles re-seeding without delete-before-create (which RLS blocks).
-  const family = await prisma.family.upsert({
-    where: { id: "seed-family-01" },
-    update: { name: "Keluarga Permoney" },
-    create: {
-      id: "seed-family-01",
-      name: "Keluarga Permoney",
-      currency: "IDR",
-    },
-  })
+  const [family, passwordHash] = await Promise.all([
+    // Create Family first (not RLS-protected) so we have a tenant ID.
+    // Upsert handles re-seeding without delete-before-create (which RLS blocks).
+    prisma.family.upsert({
+      where: { id: "seed-family-01" },
+      update: { name: "Keluarga Permoney" },
+      create: {
+        id: "seed-family-01",
+        name: "Keluarga Permoney",
+        currency: "IDR",
+      },
+    }),
+    // Hash password dengan Argon2id (sama dengan auth flow)
+    hash("password123", {
+      memoryCost: 65536, // 64 MiB
+      timeCost: 3, // 3 iterations
+      parallelism: 4, // 4 lanes
+      outputLen: 32, // 32 bytes
+      algorithm: 2, // Argon2id
+    }),
+  ])
 
-  // Set the GUC so RLS policies allow tenant-scoped reads/writes.
-  await prisma.$executeRawUnsafe(
-    `SELECT set_config('app.family_id', $1, false)`,
-    family.id
-  )
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`
+      SELECT set_config('app.family_id', ${family.id}, true)
+    `
 
-  // Clean up stale seed data scoped to this tenant.
-  await prisma.transaction.deleteMany({ where: { familyId: family.id } })
-  await prisma.splitEntry.deleteMany({
-    where: { transaction: { familyId: family.id } },
-  })
-  await prisma.account.deleteMany({ where: { familyId: family.id } })
-  await prisma.merchant.deleteMany({ where: { familyId: family.id } })
-  await prisma.category.deleteMany({
-    where: { familyId: family.id, isSystem: false },
-  })
-  await prisma.user.deleteMany({ where: { familyId: family.id } })
+    // Clean up stale seed data scoped to this tenant. Child rows go first;
+    // after transactions are gone, the remaining tenant tables are independent.
+    await tx.splitEntry.deleteMany({
+      where: { transaction: { familyId: family.id } },
+    })
+    await tx.transaction.deleteMany({ where: { familyId: family.id } })
+    await Promise.all([
+      tx.account.deleteMany({ where: { familyId: family.id } }),
+      tx.merchant.deleteMany({ where: { familyId: family.id } }),
+      tx.category.deleteMany({
+        where: { familyId: family.id, isSystem: false },
+      }),
+      tx.user.deleteMany({ where: { familyId: family.id } }),
+    ])
 
-  // Hash password dengan Argon2id (sama dengan auth flow)
-  const passwordHash = await hash("password123", {
-    memoryCost: 65536, // 64 MiB
-    timeCost: 3, // 3 iterations
-    parallelism: 4, // 4 lanes
-    outputLen: 32, // 32 bytes
-    algorithm: 2, // Argon2id
-  })
-
-  await prisma.user.upsert({
-    where: { email: "admin@permana.icu" },
-    update: { name: "Hendri", passwordHash, familyId: family.id },
-    create: {
-      email: "admin@permana.icu",
-      name: "Hendri",
-      passwordHash,
-      familyId: family.id,
-    },
-  })
-
-  await prisma.account.createMany({
-    data: [
-      {
-        name: "BCA Utama",
-        type: "DEPOSITORY",
-        // Rp 15,000,000 stored as sen (×100). See ADR-0001.
-        balance: 1_500_000_000n,
-        familyId: family.id,
-        color: "#0066AE",
-      },
-      {
-        name: "Dompet Cash",
-        type: "DEPOSITORY",
-        // Rp 500,000 → 50,000,000 sen
-        balance: 50_000_000n,
-        familyId: family.id,
-        color: "#22C55E",
-      },
-      {
-        name: "Piutang Teman",
-        type: "RECEIVABLE",
-        balance: 0n,
-        familyId: family.id,
-        color: "#F59E0B",
-      },
-    ],
-  })
-
-  await prisma.category.createMany({
-    data: [
-      {
-        name: "Makan & Minum",
-        type: "expense",
-        isSystem: true,
-        color: "#EF4444",
-        icon: "utensils",
-      },
-      {
-        name: "Groceries",
-        type: "expense",
-        isSystem: false,
-        color: "#F59E0B",
-        icon: "shopping-cart",
-      },
-      {
-        name: "Belanja",
-        type: "expense",
-        isSystem: false,
-        color: "#EC4899",
-        icon: "shopping-bag",
-      },
-      {
-        name: "Food & Drink",
-        type: "expense",
-        isSystem: false,
-        color: "#F97316",
-        icon: "coffee",
-      },
-      {
-        name: "Gaji Bulanan",
-        type: "income",
-        isSystem: true,
-        color: "#10B981",
-        icon: "wallet",
-      },
-      {
-        name: "Salary",
-        type: "income",
-        isSystem: false,
-        color: "#059669",
-        icon: "cash",
-      },
-      {
-        name: "Freelance",
-        type: "income",
-        isSystem: false,
-        color: "#3B82F6",
-        icon: "briefcase",
-      },
-    ],
-  })
-
-  await prisma.merchant.createMany({
-    data: [
-      { name: "Starbucks", familyId: family.id },
-      { name: "Budi (Teman)", familyId: family.id },
-      { name: "Indomaret", familyId: family.id },
-      { name: "Alfamart", familyId: family.id },
-      { name: "Warung Madura SQ", familyId: family.id },
-      { name: "Bebek Kaleyo", familyId: family.id },
-      { name: "Kopi Kenangan", familyId: family.id },
-      { name: "Tous Les Jours", familyId: family.id },
-      { name: "Sushi Tei", familyId: family.id },
-      { name: "Namaaz Dining", familyId: family.id },
-      { name: "Henshin", familyId: family.id },
-      { name: "Ruth's Chris Steak House", familyId: family.id },
-      { name: "Osteria Gia", familyId: family.id },
-      { name: "Pertamina", familyId: family.id },
-      { name: "Shell", familyId: family.id },
-      { name: "Vivo", familyId: family.id },
-      { name: "Smart Parking", familyId: family.id },
-      { name: "Parkir Lebusa", familyId: family.id },
-      { name: "TransJakarta", familyId: family.id },
-      { name: "MRT Jakarta", familyId: family.id },
-      { name: "KRL Commuter Line", familyId: family.id },
-      { name: "Gojek", familyId: family.id },
-      { name: "Grab", familyId: family.id },
-      { name: "ShopeeFood", familyId: family.id },
-      { name: "Tokopedia", familyId: family.id },
-    ],
+    await Promise.all([
+      tx.user.upsert({
+        where: { email: "admin@permana.icu" },
+        update: { name: "Hendri", passwordHash, familyId: family.id },
+        create: {
+          email: "admin@permana.icu",
+          name: "Hendri",
+          passwordHash,
+          familyId: family.id,
+        },
+      }),
+      tx.account.createMany({
+        data: [
+          {
+            name: "BCA Utama",
+            type: "DEPOSITORY",
+            // Rp 15,000,000 stored as sen (×100). See ADR-0001.
+            balance: 1_500_000_000n,
+            familyId: family.id,
+            color: "#0066AE",
+          },
+          {
+            name: "Dompet Cash",
+            type: "DEPOSITORY",
+            // Rp 500,000 → 50,000,000 sen
+            balance: 50_000_000n,
+            familyId: family.id,
+            color: "#22C55E",
+          },
+          {
+            name: "Piutang Teman",
+            type: "RECEIVABLE",
+            balance: 0n,
+            familyId: family.id,
+            color: "#F59E0B",
+          },
+        ],
+      }),
+      tx.category.createMany({
+        data: [
+          {
+            name: "Makan & Minum",
+            type: "expense",
+            isSystem: true,
+            color: "#EF4444",
+            icon: "utensils",
+          },
+          {
+            name: "Groceries",
+            type: "expense",
+            isSystem: false,
+            familyId: family.id,
+            color: "#F59E0B",
+            icon: "shopping-cart",
+          },
+          {
+            name: "Belanja",
+            type: "expense",
+            isSystem: false,
+            familyId: family.id,
+            color: "#EC4899",
+            icon: "shopping-bag",
+          },
+          {
+            name: "Food & Drink",
+            type: "expense",
+            isSystem: false,
+            familyId: family.id,
+            color: "#F97316",
+            icon: "coffee",
+          },
+          {
+            name: "Gaji Bulanan",
+            type: "income",
+            isSystem: true,
+            color: "#10B981",
+            icon: "wallet",
+          },
+          {
+            name: "Salary",
+            type: "income",
+            isSystem: false,
+            familyId: family.id,
+            color: "#059669",
+            icon: "cash",
+          },
+          {
+            name: "Freelance",
+            type: "income",
+            isSystem: false,
+            familyId: family.id,
+            color: "#3B82F6",
+            icon: "briefcase",
+          },
+        ],
+      }),
+      tx.merchant.createMany({
+        data: [
+          { name: "Starbucks", familyId: family.id },
+          { name: "Budi (Teman)", familyId: family.id },
+          { name: "Indomaret", familyId: family.id },
+          { name: "Alfamart", familyId: family.id },
+          { name: "Warung Madura SQ", familyId: family.id },
+          { name: "Bebek Kaleyo", familyId: family.id },
+          { name: "Kopi Kenangan", familyId: family.id },
+          { name: "Tous Les Jours", familyId: family.id },
+          { name: "Sushi Tei", familyId: family.id },
+          { name: "Namaaz Dining", familyId: family.id },
+          { name: "Henshin", familyId: family.id },
+          { name: "Ruth's Chris Steak House", familyId: family.id },
+          { name: "Osteria Gia", familyId: family.id },
+          { name: "Pertamina", familyId: family.id },
+          { name: "Shell", familyId: family.id },
+          { name: "Vivo", familyId: family.id },
+          { name: "Smart Parking", familyId: family.id },
+          { name: "Parkir Lebusa", familyId: family.id },
+          { name: "TransJakarta", familyId: family.id },
+          { name: "MRT Jakarta", familyId: family.id },
+          { name: "KRL Commuter Line", familyId: family.id },
+          { name: "Gojek", familyId: family.id },
+          { name: "Grab", familyId: family.id },
+          { name: "ShopeeFood", familyId: family.id },
+          { name: "Tokopedia", familyId: family.id },
+        ],
+      }),
+    ])
   })
 
   console.log("✅ Seeding finished. Database state is healthy.")

--- a/src/server/auth-fns.ts
+++ b/src/server/auth-fns.ts
@@ -5,6 +5,7 @@ import { signupSchema, loginSchema } from "./auth-schemas"
 import { checkRateLimit } from "./middleware/rate-limit"
 import { getSession, requireSession } from "./middleware/session"
 import { prisma } from "./db.server"
+import { setTenantGuc } from "./middleware/with-family"
 
 export { signupSchema, loginSchema }
 
@@ -82,7 +83,7 @@ export const logoutFn = createServerFn({ method: "POST" }).handler(async () => {
  * Inside one Prisma $transaction:
  *   1. Create a Family row with a safe default name.
  *   2. Update User.familyId to the new Family's id.
- *   3. Set the Postgres app.family_id GUC (via scopedTx for RLS).
+ *   3. Set the Postgres app.family_id GUC on the same transaction client.
  *
  * Returns the new familyId so the client can redirect to the dashboard.
  */
@@ -110,10 +111,7 @@ export const onboardFn = createServerFn({ method: "POST" }).handler(
         data: { name: familyName },
       })
 
-      await tx.$executeRawUnsafe(
-        `SELECT set_config('app.family_id', $1, true)`,
-        family.id
-      )
+      await setTenantGuc(tx, family.id)
 
       await tx.user.update({
         where: { id: user.id },

--- a/src/server/middleware/with-family.ts
+++ b/src/server/middleware/with-family.ts
@@ -1,172 +1,41 @@
-/**
- * M1-4: withFamily HOC + scopeTenant Prisma extension
- *
- * Architecture:
- *   - `scopeTenant(prisma, familyId)` — wraps every model-level query method
- *     with an automatic `where: { familyId }` injection via Prisma `$extends`.
- *     This is the load-bearing tenant-isolation primitive; the app middleware
- *     layer should be treated as the first wall, RLS (M1-5) as the second.
- *   - `familyMiddleware` (re-exported from session.ts) — TanStack Start
- *     createMiddleware that verifies session + familyId and injects both into
- *     the server-fn context.
- *
- * Usage in a server function:
- *
- *   ```ts
- *   export const getTransactionsFn = createServerFn({ method: "GET" })
- *     .middleware([familyMiddleware])
- *     .handler(async ({ context }) => {
- *       const db = scopeTenant(prisma, context.familyId)
- *       return db.transaction.findMany({ ... })
- *     })
- *   ```
- *
- * The scoped client automatically appends `AND family_id = '<familyId>'` to
- * every query that touches a tenant-scoped model. For `findUnique` / `findUniqueOrThrow`,
- * which require a unique filter, we fall through to the raw Prisma client so
- * that uniqueness lookups (e.g. by `id`) still work — callers must verify the
- * returned row's `familyId` matches the session's tenant when ownership matters.
- *
- * The `db.unsafe` escape hatch exposes the raw `prisma` client. Any use of it
- * MUST be grep-auditable and reviewed at PR time.
- */
-
-import { PrismaClient } from "@prisma/client"
+import type { Prisma } from "@prisma/client"
 import { prisma } from "../db.server"
 
 // Re-export middleware from session.ts for ergonomic import
 export { authMiddleware, familyMiddleware } from "./session"
 
-// ============================================================================
-// TENANT-SCOPED PRISMA CLIENT
-// ============================================================================
-// We use Prisma's `$extends` to create a lightweight proxy that automatically
-// injects `where: { familyId }` into queries for all tenant-scoped models.
-//
-// Tenant-scoped models (must match M1-5 RLS tables):
-//   Account, Merchant, Category, Transaction, SplitEntry, SmartRule, Transfer
-//
-// Non-scoped models (auth / family scaffolding):
-//   User, Session, AuthAccount, Verification, Family
-// ============================================================================
-
-const TENANT_SCOPED_MODELS = new Set([
-  "account",
-  "merchant",
-  "category",
-  "transaction",
-  "splitEntry",
-  "smartRule",
-  "transfer",
-])
-
 /**
- * Returns a PrismaClient extension that injects `familyId` into every
- * `findMany`, `findFirst`, `count`, `aggregate`, `groupBy`, `updateMany`,
- * and `deleteMany` call on tenant-scoped models.
- *
- * The extension is created per-request (cheap — no new connection is opened)
- * and garbage-collected naturally. Prisma v6+ $extends is safe for this pattern.
+ * Transaction client yang sudah punya `app.family_id` via `set_config(..., true)`.
+ * Semua query RLS-protected harus memakai client ini, bukan root `prisma`.
  */
-export function scopeTenant(
-  client: PrismaClient,
-  familyId: string
-): PrismaClient & { unsafe: PrismaClient } {
-  const extended = client.$extends({
-    query: {
-      $allModels: {
-        async $allOperations({ model, operation, args, query }) {
-          // Only inject familyId filter for tenant-scoped models
-          if (
-            model &&
-            TENANT_SCOPED_MODELS.has(
-              model.charAt(0).toLowerCase() + model.slice(1)
-            )
-          ) {
-            // Operations that accept a `where` clause for filtering by familyId:
-            const filterOps = [
-              "findMany",
-              "findFirst",
-              "findFirstOrThrow",
-              "count",
-              "aggregate",
-              "groupBy",
-              "updateMany",
-              "deleteMany",
-            ]
-            if (filterOps.includes(operation)) {
-              const typedArgs = (args ?? {}) as {
-                where?: Record<string, unknown>
-              }
-              typedArgs.where = {
-                ...typedArgs.where,
-                familyId,
-              }
-              args = typedArgs
-            }
-            // Note: `findUnique` / `findUniqueOrThrow` / `create` / `update` / `delete`
-            // are NOT injected — they require unique fields (id) or are handled
-            // explicitly by the caller with the familyId from context.
-          }
-          return query(args)
-        },
-      },
-    },
-  })
+export type TenantTransactionClient = Prisma.TransactionClient
 
-  // Attach the escape hatch as a non-enumerable property
-  Object.defineProperty(extended, "unsafe", {
-    get: () => client,
-    enumerable: false,
-    configurable: false,
-  })
+// ============================================================================
+// RLS: transaction-scoped GUC helpers
+// ============================================================================
 
-  return extended as unknown as PrismaClient & { unsafe: PrismaClient }
+interface ScopedTenantTransactionOptions {
+  isolationLevel?: Prisma.TransactionIsolationLevel
+  maxWait?: number
+  timeout?: number
 }
 
-/**
- * Convenience: creates a tenant-scoped client from the global prisma singleton.
- * This is the canonical way to create a scoped client in server functions.
- */
-export function createTenantDb(
+export async function setTenantGuc(
+  tx: TenantTransactionClient,
   familyId: string
-): PrismaClient & { unsafe: PrismaClient } {
-  return scopeTenant(prisma, familyId)
+): Promise<void> {
+  await tx.$executeRaw`
+    SELECT set_config('app.family_id', ${familyId}, true)
+  `
 }
 
-export type TenantDb = ReturnType<typeof createTenantDb>
-
-// ============================================================================
-// M1-5 RLS: Transaction-scoped GUC helpers
-// ============================================================================
-
-type PrismaTxClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0]
-
-export async function scopedTx<T>(
+export async function scopedTenantTransaction<T>(
   familyId: string,
-  fn: (tx: PrismaTxClient) => Promise<T>,
-  options?: { maxWait?: number; timeout?: number }
+  fn: (tx: TenantTransactionClient) => Promise<T>,
+  options?: ScopedTenantTransactionOptions
 ): Promise<T> {
   return prisma.$transaction(async (tx) => {
-    await tx.$executeRawUnsafe(
-      `SELECT set_config('app.family_id', $1, true)`,
-      familyId
-    )
-    return fn(tx)
+    await setTenantGuc(tx, familyId)
+    return await fn(tx)
   }, options)
-}
-
-export async function withGuc<T>(
-  familyId: string,
-  fn: () => Promise<T>
-): Promise<T> {
-  await prisma.$executeRawUnsafe(
-    `SELECT set_config('app.family_id', $1, false)`,
-    familyId
-  )
-  try {
-    return await fn()
-  } finally {
-    await prisma.$executeRawUnsafe(`RESET app.family_id`)
-  }
 }

--- a/src/server/smart-rules.ts
+++ b/src/server/smart-rules.ts
@@ -2,9 +2,7 @@ import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import {
   familyMiddleware,
-  createTenantDb,
-  scopedTx,
-  withGuc,
+  scopedTenantTransaction,
 } from "./middleware/with-family"
 
 /**
@@ -13,9 +11,9 @@ import {
 export const getSmartRulesFn = createServerFn({ method: "GET" })
   .middleware([familyMiddleware])
   .handler(async ({ context }) => {
-    return withGuc(context.familyId, async () => {
-      const db = createTenantDb(context.familyId)
-      return db.smartRule.findMany({
+    return scopedTenantTransaction(context.familyId, async (tx) => {
+      return tx.smartRule.findMany({
+        where: { familyId: context.familyId },
         include: { category: true, merchant: true },
         orderBy: { createdAt: "desc" },
       })
@@ -23,7 +21,7 @@ export const getSmartRulesFn = createServerFn({ method: "GET" })
   })
 
 /**
- * 2. CREATE NEW RULE — tenant-scoped via familyMiddleware + scopedTx
+ * 2. CREATE NEW RULE — tenant-scoped via familyMiddleware + scopedTenantTransaction
  */
 const createRuleSchema = z.object({
   keyword: z.string().min(1),
@@ -37,7 +35,7 @@ export const createSmartRuleFn = createServerFn({ method: "POST" })
     createRuleSchema.parse(data)
   )
   .handler(async ({ data, context }) => {
-    return scopedTx(context.familyId, async (tx) => {
+    return scopedTenantTransaction(context.familyId, async (tx) => {
       return tx.smartRule.create({
         data: {
           keyword: data.keyword.toLowerCase(),
@@ -50,13 +48,13 @@ export const createSmartRuleFn = createServerFn({ method: "POST" })
   })
 
 /**
- * 3. DELETE RULE — tenant-scoped via familyMiddleware + scopedTx
+ * 3. DELETE RULE — tenant-scoped via familyMiddleware + scopedTenantTransaction
  */
 export const deleteSmartRuleFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
   .inputValidator(z.object({ id: z.string() }))
   .handler(async ({ data, context }) => {
-    return scopedTx(context.familyId, async (tx) => {
+    return scopedTenantTransaction(context.familyId, async (tx) => {
       const res = await tx.smartRule.deleteMany({
         where: { id: data.id, familyId: context.familyId },
       })

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -2,28 +2,11 @@ import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { absMoney, encodeMoney, negateMoney, type Money } from "@/lib/money"
 import { assertSplitParity } from "@/lib/split-parity"
-// `import type` adalah TYPE-ONLY — di-erase compile time, tidak masuk runtime bundle.
-// TanStack Start's import-protection plugin (analysis.js:44) MEN-SKIP semua
-// `import type` dari analisis, jadi import ini TIDAK trigger warning meskipun
-// nominally berasal dari runtime-server-only package.
-import type { Prisma } from "@prisma/client"
-// Runtime import dari `.server.ts` — splitter akan strip handler bodies yang
-// memakai `prisma` di client bundle, lalu Rolldown tree-shakes import ini
-// karena unused. Plus `db.server.ts` di-replace empty stub oleh plugin via
-// pattern `**/*.server.*`. import-protection plugin tetap warn di sini karena
-// dia analisis source level — itu EXPECTED dan SAFE. Lihat AGENTS.md §6.F.
-import { prisma } from "./db.server"
 import {
   familyMiddleware,
-  createTenantDb,
-  scopedTx,
-  withGuc,
+  scopedTenantTransaction,
+  type TenantTransactionClient,
 } from "./middleware/with-family"
-
-// Canonical Prisma type untuk callback `$transaction`. Lebih bersih dari
-// `Parameters<Parameters<typeof prisma.$transaction>[0]>[0]` dan stable
-// across Prisma upgrades.
-type PrismaTxClient = Prisma.TransactionClient
 
 /**
  * BACKEND FUNCTION: Fetch reference data for the Transaction Form Dropdowns
@@ -32,17 +15,22 @@ type PrismaTxClient = Prisma.TransactionClient
 export const getTransactionFormData = createServerFn({ method: "GET" })
   .middleware([familyMiddleware])
   .handler(async ({ context }) => {
-    return withGuc(context.familyId, async () => {
-      const db = createTenantDb(context.familyId)
+    return scopedTenantTransaction(context.familyId, async (tx) => {
       const [accounts, categories, merchants] = await Promise.all([
-        db.account.findMany({ orderBy: { name: "asc" } }),
-        prisma.category.findMany({
+        tx.account.findMany({
+          where: { familyId: context.familyId },
+          orderBy: { name: "asc" },
+        }),
+        tx.category.findMany({
           where: {
             OR: [{ isSystem: true }, { familyId: context.familyId }],
           },
           orderBy: { name: "asc" },
         }),
-        db.merchant.findMany({ orderBy: { name: "asc" } }),
+        tx.merchant.findMany({
+          where: { familyId: context.familyId },
+          orderBy: { name: "asc" },
+        }),
       ])
       return { accounts, categories, merchants }
     })
@@ -192,199 +180,202 @@ export const createTransactionFn = createServerFn({ method: "POST" })
 
     // 🚀 THE ENTERPRISE MAGIC: Prisma $transaction (ACID)
     // If any process inside this block fails, all changes are rolled back automatically.
-    const result = await scopedTx(familyId, async (tx: PrismaTxClient) => {
-      // === SPLIT PARITY GUARD (GAAP Compliance) ===
-      // Backend MUST validate that SplitEntries sum === parent.amount.
-      // UI validation is a convenience; THIS is the authoritative check.
-      // Throws inside `$transaction` → automatic rollback if violated.
-      assertSplitParity(data)
+    const result = await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) => {
+        // === SPLIT PARITY GUARD (GAAP Compliance) ===
+        // Backend MUST validate that SplitEntries sum === parent.amount.
+        // UI validation is a convenience; THIS is the authoritative check.
+        // Throws inside `$transaction` → automatic rollback if violated.
+        assertSplitParity(data)
 
-      // A. HANDLE TRANSFER (DOUBLE-ENTRY)
-      if (data.type === "transfer") {
-        if (!data.toAccountId)
-          throw new Error("Transfer requires a destination account!")
+        // A. HANDLE TRANSFER (DOUBLE-ENTRY)
+        if (data.type === "transfer") {
+          if (!data.toAccountId)
+            throw new Error("Transfer requires a destination account!")
 
-        // Tenant-safe: verify account ownership via familyId
-        const toAccount = await tx.account.findFirst({
-          where: { id: data.toAccountId, familyId },
-        })
-        if (!toAccount)
-          throw new Error("Destination account not found or access denied!")
+          // Tenant-safe: verify account ownership via familyId
+          const toAccount = await tx.account.findFirst({
+            where: { id: data.toAccountId, familyId },
+          })
+          if (!toAccount)
+            throw new Error("Destination account not found or access denied!")
 
-        let kind = "funds_movement"
-        if (toAccount.type === "CREDIT") kind = "cc_payment"
-        else if (toAccount.type === "LOAN") kind = "loan_payment"
+          let kind = "funds_movement"
+          if (toAccount.type === "CREDIT") kind = "cc_payment"
+          else if (toAccount.type === "LOAN") kind = "loan_payment"
 
-        // Running Balance Snapshot: baca saldo akun setelah update atomik
-        // Tenant-safe: update with familyId constraint
-        const sourceUpdate = await tx.account.updateMany({
-          where: { id: data.accountId, familyId },
-          data: { balance: { decrement: data.amount } },
-        })
-        if (sourceUpdate.count !== 1)
-          throw new Error("Source account not found or access denied!")
-        const updatedSourceAccount = await tx.account.findFirst({
-          where: { id: data.accountId, familyId },
-          select: { balance: true },
-        })
-        const sourceBalanceAfter = updatedSourceAccount!.balance
+          // Running Balance Snapshot: baca saldo akun setelah update atomik
+          // Tenant-safe: update with familyId constraint
+          const sourceUpdate = await tx.account.updateMany({
+            where: { id: data.accountId, familyId },
+            data: { balance: { decrement: data.amount } },
+          })
+          if (sourceUpdate.count !== 1)
+            throw new Error("Source account not found or access denied!")
+          const updatedSourceAccount = await tx.account.findFirst({
+            where: { id: data.accountId, familyId },
+            select: { balance: true },
+          })
+          const sourceBalanceAfter = updatedSourceAccount!.balance
 
-        // Multi-currency: gunakan destinationAmount jika tersedia, fallback ke amount
-        const inAmount = data.destinationAmount ?? data.amount
-        const inCurrency = data.destinationCurrency ?? data.currency
+          // Multi-currency: gunakan destinationAmount jika tersedia, fallback ke amount
+          const inAmount = data.destinationAmount ?? data.amount
+          const inCurrency = data.destinationCurrency ?? data.currency
 
-        // Tenant-safe: update with familyId constraint
-        const destUpdate = await tx.account.updateMany({
-          where: { id: data.toAccountId, familyId },
-          data: { balance: { increment: inAmount } },
-        })
-        if (destUpdate.count !== 1)
-          throw new Error("Destination account not found or access denied!")
-        const updatedDestAccount = await tx.account.findFirst({
-          where: { id: data.toAccountId, familyId },
-          select: { balance: true },
-        })
-        const destBalanceAfter = updatedDestAccount!.balance
+          // Tenant-safe: update with familyId constraint
+          const destUpdate = await tx.account.updateMany({
+            where: { id: data.toAccountId, familyId },
+            data: { balance: { increment: inAmount } },
+          })
+          if (destUpdate.count !== 1)
+            throw new Error("Destination account not found or access denied!")
+          const updatedDestAccount = await tx.account.findFirst({
+            where: { id: data.toAccountId, familyId },
+            select: { balance: true },
+          })
+          const destBalanceAfter = updatedDestAccount!.balance
 
-        const outflowTx = await tx.transaction.create({
+          const outflowTx = await tx.transaction.create({
+            data: {
+              ...(data.id ? { id: data.id } : {}),
+              type: "transfer",
+              kind,
+              currency: data.currency,
+              amount: negateMoney(absMoney(data.amount)),
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.accountId,
+              toAccountId: data.toAccountId,
+              categoryId: data.categoryId || null,
+              merchantId: data.merchantId || null,
+              userId: user.id,
+              familyId,
+              status: data.status,
+              destinationAmount: data.destinationAmount,
+              destinationCurrency: data.destinationCurrency,
+              accountBalanceAfter: sourceBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+            },
+          })
+
+          const inflowTx = await tx.transaction.create({
+            data: {
+              type: "transfer",
+              kind,
+              currency: inCurrency,
+              amount: absMoney(inAmount),
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.toAccountId,
+              toAccountId: data.accountId,
+              categoryId: data.categoryId || null,
+              merchantId: data.merchantId || null,
+              userId: user.id,
+              familyId,
+              status: data.status,
+              destinationAmount: data.destinationAmount,
+              destinationCurrency: data.destinationCurrency,
+              accountBalanceAfter: destBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+            },
+          })
+
+          await tx.transfer.create({
+            data: {
+              outflowTransactionId: outflowTx.id,
+              inflowTransactionId: inflowTx.id,
+            },
+          })
+
+          return serializeTransaction({
+            ...outflowTx,
+            amount: absMoney(outflowTx.amount),
+          })
+        }
+
+        // B. HANDLE STANDARD EXPENSE / INCOME
+        const amountSign: Money =
+          data.type === "expense"
+            ? negateMoney(absMoney(data.amount))
+            : absMoney(data.amount)
+
+        // Running Balance Snapshot: baca saldo setelah update atomik
+        let accountBalanceAfter: bigint | null = null
+        if (data.type === "expense") {
+          const upd = await tx.account.updateMany({
+            where: { id: data.accountId, familyId },
+            data: { balance: { decrement: data.amount } },
+          })
+          if (upd.count !== 1)
+            throw new Error("Account not found or access denied!")
+          const updated = await tx.account.findFirst({
+            where: { id: data.accountId, familyId },
+            select: { balance: true },
+          })
+          accountBalanceAfter = updated!.balance
+        } else {
+          const upd = await tx.account.updateMany({
+            where: { id: data.accountId, familyId },
+            data: { balance: { increment: data.amount } },
+          })
+          if (upd.count !== 1)
+            throw new Error("Account not found or access denied!")
+          const updated = await tx.account.findFirst({
+            where: { id: data.accountId, familyId },
+            select: { balance: true },
+          })
+          accountBalanceAfter = updated!.balance
+        }
+
+        const newTransaction = await tx.transaction.create({
           data: {
             ...(data.id ? { id: data.id } : {}),
-            type: "transfer",
-            kind,
-            currency: data.currency,
-            amount: negateMoney(absMoney(data.amount)),
+            type: data.type,
+            amount: amountSign,
             description: data.description,
             date: data.date,
             notes: data.notes || null,
             accountId: data.accountId,
-            toAccountId: data.toAccountId,
-            categoryId: data.categoryId || null,
-            merchantId: data.merchantId || null,
+            toAccountId: data.toAccountId || null,
+            // Jika split aktif, categoryId di parent menjadi null (kategori hidup di entries)
+            categoryId: data.isSplit ? null : data.categoryId || null,
+            merchantId: data.isSplit ? null : data.merchantId || null,
+            isSplit: data.isSplit,
             userId: user.id,
             familyId,
             status: data.status,
-            destinationAmount: data.destinationAmount,
-            destinationCurrency: data.destinationCurrency,
-            accountBalanceAfter: sourceBalanceAfter,
+            accountBalanceAfter: accountBalanceAfter,
             attachmentUrl: data.attachmentUrl,
           },
         })
 
-        const inflowTx = await tx.transaction.create({
-          data: {
-            type: "transfer",
-            kind,
-            currency: inCurrency,
-            amount: absMoney(inAmount),
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.toAccountId,
-            toAccountId: data.accountId,
-            categoryId: data.categoryId || null,
-            merchantId: data.merchantId || null,
-            userId: user.id,
-            familyId,
-            status: data.status,
-            destinationAmount: data.destinationAmount,
-            destinationCurrency: data.destinationCurrency,
-            accountBalanceAfter: destBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
-        })
-
-        await tx.transfer.create({
-          data: {
-            outflowTransactionId: outflowTx.id,
-            inflowTransactionId: inflowTx.id,
-          },
-        })
+        // Jika isSplit, buat setiap line item satu-satu agar Prisma
+        // auto-generate cuid() untuk id (createMany bypass @default di SQLite)
+        if (data.isSplit && data.splitEntries?.length) {
+          await Promise.all(
+            data.splitEntries.map((entry) =>
+              tx.splitEntry.create({
+                data: {
+                  transactionId: newTransaction.id,
+                  description: entry.description,
+                  amount: absMoney(entry.amount),
+                  categoryId: entry.categoryId || null,
+                  merchantId: entry.merchantId || null,
+                },
+              })
+            )
+          )
+        }
 
         return serializeTransaction({
-          ...outflowTx,
-          amount: absMoney(outflowTx.amount),
+          ...newTransaction,
+          amount: absMoney(newTransaction.amount),
         })
       }
-
-      // B. HANDLE STANDARD EXPENSE / INCOME
-      const amountSign: Money =
-        data.type === "expense"
-          ? negateMoney(absMoney(data.amount))
-          : absMoney(data.amount)
-
-      // Running Balance Snapshot: baca saldo setelah update atomik
-      let accountBalanceAfter: bigint | null = null
-      if (data.type === "expense") {
-        const upd = await tx.account.updateMany({
-          where: { id: data.accountId, familyId },
-          data: { balance: { decrement: data.amount } },
-        })
-        if (upd.count !== 1)
-          throw new Error("Account not found or access denied!")
-        const updated = await tx.account.findFirst({
-          where: { id: data.accountId, familyId },
-          select: { balance: true },
-        })
-        accountBalanceAfter = updated!.balance
-      } else {
-        const upd = await tx.account.updateMany({
-          where: { id: data.accountId, familyId },
-          data: { balance: { increment: data.amount } },
-        })
-        if (upd.count !== 1)
-          throw new Error("Account not found or access denied!")
-        const updated = await tx.account.findFirst({
-          where: { id: data.accountId, familyId },
-          select: { balance: true },
-        })
-        accountBalanceAfter = updated!.balance
-      }
-
-      const newTransaction = await tx.transaction.create({
-        data: {
-          ...(data.id ? { id: data.id } : {}),
-          type: data.type,
-          amount: amountSign,
-          description: data.description,
-          date: data.date,
-          notes: data.notes || null,
-          accountId: data.accountId,
-          toAccountId: data.toAccountId || null,
-          // Jika split aktif, categoryId di parent menjadi null (kategori hidup di entries)
-          categoryId: data.isSplit ? null : data.categoryId || null,
-          merchantId: data.isSplit ? null : data.merchantId || null,
-          isSplit: data.isSplit,
-          userId: user.id,
-          familyId,
-          status: data.status,
-          accountBalanceAfter: accountBalanceAfter,
-          attachmentUrl: data.attachmentUrl,
-        },
-      })
-
-      // Jika isSplit, buat setiap line item satu-satu agar Prisma
-      // auto-generate cuid() untuk id (createMany bypass @default di SQLite)
-      if (data.isSplit && data.splitEntries?.length) {
-        await Promise.all(
-          data.splitEntries.map((entry) =>
-            tx.splitEntry.create({
-              data: {
-                transactionId: newTransaction.id,
-                description: entry.description,
-                amount: absMoney(entry.amount),
-                categoryId: entry.categoryId || null,
-                merchantId: entry.merchantId || null,
-              },
-            })
-          )
-        )
-      }
-
-      return serializeTransaction({
-        ...newTransaction,
-        amount: absMoney(newTransaction.amount),
-      })
-    })
+    )
 
     return result
   })
@@ -396,11 +387,11 @@ export const createTransactionFn = createServerFn({ method: "POST" })
 export const getTransactionsFn = createServerFn({ method: "GET" })
   .middleware([familyMiddleware])
   .handler(async ({ context }) => {
-    return withGuc(context.familyId, async () => {
-      const db = createTenantDb(context.familyId)
-      const transactions = await db.transaction.findMany({
+    return scopedTenantTransaction(context.familyId, async (tx) => {
+      const transactions = await tx.transaction.findMany({
         orderBy: { date: "desc" },
         where: {
+          familyId: context.familyId,
           deletedAt: null, // SOFT DELETE FILTER: hanya ambil transaksi aktif
           // Gunakan objek eksplisit untuk mengecek ketiadaan relasi (Best Practice)
           transferIn: {
@@ -462,74 +453,77 @@ export const deleteTransactionFn = createServerFn({ method: "POST" })
   .inputValidator(z.object({ id: z.string() }))
   .handler(async ({ data, context }) => {
     const { familyId } = context
-    return await scopedTx(familyId, async (tx: PrismaTxClient) => {
-      // 1. Cari transaksi lama beserta relasi transfernya
-      const oldTx = await tx.transaction.findUnique({
-        where: { id: data.id },
-        include: { transferOut: true, transferIn: true },
-      })
-
-      if (!oldTx) throw new Error("Transaction not found!")
-
-      // 2. REVERSE BALANCES (Kembalikan Saldo)
-      if (oldTx.type === "transfer" && oldTx.transferOut) {
-        // Jika ini Transfer, kita harus cari Inflow-nya juga
-        const inflowTx = await tx.transaction.findUnique({
-          where: {
-            id: oldTx.transferOut.inflowTransactionId,
-          },
+    return await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) => {
+        // 1. Cari transaksi lama beserta relasi transfernya
+        const oldTx = await tx.transaction.findUnique({
+          where: { id: data.id },
+          include: { transferOut: true, transferIn: true },
         })
 
-        // Refund akun pengirim (Outflow kan negatif, kita ubah jadi absolute lalu tambahkan)
-        // Tenant-safe: update dengan familyId constraint
-        const srcUpd = await tx.account.updateMany({
-          where: { id: oldTx.accountId, familyId },
-          data: { balance: { increment: absMoney(oldTx.amount) } },
-        })
-        if (srcUpd.count !== 1)
-          throw new Error("Source account not found or access denied!")
+        if (!oldTx) throw new Error("Transaction not found!")
 
-        // Tarik kembali uang dari akun penerima
-        if (inflowTx) {
-          const dstUpd = await tx.account.updateMany({
-            where: { id: inflowTx.accountId, familyId },
-            data: { balance: { decrement: absMoney(inflowTx.amount) } },
+        // 2. REVERSE BALANCES (Kembalikan Saldo)
+        if (oldTx.type === "transfer" && oldTx.transferOut) {
+          // Jika ini Transfer, kita harus cari Inflow-nya juga
+          const inflowTx = await tx.transaction.findUnique({
+            where: {
+              id: oldTx.transferOut.inflowTransactionId,
+            },
           })
-          if (dstUpd.count !== 1)
-            throw new Error("Destination account not found or access denied!")
-          // Soft delete: inflow transaction (TIDAK PERNAH hard delete — audit trail)
-          await tx.transaction.update({
-            where: { id: inflowTx.id },
-            data: { deletedAt: new Date() },
-          })
-        }
-      } else {
-        // Reversal untuk Expense/Income biasa
-        if (oldTx.type === "expense") {
-          const upd = await tx.account.updateMany({
+
+          // Refund akun pengirim (Outflow kan negatif, kita ubah jadi absolute lalu tambahkan)
+          // Tenant-safe: update dengan familyId constraint
+          const srcUpd = await tx.account.updateMany({
             where: { id: oldTx.accountId, familyId },
             data: { balance: { increment: absMoney(oldTx.amount) } },
           })
-          if (upd.count !== 1)
-            throw new Error("Account not found or access denied!")
-        } else if (oldTx.type === "income") {
-          const upd = await tx.account.updateMany({
-            where: { id: oldTx.accountId, familyId },
-            data: { balance: { decrement: absMoney(oldTx.amount) } },
-          })
-          if (upd.count !== 1)
-            throw new Error("Account not found or access denied!")
+          if (srcUpd.count !== 1)
+            throw new Error("Source account not found or access denied!")
+
+          // Tarik kembali uang dari akun penerima
+          if (inflowTx) {
+            const dstUpd = await tx.account.updateMany({
+              where: { id: inflowTx.accountId, familyId },
+              data: { balance: { decrement: absMoney(inflowTx.amount) } },
+            })
+            if (dstUpd.count !== 1)
+              throw new Error("Destination account not found or access denied!")
+            // Soft delete: inflow transaction (TIDAK PERNAH hard delete — audit trail)
+            await tx.transaction.update({
+              where: { id: inflowTx.id },
+              data: { deletedAt: new Date() },
+            })
+          }
+        } else {
+          // Reversal untuk Expense/Income biasa
+          if (oldTx.type === "expense") {
+            const upd = await tx.account.updateMany({
+              where: { id: oldTx.accountId, familyId },
+              data: { balance: { increment: absMoney(oldTx.amount) } },
+            })
+            if (upd.count !== 1)
+              throw new Error("Account not found or access denied!")
+          } else if (oldTx.type === "income") {
+            const upd = await tx.account.updateMany({
+              where: { id: oldTx.accountId, familyId },
+              data: { balance: { decrement: absMoney(oldTx.amount) } },
+            })
+            if (upd.count !== 1)
+              throw new Error("Account not found or access denied!")
+          }
         }
+
+        // 3. Soft Delete Data Utama (GAAP: audit trail tetap ada)
+        await tx.transaction.update({
+          where: { id: oldTx.id },
+          data: { deletedAt: new Date() },
+        })
+
+        return { success: true }
       }
-
-      // 3. Soft Delete Data Utama (GAAP: audit trail tetap ada)
-      await tx.transaction.update({
-        where: { id: oldTx.id },
-        data: { deletedAt: new Date() },
-      })
-
-      return { success: true }
-    })
+    )
   })
 
 /**
@@ -546,247 +540,250 @@ export const updateTransactionFn = createServerFn({ method: "POST" })
 
     // The Magic: Kita jalankan penghapusan murni dan pembuatan murni secara berurutan
     // dalam satu ACID Transaction. Zero Balance Mismatch Guaranteed!
-    return await scopedTx(familyId, async (tx: PrismaTxClient) => {
-      // === SPLIT PARITY GUARD (GAAP Compliance) ===
-      // Same authoritative invariant as createTransactionFn — UPDATE flow can
-      // independently violate parity if a client tampers with split entries
-      // without updating the parent amount (or vice versa). Re-validate here.
-      assertSplitParity(data)
+    return await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) => {
+        // === SPLIT PARITY GUARD (GAAP Compliance) ===
+        // Same authoritative invariant as createTransactionFn — UPDATE flow can
+        // independently violate parity if a client tampers with split entries
+        // without updating the parent amount (or vice versa). Re-validate here.
+        assertSplitParity(data)
 
-      // --- FASE 1: REVERSAL (HAPUS LAMA) ---
-      // Kita "pinjam" logika delete untuk mengembalikan saldo ke 0
-      const oldTx = await tx.transaction.findUnique({
-        where: { id: data.id },
-        include: { transferOut: true },
-      })
-
-      if (!oldTx) throw new Error("Original transaction not found")
-
-      if (oldTx.type === "transfer" && oldTx.transferOut) {
-        const inflowTx = await tx.transaction.findUnique({
-          where: {
-            id: oldTx.transferOut.inflowTransactionId,
-          },
+        // --- FASE 1: REVERSAL (HAPUS LAMA) ---
+        // Kita "pinjam" logika delete untuk mengembalikan saldo ke 0
+        const oldTx = await tx.transaction.findUnique({
+          where: { id: data.id },
+          include: { transferOut: true },
         })
-        // Tenant-safe: update dengan familyId constraint
-        const srcUpd = await tx.account.updateMany({
-          where: { id: oldTx.accountId, familyId },
-          data: { balance: { increment: absMoney(oldTx.amount) } },
-        })
-        if (srcUpd.count !== 1)
-          throw new Error("Source account not found or access denied!")
-        if (inflowTx) {
-          const dstUpd = await tx.account.updateMany({
-            where: { id: inflowTx.accountId, familyId },
-            data: { balance: { decrement: absMoney(inflowTx.amount) } },
+
+        if (!oldTx) throw new Error("Original transaction not found")
+
+        if (oldTx.type === "transfer" && oldTx.transferOut) {
+          const inflowTx = await tx.transaction.findUnique({
+            where: {
+              id: oldTx.transferOut.inflowTransactionId,
+            },
           })
-          if (dstUpd.count !== 1)
-            throw new Error("Destination account not found or access denied!")
-          // INTERNAL REVERSAL: Hard delete OK — bukan user-facing delete
-          await tx.transaction.delete({ where: { id: inflowTx.id } })
-        }
-      } else {
-        if (oldTx.type === "expense") {
-          const upd = await tx.account.updateMany({
+          // Tenant-safe: update dengan familyId constraint
+          const srcUpd = await tx.account.updateMany({
             where: { id: oldTx.accountId, familyId },
             data: { balance: { increment: absMoney(oldTx.amount) } },
           })
-          if (upd.count !== 1)
-            throw new Error("Account not found or access denied!")
-        } else if (oldTx.type === "income") {
-          const upd = await tx.account.updateMany({
-            where: { id: oldTx.accountId, familyId },
-            data: { balance: { decrement: absMoney(oldTx.amount) } },
-          })
-          if (upd.count !== 1)
-            throw new Error("Account not found or access denied!")
+          if (srcUpd.count !== 1)
+            throw new Error("Source account not found or access denied!")
+          if (inflowTx) {
+            const dstUpd = await tx.account.updateMany({
+              where: { id: inflowTx.accountId, familyId },
+              data: { balance: { decrement: absMoney(inflowTx.amount) } },
+            })
+            if (dstUpd.count !== 1)
+              throw new Error("Destination account not found or access denied!")
+            // INTERNAL REVERSAL: Hard delete OK — bukan user-facing delete
+            await tx.transaction.delete({ where: { id: inflowTx.id } })
+          }
+        } else {
+          if (oldTx.type === "expense") {
+            const upd = await tx.account.updateMany({
+              where: { id: oldTx.accountId, familyId },
+              data: { balance: { increment: absMoney(oldTx.amount) } },
+            })
+            if (upd.count !== 1)
+              throw new Error("Account not found or access denied!")
+          } else if (oldTx.type === "income") {
+            const upd = await tx.account.updateMany({
+              where: { id: oldTx.accountId, familyId },
+              data: { balance: { decrement: absMoney(oldTx.amount) } },
+            })
+            if (upd.count !== 1)
+              throw new Error("Account not found or access denied!")
+          }
         }
-      }
-      // Hapus data lama (Hard delete OK — ID akan dipertahankan via re-create)
-      await tx.transaction.delete({ where: { id: oldTx.id } })
+        // Hapus data lama (Hard delete OK — ID akan dipertahankan via re-create)
+        await tx.transaction.delete({ where: { id: oldTx.id } })
 
-      // --- FASE 2: REPLACE (BUAT BARU DENGAN DATA UPDATE) ---
-      if (data.type === "transfer") {
-        let kind = "funds_movement"
-        // Tenant-safe: verify account ownership
-        const toAccount = await tx.account.findFirst({
-          where: { id: data.toAccountId!, familyId },
-        })
-        if (!toAccount)
-          throw new Error("Destination account not found or access denied!")
-        if (toAccount.type === "CREDIT") kind = "cc_payment"
-        else if (toAccount.type === "LOAN") kind = "loan_payment"
+        // --- FASE 2: REPLACE (BUAT BARU DENGAN DATA UPDATE) ---
+        if (data.type === "transfer") {
+          let kind = "funds_movement"
+          // Tenant-safe: verify account ownership
+          const toAccount = await tx.account.findFirst({
+            where: { id: data.toAccountId!, familyId },
+          })
+          if (!toAccount)
+            throw new Error("Destination account not found or access denied!")
+          if (toAccount.type === "CREDIT") kind = "cc_payment"
+          else if (toAccount.type === "LOAN") kind = "loan_payment"
 
-        // Running Balance Snapshot: baca saldo akun setelah update atomik
-        // Tenant-safe: update dengan familyId constraint
-        const srcUpd = await tx.account.updateMany({
-          where: { id: data.accountId, familyId },
-          data: { balance: { decrement: data.amount } },
-        })
-        if (srcUpd.count !== 1)
-          throw new Error("Source account not found or access denied!")
-        const updatedSourceAccount = await tx.account.findFirst({
-          where: { id: data.accountId, familyId },
-          select: { balance: true },
-        })
-        const sourceBalanceAfter = updatedSourceAccount!.balance
-
-        // Multi-currency: gunakan destinationAmount jika tersedia, fallback ke amount
-        const inAmount = data.destinationAmount ?? data.amount
-        const inCurrency = data.destinationCurrency ?? data.currency
-
-        const dstUpd = await tx.account.updateMany({
-          where: { id: data.toAccountId!, familyId },
-          data: { balance: { increment: inAmount } },
-        })
-        if (dstUpd.count !== 1)
-          throw new Error("Destination account not found or access denied!")
-        const updatedDestAccount = await tx.account.findFirst({
-          where: { id: data.toAccountId!, familyId },
-          select: { balance: true },
-        })
-        const destBalanceAfter = updatedDestAccount!.balance
-
-        const outflowTx = await tx.transaction.create({
-          data: {
-            id: data.id, // KITA PERTAHANKAN ID LAMA AGAR UI TIDAK KACAU
-            type: "transfer",
-            kind,
-            currency: data.currency,
-            amount: negateMoney(absMoney(data.amount)),
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.accountId,
-            toAccountId: data.toAccountId,
-            categoryId: data.categoryId || null,
-            merchantId: data.merchantId || null,
-            userId: user.id,
-            familyId: context.familyId,
-            status: data.status,
-            destinationAmount: data.destinationAmount,
-            destinationCurrency: data.destinationCurrency,
-            accountBalanceAfter: sourceBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
-        })
-
-        const inflowTx = await tx.transaction.create({
-          data: {
-            type: "transfer",
-            kind,
-            currency: inCurrency,
-            amount: absMoney(inAmount),
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.toAccountId!,
-            toAccountId: data.accountId,
-            categoryId: data.categoryId || null,
-            merchantId: data.merchantId || null,
-            userId: user.id,
-            familyId: context.familyId,
-            status: data.status,
-            destinationAmount: data.destinationAmount,
-            destinationCurrency: data.destinationCurrency,
-            accountBalanceAfter: destBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
-        })
-
-        await tx.transfer.create({
-          data: {
-            outflowTransactionId: outflowTx.id,
-            inflowTransactionId: inflowTx.id,
-          },
-        })
-        return serializeTransaction({
-          ...outflowTx,
-          amount: absMoney(outflowTx.amount),
-        })
-      } else {
-        // Re-create Standard Expense/Income (dengan atau tanpa split)
-        const amountSign: Money =
-          data.type === "expense"
-            ? negateMoney(absMoney(data.amount))
-            : absMoney(data.amount)
-
-        // Running Balance Snapshot: baca saldo setelah update atomik
-        // Tenant-safe: update dengan familyId constraint
-        let accountBalanceAfter: bigint | null = null
-        if (data.type === "expense") {
-          const upd = await tx.account.updateMany({
+          // Running Balance Snapshot: baca saldo akun setelah update atomik
+          // Tenant-safe: update dengan familyId constraint
+          const srcUpd = await tx.account.updateMany({
             where: { id: data.accountId, familyId },
             data: { balance: { decrement: data.amount } },
           })
-          if (upd.count !== 1)
-            throw new Error("Account not found or access denied!")
-          const updated = await tx.account.findFirst({
+          if (srcUpd.count !== 1)
+            throw new Error("Source account not found or access denied!")
+          const updatedSourceAccount = await tx.account.findFirst({
             where: { id: data.accountId, familyId },
             select: { balance: true },
           })
-          accountBalanceAfter = updated!.balance
+          const sourceBalanceAfter = updatedSourceAccount!.balance
+
+          // Multi-currency: gunakan destinationAmount jika tersedia, fallback ke amount
+          const inAmount = data.destinationAmount ?? data.amount
+          const inCurrency = data.destinationCurrency ?? data.currency
+
+          const dstUpd = await tx.account.updateMany({
+            where: { id: data.toAccountId!, familyId },
+            data: { balance: { increment: inAmount } },
+          })
+          if (dstUpd.count !== 1)
+            throw new Error("Destination account not found or access denied!")
+          const updatedDestAccount = await tx.account.findFirst({
+            where: { id: data.toAccountId!, familyId },
+            select: { balance: true },
+          })
+          const destBalanceAfter = updatedDestAccount!.balance
+
+          const outflowTx = await tx.transaction.create({
+            data: {
+              id: data.id, // KITA PERTAHANKAN ID LAMA AGAR UI TIDAK KACAU
+              type: "transfer",
+              kind,
+              currency: data.currency,
+              amount: negateMoney(absMoney(data.amount)),
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.accountId,
+              toAccountId: data.toAccountId,
+              categoryId: data.categoryId || null,
+              merchantId: data.merchantId || null,
+              userId: user.id,
+              familyId: context.familyId,
+              status: data.status,
+              destinationAmount: data.destinationAmount,
+              destinationCurrency: data.destinationCurrency,
+              accountBalanceAfter: sourceBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+            },
+          })
+
+          const inflowTx = await tx.transaction.create({
+            data: {
+              type: "transfer",
+              kind,
+              currency: inCurrency,
+              amount: absMoney(inAmount),
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.toAccountId!,
+              toAccountId: data.accountId,
+              categoryId: data.categoryId || null,
+              merchantId: data.merchantId || null,
+              userId: user.id,
+              familyId: context.familyId,
+              status: data.status,
+              destinationAmount: data.destinationAmount,
+              destinationCurrency: data.destinationCurrency,
+              accountBalanceAfter: destBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+            },
+          })
+
+          await tx.transfer.create({
+            data: {
+              outflowTransactionId: outflowTx.id,
+              inflowTransactionId: inflowTx.id,
+            },
+          })
+          return serializeTransaction({
+            ...outflowTx,
+            amount: absMoney(outflowTx.amount),
+          })
         } else {
-          // type is "income" — only possibility after "expense" and "transfer" are handled
-          const upd = await tx.account.updateMany({
-            where: { id: data.accountId, familyId },
-            data: { balance: { increment: data.amount } },
-          })
-          if (upd.count !== 1)
-            throw new Error("Account not found or access denied!")
-          const updated = await tx.account.findFirst({
-            where: { id: data.accountId, familyId },
-            select: { balance: true },
-          })
-          accountBalanceAfter = updated!.balance
-        }
+          // Re-create Standard Expense/Income (dengan atau tanpa split)
+          const amountSign: Money =
+            data.type === "expense"
+              ? negateMoney(absMoney(data.amount))
+              : absMoney(data.amount)
 
-        const newTx = await tx.transaction.create({
-          data: {
-            id: data.id, // PERTAHANKAN ID LAMA
-            type: data.type,
-            amount: amountSign,
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.accountId,
-            toAccountId: data.toAccountId || null,
-            // Jika split, kategori hidup di entries, bukan parent
-            categoryId: data.isSplit ? null : data.categoryId || null,
-            merchantId: data.isSplit ? null : data.merchantId || null,
-            isSplit: data.isSplit,
-            userId: user.id,
-            familyId: context.familyId,
-            status: data.status,
-            accountBalanceAfter: accountBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
-        })
+          // Running Balance Snapshot: baca saldo setelah update atomik
+          // Tenant-safe: update dengan familyId constraint
+          let accountBalanceAfter: bigint | null = null
+          if (data.type === "expense") {
+            const upd = await tx.account.updateMany({
+              where: { id: data.accountId, familyId },
+              data: { balance: { decrement: data.amount } },
+            })
+            if (upd.count !== 1)
+              throw new Error("Account not found or access denied!")
+            const updated = await tx.account.findFirst({
+              where: { id: data.accountId, familyId },
+              select: { balance: true },
+            })
+            accountBalanceAfter = updated!.balance
+          } else {
+            // type is "income" — only possibility after "expense" and "transfer" are handled
+            const upd = await tx.account.updateMany({
+              where: { id: data.accountId, familyId },
+              data: { balance: { increment: data.amount } },
+            })
+            if (upd.count !== 1)
+              throw new Error("Account not found or access denied!")
+            const updated = await tx.account.findFirst({
+              where: { id: data.accountId, familyId },
+              select: { balance: true },
+            })
+            accountBalanceAfter = updated!.balance
+          }
 
-        // Recreate split entries satu-satu (parent lama sudah dihapus via CASCADE)
-        // Menggunakan create() agar Prisma generate cuid() untuk id
-        if (data.isSplit && data.splitEntries?.length) {
-          await Promise.all(
-            data.splitEntries.map((entry) =>
-              tx.splitEntry.create({
-                data: {
-                  transactionId: newTx.id,
-                  description: entry.description,
-                  amount: absMoney(entry.amount),
-                  categoryId: entry.categoryId || null,
-                  merchantId: entry.merchantId || null,
-                },
-              })
+          const newTx = await tx.transaction.create({
+            data: {
+              id: data.id, // PERTAHANKAN ID LAMA
+              type: data.type,
+              amount: amountSign,
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.accountId,
+              toAccountId: data.toAccountId || null,
+              // Jika split, kategori hidup di entries, bukan parent
+              categoryId: data.isSplit ? null : data.categoryId || null,
+              merchantId: data.isSplit ? null : data.merchantId || null,
+              isSplit: data.isSplit,
+              userId: user.id,
+              familyId: context.familyId,
+              status: data.status,
+              accountBalanceAfter: accountBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+            },
+          })
+
+          // Recreate split entries satu-satu (parent lama sudah dihapus via CASCADE)
+          // Menggunakan create() agar Prisma generate cuid() untuk id
+          if (data.isSplit && data.splitEntries?.length) {
+            await Promise.all(
+              data.splitEntries.map((entry) =>
+                tx.splitEntry.create({
+                  data: {
+                    transactionId: newTx.id,
+                    description: entry.description,
+                    amount: absMoney(entry.amount),
+                    categoryId: entry.categoryId || null,
+                    merchantId: entry.merchantId || null,
+                  },
+                })
+              )
             )
-          )
-        }
+          }
 
-        return serializeTransaction({
-          ...newTx,
-          amount: absMoney(newTx.amount),
-        })
+          return serializeTransaction({
+            ...newTx,
+            amount: absMoney(newTx.amount),
+          })
+        }
       }
-    })
+    )
   })
 
 /**
@@ -798,64 +795,70 @@ export const bulkDeleteTransactionsFn = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     if (data.ids.length === 0) return { success: true }
 
-    return await scopedTx(context.familyId, async (tx: PrismaTxClient) => {
-      // 1. Ambil data asli untuk merestore saldo
-      // (termasuk transfer out/inflow)
-      const oldTxs = await tx.transaction.findMany({
-        where: { id: { in: data.ids } },
-        include: { transferOut: true },
-      })
+    return await scopedTenantTransaction(
+      context.familyId,
+      async (tx: TenantTransactionClient) => {
+        // 1. Ambil data asli untuk merestore saldo
+        // (termasuk transfer out/inflow)
+        const oldTxs = await tx.transaction.findMany({
+          where: { id: { in: data.ids } },
+          include: { transferOut: true },
+        })
 
-      const accountDeltas: Record<string, bigint> = {}
+        const accountDeltas: Record<string, bigint> = {}
 
-      const addDelta = (id: string, amount: bigint) => {
-        if (!accountDeltas[id]) accountDeltas[id] = 0n
-        accountDeltas[id] += amount
-      }
+        const addDelta = (id: string, amount: bigint) => {
+          if (!accountDeltas[id]) accountDeltas[id] = 0n
+          accountDeltas[id] += amount
+        }
 
-      for (const oldTx of oldTxs) {
-        if (oldTx.type === "transfer" && oldTx.transferOut) {
-          const inflowTx = await tx.transaction.findUnique({
-            where: {
-              id: oldTx.transferOut.inflowTransactionId,
-            },
-          })
-          addDelta(oldTx.accountId, absMoney(oldTx.amount))
-          if (inflowTx) {
-            addDelta(inflowTx.accountId, negateMoney(absMoney(inflowTx.amount)))
-            // Soft delete: inflow transaction (TIDAK PERNAH hard delete — audit trail)
-            await tx.transaction.update({
-              where: { id: inflowTx.id },
-              data: { deletedAt: new Date() },
+        for (const oldTx of oldTxs) {
+          if (oldTx.type === "transfer" && oldTx.transferOut) {
+            const inflowTx = await tx.transaction.findUnique({
+              where: {
+                id: oldTx.transferOut.inflowTransactionId,
+              },
             })
-          }
-        } else if (oldTx.type !== "transfer") {
-          if (oldTx.type === "expense") {
             addDelta(oldTx.accountId, absMoney(oldTx.amount))
-          } else if (oldTx.type === "income") {
-            addDelta(oldTx.accountId, negateMoney(absMoney(oldTx.amount)))
+            if (inflowTx) {
+              addDelta(
+                inflowTx.accountId,
+                negateMoney(absMoney(inflowTx.amount))
+              )
+              // Soft delete: inflow transaction (TIDAK PERNAH hard delete — audit trail)
+              await tx.transaction.update({
+                where: { id: inflowTx.id },
+                data: { deletedAt: new Date() },
+              })
+            }
+          } else if (oldTx.type !== "transfer") {
+            if (oldTx.type === "expense") {
+              addDelta(oldTx.accountId, absMoney(oldTx.amount))
+            } else if (oldTx.type === "income") {
+              addDelta(oldTx.accountId, negateMoney(absMoney(oldTx.amount)))
+            }
           }
         }
-      }
 
-      // 2. Terapkan agregasi delta secara masal
-      await Promise.all(
-        Object.entries(accountDeltas).map(([accountId, delta]) =>
-          tx.account.update({
-            where: { id: accountId },
-            data: { balance: { increment: delta } },
-          })
+        // 2. Terapkan agregasi delta secara masal
+        await Promise.all(
+          Object.entries(accountDeltas).map(([accountId, delta]) =>
+            tx.account.update({
+              where: { id: accountId },
+              data: { balance: { increment: delta } },
+            })
+          )
         )
-      )
 
-      // 3. Soft delete: set deletedAt timestamp — TIDAK PERNAH hard delete
-      await tx.transaction.updateMany({
-        where: { id: { in: data.ids } },
-        data: { deletedAt: new Date() },
-      })
+        // 3. Soft delete: set deletedAt timestamp — TIDAK PERNAH hard delete
+        await tx.transaction.updateMany({
+          where: { id: { in: data.ids } },
+          data: { deletedAt: new Date() },
+        })
 
-      return { success: true }
-    })
+        return { success: true }
+      }
+    )
   })
 
 /**
@@ -875,92 +878,96 @@ export const bulkUpdateTransactionsFn = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     if (data.ids.length === 0) return { success: true }
 
-    return await scopedTx(context.familyId, async (tx: PrismaTxClient) => {
-      // 1. Handle Account Change (Requires Balance Shifting)
-      // We explicitly skip transfers for bulk account edits to prevent complex dual-leg logic breakage.
-      if (data.accountId !== undefined) {
-        const txsToMove = await tx.transaction.findMany({
-          where: {
-            id: { in: data.ids },
-            type: { not: "transfer" },
-            accountId: { not: data.accountId },
-          },
-        })
+    return await scopedTenantTransaction(
+      context.familyId,
+      async (tx: TenantTransactionClient) => {
+        // 1. Handle Account Change (Requires Balance Shifting)
+        // We explicitly skip transfers for bulk account edits to prevent complex dual-leg logic breakage.
+        if (data.accountId !== undefined) {
+          const txsToMove = await tx.transaction.findMany({
+            where: {
+              id: { in: data.ids },
+              type: { not: "transfer" },
+              accountId: { not: data.accountId },
+            },
+          })
 
-        const accountDeltas: Record<string, bigint> = {}
-        const addDelta = (id: string, amount: bigint) => {
-          if (!accountDeltas[id]) accountDeltas[id] = 0n
-          accountDeltas[id] += amount
-        }
+          const accountDeltas: Record<string, bigint> = {}
+          const addDelta = (id: string, amount: bigint) => {
+            if (!accountDeltas[id]) accountDeltas[id] = 0n
+            accountDeltas[id] += amount
+          }
 
-        for (const t of txsToMove) {
-          // Expense: Reverse old (+), Charge new (-)
-          // Income: Reverse old (-), Charge new (+)
-          const magnitude = absMoney(t.amount)
-          const refundSigned: bigint =
-            t.type === "expense" ? magnitude : negateMoney(magnitude)
-          const chargeSigned: bigint =
-            t.type === "expense" ? negateMoney(magnitude) : magnitude
+          for (const t of txsToMove) {
+            // Expense: Reverse old (+), Charge new (-)
+            // Income: Reverse old (-), Charge new (+)
+            const magnitude = absMoney(t.amount)
+            const refundSigned: bigint =
+              t.type === "expense" ? magnitude : negateMoney(magnitude)
+            const chargeSigned: bigint =
+              t.type === "expense" ? negateMoney(magnitude) : magnitude
 
-          addDelta(t.accountId, refundSigned)
-          addDelta(data.accountId, chargeSigned)
-        }
+            addDelta(t.accountId, refundSigned)
+            addDelta(data.accountId, chargeSigned)
+          }
 
-        await Promise.all(
-          Object.entries(accountDeltas).map(([accId, delta]) =>
-            tx.account.update({
-              where: { id: accId },
-              data: { balance: { increment: delta } },
-            })
+          await Promise.all(
+            Object.entries(accountDeltas).map(([accId, delta]) =>
+              tx.account.update({
+                where: { id: accId },
+                data: { balance: { increment: delta } },
+              })
+            )
           )
-        )
+        }
+
+        // 2. Prepare scalar updates payload (typed — no `any`)
+        type CategoryMerchantUpdate = {
+          categoryId?: string | null
+          merchantId?: string | null
+        }
+        type ParentUpdate = CategoryMerchantUpdate & {
+          accountId?: string
+        }
+
+        const updates: CategoryMerchantUpdate = {}
+        if (data.categoryId !== undefined) updates.categoryId = data.categoryId
+        if (data.merchantId !== undefined) updates.merchantId = data.merchantId
+
+        const parentUpdates: ParentUpdate = { ...updates }
+        if (data.accountId !== undefined)
+          parentUpdates.accountId = data.accountId
+
+        // 3. Execute DB Modifications (Super-Fast Bulk Updates)
+        if (Object.keys(parentUpdates).length > 0) {
+          await tx.transaction.updateMany({
+            // Categories only apply to non-split transactions!
+            where: {
+              id: { in: data.ids },
+              ...(data.categoryId !== undefined || data.merchantId !== undefined
+                ? { isSplit: false }
+                : {}),
+            },
+            data: parentUpdates,
+          })
+        }
+
+        const splitUpdates: CategoryMerchantUpdate = {}
+        if (data.categoryId !== undefined)
+          splitUpdates.categoryId = data.categoryId
+        if (data.merchantId !== undefined)
+          splitUpdates.merchantId = data.merchantId
+
+        if (Object.keys(splitUpdates).length > 0) {
+          await tx.splitEntry.updateMany({
+            where: { transactionId: { in: data.ids } },
+            data: splitUpdates,
+          })
+        }
+
+        return { success: true }
       }
-
-      // 2. Prepare scalar updates payload (typed — no `any`)
-      type CategoryMerchantUpdate = {
-        categoryId?: string | null
-        merchantId?: string | null
-      }
-      type ParentUpdate = CategoryMerchantUpdate & {
-        accountId?: string
-      }
-
-      const updates: CategoryMerchantUpdate = {}
-      if (data.categoryId !== undefined) updates.categoryId = data.categoryId
-      if (data.merchantId !== undefined) updates.merchantId = data.merchantId
-
-      const parentUpdates: ParentUpdate = { ...updates }
-      if (data.accountId !== undefined) parentUpdates.accountId = data.accountId
-
-      // 3. Execute DB Modifications (Super-Fast Bulk Updates)
-      if (Object.keys(parentUpdates).length > 0) {
-        await tx.transaction.updateMany({
-          // Categories only apply to non-split transactions!
-          where: {
-            id: { in: data.ids },
-            ...(data.categoryId !== undefined || data.merchantId !== undefined
-              ? { isSplit: false }
-              : {}),
-          },
-          data: parentUpdates,
-        })
-      }
-
-      const splitUpdates: CategoryMerchantUpdate = {}
-      if (data.categoryId !== undefined)
-        splitUpdates.categoryId = data.categoryId
-      if (data.merchantId !== undefined)
-        splitUpdates.merchantId = data.merchantId
-
-      if (Object.keys(splitUpdates).length > 0) {
-        await tx.splitEntry.updateMany({
-          where: { transactionId: { in: data.ids } },
-          data: splitUpdates,
-        })
-      }
-
-      return { success: true }
-    })
+    )
   })
 
 // ===================================
@@ -995,48 +1002,51 @@ export const bulkCreateTransactionsFn = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     const { user, familyId } = context
 
-    return await scopedTx(familyId, async (tx: PrismaTxClient) => {
-      // 1. Create all transactions
-      await tx.transaction.createMany({
-        data: data.transactions.map((t) => ({
-          id: t.id,
-          userId: user.id,
-          familyId,
-          type: t.type,
-          amount:
+    return await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) => {
+        // 1. Create all transactions
+        await tx.transaction.createMany({
+          data: data.transactions.map((t) => ({
+            id: t.id,
+            userId: user.id,
+            familyId,
+            type: t.type,
+            amount:
+              t.type === "expense"
+                ? negateMoney(absMoney(t.amount))
+                : absMoney(t.amount),
+            description: t.description,
+            accountId: t.accountId,
+            categoryId: t.categoryId,
+            merchantId: t.merchantId,
+            date: t.date,
+            notes: t.notes,
+            status: t.status,
+            attachmentUrl: t.attachmentUrl,
+          })),
+        })
+
+        // 2. Adjust account balances
+        const accountDeltas: Record<string, bigint> = {}
+        for (const t of data.transactions) {
+          if (!accountDeltas[t.accountId]) accountDeltas[t.accountId] = 0n
+          accountDeltas[t.accountId] +=
             t.type === "expense"
               ? negateMoney(absMoney(t.amount))
-              : absMoney(t.amount),
-          description: t.description,
-          accountId: t.accountId,
-          categoryId: t.categoryId,
-          merchantId: t.merchantId,
-          date: t.date,
-          notes: t.notes,
-          status: t.status,
-          attachmentUrl: t.attachmentUrl,
-        })),
-      })
+              : absMoney(t.amount)
+        }
 
-      // 2. Adjust account balances
-      const accountDeltas: Record<string, bigint> = {}
-      for (const t of data.transactions) {
-        if (!accountDeltas[t.accountId]) accountDeltas[t.accountId] = 0n
-        accountDeltas[t.accountId] +=
-          t.type === "expense"
-            ? negateMoney(absMoney(t.amount))
-            : absMoney(t.amount)
-      }
-
-      await Promise.all(
-        Object.entries(accountDeltas).map(([accId, delta]) =>
-          tx.account.update({
-            where: { id: accId },
-            data: { balance: { increment: delta } },
-          })
+        await Promise.all(
+          Object.entries(accountDeltas).map(([accId, delta]) =>
+            tx.account.update({
+              where: { id: accId },
+              data: { balance: { increment: delta } },
+            })
+          )
         )
-      )
 
-      return { success: true, count: data.transactions.length }
-    })
+        return { success: true, count: data.transactions.length }
+      }
+    )
   })

--- a/tests/integration/rls-guc-scoping.integration.ts
+++ b/tests/integration/rls-guc-scoping.integration.ts
@@ -1,0 +1,239 @@
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import {
+  scopedTenantTransaction,
+  type TenantTransactionClient,
+} from "../../src/server/middleware/with-family"
+import { prisma as appPrisma } from "../../src/server/db.server"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+interface CurrentSettingRow {
+  family_id: string | null
+}
+
+interface BackendPidRow {
+  pid: number
+}
+
+const PRISMA_NOT_FOUND =
+  /required but not found|No record was found|No Account found/i
+
+let harness: IntegrationHarness | null = null
+let factories: TestFactories | null = null
+
+describe("transaction-scoped RLS GUC", () => {
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await getHarness().reset()
+  })
+
+  afterAll(async () => {
+    if (process.env.DATABASE_URL) {
+      await appPrisma.$disconnect()
+    }
+    await harness?.teardown()
+  })
+
+  test("tenant-scoped reads fail without transaction-scoped app.family_id", async () => {
+    const testFactories = getFactories()
+    const owner = await testFactories.createAuthenticatedOnboardedUser()
+    const account = await testFactories.createAccount({
+      familyId: owner.family.id,
+      name: "Hidden without GUC",
+    })
+
+    await expect(
+      appPrisma.account.findFirstOrThrow({
+        where: { id: account.id },
+      })
+    ).rejects.toThrow(PRISMA_NOT_FOUND)
+  })
+
+  test("tenant-scoped reads succeed inside scopedTenantTransaction", async () => {
+    const testFactories = getFactories()
+    const owner = await testFactories.createAuthenticatedOnboardedUser()
+    const account = await testFactories.createAccount({
+      familyId: owner.family.id,
+      name: "Visible with scoped GUC",
+    })
+
+    const visible = await scopedTenantTransaction(owner.family.id, (tx) =>
+      tx.account.findUniqueOrThrow({
+        where: { id: account.id },
+      })
+    )
+
+    expect(visible.id).toBe(account.id)
+    expect(visible.familyId).toBe(owner.family.id)
+  })
+
+  test("family A cannot read or write family B rows through the helper", async () => {
+    const [familyA, familyB] = await Promise.all([
+      getFactories().createAuthenticatedOnboardedUser(),
+      getFactories().createAuthenticatedOnboardedUser(),
+    ])
+    const familyBAccount = await getFactories().createAccount({
+      familyId: familyB.family.id,
+      name: "Other tenant account",
+    })
+
+    const crossTenantRead = await scopedTenantTransaction(
+      familyA.family.id,
+      (tx) =>
+        tx.account.findFirst({
+          where: { id: familyBAccount.id },
+        })
+    )
+
+    expect(crossTenantRead).toBeNull()
+
+    await expect(
+      scopedTenantTransaction(familyA.family.id, (tx) =>
+        tx.account.create({
+          data: {
+            balance: 0n,
+            color: "#111827",
+            currency: "IDR",
+            familyId: familyB.family.id,
+            name: "Illegal cross-tenant insert",
+            status: "active",
+            type: "DEPOSITORY",
+          },
+        })
+      )
+    ).rejects.toThrow(/row-level security|policy/i)
+  })
+
+  test("back-to-back helper calls do not leak app.family_id outside the transaction", async () => {
+    const [familyA, familyB] = await Promise.all([
+      getFactories().createAuthenticatedOnboardedUser(),
+      getFactories().createAuthenticatedOnboardedUser(),
+    ])
+    const [accountA, accountB] = await Promise.all([
+      getFactories().createAccount({
+        familyId: familyA.family.id,
+        name: "Family A account",
+      }),
+      getFactories().createAccount({
+        familyId: familyB.family.id,
+        name: "Family B account",
+      }),
+    ])
+
+    const visibleToA = await scopedTenantTransaction(familyA.family.id, (tx) =>
+      tx.account.findMany({ orderBy: { name: "asc" } })
+    )
+    const visibleToB = await scopedTenantTransaction(familyB.family.id, (tx) =>
+      tx.account.findMany({ orderBy: { name: "asc" } })
+    )
+    const [setting] = await appPrisma.$queryRaw<CurrentSettingRow[]>`
+      SELECT NULLIF(current_setting('app.family_id', true), '') AS family_id
+    `
+
+    expect(visibleToA.map((account) => account.id)).toEqual([accountA.id])
+    expect(visibleToB.map((account) => account.id)).toEqual([accountB.id])
+    expect(setting?.family_id ?? null).toBeNull()
+  })
+
+  test("multi-step protected mutation stays on one transaction client", async () => {
+    const owner = await getFactories().createAuthenticatedOnboardedUser()
+
+    const result = await scopedTenantTransaction(
+      owner.family.id,
+      async (tx) => {
+        const firstPid = await readBackendPid(tx)
+        const account = await tx.account.create({
+          data: {
+            balance: 10_000n,
+            color: "#2563eb",
+            currency: "IDR",
+            familyId: owner.family.id,
+            name: "Single connection account",
+            status: "active",
+            type: "DEPOSITORY",
+          },
+        })
+        const selected = await tx.account.findUniqueOrThrow({
+          where: { id: account.id },
+        })
+        const updated = await tx.account.update({
+          where: { id: account.id },
+          data: { balance: { increment: 2_500n } },
+        })
+        const secondPid = await readBackendPid(tx)
+
+        return {
+          firstPid,
+          selectedFamilyId: selected.familyId,
+          secondPid,
+          updatedBalance: updated.balance,
+        }
+      }
+    )
+
+    expect(result.firstPid).toBe(result.secondPid)
+    expect(result.selectedFamilyId).toBe(owner.family.id)
+    expect(result.updatedBalance).toBe(12_500n)
+  })
+
+  test("root Prisma queries inside a scoped transaction do not inherit the transaction GUC", async () => {
+    const testFactories = getFactories()
+    const owner = await testFactories.createAuthenticatedOnboardedUser()
+    const account = await testFactories.createAccount({
+      familyId: owner.family.id,
+      name: "Root misuse account",
+    })
+
+    await expect(
+      scopedTenantTransaction(owner.family.id, () =>
+        appPrisma.account.findFirstOrThrow({
+          where: { id: account.id },
+        })
+      )
+    ).rejects.toThrow(PRISMA_NOT_FOUND)
+  })
+
+  test("the server helper does not expose session-scoped GUC access", async () => {
+    const source = await readFile(
+      resolve(process.cwd(), "src/server/middleware/with-family.ts"),
+      "utf8"
+    )
+
+    expect(source).not.toContain("set_config('app.family_id', $1, false)")
+    expect(source).not.toMatch(/export\s+async\s+function\s+withGuc/)
+  })
+})
+
+function getHarness(): IntegrationHarness {
+  if (!harness) throw new Error("Integration harness is not initialized")
+  return harness
+}
+
+function getFactories(): TestFactories {
+  if (!factories) throw new Error("Integration factories are not initialized")
+  return factories
+}
+
+async function readBackendPid(tx: TenantTransactionClient): Promise<number> {
+  const [row] = await tx.$queryRaw<BackendPidRow[]>`
+    SELECT pg_backend_pid() AS pid
+  `
+  if (!row) throw new Error("Unable to read Postgres backend PID")
+  return row.pid
+}


### PR DESCRIPTION
## Summary
- Replace connection/session-level tenant GUC handling with `scopedTenantTransaction(familyId, tx => ...)` and `setTenantGuc(tx, familyId)`.
- Migrate transaction, smart-rule, onboarding, and seed tenant access so RLS-protected queries run on the same Prisma transaction client that set `app.family_id`.
- Add real-Postgres RLS/GUC regression coverage for missing GUC reads, helper success, cross-family denial, GUC leak prevention, same-connection mutation work, and root-client misuse.
- Document the transaction-scoped GUC contract in ADR-0006.

## Why
PER-92 closes the gap where `app.family_id` could be set on one pooled connection while later protected reads/writes ran on another connection or depended on stale session state. Tenant isolation must be transaction-scoped for ledger correctness.

## Validation
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp test run --config vitest.integration.config.ts tests/integration/rls-guc-scoping.integration.ts` — 7/7 passed
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration` — 12/12 passed
- `vp test run` — 194/194 passed
- `vp run check` — passed
- `vp build` — passed

Linear: PER-92
