### PR TITLE
PER-17: Add transaction idempotency keys

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,15 @@
+# Runbook
+
+## Idempotency Record Cleanup
+
+ADR-0006 gives `IdempotencyRecord` rows a 24-hour replay window. Until Permoney
+has a scheduled job runner, operators can purge expired replay-cache rows with:
+
+```sql
+DELETE FROM "IdempotencyRecord"
+WHERE "expiresAt" < now();
+```
+
+This cleanup must not delete `Transaction` rows. Transaction-level
+`idempotencyKey` values are retained on the canonical ledger row as immutable
+financial evidence.

--- a/prisma/migrations/20260523100000_idempotency_keys/migration.sql
+++ b/prisma/migrations/20260523100000_idempotency_keys/migration.sql
@@ -1,0 +1,41 @@
+-- PER-17 / ADR-0006: transaction idempotency keys and replay records.
+
+ALTER TABLE "Transaction"
+  ADD COLUMN "idempotencyKey" TEXT;
+
+CREATE UNIQUE INDEX "tx_family_idempotency"
+  ON "Transaction"("familyId", "idempotencyKey");
+
+CREATE TABLE "IdempotencyRecord" (
+  "id" TEXT NOT NULL,
+  "familyId" TEXT NOT NULL,
+  "endpoint" TEXT NOT NULL,
+  "key" TEXT NOT NULL,
+  "requestHash" TEXT NOT NULL,
+  "statusCode" INTEGER NOT NULL,
+  "responseJson" JSONB NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "IdempotencyRecord_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "IdempotencyRecord_familyId_endpoint_key_key"
+  ON "IdempotencyRecord"("familyId", "endpoint", "key");
+
+CREATE INDEX "IdempotencyRecord_expiresAt_idx"
+  ON "IdempotencyRecord"("expiresAt");
+
+ALTER TABLE "IdempotencyRecord"
+  ADD CONSTRAINT "IdempotencyRecord_familyId_fkey"
+  FOREIGN KEY ("familyId") REFERENCES "Family"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "IdempotencyRecord" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY idempotency_record_tenant_isolation ON "IdempotencyRecord"
+  FOR ALL
+  USING ("familyId" = current_setting('app.family_id', true)::text)
+  WITH CHECK ("familyId" = current_setting('app.family_id', true)::text);
+
+ALTER TABLE "IdempotencyRecord" FORCE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Family {
   categories   Category[]
   smartRules   SmartRule[]
   transactions Transaction[]
+  idempotencyRecords IdempotencyRecord[]
 }
 
 model User {
@@ -191,6 +192,7 @@ model Transaction {
   // Soft Delete (GAAP Compliance): Transaksi tidak pernah benar-benar dihapus
   // NULL = aktif, ada timestamp = soft-deleted (audit trail tetap ada)
   deletedAt DateTime?
+  idempotencyKey String?
 
   merchantId String?
   merchant   Merchant? @relation(fields: [merchantId], references: [id])
@@ -233,6 +235,23 @@ model Transaction {
   @@index([familyId, deletedAt, date(sort: Desc)])
   @@index([categoryId])
   @@index([merchantId])
+  @@unique([familyId, idempotencyKey], name: "tx_family_idempotency")
+}
+
+model IdempotencyRecord {
+  id           String   @id @default(cuid())
+  familyId     String
+  family       Family   @relation(fields: [familyId], references: [id], onDelete: Restrict)
+  endpoint     String
+  key          String
+  requestHash  String
+  statusCode   Int
+  responseJson Json
+  createdAt    DateTime @default(now())
+  expiresAt    DateTime
+
+  @@unique([familyId, endpoint, key])
+  @@index([expiresAt])
 }
 
 model Transfer {

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { useForm } from "@tanstack/react-form"
+import { useForm, type ReactFormExtendedApi } from "@tanstack/react-form"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { useQuery } from "@tanstack/react-query"
 import {
@@ -132,6 +132,68 @@ interface TransactionFormModalProps {
   onClose?: () => void
 }
 
+type TransactionType = TransactionFormValues["type"]
+type TransactionStatus = TransactionFormValues["status"]
+type TransactionFormInstance = ReactFormExtendedApi<
+  TransactionFormValues,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  unknown
+>
+type TransactionFormLookupData = {
+  accounts: Array<FormAccount>
+  categories: Array<FormCategory>
+  merchants: Array<FormMerchant>
+}
+type SplitEntryState = Array<SplitEntryValue>
+type SplitEntryStateSetter = React.Dispatch<
+  React.SetStateAction<SplitEntryState>
+>
+
+interface TransactionFormSectionProps {
+  form: TransactionFormInstance
+  activeTab: TransactionType
+  formData?: TransactionFormLookupData
+  isLoading: boolean
+}
+
+const transactionStatusOptions: Array<{
+  value: TransactionStatus
+  label: string
+  icon: string
+  activeClass: string
+}> = [
+  {
+    value: "PENDING",
+    label: "Pending",
+    icon: "⏳",
+    activeClass:
+      "border-amber-400 bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-400",
+  },
+  {
+    value: "CLEARED",
+    label: "Cleared",
+    icon: "✓",
+    activeClass:
+      "border-emerald-400 bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400",
+  },
+  {
+    value: "RECONCILED",
+    label: "Reconciled",
+    icon: "⊙",
+    activeClass:
+      "border-blue-400 bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-400",
+  },
+]
+
 /**
  * Coerce an EditAmount (which may be Money/bigint OR a JS number) to the
  * decimal-major number the HTML input expects. Currency drives the scale
@@ -147,11 +209,977 @@ function editAmountToInputNumber(amount: EditAmount, currency: string): number {
   return amount
 }
 
-export function TransactionFormModal({
-  editData,
+function createBlankSplitEntry(): SplitEntryValue {
+  return {
+    id: createUuidV7(),
+    description: "",
+    amount: 0,
+    categoryId: "",
+    merchantId: "",
+  }
+}
+
+function CategoryOptions({
+  categories,
+  type,
+}: {
+  categories: Array<FormCategory> | undefined
+  type: TransactionType
+}) {
+  return categories?.reduce<Array<React.ReactNode>>((options, category) => {
+    if (category.type === type) {
+      options.push(
+        <option key={category.id} value={category.id}>
+          {category.name}
+        </option>
+      )
+    }
+    return options
+  }, [])
+}
+
+function TransactionDialogTrigger({
   customTrigger,
+}: {
+  customTrigger?: React.ReactNode
+}) {
+  return (
+    <DialogTrigger asChild>
+      {customTrigger ? (
+        customTrigger
+      ) : (
+        <Button className="bg-yellow-500 font-bold text-black shadow-md hover:bg-yellow-600">
+          <IconPlus className="mr-2 size-4" /> New Transaction
+        </Button>
+      )}
+    </DialogTrigger>
+  )
+}
+
+function TransactionTypeTabs({
+  activeTab,
+  form,
+  setActiveTab,
+}: {
+  activeTab: TransactionType
+  form: TransactionFormInstance
+  setActiveTab: React.Dispatch<React.SetStateAction<TransactionType>>
+}) {
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(v) => {
+        const selectedType = v as TransactionType
+        setActiveTab(selectedType)
+        form.setFieldValue("type", selectedType)
+        if (selectedType === "transfer") form.setFieldValue("categoryId", "")
+        else form.setFieldValue("toAccountId", "")
+      }}
+      className="mt-2 w-full"
+    >
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger
+          value="expense"
+          className="data-[state=active]:text-red-600"
+        >
+          <IconArrowUpRight className="mr-1 size-4" /> Expense
+        </TabsTrigger>
+        <TabsTrigger
+          value="income"
+          className="data-[state=active]:text-emerald-600"
+        >
+          <IconArrowDownLeft className="mr-1 size-4" /> Income
+        </TabsTrigger>
+        <TabsTrigger
+          value="transfer"
+          className="data-[state=active]:text-blue-600"
+        >
+          <IconArrowsExchange className="mr-1 size-4" /> Transfer
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  )
+}
+
+function FormErrorBanner({ formError }: { formError: string | null }) {
+  if (!formError) return null
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive dark:bg-destructive/20"
+    >
+      <span aria-hidden="true" className="mt-0.5">
+        ⚠
+      </span>
+      <span className="flex-1">{formError}</span>
+    </div>
+  )
+}
+
+function DescriptionField({
+  activeTab,
+  form,
+}: Pick<TransactionFormSectionProps, "activeTab" | "form">) {
+  return (
+    <form.Field
+      name="description"
+      validators={{
+        onChange: transactionSchema.shape.description,
+      }}
+    >
+      {(field) => (
+        <div className="space-y-2">
+          <Label htmlFor={field.name}>
+            {activeTab === "transfer" ? "Transfer Note *" : "Description *"}
+          </Label>
+          <Input
+            id={field.name}
+            name={field.name}
+            placeholder={
+              activeTab === "transfer"
+                ? "e.g., Transfer to savings account"
+                : "e.g., Target shopping, February Salary"
+            }
+            value={field.state.value}
+            onBlur={field.handleBlur}
+            onChange={(e) => field.handleChange(e.target.value)}
+            aria-invalid={field.state.meta.errors.length > 0}
+            aria-describedby={
+              field.state.meta.errors.length > 0
+                ? `${field.name}-error`
+                : undefined
+            }
+          />
+          <FieldError
+            id={`${field.name}-error`}
+            errors={field.state.meta.errors}
+          />
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+function AmountAccountFields({
+  activeTab,
+  form,
+  formData,
+  isLoading,
+}: TransactionFormSectionProps) {
+  return (
+    <div
+      className={cn(
+        "grid gap-4",
+        activeTab === "transfer" ? "grid-cols-1" : "grid-cols-2"
+      )}
+    >
+      <form.Field
+        name="amount"
+        validators={{
+          onChange: transactionSchema.shape.amount,
+        }}
+      >
+        {(field) => (
+          <div className="space-y-2">
+            <Label htmlFor={field.name}>Amount *</Label>
+            <div className="relative">
+              <form.Subscribe selector={(state) => state.values.accountId}>
+                {(currentAccountId) => {
+                  const selectedCurrency =
+                    formData?.accounts.find((a) => a.id === currentAccountId)
+                      ?.currency ?? "IDR"
+                  return (
+                    <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
+                      {getCurrencySymbol(selectedCurrency)}
+                    </span>
+                  )
+                }}
+              </form.Subscribe>
+              <Input
+                id={field.name}
+                name={field.name}
+                type="number"
+                className="pl-7 text-lg font-bold"
+                value={field.state.value || ""}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(Number(e.target.value))}
+                aria-invalid={field.state.meta.errors.length > 0}
+                aria-describedby={
+                  field.state.meta.errors.length > 0
+                    ? `${field.name}-error`
+                    : undefined
+                }
+              />
+            </div>
+            <FieldError
+              id={`${field.name}-error`}
+              errors={field.state.meta.errors}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      {activeTab !== "transfer" && (
+        <form.Field
+          name="accountId"
+          validators={{
+            onChange: transactionSchema.shape.accountId,
+          }}
+        >
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Account *</Label>
+              <select
+                id={field.name}
+                name={field.name}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                disabled={isLoading}
+                aria-invalid={field.state.meta.errors.length > 0}
+                aria-describedby={
+                  field.state.meta.errors.length > 0
+                    ? `${field.name}-error`
+                    : undefined
+                }
+              >
+                <option value="" disabled>
+                  {isLoading ? "Loading..." : "Select Account"}
+                </option>
+                {formData?.accounts.map((acc) => (
+                  <option key={acc.id} value={acc.id}>
+                    {acc.name} ({acc.currency})
+                  </option>
+                ))}
+              </select>
+              <FieldError
+                id={`${field.name}-error`}
+                errors={field.state.meta.errors}
+              />
+            </div>
+          )}
+        </form.Field>
+      )}
+    </div>
+  )
+}
+
+function TransferAccountFields({
+  activeTab,
+  form,
+  formData,
+  isLoading,
+}: TransactionFormSectionProps) {
+  if (activeTab !== "transfer") return null
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <form.Field
+        name="accountId"
+        validators={{
+          onChange: transactionSchema.shape.accountId,
+        }}
+      >
+        {(field) => (
+          <div className="space-y-2">
+            <Label htmlFor="transfer-source-accountId">From Account *</Label>
+            <select
+              id="transfer-source-accountId"
+              name={field.name}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              disabled={isLoading}
+              aria-invalid={field.state.meta.errors.length > 0}
+              aria-describedby={
+                field.state.meta.errors.length > 0
+                  ? `transfer-source-accountId-error`
+                  : undefined
+              }
+            >
+              <option value="" disabled>
+                {isLoading ? "Loading..." : "Select Source"}
+              </option>
+              {formData?.accounts.map((acc) => (
+                <option key={acc.id} value={acc.id}>
+                  {acc.name} ({acc.currency})
+                </option>
+              ))}
+            </select>
+            <FieldError
+              id="transfer-source-accountId-error"
+              errors={field.state.meta.errors}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="toAccountId"
+        validators={{
+          onChange: z.string().min(1, "Destination account is required"),
+        }}
+      >
+        {(field) => (
+          <div className="space-y-2">
+            <Label htmlFor={field.name}>To Account *</Label>
+            <form.Subscribe selector={(state) => state.values.accountId}>
+              {(currentAccountId) => (
+                <select
+                  id={field.name}
+                  name={field.name}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  disabled={isLoading}
+                  aria-invalid={field.state.meta.errors.length > 0}
+                  aria-describedby={
+                    field.state.meta.errors.length > 0
+                      ? `${field.name}-error`
+                      : undefined
+                  }
+                >
+                  <option value="" disabled>
+                    {isLoading ? "Loading..." : "Select Destination"}
+                  </option>
+                  {formData?.accounts.map((acc) => (
+                    <option
+                      key={acc.id}
+                      value={acc.id}
+                      disabled={acc.id === currentAccountId}
+                    >
+                      {acc.name} ({acc.currency})
+                    </option>
+                  ))}
+                </select>
+              )}
+            </form.Subscribe>
+            <FieldError
+              id={`${field.name}-error`}
+              errors={field.state.meta.errors}
+            />
+          </div>
+        )}
+      </form.Field>
+    </div>
+  )
+}
+
+function DestinationAmountField({
+  activeTab,
+  form,
+  formData,
+}: Pick<TransactionFormSectionProps, "activeTab" | "form" | "formData">) {
+  if (activeTab !== "transfer") return null
+
+  return (
+    <form.Subscribe
+      selector={(state) => ({
+        accountId: state.values.accountId,
+        toAccountId: state.values.toAccountId,
+        sourceAmount: state.values.amount,
+      })}
+    >
+      {({ accountId, toAccountId, sourceAmount }) => {
+        const srcAccount = formData?.accounts.find((a) => a.id === accountId)
+        const dstAccount = formData?.accounts.find((a) => a.id === toAccountId)
+        const isCrossCurrency =
+          srcAccount &&
+          dstAccount &&
+          srcAccount.currency !== dstAccount.currency
+
+        if (!isCrossCurrency) return null
+
+        return (
+          <form.Field name="destinationAmount">
+            {(field) => (
+              <div className="space-y-2 rounded-lg border border-blue-200 bg-blue-50/40 p-3 dark:border-blue-800 dark:bg-blue-950/20">
+                <Label
+                  htmlFor="destination-amount"
+                  className="flex items-center gap-1.5 text-sm font-semibold text-blue-700 dark:text-blue-400"
+                >
+                  <IconArrowsExchange className="size-4" />
+                  Destination Amount ({dstAccount.currency})
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Enter the EXACT amount credited to the destination account.
+                  This locks the implied exchange rate for historical accuracy.
+                </p>
+                <div className="relative">
+                  <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
+                    {getCurrencySymbol(dstAccount.currency)}
+                  </span>
+                  <Input
+                    id="destination-amount"
+                    name="destination-amount"
+                    type="number"
+                    className="pl-8 text-lg font-bold"
+                    placeholder="0"
+                    value={field.state.value ?? ""}
+                    onBlur={field.handleBlur}
+                    onChange={(e) =>
+                      field.handleChange(
+                        e.target.value ? Number(e.target.value) : undefined
+                      )
+                    }
+                  />
+                </div>
+                {field.state.value && sourceAmount > 0 && (
+                  <p className="text-xs font-medium text-blue-600 dark:text-blue-400">
+                    Implied rate: 1 {srcAccount.currency} ={" "}
+                    {(field.state.value / sourceAmount).toLocaleString(
+                      "en-US",
+                      {
+                        minimumFractionDigits: 4,
+                        maximumFractionDigits: 4,
+                      }
+                    )}{" "}
+                    {dstAccount.currency}
+                  </p>
+                )}
+              </div>
+            )}
+          </form.Field>
+        )
+      }}
+    </form.Subscribe>
+  )
+}
+
+function DateTimeFields({ form }: Pick<TransactionFormSectionProps, "form">) {
+  return (
+    <div className="grid grid-cols-[1fr_auto] gap-4">
+      <form.Field name="date">
+        {(field) => (
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="transaction-date">Date *</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  id="transaction-date"
+                  name="transaction-date"
+                  variant={"outline"}
+                  className={cn(
+                    "w-full justify-start text-left font-normal",
+                    !field.state.value && "text-muted-foreground"
+                  )}
+                >
+                  <IconCalendar className="mr-2 size-4" />
+                  {field.state.value ? (
+                    format(field.state.value, "PPP")
+                  ) : (
+                    <span>Pick a date</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={field.state.value}
+                  onSelect={(picked) => {
+                    if (!picked) return
+                    const existing = field.state.value
+                    const merged = new Date(picked)
+                    merged.setHours(
+                      existing.getHours(),
+                      existing.getMinutes(),
+                      0,
+                      0
+                    )
+                    field.handleChange(merged)
+                  }}
+                  autoFocus
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="date">
+        {(field) => (
+          <div className="flex min-w-35 flex-col gap-2">
+            <Label
+              htmlFor="transaction-time"
+              className="flex items-center gap-1"
+            >
+              <IconClock className="size-3" /> Time
+            </Label>
+            <TimeInput
+              id="transaction-time"
+              name="transaction-time"
+              value={field.state.value}
+              onChange={(newDate) => {
+                const existing = field.state.value
+                const merged = new Date(existing)
+                merged.setHours(newDate.getHours(), newDate.getMinutes(), 0, 0)
+                field.handleChange(merged)
+              }}
+            />
+          </div>
+        )}
+      </form.Field>
+    </div>
+  )
+}
+
+function MerchantField({
+  activeTab,
+  form,
+  formData,
+  isLoading,
+}: TransactionFormSectionProps) {
+  if (activeTab === "transfer") return null
+
+  return (
+    <form.Field name="merchantId">
+      {(field) => (
+        <div className="space-y-2">
+          <Label htmlFor={field.name}>Merchant (Optional)</Label>
+          <select
+            id={field.name}
+            name={field.name}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={field.state.value}
+            onChange={(e) => field.handleChange(e.target.value)}
+            disabled={isLoading}
+          >
+            <option value="">-- No Merchant / General --</option>
+            {formData?.merchants.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+function SplitModeToggle({
+  activeTab,
+  isSplit,
+  setIsSplit,
+}: {
+  activeTab: TransactionType
+  isSplit: boolean
+  setIsSplit: React.Dispatch<React.SetStateAction<boolean>>
+}) {
+  if (activeTab === "transfer") return null
+
+  return (
+    <div className="flex items-center justify-between rounded-md border border-dashed px-3 py-2">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <IconScissors className="size-4" />
+        <Label
+          htmlFor="split-mode-toggle"
+          className="cursor-pointer text-sm font-medium"
+        >
+          Split Transaction
+        </Label>
+        {isSplit && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-700">
+            ACTIVE
+          </span>
+        )}
+      </div>
+      <Switch
+        id="split-mode-toggle"
+        checked={isSplit}
+        onCheckedChange={setIsSplit}
+      />
+    </div>
+  )
+}
+
+function CategoryField({
+  activeTab,
+  form,
+  formData,
+  isLoading,
+  isSplit,
+}: TransactionFormSectionProps & { isSplit: boolean }) {
+  if (activeTab === "transfer" || isSplit) return null
+
+  return (
+    <form.Field
+      name="categoryId"
+      validators={{
+        onChange: z.string().min(1, "Category is required"),
+      }}
+    >
+      {(field) => (
+        <div className="space-y-2">
+          <Label htmlFor={field.name}>Category *</Label>
+          <select
+            id={field.name}
+            name={field.name}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
+            value={field.state.value}
+            onChange={(e) => field.handleChange(e.target.value)}
+            disabled={isLoading}
+            aria-invalid={field.state.meta.errors.length > 0}
+            aria-describedby={
+              field.state.meta.errors.length > 0
+                ? `${field.name}-error`
+                : undefined
+            }
+          >
+            <option value="" disabled>
+              {isLoading ? "Loading..." : "Select Category"}
+            </option>
+            <CategoryOptions
+              categories={formData?.categories}
+              type={activeTab}
+            />
+          </select>
+          <FieldError
+            id={`${field.name}-error`}
+            errors={field.state.meta.errors}
+          />
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+function SplitEntriesPanel({
+  activeTab,
+  form,
+  formData,
+  isSplit,
+  setSplitEntries,
+  splitEntries,
+}: Pick<TransactionFormSectionProps, "activeTab" | "form" | "formData"> & {
+  isSplit: boolean
+  setSplitEntries: SplitEntryStateSetter
+  splitEntries: SplitEntryState
+}) {
+  if (!isSplit || activeTab === "transfer") return null
+
+  const selectedAccountCurrency =
+    formData?.accounts.find((a) => a.id === form.getFieldValue("accountId"))
+      ?.currency ?? "IDR"
+
+  return (
+    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50/40 p-3 dark:border-amber-800 dark:bg-amber-950/20">
+      <p className="text-xs font-semibold tracking-wider text-amber-700 uppercase dark:text-amber-400">
+        Category Allocation
+      </p>
+
+      <div className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] gap-2 px-0.5">
+        <span className="text-xs font-medium text-muted-foreground">
+          Category
+        </span>
+        <span className="text-xs font-medium text-muted-foreground">
+          Item Note
+        </span>
+        <span className="text-right text-xs font-medium text-muted-foreground">
+          Amount
+        </span>
+        <span />
+      </div>
+
+      <div className="space-y-2">
+        {splitEntries.map((entry) => (
+          <div
+            key={entry.id}
+            className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] items-center gap-2"
+          >
+            <select
+              aria-label="Category for split entry"
+              name={`split-category-${entry.id}`}
+              id={`split-category-${entry.id}`}
+              className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs"
+              value={entry.categoryId ?? ""}
+              onChange={(e) =>
+                setSplitEntries((prev) =>
+                  prev.map((en) =>
+                    en.id === entry.id
+                      ? {
+                          ...en,
+                          categoryId: e.target.value,
+                        }
+                      : en
+                  )
+                )
+              }
+            >
+              <option value="">-- Select --</option>
+              <CategoryOptions
+                categories={formData?.categories}
+                type={activeTab}
+              />
+            </select>
+
+            <Input
+              aria-label="Description for split entry"
+              name={`split-desc-${entry.id}`}
+              id={`split-desc-${entry.id}`}
+              placeholder="e.g., Soap & Shampoo"
+              className="h-8 text-sm"
+              value={entry.description}
+              onChange={(e) =>
+                setSplitEntries((prev) =>
+                  prev.map((en) =>
+                    en.id === entry.id
+                      ? {
+                          ...en,
+                          description: e.target.value,
+                        }
+                      : en
+                  )
+                )
+              }
+            />
+
+            <Input
+              aria-label="Amount for split entry"
+              name={`split-amount-${entry.id}`}
+              id={`split-amount-${entry.id}`}
+              type="number"
+              placeholder="0"
+              className="h-8 text-right text-sm font-semibold"
+              value={entry.amount || ""}
+              onChange={(e) =>
+                setSplitEntries((prev) =>
+                  prev.map((en) =>
+                    en.id === entry.id
+                      ? {
+                          ...en,
+                          amount: Number(e.target.value),
+                        }
+                      : en
+                  )
+                )
+              }
+            />
+
+            <button
+              type="button"
+              disabled={splitEntries.length <= 2}
+              onClick={() =>
+                setSplitEntries((prev) =>
+                  prev.filter((en) => en.id !== entry.id)
+                )
+              }
+              className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-red-100 hover:text-red-600 disabled:opacity-30"
+            >
+              <IconX className="size-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 w-full border border-dashed text-xs text-muted-foreground hover:border-amber-400 hover:text-amber-700"
+        onClick={() =>
+          setSplitEntries((prev) => [...prev, createBlankSplitEntry()])
+        }
+      >
+        <IconPlus className="mr-1 size-3" /> Add Row
+      </Button>
+
+      <form.Subscribe selector={(state) => state.values.amount}>
+        {(parentAmount) => {
+          const splitTotal = splitEntries.reduce((s, e) => s + e.amount, 0)
+          const remaining = parentAmount - splitTotal
+
+          if (remaining === 0 && parentAmount > 0) {
+            return (
+              <p className="flex items-center gap-1.5 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+                <span>✓</span>
+                <span>Perfect! All funds allocated</span>
+              </p>
+            )
+          }
+          if (remaining > 0) {
+            return (
+              <p className="flex items-center gap-1.5 rounded-md bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
+                <span>○</span>
+                <span>
+                  Remaining{" "}
+                  <strong>
+                    {getCurrencySymbol(selectedAccountCurrency)}{" "}
+                    {remaining.toLocaleString("en-US")}
+                  </strong>{" "}
+                  unallocated
+                </span>
+              </p>
+            )
+          }
+          return (
+            <p className="flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950/30 dark:text-red-400">
+              <span>✕</span>
+              <span>
+                Over allocated by{" "}
+                <strong>
+                  {getCurrencySymbol(selectedAccountCurrency)}{" "}
+                  {Math.abs(remaining).toLocaleString("en-US")}
+                </strong>
+              </span>
+            </p>
+          )
+        }}
+      </form.Subscribe>
+    </div>
+  )
+}
+
+function StatusField({ form }: Pick<TransactionFormSectionProps, "form">) {
+  return (
+    <form.Field name="status">
+      {(field) => (
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Status</Label>
+          <div className="flex gap-2">
+            {transactionStatusOptions.map((status) => (
+              <button
+                key={status.value}
+                type="button"
+                onClick={() => field.handleChange(status.value)}
+                className={cn(
+                  "flex flex-1 items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-semibold transition-all",
+                  field.state.value === status.value
+                    ? status.activeClass
+                    : "border-input bg-background text-muted-foreground hover:border-zinc-400 dark:hover:border-zinc-500"
+                )}
+              >
+                <span>{status.icon}</span>
+                <span>{status.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+function NotesField({
+  activeTab,
+  form,
+}: Pick<TransactionFormSectionProps, "activeTab" | "form">) {
+  if (activeTab === "transfer") return null
+
+  return (
+    <form.Field name="notes">
+      {(field) => (
+        <div className="space-y-2">
+          <Label htmlFor={field.name}>Notes (Optional)</Label>
+          <Textarea
+            id={field.name}
+            name={field.name}
+            placeholder="Add additional details here..."
+            className="resize-none"
+            value={field.state.value}
+            onChange={(e) => field.handleChange(e.target.value)}
+          />
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+function AttachmentField({ form }: Pick<TransactionFormSectionProps, "form">) {
+  return (
+    <form.Field name="attachmentUrl">
+      {(field) => (
+        <div className="space-y-2">
+          <Label
+            htmlFor="attachment-url"
+            className="flex items-center gap-1.5 text-sm"
+          >
+            <IconPaperclip className="size-3.5" />
+            Receipt / Attachment URL
+            <span className="text-xs font-normal text-muted-foreground">
+              (Optional)
+            </span>
+          </Label>
+          <Input
+            id="attachment-url"
+            name="attachment-url"
+            type="url"
+            placeholder="https://... (paste receipt photo URL)"
+            value={field.state.value ?? ""}
+            onBlur={field.handleBlur}
+            onChange={(e) => field.handleChange(e.target.value)}
+          />
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+function TransactionActionBar({
+  activeTab,
+  form,
+  isEditMode,
+  isSplit,
+  onCancel,
+  onDelete,
+  splitEntries,
+}: {
+  activeTab: TransactionType
+  form: TransactionFormInstance
+  isEditMode: boolean
+  isSplit: boolean
+  onCancel: () => void
+  onDelete: () => void | Promise<void>
+  splitEntries: SplitEntryState
+}) {
+  return (
+    <form.Subscribe selector={(state) => state.values.amount}>
+      {(parentAmount) => {
+        const splitTotal = splitEntries.reduce((s, e) => s + e.amount, 0)
+        const remaining = parentAmount - splitTotal
+        const isSaveDisabled =
+          isSplit && activeTab !== "transfer" && remaining !== 0
+
+        return (
+          <div className="mt-6 flex items-center justify-between border-t pt-4">
+            <div>
+              {isEditMode && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={onDelete}
+                  className="bg-red-500/10 text-red-600 hover:bg-red-500/20"
+                >
+                  <IconTrash className="mr-2 size-4" /> Delete
+                </Button>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSaveDisabled}
+                className="bg-yellow-500 font-bold text-black hover:bg-yellow-600 disabled:opacity-50"
+              >
+                {isEditMode ? "Update Changes" : "Save Transaction"}
+              </Button>
+            </div>
+          </div>
+        )
+      }}
+    </form.Subscribe>
+  )
+}
+
+function useTransactionFormModalController({
+  editData,
   onClose,
-}: TransactionFormModalProps) {
+}: Pick<TransactionFormModalProps, "editData" | "onClose">) {
   const isEditMode = !!editData
 
   // THE TOP-LEVEL FIX:
@@ -181,22 +1209,7 @@ export function TransactionFormModal({
           categoryId: e.categoryId,
           merchantId: e.merchantId,
         }))
-      : [
-          {
-            id: crypto.randomUUID(),
-            description: "",
-            amount: 0,
-            categoryId: "",
-            merchantId: "",
-          },
-          {
-            id: crypto.randomUUID(),
-            description: "",
-            amount: 0,
-            categoryId: "",
-            merchantId: "",
-          },
-        ]
+      : [createBlankSplitEntry(), createBlankSplitEntry()]
   )
 
   useHotkeys([
@@ -265,7 +1278,20 @@ export function TransactionFormModal({
   // this banner is reserved for issues that span >1 field or a row collection.
   const [formError, setFormError] = React.useState<string | null>(null)
 
-  const form = useForm({
+  const form = useForm<
+    TransactionFormValues,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    unknown
+  >({
     defaultValues: defaultFormValues,
     onSubmit: async ({ value }) => {
       // Field-level validators (wired below on each <form.Field>) already
@@ -497,17 +1523,56 @@ export function TransactionFormModal({
     }
   }
 
+  const handleCancel = () => {
+    setIsOpen(false)
+    if (onClose) onClose()
+  }
+
+  return {
+    activeTab,
+    form,
+    formData,
+    formError,
+    handleCancel,
+    handleDelete,
+    handleOpenChange,
+    isEditMode,
+    isLoading,
+    isOpen,
+    isSplit,
+    setActiveTab,
+    setIsSplit,
+    setSplitEntries,
+    splitEntries,
+  }
+}
+
+export function TransactionFormModal({
+  editData,
+  customTrigger,
+  onClose,
+}: TransactionFormModalProps) {
+  const {
+    activeTab,
+    form,
+    formData,
+    formError,
+    handleCancel,
+    handleDelete,
+    handleOpenChange,
+    isEditMode,
+    isLoading,
+    isOpen,
+    isSplit,
+    setActiveTab,
+    setIsSplit,
+    setSplitEntries,
+    splitEntries,
+  } = useTransactionFormModalController({ editData, onClose })
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        {customTrigger ? (
-          customTrigger
-        ) : (
-          <Button className="bg-yellow-500 font-bold text-black shadow-md hover:bg-yellow-600">
-            <IconPlus className="mr-2 h-4 w-4" /> New Transaction
-          </Button>
-        )}
-      </DialogTrigger>
+      <TransactionDialogTrigger customTrigger={customTrigger} />
 
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
@@ -521,46 +1586,13 @@ export function TransactionFormModal({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs
-          value={activeTab}
-          onValueChange={(v) => {
-            const selectedType = v as "expense" | "income" | "transfer"
-            setActiveTab(selectedType)
-            form.setFieldValue("type", selectedType)
-            if (selectedType === "transfer")
-              form.setFieldValue("categoryId", "")
-            else form.setFieldValue("toAccountId", "")
-          }}
-          className="mt-2 w-full"
-        >
-          <TabsList className="grid w-full grid-cols-3">
-            <TabsTrigger
-              value="expense"
-              className="data-[state=active]:text-red-600"
-            >
-              <IconArrowUpRight className="mr-1 h-4 w-4" /> Expense
-            </TabsTrigger>
-            <TabsTrigger
-              value="income"
-              className="data-[state=active]:text-emerald-600"
-            >
-              <IconArrowDownLeft className="mr-1 h-4 w-4" /> Income
-            </TabsTrigger>
-            <TabsTrigger
-              value="transfer"
-              className="data-[state=active]:text-blue-600"
-            >
-              <IconArrowsExchange className="mr-1 h-4 w-4" /> Transfer
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
+        <TransactionTypeTabs
+          activeTab={activeTab}
+          form={form}
+          setActiveTab={setActiveTab}
+        />
 
         <form
-          // `noValidate` suppresses any native HTML5 validation popup that
-          // could appear if a future contributor adds a `required` attr to an
-          // <Input>. We surface ALL validation through TanStack Form +
-          // <FieldError> so the visual language is consistent (no jarring
-          // browser-default tooltip).
           noValidate
           onSubmit={(e) => {
             e.preventDefault()
@@ -569,901 +1601,63 @@ export function TransactionFormModal({
           }}
           className="mt-4 space-y-4"
         >
-          {/* Form-level error banner — surfaces cross-field issues that can't
-              attach to a single <FieldError> (split parity, missing split-row
-              description, post-submit server failures). Hidden when null. */}
-          {formError && (
-            <div
-              role="alert"
-              aria-live="polite"
-              className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive dark:bg-destructive/20"
-            >
-              <span aria-hidden="true" className="mt-0.5">
-                ⚠
-              </span>
-              <span className="flex-1">{formError}</span>
-            </div>
-          )}
-
-          {/* Main Description */}
-          <form.Field
-            name="description"
-            validators={{
-              onChange: transactionSchema.shape.description,
-            }}
-            children={(field) => (
-              <div className="space-y-2">
-                <Label htmlFor={field.name}>
-                  {activeTab === "transfer"
-                    ? "Transfer Note *"
-                    : "Description *"}
-                </Label>
-                <Input
-                  id={field.name}
-                  name={field.name}
-                  placeholder={
-                    activeTab === "transfer"
-                      ? "e.g., Transfer to savings account"
-                      : "e.g., Target shopping, February Salary"
-                  }
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  aria-invalid={field.state.meta.errors.length > 0}
-                  aria-describedby={
-                    field.state.meta.errors.length > 0
-                      ? `${field.name}-error`
-                      : undefined
-                  }
-                />
-                <FieldError
-                  id={`${field.name}-error`}
-                  errors={field.state.meta.errors}
-                />
-              </div>
-            )}
+          <FormErrorBanner formError={formError} />
+          <DescriptionField activeTab={activeTab} form={form} />
+          <AmountAccountFields
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+            isLoading={isLoading}
           />
-
-          {/* ═══════════════════════════════════════════════════════
-              ZONE 1 — PARENT DATA
-              Baris 1: [Amount] [Account]  →  "Berapa?" + "Dari mana?"
-              Baris 2: [Date]   [Time]     →  "Kapan?"
-          ══════════════════════════════════════════════════════ */}
-
-          {/* Baris 1: Amount + Account */}
-          <div
-            className={cn(
-              "grid gap-4",
-              activeTab === "transfer" ? "grid-cols-1" : "grid-cols-2"
-            )}
-          >
-            {/* 1a. Amount */}
-            <form.Field
-              name="amount"
-              validators={{
-                onChange: transactionSchema.shape.amount,
-              }}
-              children={(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Amount *</Label>
-                  <div className="relative">
-                    <form.Subscribe
-                      selector={(state) => state.values.accountId}
-                      children={(currentAccountId) => {
-                        const selectedCurrency =
-                          formData?.accounts.find(
-                            (a) => a.id === currentAccountId
-                          )?.currency ?? "IDR"
-                        return (
-                          <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
-                            {getCurrencySymbol(selectedCurrency)}
-                          </span>
-                        )
-                      }}
-                    />
-                    <Input
-                      id={field.name}
-                      name={field.name}
-                      type="number"
-                      className="pl-7 text-lg font-bold"
-                      value={field.state.value || ""}
-                      onBlur={field.handleBlur}
-                      onChange={(e) =>
-                        field.handleChange(Number(e.target.value))
-                      }
-                      aria-invalid={field.state.meta.errors.length > 0}
-                      aria-describedby={
-                        field.state.meta.errors.length > 0
-                          ? `${field.name}-error`
-                          : undefined
-                      }
-                    />
-                  </div>
-                  <FieldError
-                    id={`${field.name}-error`}
-                    errors={field.state.meta.errors}
-                  />
-                </div>
-              )}
-            />
-
-            {/* 1b. Account — required for expense/income. Validator inherits
-                from the form-level schema (`transactionSchema.shape.accountId`)
-                so the message stays single-source-of-truth. TanStack Form
-                runs onChange validators on submit too, so an unselected
-                account is caught client-side BEFORE it ever reaches the
-                server's Zod parse (which previously crashed with an opaque
-                `too_small` error and rolled back the optimistic insert). */}
-            {activeTab !== "transfer" && (
-              <form.Field
-                name="accountId"
-                validators={{
-                  onChange: transactionSchema.shape.accountId,
-                }}
-                children={(field) => (
-                  <div className="space-y-2">
-                    <Label htmlFor={field.name}>Account *</Label>
-                    <select
-                      id={field.name}
-                      name={field.name}
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
-                      value={field.state.value}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      disabled={isLoading}
-                      aria-invalid={field.state.meta.errors.length > 0}
-                      aria-describedby={
-                        field.state.meta.errors.length > 0
-                          ? `${field.name}-error`
-                          : undefined
-                      }
-                    >
-                      <option value="" disabled>
-                        {isLoading ? "Loading..." : "Select Account"}
-                      </option>
-                      {formData?.accounts.map((acc) => (
-                        <option key={acc.id} value={acc.id}>
-                          {acc.name} ({acc.currency})
-                        </option>
-                      ))}
-                    </select>
-                    <FieldError
-                      id={`${field.name}-error`}
-                      errors={field.state.meta.errors}
-                    />
-                  </div>
-                )}
-              />
-            )}
-          </div>
-
-          {/* Baris Khusus Transfer: From & To Account.
-              Both selects are required — we share the SAME `accountId` schema
-              fragment for the source so the error wording stays uniform with
-              the expense/income flow. The destination uses an inline
-              `z.string().min(1, ...)` because the schema's `toAccountId` is
-              optional at the type level (transfers are the only mode that
-              needs it). The field is also conditionally rendered, so the
-              validator only mounts when activeTab === "transfer" — no
-              spurious "required" errors leak into expense/income mode. */}
-          {activeTab === "transfer" && (
-            <div className="grid grid-cols-2 gap-4">
-              <form.Field
-                name="accountId"
-                validators={{
-                  onChange: transactionSchema.shape.accountId,
-                }}
-                children={(field) => (
-                  <div className="space-y-2">
-                    <Label htmlFor="transfer-source-accountId">
-                      From Account *
-                    </Label>
-                    <select
-                      id="transfer-source-accountId"
-                      name={field.name}
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
-                      value={field.state.value}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      disabled={isLoading}
-                      aria-invalid={field.state.meta.errors.length > 0}
-                      aria-describedby={
-                        field.state.meta.errors.length > 0
-                          ? `transfer-source-accountId-error`
-                          : undefined
-                      }
-                    >
-                      <option value="" disabled>
-                        {isLoading ? "Loading..." : "Select Source"}
-                      </option>
-                      {formData?.accounts.map((acc) => (
-                        <option key={acc.id} value={acc.id}>
-                          {acc.name} ({acc.currency})
-                        </option>
-                      ))}
-                    </select>
-                    <FieldError
-                      id="transfer-source-accountId-error"
-                      errors={field.state.meta.errors}
-                    />
-                  </div>
-                )}
-              />
-
-              <form.Field
-                name="toAccountId"
-                validators={{
-                  onChange: z
-                    .string()
-                    .min(1, "Destination account is required"),
-                }}
-                children={(field) => (
-                  <div className="space-y-2">
-                    <Label htmlFor={field.name}>To Account *</Label>
-                    <form.Subscribe
-                      selector={(state) => state.values.accountId}
-                      children={(currentAccountId) => (
-                        <select
-                          id={field.name}
-                          name={field.name}
-                          className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
-                          value={field.state.value}
-                          onChange={(e) => field.handleChange(e.target.value)}
-                          disabled={isLoading}
-                          aria-invalid={field.state.meta.errors.length > 0}
-                          aria-describedby={
-                            field.state.meta.errors.length > 0
-                              ? `${field.name}-error`
-                              : undefined
-                          }
-                        >
-                          <option value="" disabled>
-                            {isLoading ? "Loading..." : "Select Destination"}
-                          </option>
-                          {formData?.accounts.map((acc) => (
-                            <option
-                              key={acc.id}
-                              value={acc.id}
-                              disabled={acc.id === currentAccountId}
-                            >
-                              {acc.name} ({acc.currency})
-                            </option>
-                          ))}
-                        </select>
-                      )}
-                    />
-                    <FieldError
-                      id={`${field.name}-error`}
-                      errors={field.state.meta.errors}
-                    />
-                  </div>
-                )}
-              />
-            </div>
-          )}
-
-          {/* Destination Amount — hanya tampil saat Transfer antar mata uang berbeda */}
-          {activeTab === "transfer" && (
-            <form.Subscribe
-              selector={(state) => ({
-                accountId: state.values.accountId,
-                toAccountId: state.values.toAccountId,
-                sourceAmount: state.values.amount,
-              })}
-              children={({ accountId, toAccountId, sourceAmount }) => {
-                const srcAccount = formData?.accounts.find(
-                  (a) => a.id === accountId
-                )
-                const dstAccount = formData?.accounts.find(
-                  (a) => a.id === toAccountId
-                )
-                const isCrossCurrency =
-                  srcAccount &&
-                  dstAccount &&
-                  srcAccount.currency !== dstAccount.currency
-
-                if (!isCrossCurrency) return null
-
-                return (
-                  <form.Field
-                    name="destinationAmount"
-                    children={(field) => (
-                      <div className="space-y-2 rounded-lg border border-blue-200 bg-blue-50/40 p-3 dark:border-blue-800 dark:bg-blue-950/20">
-                        <Label
-                          htmlFor="destination-amount"
-                          className="flex items-center gap-1.5 text-sm font-semibold text-blue-700 dark:text-blue-400"
-                        >
-                          <IconArrowsExchange className="size-4" />
-                          Destination Amount ({dstAccount.currency})
-                        </Label>
-                        <p className="text-xs text-muted-foreground">
-                          Enter the EXACT amount credited to the destination
-                          account. This locks the implied exchange rate for
-                          historical accuracy.
-                        </p>
-                        <div className="relative">
-                          <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
-                            {getCurrencySymbol(dstAccount.currency)}
-                          </span>
-                          <Input
-                            id="destination-amount"
-                            name="destination-amount"
-                            type="number"
-                            className="pl-8 text-lg font-bold"
-                            placeholder="0"
-                            value={field.state.value ?? ""}
-                            onBlur={field.handleBlur}
-                            onChange={(e) =>
-                              field.handleChange(
-                                e.target.value
-                                  ? Number(e.target.value)
-                                  : undefined
-                              )
-                            }
-                          />
-                        </div>
-                        {/* Implied Rate Display */}
-                        {field.state.value && sourceAmount > 0 && (
-                          <p className="text-xs font-medium text-blue-600 dark:text-blue-400">
-                            Implied rate: 1 {srcAccount.currency} ={" "}
-                            {(field.state.value / sourceAmount).toLocaleString(
-                              "en-US",
-                              {
-                                minimumFractionDigits: 4,
-                                maximumFractionDigits: 4,
-                              }
-                            )}{" "}
-                            {dstAccount.currency}
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  />
-                )
-              }}
-            />
-          )}
-
-          {/* Baris 2: Date + Time */}
-          <div className="grid grid-cols-[1fr_auto] gap-4">
-            {/* 1c. Date Picker */}
-            <form.Field
-              name="date"
-              children={(field) => (
-                <div className="flex flex-col space-y-2">
-                  <Label htmlFor="transaction-date">Date *</Label>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        id="transaction-date"
-                        name="transaction-date"
-                        variant={"outline"}
-                        className={cn(
-                          "w-full justify-start text-left font-normal",
-                          !field.state.value && "text-muted-foreground"
-                        )}
-                      >
-                        <IconCalendar className="mr-2 h-4 w-4" />
-                        {field.state.value ? (
-                          format(field.state.value, "PPP")
-                        ) : (
-                          <span>Pick a date</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={field.state.value}
-                        onSelect={(picked) => {
-                          if (!picked) return
-                          // 1. Pertahankan komponen waktu yang sudah ada
-                          const existing = field.state.value
-                          const merged = new Date(picked)
-                          merged.setHours(
-                            existing.getHours(),
-                            existing.getMinutes(),
-                            0,
-                            0
-                          )
-                          field.handleChange(merged)
-                        }}
-                        autoFocus
-                      />
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              )}
-            />
-
-            {/* 1d. Time Picker */}
-            <form.Field
-              name="date"
-              children={(field) => (
-                <div className="flex min-w-35 flex-col space-y-2">
-                  <Label
-                    htmlFor="transaction-time"
-                    className="flex items-center gap-1"
-                  >
-                    <IconClock className="size-3" /> Time
-                  </Label>
-                  <TimeInput
-                    id="transaction-time"
-                    name="transaction-time"
-                    value={field.state.value}
-                    onChange={(newDate) => {
-                      // Pertahankan tanggal, hanya update waktu
-                      const existing = field.state.value
-                      const merged = new Date(existing)
-                      merged.setHours(
-                        newDate.getHours(),
-                        newDate.getMinutes(),
-                        0,
-                        0
-                      )
-                      field.handleChange(merged)
-                    }}
-                  />
-                </div>
-              )}
-            />
-          </div>
-
-          {/* ═══════════════════════════════════════════════════════
-              ZONE 2 — IDENTITAS + MERCHANT + TOGGLE + CATEGORY
-          ══════════════════════════════════════════════════════ */}
-
-          {/* 2a. Merchant dropdown — selalu tampil untuk expense/income (semua mode)
-               Merchant = entitas toko/vendor di DB (e.g., Indomaret, Grab).
-               Ini BERBEDA dari field Keterangan (teks bebas). Keduanya independen. */}
-          {activeTab !== "transfer" && (
-            <form.Field
-              name="merchantId"
-              children={(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Merchant (Optional)</Label>
-                  <select
-                    id={field.name}
-                    name={field.name}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    disabled={isLoading}
-                  >
-                    <option value="">-- No Merchant / General --</option>
-                    {formData?.merchants.map((m) => (
-                      <option key={m.id} value={m.id}>
-                        {m.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
-            />
-          )}
-
-          {/* 2d. Split Transaction Toggle — expense/income only */}
-          {activeTab !== "transfer" && (
-            <div className="flex items-center justify-between rounded-md border border-dashed px-3 py-2">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <IconScissors className="size-4" />
-                <Label
-                  htmlFor="split-mode-toggle"
-                  className="cursor-pointer text-sm font-medium"
-                >
-                  Split Transaction
-                </Label>
-                {isSplit && (
-                  <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-700">
-                    ACTIVE
-                  </span>
-                )}
-              </div>
-              <Switch
-                id="split-mode-toggle"
-                checked={isSplit}
-                onCheckedChange={setIsSplit}
-              />
-            </div>
-          )}
-
-          {/* 2e. Category — conditionally rendered (non-transfer AND non-split).
-              Validator is inline because the form-level schema declares
-              categoryId as optional (transfer/split paths legitimately leave
-              it null). Mounting only inside this branch means the validator
-              is scoped exactly to the cases where Category IS required — no
-              cross-mode leakage. Replaces the prior `alert()` popup. */}
-          {activeTab !== "transfer" && !isSplit && (
-            <form.Field
-              name="categoryId"
-              validators={{
-                onChange: z.string().min(1, "Category is required"),
-              }}
-              children={(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Category *</Label>
-                  <select
-                    id={field.name}
-                    name={field.name}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    disabled={isLoading}
-                    aria-invalid={field.state.meta.errors.length > 0}
-                    aria-describedby={
-                      field.state.meta.errors.length > 0
-                        ? `${field.name}-error`
-                        : undefined
-                    }
-                  >
-                    <option value="" disabled>
-                      {isLoading ? "Loading..." : "Select Category"}
-                    </option>
-                    {formData?.categories
-                      .filter((cat) => cat.type === activeTab)
-                      .map((cat) => (
-                        <option key={cat.id} value={cat.id}>
-                          {cat.name}
-                        </option>
-                      ))}
-                  </select>
-                  <FieldError
-                    id={`${field.name}-error`}
-                    errors={field.state.meta.errors}
-                  />
-                </div>
-              )}
-            />
-          )}
-
-          {/* ═══════════════════════════════════════════════════════
-              ZONE 3 — LINE ITEMS (hanya saat isSplit === true)
-              Layout per baris: [Kategori] [Catatan] [Jumlah] [X]
-          ══════════════════════════════════════════════════════ */}
-          {isSplit && activeTab !== "transfer" && (
-            <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50/40 p-3 dark:border-amber-800 dark:bg-amber-950/20">
-              {/* Header panel */}
-              <p className="text-xs font-semibold tracking-wider text-amber-700 uppercase dark:text-amber-400">
-                Category Allocation
-              </p>
-
-              {/* Header kolom */}
-              <div className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] gap-2 px-0.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Category
-                </span>
-                <span className="text-xs font-medium text-muted-foreground">
-                  Item Note
-                </span>
-                <span className="text-right text-xs font-medium text-muted-foreground">
-                  Amount
-                </span>
-                <span />
-              </div>
-
-              {/* Baris dinamis */}
-              <div className="space-y-2">
-                {splitEntries.map((entry) => (
-                  <div
-                    key={entry.id}
-                    className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] items-center gap-2"
-                  >
-                    {/* Kategori per baris */}
-                    <select
-                      aria-label="Category for split entry"
-                      name={`split-category-${entry.id}`}
-                      id={`split-category-${entry.id}`}
-                      className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs"
-                      value={entry.categoryId ?? ""}
-                      onChange={(e) =>
-                        setSplitEntries((prev) =>
-                          prev.map((en) =>
-                            en.id === entry.id
-                              ? {
-                                  ...en,
-                                  categoryId: e.target.value,
-                                }
-                              : en
-                          )
-                        )
-                      }
-                    >
-                      <option value="">-- Select --</option>
-                      {formData?.categories
-                        .filter((c) => c.type === activeTab)
-                        .map((c) => (
-                          <option key={c.id} value={c.id}>
-                            {c.name}
-                          </option>
-                        ))}
-                    </select>
-
-                    {/* Catatan item (deskripsi per baris) */}
-                    <Input
-                      aria-label="Description for split entry"
-                      name={`split-desc-${entry.id}`}
-                      id={`split-desc-${entry.id}`}
-                      placeholder="e.g., Soap & Shampoo"
-                      className="h-8 text-sm"
-                      value={entry.description}
-                      onChange={(e) =>
-                        setSplitEntries((prev) =>
-                          prev.map((en) =>
-                            en.id === entry.id
-                              ? {
-                                  ...en,
-                                  description: e.target.value,
-                                }
-                              : en
-                          )
-                        )
-                      }
-                    />
-
-                    {/* Jumlah per baris */}
-                    <Input
-                      aria-label="Amount for split entry"
-                      name={`split-amount-${entry.id}`}
-                      id={`split-amount-${entry.id}`}
-                      type="number"
-                      placeholder="0"
-                      className="h-8 text-right text-sm font-semibold"
-                      value={entry.amount || ""}
-                      onChange={(e) =>
-                        setSplitEntries((prev) =>
-                          prev.map((en) =>
-                            en.id === entry.id
-                              ? {
-                                  ...en,
-                                  amount: Number(e.target.value),
-                                }
-                              : en
-                          )
-                        )
-                      }
-                    />
-
-                    {/* Hapus baris */}
-                    <button
-                      type="button"
-                      disabled={splitEntries.length <= 2}
-                      onClick={() =>
-                        setSplitEntries((prev) =>
-                          prev.filter((en) => en.id !== entry.id)
-                        )
-                      }
-                      className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-red-100 hover:text-red-600 disabled:opacity-30"
-                    >
-                      <IconX className="size-3.5" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-
-              {/* Tombol tambah baris */}
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7 w-full border border-dashed text-xs text-muted-foreground hover:border-amber-400 hover:text-amber-700"
-                onClick={() =>
-                  setSplitEntries((prev) => [
-                    ...prev,
-                    {
-                      id: crypto.randomUUID(),
-                      description: "",
-                      amount: 0,
-                      categoryId: "",
-                      merchantId: "",
-                    },
-                  ])
-                }
-              >
-                <IconPlus className="mr-1 size-3" /> Add Row
-              </Button>
-
-              {/* Smart Validator — teks human-readable, reaktif terhadap parentAmount */}
-              <form.Subscribe
-                selector={(state) => state.values.amount}
-                children={(parentAmount) => {
-                  const splitTotal = splitEntries.reduce(
-                    (s, e) => s + e.amount,
-                    0
-                  )
-                  const remaining = parentAmount - splitTotal
-
-                  if (remaining === 0 && parentAmount > 0) {
-                    return (
-                      <p className="flex items-center gap-1.5 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
-                        <span>✓</span>
-                        <span>Perfect! All funds allocated</span>
-                      </p>
-                    )
-                  }
-                  if (remaining > 0) {
-                    return (
-                      <p className="flex items-center gap-1.5 rounded-md bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
-                        <span>○</span>
-                        <span>
-                          Remaining{" "}
-                          <strong>
-                            {getCurrencySymbol(
-                              formData?.accounts.find(
-                                (a) => a.id === form.getFieldValue("accountId")
-                              )?.currency ?? "IDR"
-                            )}{" "}
-                            {remaining.toLocaleString("en-US")}
-                          </strong>{" "}
-                          unallocated
-                        </span>
-                      </p>
-                    )
-                  }
-                  return (
-                    <p className="flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950/30 dark:text-red-400">
-                      <span>✕</span>
-                      <span>
-                        Over allocated by{" "}
-                        <strong>
-                          {getCurrencySymbol(
-                            formData?.accounts.find(
-                              (a) => a.id === form.getFieldValue("accountId")
-                            )?.currency ?? "IDR"
-                          )}{" "}
-                          {Math.abs(remaining).toLocaleString("en-US")}
-                        </strong>
-                      </span>
-                    </p>
-                  )
-                }}
-              />
-            </div>
-          )}
-
-          {/* Status Selector — Transaction Lifecycle */}
-          <form.Field
-            name="status"
-            children={(field) => (
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">Status</Label>
-                <div className="flex gap-2">
-                  {(
-                    [
-                      {
-                        value: "PENDING",
-                        label: "Pending",
-                        icon: "⏳",
-                        activeClass:
-                          "border-amber-400 bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-400",
-                      },
-                      {
-                        value: "CLEARED",
-                        label: "Cleared",
-                        icon: "✓",
-                        activeClass:
-                          "border-emerald-400 bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400",
-                      },
-                      {
-                        value: "RECONCILED",
-                        label: "Reconciled",
-                        icon: "⊙",
-                        activeClass:
-                          "border-blue-400 bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-400",
-                      },
-                    ] as const
-                  ).map((s) => (
-                    <button
-                      key={s.value}
-                      type="button"
-                      onClick={() => field.handleChange(s.value)}
-                      className={cn(
-                        "flex flex-1 items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-semibold transition-all",
-                        field.state.value === s.value
-                          ? s.activeClass
-                          : "border-input bg-background text-muted-foreground hover:border-zinc-400 dark:hover:border-zinc-500"
-                      )}
-                    >
-                      <span>{s.icon}</span>
-                      <span>{s.label}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
+          <TransferAccountFields
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+            isLoading={isLoading}
           />
-
-          {activeTab !== "transfer" && (
-            <form.Field
-              name="notes"
-              children={(field) => (
-                <div className="space-y-2">
-                  <Label htmlFor={field.name}>Notes (Optional)</Label>
-                  <Textarea
-                    id={field.name}
-                    name={field.name}
-                    placeholder="Add additional details here..."
-                    className="resize-none"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </div>
-              )}
-            />
-          )}
-
-          {/* Attachment URL — Proof of Purchase / Receipt */}
-          <form.Field
-            name="attachmentUrl"
-            children={(field) => (
-              <div className="space-y-2">
-                <Label
-                  htmlFor="attachment-url"
-                  className="flex items-center gap-1.5 text-sm"
-                >
-                  <IconPaperclip className="size-3.5" />
-                  Receipt / Attachment URL
-                  <span className="text-xs font-normal text-muted-foreground">
-                    (Optional)
-                  </span>
-                </Label>
-                <Input
-                  id="attachment-url"
-                  name="attachment-url"
-                  type="url"
-                  placeholder="https://... (paste receipt photo URL)"
-                  value={field.state.value ?? ""}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </div>
-            )}
+          <DestinationAmountField
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
           />
-
-          {/* ─── Action Bar ─── */}
-          <form.Subscribe
-            selector={(state) => state.values.amount}
-            children={(parentAmount) => {
-              // Hitung sisa untuk disable Save saat split belum seimbang
-              const splitTotal = splitEntries.reduce((s, e) => s + e.amount, 0)
-              const remaining = parentAmount - splitTotal
-              const isSaveDisabled =
-                isSplit && activeTab !== "transfer" && remaining !== 0
-
-              return (
-                <div className="mt-6 flex items-center justify-between border-t pt-4">
-                  <div>
-                    {isEditMode && (
-                      <Button
-                        type="button"
-                        variant="destructive"
-                        onClick={handleDelete}
-                        className="bg-red-500/10 text-red-600 hover:bg-red-500/20"
-                      >
-                        <IconTrash className="mr-2 h-4 w-4" /> Delete
-                      </Button>
-                    )}
-                  </div>
-
-                  <div className="flex gap-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={() => {
-                        setIsOpen(false)
-                        if (onClose) onClose()
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      type="submit"
-                      disabled={isSaveDisabled}
-                      className="bg-yellow-500 font-bold text-black hover:bg-yellow-600 disabled:opacity-50"
-                    >
-                      {isEditMode ? "Update Changes" : "Save Transaction"}
-                    </Button>
-                  </div>
-                </div>
-              )
-            }}
+          <DateTimeFields form={form} />
+          <MerchantField
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+            isLoading={isLoading}
+          />
+          <SplitModeToggle
+            activeTab={activeTab}
+            isSplit={isSplit}
+            setIsSplit={setIsSplit}
+          />
+          <CategoryField
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+            isLoading={isLoading}
+            isSplit={isSplit}
+          />
+          <SplitEntriesPanel
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+            isSplit={isSplit}
+            setSplitEntries={setSplitEntries}
+            splitEntries={splitEntries}
+          />
+          <StatusField form={form} />
+          <NotesField activeTab={activeTab} form={form} />
+          <AttachmentField form={form} />
+          <TransactionActionBar
+            activeTab={activeTab}
+            form={form}
+            isEditMode={isEditMode}
+            isSplit={isSplit}
+            onCancel={handleCancel}
+            onDelete={handleDelete}
+            splitEntries={splitEntries}
           />
         </form>
       </DialogContent>

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -23,13 +23,17 @@ import { cn } from "@/lib/utils"
 import { getTransactionFormData } from "@/server/transactions"
 import { toDisplayNumber, toMinorUnits, type Money } from "@/lib/money"
 import { CURRENCIES, type CurrencyCode } from "@/lib/data/currencies"
+import { createUuidV7 } from "@/lib/uuid-v7"
 
 type TransactionFormData = Awaited<ReturnType<typeof getTransactionFormData>>
 type FormAccount = TransactionFormData["accounts"][number]
 type FormCategory = TransactionFormData["categories"][number]
 type FormMerchant = TransactionFormData["merchants"][number]
 
-import { transactionCollection } from "@/lib/collections"
+import {
+  transactionCollection,
+  type TransactionRecord,
+} from "@/lib/collections"
 import { TimeInput } from "@/components/ui/time-input"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -62,6 +66,15 @@ const splitEntrySchema = z.object({
 })
 
 type SplitEntryValue = z.infer<typeof splitEntrySchema>
+
+interface OptimisticTransactionRelationDraft {
+  account: unknown
+  category: unknown
+  isSplit: boolean
+  merchant: unknown
+  splitEntries: unknown
+  toAccount: unknown
+}
 
 const transactionSchema = z.object({
   type: z.enum(["expense", "income", "transfer"]),
@@ -407,26 +420,31 @@ export function TransactionFormModal({
             draft.updatedAt = payload.updatedAt
             // Immer draft hanya mengenal scalar fields di schema collection-nya.
             // Relasi dan field baru (account, isSplit, splitEntries) di-cast secara eksplisit.
-            ;(draft as any).account = payload.account
-            ;(draft as any).toAccount = payload.toAccount
-            ;(draft as any).category = payload.category
-            ;(draft as any).merchant = payload.merchant
-            ;(draft as any).isSplit = payload.isSplit
-            ;(draft as any).splitEntries = payload.splitEntries
+            const relationDraft =
+              draft as unknown as OptimisticTransactionRelationDraft
+            relationDraft.account = payload.account
+            relationDraft.toAccount = payload.toAccount
+            relationDraft.category = payload.category
+            relationDraft.merchant = payload.merchant
+            relationDraft.isSplit = payload.isSplit
+            relationDraft.splitEntries = payload.splitEntries
           })
         } else {
           // 1. Generate Client-Side ID untuk Sinkronisasi Optimistic ke Database
-          const optimisticId = crypto.randomUUID()
+          const optimisticId = createUuidV7()
+          const idempotencyKey = createUuidV7()
 
           // 2. CUKUP Insert ke UI Lokal saja!
           // Arsitektur kita di collections.ts (onInsert) akan melanjutkannya ke server secara gaib.
           transactionCollection.insert({
             ...payload,
             id: optimisticId,
+            idempotencyKey,
             createdAt: new Date(),
             familyId: "",
             // splitEntries di optimistic payload adalah versi ringkas (tanpa relasi Prisma)
-            splitEntries: payload.splitEntries as any,
+            splitEntries:
+              payload.splitEntries as TransactionRecord["splitEntries"],
           })
         }
 

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -136,6 +136,7 @@ export const transactionCollection = createCollection(
         await createTransactionFn({
           data: {
             id: payload.id as string,
+            idempotencyKey: payload.idempotencyKey as string,
             type: payload.type as "expense" | "income" | "transfer",
             amount: encodeMoney(payload.amount as Money),
             description: payload.description as string,

--- a/src/lib/uuid-v7.test.ts
+++ b/src/lib/uuid-v7.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "vite-plus/test"
+import { createUuidV7 } from "./uuid-v7"
+
+describe("createUuidV7", () => {
+  test("generates UUIDv7-shaped keys for client idempotency", () => {
+    expect(createUuidV7()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    )
+  })
+})

--- a/src/lib/uuid-v7.ts
+++ b/src/lib/uuid-v7.ts
@@ -1,0 +1,31 @@
+export function createUuidV7(): string {
+  const cryptoApi = globalThis.crypto
+  if (!cryptoApi) {
+    throw new Error("Web Crypto API is required to generate UUIDv7")
+  }
+
+  const bytes = new Uint8Array(16)
+  cryptoApi.getRandomValues(bytes)
+
+  let timestamp = BigInt(Date.now())
+  for (let index = 5; index >= 0; index -= 1) {
+    bytes[index] = Number(timestamp & 0xffn)
+    timestamp >>= 8n
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x70
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  return formatUuid(bytes)
+}
+
+function formatUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("")
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16
+  )}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -167,22 +167,325 @@ const transactionInputSchema = z.object({
   attachmentUrl: z.string().nullable().optional(),
 })
 
-/**
- * BACKEND FUNCTION: Create Transaction & Update Balances (ACID Compliant)
- */
-export const createTransactionFn = createServerFn({ method: "POST" })
-  .middleware([familyMiddleware])
-  .inputValidator((data: z.input<typeof transactionInputSchema>) =>
-    transactionInputSchema.parse(data)
+const uuidV7Schema = z
+  .string()
+  .trim()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    "idempotencyKey must be a UUIDv7"
   )
-  .handler(async ({ data, context }) => {
-    const { user, familyId } = context
+  .transform((value) => value.toLowerCase())
 
-    // 🚀 THE ENTERPRISE MAGIC: Prisma $transaction (ACID)
-    // If any process inside this block fails, all changes are rolled back automatically.
-    const result = await scopedTenantTransaction(
+const createTransactionTransportInputSchema = transactionInputSchema.extend({
+  idempotencyKey: uuidV7Schema.optional(),
+})
+
+const createTransactionInputSchema =
+  createTransactionTransportInputSchema.required({
+    idempotencyKey: true,
+  })
+
+type CreateTransactionInput = z.infer<typeof createTransactionInputSchema>
+type RunInTenantTransaction = <T>(
+  familyId: string,
+  callback: (tx: TenantTransactionClient) => Promise<T>
+) => Promise<T>
+
+interface CreateTransactionForFamilyArgs {
+  data: unknown
+  familyId: string
+  runInTenantTransaction?: RunInTenantTransaction
+  user: { id: string }
+}
+
+export class IdempotencyConflictError extends Error {
+  statusCode = 409
+
+  constructor(message = "Idempotency key reused with a different payload") {
+    super(message)
+    this.name = "IdempotencyConflictError"
+  }
+}
+
+interface PersistedSplitEntryForIdempotency {
+  amount: bigint
+  categoryId: string | null
+  description: string
+  merchantId: string | null
+}
+
+interface PersistedTransferOutForIdempotency {
+  inflowTransaction: {
+    accountId: string
+    amount: bigint
+    categoryId: string | null
+    currency: string
+    date: Date
+    description: string
+    destinationAmount: bigint | null
+    destinationCurrency: string | null
+    merchantId: string | null
+    notes: string | null
+    status: string
+    toAccountId: string | null
+    type: string
+  } | null
+}
+
+interface PersistedTransactionForIdempotency {
+  accountBalanceAfter: bigint | null
+  accountId: string
+  amount: bigint
+  attachmentUrl: string | null
+  categoryId: string | null
+  createdAt: Date
+  currency: string
+  date: Date
+  deletedAt: Date | null
+  description: string
+  destinationAmount: bigint | null
+  destinationCurrency: string | null
+  excluded: boolean
+  familyId: string
+  id: string
+  idempotencyKey: string | null
+  isSplit: boolean
+  kind: string
+  merchantId: string | null
+  notes: string | null
+  splitEntries: PersistedSplitEntryForIdempotency[]
+  status: string
+  toAccountId: string | null
+  transferIn: unknown
+  transferOut: PersistedTransferOutForIdempotency | null
+  type: string
+  updatedAt: Date
+  userId: string
+}
+
+function canonicalMoney(value: bigint | null | undefined): string | null {
+  return value == null ? null : encodeMoney(absMoney(value))
+}
+
+function canonicalSplitEntries(
+  entries: Array<{
+    amount: bigint
+    categoryId?: string | null
+    description: string
+    merchantId?: string | null
+  }>
+) {
+  return entries.map((entry) => ({
+    amount: encodeMoney(absMoney(entry.amount)),
+    categoryId: entry.categoryId ?? null,
+    description: entry.description,
+    merchantId: entry.merchantId ?? null,
+  }))
+}
+
+function canonicalRequestPayload(data: CreateTransactionInput) {
+  return {
+    accountId: data.accountId,
+    amount: encodeMoney(absMoney(data.amount)),
+    attachmentUrl: data.attachmentUrl ?? null,
+    categoryId: data.isSplit ? null : (data.categoryId ?? null),
+    currency: data.currency,
+    date: data.date.toISOString(),
+    description: data.description,
+    destinationAmount: canonicalMoney(data.destinationAmount),
+    destinationCurrency: data.destinationCurrency ?? null,
+    isSplit: data.isSplit,
+    merchantId: data.isSplit ? null : (data.merchantId ?? null),
+    notes: data.notes ?? null,
+    splitEntries: data.isSplit
+      ? canonicalSplitEntries(data.splitEntries ?? [])
+      : [],
+    status: data.status,
+    toAccountId: data.toAccountId ?? null,
+    transferPartner:
+      data.type === "transfer"
+        ? {
+            accountId: data.toAccountId ?? null,
+            amount: encodeMoney(
+              absMoney(data.destinationAmount ?? data.amount)
+            ),
+            categoryId: data.categoryId ?? null,
+            currency: data.destinationCurrency ?? data.currency,
+            date: data.date.toISOString(),
+            description: data.description,
+            destinationAmount: canonicalMoney(data.destinationAmount),
+            destinationCurrency: data.destinationCurrency ?? null,
+            merchantId: data.merchantId ?? null,
+            notes: data.notes ?? null,
+            status: data.status,
+            toAccountId: data.accountId,
+            type: "transfer",
+          }
+        : null,
+    type: data.type,
+  }
+}
+
+function canonicalPersistedPayload(tx: PersistedTransactionForIdempotency) {
+  const transferPartner = tx.transferOut?.inflowTransaction ?? null
+
+  return {
+    accountId: tx.accountId,
+    amount: encodeMoney(absMoney(tx.amount)),
+    attachmentUrl: tx.attachmentUrl,
+    categoryId: tx.isSplit ? null : tx.categoryId,
+    currency: tx.currency,
+    date: tx.date.toISOString(),
+    description: tx.description,
+    destinationAmount: canonicalMoney(tx.destinationAmount),
+    destinationCurrency: tx.destinationCurrency,
+    isSplit: tx.isSplit,
+    merchantId: tx.isSplit ? null : tx.merchantId,
+    notes: tx.notes,
+    splitEntries: tx.isSplit ? canonicalSplitEntries(tx.splitEntries) : [],
+    status: tx.status,
+    toAccountId: tx.toAccountId,
+    transferPartner:
+      tx.type === "transfer"
+        ? transferPartner && {
+            accountId: transferPartner.accountId,
+            amount: encodeMoney(absMoney(transferPartner.amount)),
+            categoryId: transferPartner.categoryId,
+            currency: transferPartner.currency,
+            date: transferPartner.date.toISOString(),
+            description: transferPartner.description,
+            destinationAmount: canonicalMoney(
+              transferPartner.destinationAmount
+            ),
+            destinationCurrency: transferPartner.destinationCurrency,
+            merchantId: transferPartner.merchantId,
+            notes: transferPartner.notes,
+            status: transferPartner.status,
+            toAccountId: transferPartner.toAccountId,
+            type: transferPartner.type,
+          }
+        : null,
+    type: tx.type,
+  }
+}
+
+function assertIdempotentPayloadMatches(
+  data: CreateTransactionInput,
+  existing: PersistedTransactionForIdempotency
+): void {
+  if (
+    JSON.stringify(canonicalRequestPayload(data)) !==
+    JSON.stringify(canonicalPersistedPayload(existing))
+  ) {
+    throw new IdempotencyConflictError()
+  }
+}
+
+async function findIdempotentTransaction(
+  tx: TenantTransactionClient,
+  familyId: string,
+  idempotencyKey: string
+): Promise<PersistedTransactionForIdempotency | null> {
+  return await tx.transaction.findUnique({
+    where: {
+      tx_family_idempotency: {
+        familyId,
+        idempotencyKey,
+      },
+    },
+    include: {
+      splitEntries: {
+        orderBy: { createdAt: "asc" },
+      },
+      transferIn: true,
+      transferOut: {
+        include: {
+          inflowTransaction: true,
+        },
+      },
+    },
+  })
+}
+
+function serializePersistedReplay(tx: PersistedTransactionForIdempotency) {
+  const {
+    splitEntries: _splitEntries,
+    transferIn: _transferIn,
+    transferOut: _transferOut,
+    ...transaction
+  } = tx
+
+  return serializeTransaction({
+    ...transaction,
+    amount: absMoney(transaction.amount),
+  })
+}
+
+async function replayIdempotentTransaction(
+  tx: TenantTransactionClient,
+  familyId: string,
+  data: CreateTransactionInput
+) {
+  const existing = await findIdempotentTransaction(
+    tx,
+    familyId,
+    data.idempotencyKey
+  )
+  if (!existing) return null
+
+  assertIdempotentPayloadMatches(data, existing)
+  return serializePersistedReplay(existing)
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false
+  }
+
+  const code = (error as { code?: unknown }).code
+  return code === "P2002"
+}
+
+async function readIdempotencyHeader(): Promise<string | null> {
+  try {
+    const { getRequest } = await import("@tanstack/react-start/server")
+    return getRequest().headers.get("Idempotency-Key")
+  } catch {
+    return null
+  }
+}
+
+async function normalizeCreateTransactionTransportInput(
+  data: z.infer<typeof createTransactionTransportInputSchema>
+): Promise<CreateTransactionInput> {
+  const rawHeaderKey = await readIdempotencyHeader()
+  const headerKey =
+    rawHeaderKey == null ? null : uuidV7Schema.parse(rawHeaderKey)
+  if (headerKey && data.idempotencyKey && headerKey !== data.idempotencyKey) {
+    throw new Error("Idempotency-Key header does not match idempotencyKey")
+  }
+
+  return createTransactionInputSchema.parse({
+    ...data,
+    idempotencyKey: headerKey ?? data.idempotencyKey,
+  })
+}
+
+export async function createTransactionForFamily({
+  data: rawData,
+  familyId,
+  runInTenantTransaction = scopedTenantTransaction,
+  user,
+}: CreateTransactionForFamilyArgs) {
+  const data = createTransactionInputSchema.parse(rawData)
+
+  const createOrReplay = async () =>
+    await runInTenantTransaction(
       familyId,
       async (tx: TenantTransactionClient) => {
+        const replay = await replayIdempotentTransaction(tx, familyId, data)
+        if (replay) return replay
+
         // === SPLIT PARITY GUARD (GAAP Compliance) ===
         // Backend MUST validate that SplitEntries sum === parent.amount.
         // UI validation is a convenience; THIS is the authoritative check.
@@ -257,6 +560,7 @@ export const createTransactionFn = createServerFn({ method: "POST" })
               destinationCurrency: data.destinationCurrency,
               accountBalanceAfter: sourceBalanceAfter,
               attachmentUrl: data.attachmentUrl,
+              idempotencyKey: data.idempotencyKey,
             },
           })
 
@@ -349,6 +653,7 @@ export const createTransactionFn = createServerFn({ method: "POST" })
             status: data.status,
             accountBalanceAfter: accountBalanceAfter,
             attachmentUrl: data.attachmentUrl,
+            idempotencyKey: data.idempotencyKey,
           },
         })
 
@@ -377,7 +682,37 @@ export const createTransactionFn = createServerFn({ method: "POST" })
       }
     )
 
-    return result
+  try {
+    return await createOrReplay()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+
+    const replay = await runInTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) =>
+        await replayIdempotentTransaction(tx, familyId, data)
+    )
+    if (replay) return replay
+
+    throw error
+  }
+}
+
+/**
+ * BACKEND FUNCTION: Create Transaction & Update Balances (ACID Compliant)
+ */
+export const createTransactionFn = createServerFn({ method: "POST" })
+  .middleware([familyMiddleware])
+  .inputValidator(
+    (data: z.input<typeof createTransactionTransportInputSchema>) =>
+      createTransactionTransportInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await createTransactionForFamily({
+      data: await normalizeCreateTransactionTransportInput(data),
+      familyId: context.familyId,
+      user: context.user,
+    })
   })
 
 /**

--- a/tests/integration/support/database.ts
+++ b/tests/integration/support/database.ts
@@ -14,6 +14,7 @@ const RESET_TABLES = [
   "Transfer",
   "SplitEntry",
   "Transaction",
+  "IdempotencyRecord",
   "SmartRule",
   "Merchant",
   "Category",

--- a/tests/integration/transaction-idempotency.integration.ts
+++ b/tests/integration/transaction-idempotency.integration.ts
@@ -1,0 +1,218 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import {
+  createTransactionForFamily,
+  IdempotencyConflictError,
+} from "../../src/server/transactions"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+describe("transaction idempotency", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  test("same idempotency key fired in parallel creates one ledger row and one balance mutation", async () => {
+    const { account, category, owner } = await createLedgerFixture()
+    const transactionId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+    const payload = {
+      id: transactionId,
+      idempotencyKey,
+      accountId: account.id,
+      amount: 12_345n,
+      categoryId: category.id,
+      date: new Date("2026-05-23T00:00:00.000Z"),
+      description: "Parallel idempotent expense",
+      type: "expense",
+    }
+
+    const responses = await Promise.all([
+      createTransactionForFamily({
+        data: payload,
+        familyId: owner.family.id,
+        runInTenantTransaction: harness.withFamily,
+        user: owner.user,
+      }),
+      createTransactionForFamily({
+        data: payload,
+        familyId: owner.family.id,
+        runInTenantTransaction: harness.withFamily,
+        user: owner.user,
+      }),
+      createTransactionForFamily({
+        data: payload,
+        familyId: owner.family.id,
+        runInTenantTransaction: harness.withFamily,
+        user: owner.user,
+      }),
+    ])
+
+    const [transactions, storedAccount] = await Promise.all([
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.transaction.findMany({
+          where: { familyId: owner.family.id, idempotencyKey },
+          orderBy: { createdAt: "asc" },
+        })
+      ),
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.account.findUniqueOrThrow({ where: { id: account.id } })
+      ),
+    ])
+
+    expect(responses.map((response) => response.id)).toEqual([
+      transactionId,
+      transactionId,
+      transactionId,
+    ])
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0]?.amount).toBe(-12_345n)
+    expect(storedAccount.balance).toBe(87_655n)
+  })
+
+  test("same idempotency key with a different payload fails with conflict", async () => {
+    const { account, category, owner } = await createLedgerFixture()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    await createTransactionForFamily({
+      data: {
+        id: factories.createIdempotencyKey(),
+        idempotencyKey,
+        accountId: account.id,
+        amount: 12_345n,
+        categoryId: category.id,
+        date: new Date("2026-05-23T00:00:00.000Z"),
+        description: "Original idempotent expense",
+        type: "expense",
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    await expect(
+      createTransactionForFamily({
+        data: {
+          id: factories.createIdempotencyKey(),
+          idempotencyKey,
+          accountId: account.id,
+          amount: 22_000n,
+          categoryId: category.id,
+          date: new Date("2026-05-23T00:00:00.000Z"),
+          description: "Different idempotent expense",
+          type: "expense",
+        },
+        familyId: owner.family.id,
+        runInTenantTransaction: harness.withFamily,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(IdempotencyConflictError)
+  })
+
+  test("missing idempotency key on createTransactionForFamily is rejected", async () => {
+    const { account, category, owner } = await createLedgerFixture()
+    const payloadWithoutKey: Record<string, unknown> = {
+      id: factories.createIdempotencyKey(),
+      accountId: account.id,
+      amount: 12_345n,
+      categoryId: category.id,
+      date: new Date("2026-05-23T00:00:00.000Z"),
+      description: "Missing idempotency key expense",
+      type: "expense",
+    }
+
+    await expect(
+      createTransactionForFamily({
+        data: payloadWithoutKey,
+        familyId: owner.family.id,
+        runInTenantTransaction: harness.withFamily,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/idempotency/i)
+  })
+
+  test("expired IdempotencyRecord rows can be purged so the same scoped key is reusable", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const key = factories.createIdempotencyKey()
+    const endpoint = "createTransactionFn"
+
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await tx.idempotencyRecord.create({
+        data: {
+          endpoint,
+          expiresAt: new Date("2026-05-22T00:00:00.000Z"),
+          familyId: owner.family.id,
+          key,
+          requestHash: "expired-hash",
+          responseJson: { ok: true },
+          statusCode: 200,
+        },
+      })
+
+      await tx.$executeRaw`
+        DELETE FROM "IdempotencyRecord"
+        WHERE "expiresAt" < ${new Date("2026-05-23T00:00:00.000Z")}
+      `
+
+      await tx.idempotencyRecord.create({
+        data: {
+          endpoint,
+          expiresAt: new Date("2026-05-24T00:00:00.000Z"),
+          familyId: owner.family.id,
+          key,
+          requestHash: "fresh-hash",
+          responseJson: { ok: true },
+          statusCode: 200,
+        },
+      })
+    })
+
+    const records = await harness.withFamily(owner.family.id, (tx) =>
+      tx.idempotencyRecord.findMany({
+        where: { endpoint, familyId: owner.family.id, key },
+      })
+    )
+
+    expect(records).toHaveLength(1)
+    expect(records[0]?.requestHash).toBe("fresh-hash")
+  })
+
+  async function createLedgerFixture() {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [account, category] = await Promise.all([
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "Idempotency checking",
+      }),
+      factories.createCategory({
+        familyId: owner.family.id,
+        name: "Idempotency category",
+        type: "expense",
+      }),
+    ])
+
+    return { account, category, owner }
+  }
+})

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite-plus"
 
 export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     fileParallelism: false,
     hookTimeout: 120_000,


### PR DESCRIPTION
## Summary
- Add `Transaction.idempotencyKey` plus unique `(familyId, idempotencyKey)` and an `IdempotencyRecord` table with TTL cleanup support.
- Make `createTransactionFn` require UUIDv7 idempotency keys, replay same-payload creates, reject same-key different-payload creates, and recover concurrent unique races by replaying the persisted winner.
- Generate client UUIDv7 idempotency keys for optimistic transaction inserts and add real-Postgres regression coverage.

## Why
PER-17 / ADR-0006 requires retried transaction creates to be safe: browser double-clicks, network retries, and optimistic insert replays must not double-debit accounts.

## Validation
- `git diff --check`
- `vp check`
- `vp test` — 205 tests passed
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration` — 35 tests passed
- `vp run test:unit:coverage` — statements 98.46%, branches 95.48%, functions 100%, lines 98.87%
- `vp build`
- `vp dlx react-doctor@latest . --verbose --diff` — exit 0, score 96/100
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e` — 7 tests passed after clearing generated Nitro/build artifacts from the previous build run
- Local secret-pattern scan over changed files found no obvious secrets. `ggshield` is installed but not authenticated locally, so GitGuardian remains a CI/source-control gate.

## Follow-up Work Split Out
- PER-107 — login/onboarding hydration mismatch cleanup.
- PER-108 — pg `client.query()` deprecation cleanup in the real-Postgres harness.
- PER-109 — TransactionFormModal React Doctor cleanup/refactor.
