### PR TITLE
test: add protected route regression coverage

### DIFF
--- a/tests/e2e/auth-routes.e2e.ts
+++ b/tests/e2e/auth-routes.e2e.ts
@@ -1,12 +1,24 @@
-import { randomUUID } from "node:crypto"
-import type { Page } from "@playwright/test"
+import { createHash, randomUUID } from "node:crypto"
+import type { Page, Request } from "@playwright/test"
 import { expect, test } from "./support/fixtures"
+
+const SERVER_FUNCTION_BASE_PATH = "/_serverFn/"
 
 interface SignupIdentity {
   email: string
   fullName: string
   password: string
   username: string
+}
+
+interface ServerFunctionMatcher {
+  displayName: string
+  paths: ReadonlySet<string>
+}
+
+interface ServerFunctionCall {
+  method: string
+  url: string
 }
 
 function createSignupIdentity(): SignupIdentity {
@@ -21,10 +33,128 @@ function createSignupIdentity(): SignupIdentity {
   }
 }
 
+function createServerFunctionMatcher(options: {
+  exportName: string
+  sourcePath: string
+}): ServerFunctionMatcher {
+  const functionName = `${options.exportName}_createServerFn_handler`
+  const devId = Buffer.from(
+    JSON.stringify({
+      file: `/${options.sourcePath}?tss-serverfn-split`,
+      export: functionName,
+    }),
+    "utf8"
+  ).toString("base64url")
+  const buildId = createHash("sha256")
+    .update(`${options.sourcePath}--${functionName}`)
+    .digest("hex")
+
+  return {
+    displayName: options.exportName,
+    paths: new Set([
+      `${SERVER_FUNCTION_BASE_PATH}${devId}`,
+      `${SERVER_FUNCTION_BASE_PATH}${buildId}`,
+    ]),
+  }
+}
+
+const getTransactionsFnMatcher = createServerFunctionMatcher({
+  exportName: "getTransactionsFn",
+  sourcePath: "src/server/transactions.ts",
+})
+
 async function waitForHydration(page: Page): Promise<void> {
   await page.waitForFunction(
     () => document.documentElement.dataset.permoneyHydrated === "true"
   )
+}
+
+function startServerFunctionRecorder(
+  page: Page,
+  matcher: ServerFunctionMatcher
+) {
+  const calls: Array<ServerFunctionCall> = []
+  const onRequest = (request: Request) => {
+    const url = new URL(request.url())
+    if (!matcher.paths.has(url.pathname)) return
+    calls.push({ method: request.method(), url: request.url() })
+  }
+
+  page.on("request", onRequest)
+
+  return {
+    calls,
+    stop: () => {
+      page.off("request", onRequest)
+    },
+  }
+}
+
+async function expectNoServerFunctionCalls(
+  recorder: ReturnType<typeof startServerFunctionRecorder>
+): Promise<void> {
+  await expect
+    .poll(() => recorder.calls.length, {
+      message: `${getTransactionsFnMatcher.displayName} must not be called`,
+      timeout: 500,
+    })
+    .toBe(0)
+}
+
+async function expectServerFunctionCalled(
+  recorder: ReturnType<typeof startServerFunctionRecorder>
+): Promise<void> {
+  await expect
+    .poll(() => recorder.calls.length, {
+      message: `${getTransactionsFnMatcher.displayName} should be called`,
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0)
+}
+
+async function expectLoginRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/login(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(page.getByRole("button", { name: "Login" })).toBeVisible()
+}
+
+async function expectOnboardingRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(
+    page.getByRole("heading", { name: "Welcome to Permoney" })
+  ).toBeVisible()
+}
+
+async function expectDashboardRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible()
+}
+
+async function expectTransactionsRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/transactions(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(
+    page.getByRole("heading", { name: "Transactions" })
+  ).toBeVisible()
+  await expect(page.getByLabel("Search transactions")).toBeVisible()
+}
+
+async function expectTransactionsErrorBoundaryAbsent(
+  page: Page
+): Promise<void> {
+  await expect(
+    page.getByRole("heading", { name: "Failed to load transactions" })
+  ).toHaveCount(0)
 }
 
 async function signUpWithoutFamily(page: Page): Promise<SignupIdentity> {
@@ -37,10 +167,7 @@ async function signUpWithoutFamily(page: Page): Promise<SignupIdentity> {
   await page.getByLabel("Email").fill(identity.email)
   await page.getByLabel("Password").fill(identity.password)
   await page.getByRole("button", { name: "Create Account" }).click()
-  await expect(page).toHaveURL(/\/onboarding$/)
-  await expect(
-    page.getByRole("heading", { name: "Welcome to Permoney" })
-  ).toBeVisible()
+  await expectOnboardingRoute(page)
 
   return identity
 }
@@ -49,10 +176,18 @@ async function completeOnboarding(page: Page): Promise<SignupIdentity> {
   const identity = await signUpWithoutFamily(page)
 
   await page.getByRole("button", { name: "Get Started" }).click()
-  await expect(page).toHaveURL(/\/dashboard$/)
-  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible()
+  await expectDashboardRoute(page)
 
   return identity
+}
+
+async function login(page: Page, identity: SignupIdentity): Promise<void> {
+  await page.goto("/login")
+  await waitForHydration(page)
+  await page.getByLabel("Email").fill(identity.email)
+  await page.getByLabel("Password").fill(identity.password)
+  await page.getByRole("button", { name: "Login" }).click()
+  await expectDashboardRoute(page)
 }
 
 test.describe("core auth and transaction route smoke flows", () => {
@@ -82,22 +217,29 @@ test.describe("core auth and transaction route smoke flows", () => {
     page,
   }) => {
     await page.goto("/dashboard")
-    await Promise.all([
-      expect(page).toHaveURL(/\/login$/),
-      waitForHydration(page),
-    ])
-    await expect(page.getByRole("button", { name: "Login" })).toBeVisible()
+    await expectLoginRoute(page)
   })
 
   test("logged-out user hitting transactions is redirected before ledger preload", async ({
     page,
   }) => {
+    const ledgerRecorder = startServerFunctionRecorder(
+      page,
+      getTransactionsFnMatcher
+    )
+
     await page.goto("/transactions")
-    await Promise.all([
-      expect(page).toHaveURL(/\/login$/),
-      waitForHydration(page),
-    ])
-    await expect(page.getByRole("button", { name: "Login" })).toBeVisible()
+    await expectLoginRoute(page)
+    await expectTransactionsErrorBoundaryAbsent(page)
+    await expectNoServerFunctionCalls(ledgerRecorder)
+    ledgerRecorder.stop()
+  })
+
+  test("logged-out user hitting onboarding is redirected to login", async ({
+    page,
+  }) => {
+    await page.goto("/onboarding")
+    await expectLoginRoute(page)
   })
 
   test("signed-up user without family is routed to onboarding", async ({
@@ -106,20 +248,50 @@ test.describe("core auth and transaction route smoke flows", () => {
     await signUpWithoutFamily(page)
   })
 
-  test("onboarded user can reach dashboard", async ({ page }) => {
-    await completeOnboarding(page)
-  })
-
-  test("onboarded user can reach transactions without blocked console errors", async ({
+  test("signed-up user without family is blocked from protected app routes", async ({
     page,
   }) => {
-    await completeOnboarding(page)
+    await signUpWithoutFamily(page)
+
+    await page.goto("/dashboard")
+    await expectOnboardingRoute(page)
+
+    const ledgerRecorder = startServerFunctionRecorder(
+      page,
+      getTransactionsFnMatcher
+    )
+    await page.goto("/transactions")
+    await expectOnboardingRoute(page)
+    await expectTransactionsErrorBoundaryAbsent(page)
+    await expectNoServerFunctionCalls(ledgerRecorder)
+    ledgerRecorder.stop()
+
+    await page.goto("/onboarding")
+    await expectOnboardingRoute(page)
+  })
+
+  test("onboarded user lands on dashboard and can reach protected routes", async ({
+    page,
+  }) => {
+    const identity = await completeOnboarding(page)
+
+    await page.goto("/dashboard")
+    await expectDashboardRoute(page)
+
+    await page.goto("/onboarding")
+    await expectDashboardRoute(page)
+
+    const ledgerRecorder = startServerFunctionRecorder(
+      page,
+      getTransactionsFnMatcher
+    )
 
     await page.goto("/transactions")
-    await Promise.all([
-      expect(page).toHaveURL(/\/transactions(?:\?.*)?$/),
-      expect(page.getByRole("heading", { name: "Transactions" })).toBeVisible(),
-      expect(page.getByLabel("Search transactions")).toBeVisible(),
-    ])
+    await expectTransactionsRoute(page)
+    await expectServerFunctionCalled(ledgerRecorder)
+    ledgerRecorder.stop()
+
+    await page.context().clearCookies()
+    await login(page, identity)
   })
 })


### PR DESCRIPTION
## Summary

- Expand Playwright guard matrix for `/dashboard`, `/transactions`, and `/onboarding` across logged-out, signed-up/no-family, and onboarded users.
- Record TanStack Start server-function requests in dev/preview shapes so blocked `/transactions` visits prove `getTransactionsFn()` is not called before auth/onboarding guards.
- Keep default post-login/onboarding flow anchored on `/dashboard` while testing `/transactions` as the protected ledger route.

## Test Plan

- `vp check`
- `vp test`
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e`
- `vp dlx react-doctor@latest . --verbose --diff`

## Security/Quality Notes

- Local diff scan found no static secrets; password matches are generated E2E test credentials only.
- Repository workflows do not expose GitGuardian or SonarQube configuration locally; PR checks will be monitored after opening for any provider-level failures.