### PR TITLE
PER-19 add immutable audit logging

### DIFF
--- a/prisma/migrations/20260524071837_add_audit_log/migration.sql
+++ b/prisma/migrations/20260524071837_add_audit_log/migration.sql
@@ -1,0 +1,72 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "beforeJson" JSONB,
+    "afterJson" JSONB,
+    "ip" TEXT,
+    "userAgent" TEXT,
+    "requestId" TEXT NOT NULL,
+    "idempotencyKey" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AuditLog_familyId_createdAt_id_idx" ON "AuditLog"("familyId", "createdAt" DESC, "id" DESC);
+
+-- CreateIndex
+CREATE INDEX "AuditLog_entityType_entityId_idx" ON "AuditLog"("entityType", "entityId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_requestId_idx" ON "AuditLog"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuditLog_createdAt_id_key" ON "AuditLog"("createdAt", "id");
+
+-- RLS & Grants for AuditLog
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'permoney_audit_retention') THEN
+    CREATE ROLE permoney_audit_retention;
+  END IF;
+END
+$$;
+
+ALTER TABLE "AuditLog" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY audit_log_tenant_select ON "AuditLog"
+  FOR SELECT
+  USING ("familyId" = current_setting('app.family_id', true)::text);
+
+CREATE POLICY audit_log_tenant_insert ON "AuditLog"
+  FOR INSERT
+  WITH CHECK ("familyId" = current_setting('app.family_id', true)::text);
+
+CREATE POLICY audit_log_retention_delete ON "AuditLog"
+  FOR DELETE TO permoney_audit_retention
+  USING ("createdAt" < now() - interval '7 years');
+
+CREATE POLICY audit_log_retention_select ON "AuditLog"
+  FOR SELECT TO permoney_audit_retention
+  USING (true);
+
+ALTER TABLE "AuditLog" FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  -- Konfigurasi role permoney_app jika ada
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'permoney_app') THEN
+    REVOKE UPDATE, DELETE, TRUNCATE ON "AuditLog" FROM permoney_app;
+    GRANT INSERT, SELECT ON "AuditLog" TO permoney_app;
+  END IF;
+
+  -- Konfigurasi role retention
+  GRANT SELECT, DELETE ON "AuditLog" TO permoney_audit_retention;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -254,6 +254,27 @@ model IdempotencyRecord {
   @@index([expiresAt])
 }
 
+model AuditLog {
+  id             String   @id @default(cuid())
+  familyId       String
+  userId         String
+  action         String
+  entityType     String
+  entityId       String
+  beforeJson     Json?
+  afterJson      Json?
+  ip             String?
+  userAgent      String?
+  requestId      String
+  idempotencyKey String?
+  createdAt      DateTime @default(now())
+
+  @@index([familyId, createdAt(sort: Desc), id(sort: Desc)])
+  @@index([entityType, entityId])
+  @@index([requestId])
+  @@unique([createdAt, id])
+}
+
 model Transfer {
   id String @id @default(cuid())
 

--- a/src/server/audit-log.ts
+++ b/src/server/audit-log.ts
@@ -1,0 +1,100 @@
+import { Prisma } from "@prisma/client"
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import {
+  familyMiddleware,
+  scopedTenantTransaction,
+} from "./middleware/with-family"
+
+// Schema input validator untuk pagination dan filtering audit log
+const getAuditLogInputSchema = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  cursor: z
+    .object({
+      createdAt: z.string(), // Format ISO string dari Date
+      id: z.string(),
+    })
+    .optional(),
+  entityType: z.string().optional(),
+  entityId: z.string().optional(),
+})
+
+/**
+ * Mengambil data AuditLog terpaginasi secara stabil (cursor-based) untuk keluarga/family tertentu.
+ */
+export async function getAuditLogForFamily({
+  data,
+  familyId,
+}: {
+  data: z.infer<typeof getAuditLogInputSchema>
+  familyId: string
+}) {
+  return await scopedTenantTransaction(familyId, async (tx) => {
+    const limit = Math.min(data.limit ?? 50, 100)
+
+    // Definisikan filter pencarian dengan tipe data Prisma yang aman
+    const where: Prisma.AuditLogWhereInput = {
+      familyId,
+    }
+
+    if (data.entityType) {
+      where.entityType = data.entityType
+    }
+    if (data.entityId) {
+      where.entityId = data.entityId
+    }
+
+    // Query database dengan limit + 1 untuk mengetahui apakah ada data selanjutnya (hasNextPage)
+    const logs = await tx.auditLog.findMany({
+      where,
+      take: limit + 1,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      cursor: data.cursor
+        ? {
+            createdAt_id: {
+              createdAt: new Date(data.cursor.createdAt),
+              id: data.cursor.id,
+            },
+          }
+        : undefined,
+      // Jika cursor aktif, kita lewati elemen pertama (karena cursor mengembalikan data yang ditunjuk)
+      skip: data.cursor ? 1 : undefined,
+    })
+
+    const hasNextPage = logs.length > limit
+    const items = hasNextPage ? logs.slice(0, limit) : logs
+
+    let nextCursor = null
+    if (items.length > 0 && hasNextPage) {
+      const lastItem = items[items.length - 1]
+      if (lastItem) {
+        nextCursor = {
+          createdAt: lastItem.createdAt.toISOString(),
+          id: lastItem.id,
+        }
+      }
+    }
+
+    return {
+      items,
+      nextCursor,
+      hasNextPage,
+    }
+  })
+}
+
+/**
+ * BACKEND FUNCTION: Mengambil data AuditLog terpaginasi secara stabil (cursor-based).
+ * Dilindungi oleh familyMiddleware dan berjalan dalam context scopedTenantTransaction.
+ */
+export const getAuditLogFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: z.infer<typeof getAuditLogInputSchema>) =>
+    getAuditLogInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await getAuditLogForFamily({
+      data,
+      familyId: context.familyId,
+    })
+  })

--- a/src/server/middleware/audit.test.ts
+++ b/src/server/middleware/audit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vite-plus/test"
+import { safeJsonCanonicalize } from "./audit"
+
+describe("safeJsonCanonicalize", () => {
+  test("converts BigInt to string", () => {
+    expect(safeJsonCanonicalize(12345n)).toBe("12345")
+    expect(safeJsonCanonicalize({ amount: 100n })).toEqual({ amount: "100" })
+  })
+
+  test("converts Date to ISO string", () => {
+    const date = new Date("2026-05-24T12:00:00.000Z")
+    expect(safeJsonCanonicalize(date)).toBe("2026-05-24T12:00:00.000Z")
+    expect(safeJsonCanonicalize({ date })).toEqual({
+      date: "2026-05-24T12:00:00.000Z",
+    })
+  })
+
+  test("preserves array index position for undefined by mapping to null", () => {
+    const arr = [1, undefined, 3]
+    expect(safeJsonCanonicalize(arr)).toEqual([1, null, 3])
+  })
+
+  test("omits undefined fields in objects", () => {
+    const obj = {
+      keep: "value",
+      remove: undefined,
+      nested: {
+        keep: 12n,
+        remove: undefined,
+      },
+    }
+    expect(safeJsonCanonicalize(obj)).toEqual({
+      keep: "value",
+      nested: {
+        keep: "12",
+      },
+    })
+  })
+
+  test("redacts sensitive fields (case-insensitive)", () => {
+    const obj = {
+      password: "secret_password",
+      token: "secret_token",
+      accessToken: "secret_access_token",
+      SECRET: "confidential",
+      passwordHash: "hash123",
+      safe: "public",
+      nested: {
+        password: "nested_password",
+      },
+    }
+    expect(safeJsonCanonicalize(obj)).toEqual({
+      password: "[REDACTED]",
+      token: "[REDACTED]",
+      accessToken: "[REDACTED]",
+      SECRET: "[REDACTED]",
+      passwordHash: "[REDACTED]",
+      safe: "public",
+      nested: {
+        password: "[REDACTED]",
+      },
+    })
+  })
+})

--- a/src/server/middleware/audit.ts
+++ b/src/server/middleware/audit.ts
@@ -1,0 +1,158 @@
+import { Prisma } from "@prisma/client"
+
+export type AuditAction = "create" | "update" | "soft_delete" | "delete"
+
+export interface AuditContext {
+  session: {
+    user: {
+      id: string
+      familyId: string | null
+    }
+  }
+  requestId: string
+  idempotencyKey?: string | null
+  ip?: string | null
+  userAgent?: string | null
+}
+
+const SENSITIVE_KEY_PATTERNS = ["password", "token", "secret"] as const
+
+/**
+ * Mengonversi nilai secara aman ke format yang kompatibel dengan JSON (tidak ada BigInt),
+ * menangani Date, undefined, serta menyensor data sensitif (password, token, dll).
+ */
+export function safeJsonCanonicalize(val: unknown): unknown {
+  if (val === null || val === undefined) {
+    return null
+  }
+
+  if (typeof val === "bigint") {
+    return val.toString()
+  }
+
+  if (val instanceof Date) {
+    return val.toISOString()
+  }
+
+  if (Array.isArray(val)) {
+    return val.map((item) => {
+      if (item === undefined) {
+        return null // Menjaga urutan/posisi indeks array
+      }
+      return safeJsonCanonicalize(item)
+    })
+  }
+
+  if (typeof val === "object") {
+    const res: Record<string, unknown> = {}
+    const obj = val as Record<string, unknown>
+
+    for (const key of Object.keys(obj)) {
+      const v = obj[key]
+      if (v === undefined) {
+        continue // Omit undefined properties
+      }
+
+      const normalizedKey = key.toLowerCase()
+      if (
+        SENSITIVE_KEY_PATTERNS.some((pattern) =>
+          normalizedKey.includes(pattern)
+        )
+      ) {
+        res[key] = "[REDACTED]"
+      } else {
+        res[key] = safeJsonCanonicalize(v)
+      }
+    }
+    return res
+  }
+
+  return val
+}
+
+/**
+ * Membuat context audit terpadu di awal mutasi.
+ * Fungsi ini server-only dan menggunakan dynamic import untuk mencegah kebocoran modul server.
+ */
+export async function createAuditContext(
+  session: { user: { id: string; familyId?: string | null } },
+  idempotencyKey?: string | null
+): Promise<AuditContext> {
+  const { getRequest } = await import("@tanstack/react-start/server")
+  let ip: string | null = null
+  let userAgent: string | null = null
+  let requestId: string | null = null
+
+  try {
+    const req = getRequest()
+    userAgent = req.headers.get("user-agent")
+    requestId = req.headers.get("x-request-id")
+
+    ip =
+      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      req.headers.get("x-real-ip") ||
+      null
+  } catch {
+    // Abaikan jika tidak berjalan dalam context HTTP request (misalnya unit test)
+  }
+
+  if (!requestId) {
+    requestId = crypto.randomUUID()
+  }
+
+  return {
+    session: {
+      user: {
+        id: session.user.id,
+        familyId: session.user.familyId ?? null,
+      },
+    },
+    requestId,
+    idempotencyKey: idempotencyKey ?? null,
+    ip,
+    userAgent,
+  }
+}
+
+/**
+ * Menulis baris audit ke database di bawah transaksi yang sama.
+ */
+export async function auditLog(
+  tx: Prisma.TransactionClient,
+  ctx: AuditContext,
+  entry: {
+    action: AuditAction
+    entityType: string
+    entityId: string
+    before?: unknown
+    after?: unknown
+    familyId?: string // override opsional untuk onboarding
+  }
+): Promise<void> {
+  const familyId = entry.familyId ?? ctx.session.user.familyId
+  if (!familyId) {
+    throw new Error("Cannot write audit log without familyId")
+  }
+
+  await tx.auditLog.create({
+    data: {
+      familyId,
+      userId: ctx.session.user.id,
+      action: entry.action,
+      entityType: entry.entityType,
+      entityId: entry.entityId,
+      beforeJson:
+        entry.before === undefined
+          ? Prisma.DbNull
+          : (safeJsonCanonicalize(entry.before) as Prisma.InputJsonValue),
+      afterJson:
+        entry.after === undefined
+          ? Prisma.DbNull
+          : (safeJsonCanonicalize(entry.after) as Prisma.InputJsonValue),
+      ip: ctx.ip ?? null,
+      userAgent: ctx.userAgent ?? null,
+      requestId: ctx.requestId,
+      idempotencyKey: ctx.idempotencyKey ?? null,
+    },
+  })
+}

--- a/src/server/middleware/audit.ts
+++ b/src/server/middleware/audit.ts
@@ -15,7 +15,16 @@ export interface AuditContext {
   userAgent?: string | null
 }
 
-const SENSITIVE_KEY_PATTERNS = ["password", "token", "secret"] as const
+export interface AuditLogEntry {
+  action: AuditAction
+  entityType: string
+  entityId: string
+  before?: unknown
+  after?: unknown
+  familyId?: string
+}
+
+const SENSITIVE_KEY_PATTERN = /password|token|secret/i
 
 /**
  * Mengonversi nilai secara aman ke format yang kompatibel dengan JSON (tidak ada BigInt),
@@ -53,12 +62,7 @@ export function safeJsonCanonicalize(val: unknown): unknown {
         continue // Omit undefined properties
       }
 
-      const normalizedKey = key.toLowerCase()
-      if (
-        SENSITIVE_KEY_PATTERNS.some((pattern) =>
-          normalizedKey.includes(pattern)
-        )
-      ) {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
         res[key] = "[REDACTED]"
       } else {
         res[key] = safeJsonCanonicalize(v)
@@ -120,39 +124,48 @@ export async function createAuditContext(
 export async function auditLog(
   tx: Prisma.TransactionClient,
   ctx: AuditContext,
-  entry: {
-    action: AuditAction
-    entityType: string
-    entityId: string
-    before?: unknown
-    after?: unknown
-    familyId?: string // override opsional untuk onboarding
-  }
+  entry: AuditLogEntry
 ): Promise<void> {
-  const familyId = entry.familyId ?? ctx.session.user.familyId
-  if (!familyId) {
-    throw new Error("Cannot write audit log without familyId")
-  }
+  await auditLogs(tx, ctx, [entry])
+}
 
-  await tx.auditLog.create({
-    data: {
-      familyId,
-      userId: ctx.session.user.id,
-      action: entry.action,
-      entityType: entry.entityType,
-      entityId: entry.entityId,
-      beforeJson:
-        entry.before === undefined
-          ? Prisma.DbNull
-          : (safeJsonCanonicalize(entry.before) as Prisma.InputJsonValue),
-      afterJson:
-        entry.after === undefined
-          ? Prisma.DbNull
-          : (safeJsonCanonicalize(entry.after) as Prisma.InputJsonValue),
-      ip: ctx.ip ?? null,
-      userAgent: ctx.userAgent ?? null,
-      requestId: ctx.requestId,
-      idempotencyKey: ctx.idempotencyKey ?? null,
-    },
+/**
+ * Menulis beberapa baris audit dalam satu query supaya mutation path tidak
+ * mengulang blok create dan tidak memicu waterfall await di loop.
+ */
+export async function auditLogs(
+  tx: Prisma.TransactionClient,
+  ctx: AuditContext,
+  entries: AuditLogEntry[]
+): Promise<void> {
+  if (entries.length === 0) return
+
+  await tx.auditLog.createMany({
+    data: entries.map((entry) => {
+      const familyId = entry.familyId ?? ctx.session.user.familyId
+      if (!familyId) {
+        throw new Error("Cannot write audit log without familyId")
+      }
+
+      return {
+        familyId,
+        userId: ctx.session.user.id,
+        action: entry.action,
+        entityType: entry.entityType,
+        entityId: entry.entityId,
+        beforeJson:
+          entry.before === undefined
+            ? Prisma.DbNull
+            : (safeJsonCanonicalize(entry.before) as Prisma.InputJsonValue),
+        afterJson:
+          entry.after === undefined
+            ? Prisma.DbNull
+            : (safeJsonCanonicalize(entry.after) as Prisma.InputJsonValue),
+        ip: ctx.ip ?? null,
+        userAgent: ctx.userAgent ?? null,
+        requestId: ctx.requestId,
+        idempotencyKey: ctx.idempotencyKey ?? null,
+      }
+    }),
   })
 }

--- a/src/server/onboarding-service.ts
+++ b/src/server/onboarding-service.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from "@prisma/client"
+import { auditLog, createAuditContext } from "./middleware/audit"
 import { setTenantGuc } from "./middleware/with-family"
 
 interface LockedOnboardingUser {
@@ -17,6 +18,10 @@ export async function initializeOnboardingForUser(
   client: PrismaClient,
   userId: string
 ): Promise<OnboardingInitializationResult> {
+  const auditCtx = await createAuditContext({
+    user: { id: userId, familyId: null },
+  })
+
   return await client.$transaction(async (tx) => {
     const user = await lockUserForOnboarding(tx, userId)
 
@@ -43,6 +48,16 @@ export async function initializeOnboardingForUser(
     await tx.user.update({
       where: { id: user.id },
       data: { familyId: scopedFamilyId },
+    })
+
+    // Catat audit log untuk pembuatan Family baru (onboarding)
+    await auditLog(tx, auditCtx, {
+      action: "create",
+      entityType: "Family",
+      entityId: family.id,
+      before: null,
+      after: family,
+      familyId: family.id,
     })
 
     return { created: true, familyId: scopedFamilyId }

--- a/src/server/smart-rules.ts
+++ b/src/server/smart-rules.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
+import { auditLog, createAuditContext } from "./middleware/audit"
 import {
   familyMiddleware,
   scopedTenantTransaction,
@@ -29,21 +30,82 @@ const createRuleSchema = z.object({
   merchantId: z.string().nullable().optional(),
 })
 
+export async function createSmartRuleForFamily({
+  data,
+  familyId,
+  user,
+}: {
+  data: z.infer<typeof createRuleSchema>
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return scopedTenantTransaction(familyId, async (tx) => {
+    const newRule = await tx.smartRule.create({
+      data: {
+        keyword: data.keyword.toLowerCase(),
+        categoryId: data.categoryId,
+        merchantId: data.merchantId,
+        familyId,
+      },
+    })
+
+    await auditLog(tx, auditCtx, {
+      action: "create",
+      entityType: "SmartRule",
+      entityId: newRule.id,
+      before: null,
+      after: newRule,
+    })
+
+    return newRule
+  })
+}
+
+export async function deleteSmartRuleForFamily({
+  id,
+  familyId,
+  user,
+}: {
+  id: string
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return scopedTenantTransaction(familyId, async (tx) => {
+    const oldRule = await tx.smartRule.findFirst({
+      where: { id, familyId },
+    })
+    if (!oldRule) {
+      throw new Error("Smart rule not found or access denied")
+    }
+
+    await tx.smartRule.delete({
+      where: { id },
+    })
+
+    await auditLog(tx, auditCtx, {
+      action: "delete",
+      entityType: "SmartRule",
+      entityId: id,
+      before: oldRule,
+      after: null,
+    })
+
+    return { success: true, deletedId: id }
+  })
+}
+
 export const createSmartRuleFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
   .inputValidator((data: z.infer<typeof createRuleSchema>) =>
     createRuleSchema.parse(data)
   )
   .handler(async ({ data, context }) => {
-    return scopedTenantTransaction(context.familyId, async (tx) => {
-      return tx.smartRule.create({
-        data: {
-          keyword: data.keyword.toLowerCase(),
-          categoryId: data.categoryId,
-          merchantId: data.merchantId,
-          familyId: context.familyId,
-        },
-      })
+    return await createSmartRuleForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
     })
   })
 
@@ -54,12 +116,9 @@ export const deleteSmartRuleFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
   .inputValidator(z.object({ id: z.string() }))
   .handler(async ({ data, context }) => {
-    return scopedTenantTransaction(context.familyId, async (tx) => {
-      const res = await tx.smartRule.deleteMany({
-        where: { id: data.id, familyId: context.familyId },
-      })
-      if (res.count !== 1)
-        throw new Error("Smart rule not found or access denied")
-      return { success: true, deletedId: data.id }
+    return await deleteSmartRuleForFamily({
+      id: data.id,
+      familyId: context.familyId,
+      user: context.user,
     })
   })

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -7,7 +7,11 @@ import {
   scopedTenantTransaction,
   type TenantTransactionClient,
 } from "./middleware/with-family"
-import { auditLog, createAuditContext } from "./middleware/audit"
+import {
+  auditLogs,
+  createAuditContext,
+  type AuditLogEntry,
+} from "./middleware/audit"
 
 /**
  * BACKEND FUNCTION: Fetch reference data for the Transaction Form Dropdowns
@@ -130,6 +134,66 @@ function serializeTransaction<
     }))
   }
   return out as Serialized<T>
+}
+
+function indexById<T extends { id: string }>(
+  items: readonly T[]
+): Map<string, T> {
+  return new Map(items.map((item) => [item.id, item]))
+}
+
+function accountBalanceAuditEntries<T extends { id: string; balance: bigint }>(
+  oldAccounts: readonly T[],
+  newAccounts: readonly T[]
+): AuditLogEntry[] {
+  const newAccountsById = indexById(newAccounts)
+  return oldAccounts.flatMap((oldAccount) => {
+    const newAccount = newAccountsById.get(oldAccount.id)
+    if (!newAccount || oldAccount.balance === newAccount.balance) return []
+    return [
+      {
+        action: "update",
+        entityType: "Account",
+        entityId: oldAccount.id,
+        before: oldAccount,
+        after: newAccount,
+      },
+    ]
+  })
+}
+
+function pairedAuditEntries<TBefore extends { id: string }, TAfter>({
+  action,
+  afterItems,
+  beforeItems,
+  entityType,
+}: {
+  action: AuditLogEntry["action"]
+  afterItems: readonly (TAfter & { id: string })[]
+  beforeItems: readonly TBefore[]
+  entityType: string
+}): AuditLogEntry[] {
+  const afterById = indexById(afterItems)
+  return beforeItems.map((beforeItem) => ({
+    action,
+    entityType,
+    entityId: beforeItem.id,
+    before: beforeItem,
+    after: afterById.get(beforeItem.id),
+  }))
+}
+
+function createdAuditEntries<T extends { id: string }>(
+  entityType: string,
+  items: readonly T[]
+): AuditLogEntry[] {
+  return items.map((item) => ({
+    action: "create",
+    entityType,
+    entityId: item.id,
+    before: null,
+    after: item,
+  }))
 }
 
 // Schema untuk setiap baris line item dalam split transaction
@@ -480,6 +544,10 @@ export async function createTransactionForFamily({
   user,
 }: CreateTransactionForFamilyArgs) {
   const data = createTransactionInputSchema.parse(rawData)
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
 
   const createOrReplay = async () =>
     await runInTenantTransaction(
@@ -606,45 +674,14 @@ export async function createTransactionForFamily({
             tx.account.findUniqueOrThrow({ where: { id: data.toAccountId } }),
           ])
 
-          const auditCtx = await createAuditContext(
-            { user: { id: user.id, familyId } },
-            data.idempotencyKey
-          )
-          await auditLog(tx, auditCtx, {
-            action: "update",
-            entityType: "Account",
-            entityId: data.accountId,
-            before: oldSrcAcc,
-            after: newSrcAcc,
-          })
-          await auditLog(tx, auditCtx, {
-            action: "update",
-            entityType: "Account",
-            entityId: data.toAccountId,
-            before: oldDstAcc,
-            after: newDstAcc,
-          })
-          await auditLog(tx, auditCtx, {
-            action: "create",
-            entityType: "Transaction",
-            entityId: outflowTx.id,
-            before: null,
-            after: outflowTx,
-          })
-          await auditLog(tx, auditCtx, {
-            action: "create",
-            entityType: "Transaction",
-            entityId: inflowTx.id,
-            before: null,
-            after: inflowTx,
-          })
-          await auditLog(tx, auditCtx, {
-            action: "create",
-            entityType: "Transfer",
-            entityId: createdTransfer.id,
-            before: null,
-            after: createdTransfer,
-          })
+          await auditLogs(tx, auditCtx, [
+            ...accountBalanceAuditEntries(
+              [oldSrcAcc, oldDstAcc],
+              [newSrcAcc, newDstAcc]
+            ),
+            ...createdAuditEntries("Transaction", [outflowTx, inflowTx]),
+            ...createdAuditEntries("Transfer", [createdTransfer]),
+          ])
 
           return serializeTransaction({
             ...outflowTx,
@@ -731,43 +768,22 @@ export async function createTransactionForFamily({
           )
         }
 
-        const newAccount = await tx.account.findUniqueOrThrow({
-          where: { id: data.accountId },
-        })
+        const [newAccount, createdSplitEntries] = await Promise.all([
+          tx.account.findUniqueOrThrow({
+            where: { id: data.accountId },
+          }),
+          data.isSplit && data.splitEntries?.length
+            ? tx.splitEntry.findMany({
+                where: { transactionId: newTransaction.id },
+              })
+            : Promise.resolve([]),
+        ])
 
-        const auditCtx = await createAuditContext(
-          { user: { id: user.id, familyId } },
-          data.idempotencyKey
-        )
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Account",
-          entityId: data.accountId,
-          before: oldAccount,
-          after: newAccount,
-        })
-        await auditLog(tx, auditCtx, {
-          action: "create",
-          entityType: "Transaction",
-          entityId: newTransaction.id,
-          before: null,
-          after: newTransaction,
-        })
-
-        if (data.isSplit && data.splitEntries?.length) {
-          const createdSplitEntries = await tx.splitEntry.findMany({
-            where: { transactionId: newTransaction.id },
-          })
-          for (const entry of createdSplitEntries) {
-            await auditLog(tx, auditCtx, {
-              action: "create",
-              entityType: "SplitEntry",
-              entityId: entry.id,
-              before: null,
-              after: entry,
-            })
-          }
-        }
+        await auditLogs(tx, auditCtx, [
+          ...accountBalanceAuditEntries([oldAccount], [newAccount]),
+          ...createdAuditEntries("Transaction", [newTransaction]),
+          ...createdAuditEntries("SplitEntry", createdSplitEntries),
+        ])
 
         return serializeTransaction({
           ...newTransaction,
@@ -998,47 +1014,38 @@ export async function deleteTransactionForFamily({
           : Promise.resolve(null),
       ])
 
-      // Tulis audit log Account/update
-      for (const oldAcc of oldAccounts) {
-        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
-        if (!newAcc || oldAcc.balance === newAcc.balance) continue
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Account",
-          entityId: oldAcc.id,
-          before: oldAcc,
-          after: newAcc,
-        })
-      }
-
-      // Tulis audit log Transaction/soft_delete
-      await auditLog(tx, auditCtx, {
-        action: "soft_delete",
-        entityType: "Transaction",
-        entityId: oldTx.id,
-        before: oldTx,
-        after: updatedOutflowTx,
-      })
-
-      if (updatedInflowTx && inflowTx) {
-        await auditLog(tx, auditCtx, {
+      await auditLogs(tx, auditCtx, [
+        ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+        {
           action: "soft_delete",
           entityType: "Transaction",
-          entityId: inflowTx.id,
-          before: inflowTx,
-          after: updatedInflowTx,
-        })
-      }
-
-      if (oldTransferGraph && updatedTransferGraph) {
-        await auditLog(tx, auditCtx, {
-          action: "soft_delete",
-          entityType: "Transfer",
-          entityId: oldTransferGraph.id,
-          before: oldTransferGraph,
-          after: updatedTransferGraph,
-        })
-      }
+          entityId: oldTx.id,
+          before: oldTx,
+          after: updatedOutflowTx,
+        },
+        ...(updatedInflowTx && inflowTx
+          ? [
+              {
+                action: "soft_delete" as const,
+                entityType: "Transaction",
+                entityId: inflowTx.id,
+                before: inflowTx,
+                after: updatedInflowTx,
+              },
+            ]
+          : []),
+        ...(oldTransferGraph && updatedTransferGraph
+          ? [
+              {
+                action: "soft_delete" as const,
+                entityType: "Transfer",
+                entityId: oldTransferGraph.id,
+                before: oldTransferGraph,
+                after: updatedTransferGraph,
+              },
+            ]
+          : []),
+      ])
 
       return { success: true }
     }
@@ -1259,64 +1266,36 @@ export async function updateTransactionForFamily({
           }),
         ])
 
-        // Tulis audit log Account/update
-        for (const oldAcc of oldAccounts) {
-          const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
-          if (!newAcc || oldAcc.balance === newAcc.balance) continue
-          await auditLog(tx, auditCtx, {
-            action: "update",
-            entityType: "Account",
-            entityId: oldAcc.id,
-            before: oldAcc,
-            after: newAcc,
-          })
-        }
-
-        // Tulis audit log Transaction/update
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Transaction",
-          entityId: oldTx.id,
-          before: oldTx,
-          after: newOutflow,
-        })
-
-        if (oldInflowTx) {
-          await auditLog(tx, auditCtx, {
+        await auditLogs(tx, auditCtx, [
+          ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+          {
             action: "update",
             entityType: "Transaction",
-            entityId: oldInflowTx.id,
-            before: oldInflowTx,
-            after: newInflow,
-          })
-        } else {
-          await auditLog(tx, auditCtx, {
-            action: "create",
-            entityType: "Transaction",
-            entityId: newInflow.id,
-            before: null,
-            after: newInflow,
-          })
-        }
-
-        // Tulis audit log Transfer
-        if (oldTransfer) {
-          await auditLog(tx, auditCtx, {
-            action: "update",
-            entityType: "Transfer",
-            entityId: oldTransfer.id,
-            before: oldTransfer,
-            after: createdTransfer,
-          })
-        } else {
-          await auditLog(tx, auditCtx, {
-            action: "create",
-            entityType: "Transfer",
-            entityId: createdTransfer.id,
-            before: null,
-            after: createdTransfer,
-          })
-        }
+            entityId: oldTx.id,
+            before: oldTx,
+            after: newOutflow,
+          },
+          ...(oldInflowTx
+            ? [
+                {
+                  action: "update" as const,
+                  entityType: "Transaction",
+                  entityId: oldInflowTx.id,
+                  before: oldInflowTx,
+                  after: newInflow,
+                },
+              ]
+            : createdAuditEntries("Transaction", [newInflow])),
+          oldTransfer
+            ? {
+                action: "update",
+                entityType: "Transfer",
+                entityId: oldTransfer.id,
+                before: oldTransfer,
+                after: createdTransfer,
+              }
+            : createdAuditEntries("Transfer", [createdTransfer])[0]!,
+        ])
       } else {
         const amountSign: Money =
           data.type === "expense"
@@ -1400,70 +1379,46 @@ export async function updateTransactionForFamily({
           }),
         ])
 
-        // Tulis audit log Account/update
-        for (const oldAcc of oldAccounts) {
-          const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
-          if (!newAcc || oldAcc.balance === newAcc.balance) continue
-          await auditLog(tx, auditCtx, {
+        await auditLogs(tx, auditCtx, [
+          ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+          {
             action: "update",
-            entityType: "Account",
-            entityId: oldAcc.id,
-            before: oldAcc,
-            after: newAcc,
-          })
-        }
-
-        // Tulis audit log Transaction/update
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Transaction",
-          entityId: oldTx.id,
-          before: oldTx,
-          after: updatedTx,
-        })
-
-        // Split entries logs
-        if (oldTx.splitEntries?.length) {
-          for (const entry of oldTx.splitEntries) {
-            await auditLog(tx, auditCtx, {
-              action: "delete",
-              entityType: "SplitEntry",
-              entityId: entry.id,
-              before: entry,
-              after: null,
-            })
-          }
-        }
-        if (updatedTx.splitEntries?.length) {
-          for (const entry of updatedTx.splitEntries) {
-            await auditLog(tx, auditCtx, {
-              action: "create",
-              entityType: "SplitEntry",
-              entityId: entry.id,
-              before: null,
-              after: entry,
-            })
-          }
-        }
-
-        if (oldInflowTx) {
-          await auditLog(tx, auditCtx, {
-            action: "delete",
             entityType: "Transaction",
-            entityId: oldInflowTx.id,
-            before: oldInflowTx,
+            entityId: oldTx.id,
+            before: oldTx,
+            after: updatedTx,
+          },
+          ...oldTx.splitEntries.map((entry) => ({
+            action: "delete" as const,
+            entityType: "SplitEntry",
+            entityId: entry.id,
+            before: entry,
             after: null,
-          })
-        }
-        if (oldTransfer) {
-          await auditLog(tx, auditCtx, {
-            action: "delete",
-            entityType: "Transfer",
-            entityId: oldTransfer.id,
-            before: oldTransfer,
-            after: null,
-          })
-        }
+          })),
+          ...createdAuditEntries("SplitEntry", updatedTx.splitEntries),
+          ...(oldInflowTx
+            ? [
+                {
+                  action: "delete" as const,
+                  entityType: "Transaction",
+                  entityId: oldInflowTx.id,
+                  before: oldInflowTx,
+                  after: null,
+                },
+              ]
+            : []),
+          ...(oldTransfer
+            ? [
+                {
+                  action: "delete" as const,
+                  entityType: "Transfer",
+                  entityId: oldTransfer.id,
+                  before: oldTransfer,
+                  after: null,
+                },
+              ]
+            : []),
+        ])
       }
 
       return serializeTransaction({
@@ -1510,9 +1465,14 @@ export async function bulkDeleteTransactionsForFamily({
         include: { transferOut: true, splitEntries: true },
       })
 
-      const inflowTxIds = oldTxs
-        .filter((t) => t.type === "transfer" && t.transferOut)
-        .map((t) => t.transferOut!.inflowTransactionId)
+      const inflowTxIds: string[] = []
+      const outflowTxIds: string[] = []
+      for (const oldTx of oldTxs) {
+        outflowTxIds.push(oldTx.id)
+        if (oldTx.type === "transfer" && oldTx.transferOut) {
+          inflowTxIds.push(oldTx.transferOut.inflowTransactionId)
+        }
+      }
 
       const oldInflowTxs =
         inflowTxIds.length > 0
@@ -1525,7 +1485,7 @@ export async function bulkDeleteTransactionsForFamily({
       const oldTransfers =
         oldTxs.length > 0
           ? await tx.transfer.findMany({
-              where: { outflowTransactionId: { in: oldTxs.map((t) => t.id) } },
+              where: { outflowTransactionId: { in: outflowTxIds } },
               include: {
                 inflowTransaction: true,
                 outflowTransaction: true,
@@ -1546,18 +1506,15 @@ export async function bulkDeleteTransactionsForFamily({
         accountDeltas[id] += amount
       }
 
+      const oldInflowTxsById = indexById(oldInflowTxs)
       for (const oldTx of oldTxs) {
         if (oldTx.type === "transfer" && oldTx.transferOut) {
-          const inflowTx = oldInflowTxs.find(
-            (t) => t.id === oldTx.transferOut!.inflowTransactionId
+          const inflowTx = oldInflowTxsById.get(
+            oldTx.transferOut.inflowTransactionId
           )
           addDelta(oldTx.accountId, absMoney(oldTx.amount))
           if (inflowTx) {
             addDelta(inflowTx.accountId, negateMoney(absMoney(inflowTx.amount)))
-            await tx.transaction.update({
-              where: { id: inflowTx.id },
-              data: { deletedAt: new Date() },
-            })
           }
         } else if (oldTx.type !== "transfer") {
           if (oldTx.type === "expense") {
@@ -1566,6 +1523,13 @@ export async function bulkDeleteTransactionsForFamily({
             addDelta(oldTx.accountId, negateMoney(absMoney(oldTx.amount)))
           }
         }
+      }
+
+      if (inflowTxIds.length > 0) {
+        await tx.transaction.updateMany({
+          where: { id: { in: inflowTxIds } },
+          data: { deletedAt: new Date() },
+        })
       }
 
       // 2. Terapkan agregasi delta secara masal
@@ -1611,50 +1575,27 @@ export async function bulkDeleteTransactionsForFamily({
             : Promise.resolve([]),
         ])
 
-      // Tulis audit log Account/update (1 per touched Account)
-      for (const oldAcc of oldAccounts) {
-        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
-        if (!newAcc || oldAcc.balance === newAcc.balance) continue
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Account",
-          entityId: oldAcc.id,
-          before: oldAcc,
-          after: newAcc,
-        })
-      }
-
-      // Tulis audit log Transaction/soft_delete
-      for (const oldTx of oldTxs) {
-        const newTx = newOutflowTxs.find((t) => t.id === oldTx.id)
-        await auditLog(tx, auditCtx, {
+      await auditLogs(tx, auditCtx, [
+        ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+        ...pairedAuditEntries({
           action: "soft_delete",
+          beforeItems: oldTxs,
+          afterItems: newOutflowTxs,
           entityType: "Transaction",
-          entityId: oldTx.id,
-          before: oldTx,
-          after: newTx,
-        })
-      }
-      for (const oldInflow of oldInflowTxs) {
-        const newInflow = newInflowTxs.find((t) => t.id === oldInflow.id)
-        await auditLog(tx, auditCtx, {
+        }),
+        ...pairedAuditEntries({
           action: "soft_delete",
+          beforeItems: oldInflowTxs,
+          afterItems: newInflowTxs,
           entityType: "Transaction",
-          entityId: oldInflow.id,
-          before: oldInflow,
-          after: newInflow,
-        })
-      }
-      for (const oldTransfer of oldTransfers) {
-        const newTransfer = newTransfers.find((t) => t.id === oldTransfer.id)
-        await auditLog(tx, auditCtx, {
+        }),
+        ...pairedAuditEntries({
           action: "soft_delete",
+          beforeItems: oldTransfers,
+          afterItems: newTransfers,
           entityType: "Transfer",
-          entityId: oldTransfer.id,
-          before: oldTransfer,
-          after: newTransfer,
-        })
-      }
+        }),
+      ])
 
       return { success: true }
     }
@@ -1799,30 +1740,15 @@ export async function bulkUpdateTransactionsForFamily({
         }),
       ])
 
-      // Tulis audit log Account/update (1 per touched Account)
-      for (const oldAcc of oldAccounts) {
-        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
-        if (!newAcc || oldAcc.balance === newAcc.balance) continue
-        await auditLog(tx, auditCtx, {
+      await auditLogs(tx, auditCtx, [
+        ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+        ...pairedAuditEntries({
           action: "update",
-          entityType: "Account",
-          entityId: oldAcc.id,
-          before: oldAcc,
-          after: newAcc,
-        })
-      }
-
-      // Tulis audit log Transaction/update
-      for (const oldTx of oldTxs) {
-        const newTx = newTxs.find((t) => t.id === oldTx.id)
-        await auditLog(tx, auditCtx, {
-          action: "update",
+          beforeItems: oldTxs,
+          afterItems: newTxs,
           entityType: "Transaction",
-          entityId: oldTx.id,
-          before: oldTx,
-          after: newTx,
-        })
-      }
+        }),
+      ])
 
       return { success: true }
     }
@@ -1924,29 +1850,10 @@ export async function bulkCreateTransactionsForFamily({
         }),
       ])
 
-      // Tulis audit log Account/update (1 per touched Account)
-      for (const oldAcc of oldAccounts) {
-        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
-        if (!newAcc || oldAcc.balance === newAcc.balance) continue
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Account",
-          entityId: oldAcc.id,
-          before: oldAcc,
-          after: newAcc,
-        })
-      }
-
-      // Tulis audit log Transaction/create
-      for (const newTx of newTxs) {
-        await auditLog(tx, auditCtx, {
-          action: "create",
-          entityType: "Transaction",
-          entityId: newTx.id,
-          before: null,
-          after: newTx,
-        })
-      }
+      await auditLogs(tx, auditCtx, [
+        ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+        ...createdAuditEntries("Transaction", newTxs),
+      ])
 
       return { success: true, count: data.transactions.length }
     }

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -7,6 +7,7 @@ import {
   scopedTenantTransaction,
   type TenantTransactionClient,
 } from "./middleware/with-family"
+import { auditLog, createAuditContext } from "./middleware/audit"
 
 /**
  * BACKEND FUNCTION: Fetch reference data for the Transaction Form Dropdowns
@@ -465,6 +466,7 @@ async function normalizeCreateTransactionTransportInput(
     throw new Error("Idempotency-Key header does not match idempotencyKey")
   }
 
+  // Normalisasi data dengan menyertakan idempotencyKey dari header jika ada
   return createTransactionInputSchema.parse({
     ...data,
     idempotencyKey: headerKey ?? data.idempotencyKey,
@@ -507,6 +509,11 @@ export async function createTransactionForFamily({
           let kind = "funds_movement"
           if (toAccount.type === "CREDIT") kind = "cc_payment"
           else if (toAccount.type === "LOAN") kind = "loan_payment"
+
+          const [oldSrcAcc, oldDstAcc] = await Promise.all([
+            tx.account.findUniqueOrThrow({ where: { id: data.accountId } }),
+            tx.account.findUniqueOrThrow({ where: { id: data.toAccountId } }),
+          ])
 
           // Running Balance Snapshot: baca saldo akun setelah update atomik
           // Tenant-safe: update with familyId constraint
@@ -587,11 +594,56 @@ export async function createTransactionForFamily({
             },
           })
 
-          await tx.transfer.create({
+          const createdTransfer = await tx.transfer.create({
             data: {
               outflowTransactionId: outflowTx.id,
               inflowTransactionId: inflowTx.id,
             },
+          })
+
+          const [newSrcAcc, newDstAcc] = await Promise.all([
+            tx.account.findUniqueOrThrow({ where: { id: data.accountId } }),
+            tx.account.findUniqueOrThrow({ where: { id: data.toAccountId } }),
+          ])
+
+          const auditCtx = await createAuditContext(
+            { user: { id: user.id, familyId } },
+            data.idempotencyKey
+          )
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Account",
+            entityId: data.accountId,
+            before: oldSrcAcc,
+            after: newSrcAcc,
+          })
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Account",
+            entityId: data.toAccountId,
+            before: oldDstAcc,
+            after: newDstAcc,
+          })
+          await auditLog(tx, auditCtx, {
+            action: "create",
+            entityType: "Transaction",
+            entityId: outflowTx.id,
+            before: null,
+            after: outflowTx,
+          })
+          await auditLog(tx, auditCtx, {
+            action: "create",
+            entityType: "Transaction",
+            entityId: inflowTx.id,
+            before: null,
+            after: inflowTx,
+          })
+          await auditLog(tx, auditCtx, {
+            action: "create",
+            entityType: "Transfer",
+            entityId: createdTransfer.id,
+            before: null,
+            after: createdTransfer,
           })
 
           return serializeTransaction({
@@ -605,6 +657,10 @@ export async function createTransactionForFamily({
           data.type === "expense"
             ? negateMoney(absMoney(data.amount))
             : absMoney(data.amount)
+
+        const oldAccount = await tx.account.findUniqueOrThrow({
+          where: { id: data.accountId },
+        })
 
         // Running Balance Snapshot: baca saldo setelah update atomik
         let accountBalanceAfter: bigint | null = null
@@ -673,6 +729,44 @@ export async function createTransactionForFamily({
               })
             )
           )
+        }
+
+        const newAccount = await tx.account.findUniqueOrThrow({
+          where: { id: data.accountId },
+        })
+
+        const auditCtx = await createAuditContext(
+          { user: { id: user.id, familyId } },
+          data.idempotencyKey
+        )
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Account",
+          entityId: data.accountId,
+          before: oldAccount,
+          after: newAccount,
+        })
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Transaction",
+          entityId: newTransaction.id,
+          before: null,
+          after: newTransaction,
+        })
+
+        if (data.isSplit && data.splitEntries?.length) {
+          const createdSplitEntries = await tx.splitEntry.findMany({
+            where: { transactionId: newTransaction.id },
+          })
+          for (const entry of createdSplitEntries) {
+            await auditLog(tx, auditCtx, {
+              action: "create",
+              entityType: "SplitEntry",
+              entityId: entry.id,
+              before: null,
+              after: entry,
+            })
+          }
         }
 
         return serializeTransaction({
@@ -775,9 +869,181 @@ export const getTransactionsFn = createServerFn({ method: "GET" })
     })
   })
 
-// =========================================================================
-// THE INVISIBLE LEDGER: SMART DELETE & UPDATE (ENTERPRISE ARCHITECTURE)
-// =========================================================================
+export async function deleteTransactionForFamily({
+  id,
+  familyId,
+  user,
+}: {
+  id: string
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return await scopedTenantTransaction(
+    familyId,
+    async (tx: TenantTransactionClient) => {
+      // 1. Cari transaksi lama beserta relasi transfernya dan split entries
+      const oldTx = await tx.transaction.findUnique({
+        where: { id },
+        include: { transferOut: true, transferIn: true, splitEntries: true },
+      })
+
+      if (!oldTx) throw new Error("Transaction not found!")
+
+      const oldTransferGraph =
+        oldTx.type === "transfer" && oldTx.transferOut
+          ? await tx.transfer.findUnique({
+              where: { id: oldTx.transferOut.id },
+              include: {
+                inflowTransaction: true,
+                outflowTransaction: true,
+              },
+            })
+          : null
+
+      // Cari inflow transaction jika ini transfer
+      const inflowTx =
+        oldTx.type === "transfer" && oldTx.transferOut
+          ? await tx.transaction.findUnique({
+              where: {
+                id: oldTx.transferOut.inflowTransactionId,
+              },
+              include: { splitEntries: true },
+            })
+          : null
+
+      // Ambil akun-akun yang terpengaruh sebelum mutasi
+      const affectedAccountIds = [oldTx.accountId]
+      if (inflowTx) {
+        affectedAccountIds.push(inflowTx.accountId)
+      }
+      const oldAccounts = await tx.account.findMany({
+        where: { id: { in: affectedAccountIds } },
+      })
+
+      // 2. REVERSE BALANCES (Kembalikan Saldo)
+      if (oldTx.type === "transfer" && oldTx.transferOut) {
+        const srcUpd = await tx.account.updateMany({
+          where: { id: oldTx.accountId, familyId },
+          data: { balance: { increment: absMoney(oldTx.amount) } },
+        })
+        if (srcUpd.count !== 1)
+          throw new Error("Source account not found or access denied!")
+
+        if (inflowTx) {
+          const dstUpd = await tx.account.updateMany({
+            where: { id: inflowTx.accountId, familyId },
+            data: { balance: { decrement: absMoney(inflowTx.amount) } },
+          })
+          if (dstUpd.count !== 1)
+            throw new Error("Destination account not found or access denied!")
+        }
+      } else {
+        const upd = await tx.account.updateMany({
+          where: { id: oldTx.accountId, familyId },
+          data: { balance: { decrement: oldTx.amount } },
+        })
+        if (upd.count !== 1)
+          throw new Error("Account not found or access denied!")
+      }
+
+      // 3. SOFT DELETE (GAAP Compliance)
+      if (oldTx.type === "transfer" && oldTx.transferOut && inflowTx) {
+        // Soft delete outflow
+        await tx.transaction.update({
+          where: { id: oldTx.id },
+          data: { deletedAt: new Date() },
+        })
+
+        // Soft delete inflow
+        await tx.transaction.update({
+          where: { id: inflowTx.id },
+          data: { deletedAt: new Date() },
+        })
+      } else {
+        await tx.transaction.update({
+          where: { id: oldTx.id },
+          data: { deletedAt: new Date() },
+        })
+      }
+
+      // Ambil data terbaru setelah mutasi selesai diaplikasikan
+      const [
+        updatedOutflowTx,
+        updatedInflowTx,
+        newAccounts,
+        updatedTransferGraph,
+      ] = await Promise.all([
+        tx.transaction.findUniqueOrThrow({
+          where: { id: oldTx.id },
+          include: { splitEntries: true },
+        }),
+        inflowTx
+          ? tx.transaction.findUniqueOrThrow({
+              where: { id: inflowTx.id },
+              include: { splitEntries: true },
+            })
+          : Promise.resolve(null),
+        tx.account.findMany({
+          where: { id: { in: affectedAccountIds } },
+        }),
+        oldTransferGraph
+          ? tx.transfer.findUnique({
+              where: { id: oldTransferGraph.id },
+              include: {
+                inflowTransaction: true,
+                outflowTransaction: true,
+              },
+            })
+          : Promise.resolve(null),
+      ])
+
+      // Tulis audit log Account/update
+      for (const oldAcc of oldAccounts) {
+        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
+        if (!newAcc || oldAcc.balance === newAcc.balance) continue
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Account",
+          entityId: oldAcc.id,
+          before: oldAcc,
+          after: newAcc,
+        })
+      }
+
+      // Tulis audit log Transaction/soft_delete
+      await auditLog(tx, auditCtx, {
+        action: "soft_delete",
+        entityType: "Transaction",
+        entityId: oldTx.id,
+        before: oldTx,
+        after: updatedOutflowTx,
+      })
+
+      if (updatedInflowTx && inflowTx) {
+        await auditLog(tx, auditCtx, {
+          action: "soft_delete",
+          entityType: "Transaction",
+          entityId: inflowTx.id,
+          before: inflowTx,
+          after: updatedInflowTx,
+        })
+      }
+
+      if (oldTransferGraph && updatedTransferGraph) {
+        await auditLog(tx, auditCtx, {
+          action: "soft_delete",
+          entityType: "Transfer",
+          entityId: oldTransferGraph.id,
+          before: oldTransferGraph,
+          after: updatedTransferGraph,
+        })
+      }
+
+      return { success: true }
+    }
+  )
+}
 
 /**
  * BACKEND FUNCTION: Delete Transaction (Soft Delete — GAAP Compliance)
@@ -787,79 +1053,426 @@ export const deleteTransactionFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
   .inputValidator(z.object({ id: z.string() }))
   .handler(async ({ data, context }) => {
-    const { familyId } = context
-    return await scopedTenantTransaction(
-      familyId,
-      async (tx: TenantTransactionClient) => {
-        // 1. Cari transaksi lama beserta relasi transfernya
-        const oldTx = await tx.transaction.findUnique({
-          where: { id: data.id },
-          include: { transferOut: true, transferIn: true },
+    return await deleteTransactionForFamily({
+      id: data.id,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+export async function updateTransactionForFamily({
+  data,
+  familyId,
+  user,
+}: {
+  data: z.infer<typeof transactionInputSchema>
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return await scopedTenantTransaction(
+    familyId,
+    async (tx: TenantTransactionClient) => {
+      assertSplitParity(data)
+
+      // --- FASE 1: REVERSAL (HAPUS LAMA) ---
+      // Ambil snapshot graph lengkap sebelum mutasi dilakukan
+      const oldTx = await tx.transaction.findUnique({
+        where: { id: data.id },
+        include: {
+          transferOut: {
+            include: {
+              inflowTransaction: {
+                include: { splitEntries: true },
+              },
+            },
+          },
+          splitEntries: true,
+        },
+      })
+
+      if (!oldTx) throw new Error("Original transaction not found")
+
+      const oldInflowTx =
+        oldTx.type === "transfer" && oldTx.transferOut
+          ? oldTx.transferOut.inflowTransaction
+          : null
+      const oldTransfer =
+        oldTx.type === "transfer" && oldTx.transferOut
+          ? {
+              id: oldTx.transferOut.id,
+              outflowTransactionId: oldTx.transferOut.outflowTransactionId,
+              inflowTransactionId: oldTx.transferOut.inflowTransactionId,
+              createdAt: oldTx.transferOut.createdAt,
+            }
+          : null
+
+      // Kumpulkan semua akun yang terpengaruh (sebelum dan sesudah)
+      const touchedAccountIds = new Set([oldTx.accountId, data.accountId])
+      if (oldInflowTx) touchedAccountIds.add(oldInflowTx.accountId)
+      if (data.toAccountId) touchedAccountIds.add(data.toAccountId)
+
+      const oldAccounts = await tx.account.findMany({
+        where: { id: { in: Array.from(touchedAccountIds) } },
+      })
+
+      if (oldTx.type === "transfer" && oldTx.transferOut) {
+        const inflowTx = await tx.transaction.findUnique({
+          where: {
+            id: oldTx.transferOut.inflowTransactionId,
+          },
+        })
+        const srcUpd = await tx.account.updateMany({
+          where: { id: oldTx.accountId, familyId },
+          data: { balance: { increment: absMoney(oldTx.amount) } },
+        })
+        if (srcUpd.count !== 1)
+          throw new Error("Source account not found or access denied!")
+        if (inflowTx) {
+          const dstUpd = await tx.account.updateMany({
+            where: { id: inflowTx.accountId, familyId },
+            data: { balance: { decrement: absMoney(inflowTx.amount) } },
+          })
+          if (dstUpd.count !== 1)
+            throw new Error("Destination account not found or access denied!")
+          await tx.transaction.delete({ where: { id: inflowTx.id } })
+        }
+      } else {
+        const upd = await tx.account.updateMany({
+          where: { id: oldTx.accountId, familyId },
+          data: { balance: { decrement: oldTx.amount } },
+        })
+        if (upd.count !== 1)
+          throw new Error("Account not found or access denied!")
+      }
+      await tx.transaction.delete({ where: { id: oldTx.id } })
+
+      // --- FASE 2: REPLACE (BUAT BARU DENGAN DATA UPDATE) ---
+      let resultTransaction
+
+      if (data.type === "transfer") {
+        let kind = "funds_movement"
+        const toAccount = await tx.account.findFirst({
+          where: { id: data.toAccountId!, familyId },
+        })
+        if (!toAccount)
+          throw new Error("Destination account not found or access denied!")
+        if (toAccount.type === "CREDIT") kind = "cc_payment"
+        else if (toAccount.type === "LOAN") kind = "loan_payment"
+
+        const srcUpd = await tx.account.updateMany({
+          where: { id: data.accountId, familyId },
+          data: { balance: { decrement: data.amount } },
+        })
+        if (srcUpd.count !== 1)
+          throw new Error("Source account not found or access denied!")
+        const updatedSourceAccount = await tx.account.findFirst({
+          where: { id: data.accountId, familyId },
+          select: { balance: true },
+        })
+        const sourceBalanceAfter = updatedSourceAccount!.balance
+
+        const inAmount = data.destinationAmount ?? data.amount
+        const inCurrency = data.destinationCurrency ?? data.currency
+
+        const dstUpd = await tx.account.updateMany({
+          where: { id: data.toAccountId!, familyId },
+          data: { balance: { increment: inAmount } },
+        })
+        if (dstUpd.count !== 1)
+          throw new Error("Destination account not found or access denied!")
+        const updatedDestAccount = await tx.account.findFirst({
+          where: { id: data.toAccountId!, familyId },
+          select: { balance: true },
+        })
+        const destBalanceAfter = updatedDestAccount!.balance
+
+        const outflowTx = await tx.transaction.create({
+          data: {
+            id: data.id,
+            type: "transfer",
+            kind,
+            currency: data.currency,
+            amount: negateMoney(absMoney(data.amount)),
+            description: data.description,
+            date: data.date,
+            notes: data.notes || null,
+            accountId: data.accountId,
+            toAccountId: data.toAccountId,
+            categoryId: data.categoryId || null,
+            merchantId: data.merchantId || null,
+            userId: user.id,
+            familyId,
+            status: data.status,
+            destinationAmount: data.destinationAmount,
+            destinationCurrency: data.destinationCurrency,
+            accountBalanceAfter: sourceBalanceAfter,
+            attachmentUrl: data.attachmentUrl,
+          },
         })
 
-        if (!oldTx) throw new Error("Transaction not found!")
+        const inflowTx = await tx.transaction.create({
+          data: {
+            type: "transfer",
+            kind,
+            currency: inCurrency,
+            amount: absMoney(inAmount),
+            description: data.description,
+            date: data.date,
+            notes: data.notes || null,
+            accountId: data.toAccountId!,
+            toAccountId: data.accountId,
+            categoryId: data.categoryId || null,
+            merchantId: data.merchantId || null,
+            userId: user.id,
+            familyId,
+            status: data.status,
+            destinationAmount: data.destinationAmount,
+            destinationCurrency: data.destinationCurrency,
+            accountBalanceAfter: destBalanceAfter,
+            attachmentUrl: data.attachmentUrl,
+          },
+        })
 
-        // 2. REVERSE BALANCES (Kembalikan Saldo)
-        if (oldTx.type === "transfer" && oldTx.transferOut) {
-          // Jika ini Transfer, kita harus cari Inflow-nya juga
-          const inflowTx = await tx.transaction.findUnique({
-            where: {
-              id: oldTx.transferOut.inflowTransactionId,
-            },
+        const createdTransfer = await tx.transfer.create({
+          data: {
+            ...(oldTransfer ? { id: oldTransfer.id } : {}),
+            outflowTransactionId: outflowTx.id,
+            inflowTransactionId: inflowTx.id,
+          },
+        })
+
+        resultTransaction = outflowTx
+
+        // Re-read data terbaru setelah mutasi
+        const [newOutflow, newInflow, newAccounts] = await Promise.all([
+          tx.transaction.findUniqueOrThrow({
+            where: { id: outflowTx.id },
+            include: { splitEntries: true },
+          }),
+          tx.transaction.findUniqueOrThrow({
+            where: { id: inflowTx.id },
+            include: { splitEntries: true },
+          }),
+          tx.account.findMany({
+            where: { id: { in: Array.from(touchedAccountIds) } },
+          }),
+        ])
+
+        // Tulis audit log Account/update
+        for (const oldAcc of oldAccounts) {
+          const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
+          if (!newAcc || oldAcc.balance === newAcc.balance) continue
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Account",
+            entityId: oldAcc.id,
+            before: oldAcc,
+            after: newAcc,
           })
+        }
 
-          // Refund akun pengirim (Outflow kan negatif, kita ubah jadi absolute lalu tambahkan)
-          // Tenant-safe: update dengan familyId constraint
-          const srcUpd = await tx.account.updateMany({
-            where: { id: oldTx.accountId, familyId },
-            data: { balance: { increment: absMoney(oldTx.amount) } },
+        // Tulis audit log Transaction/update
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Transaction",
+          entityId: oldTx.id,
+          before: oldTx,
+          after: newOutflow,
+        })
+
+        if (oldInflowTx) {
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Transaction",
+            entityId: oldInflowTx.id,
+            before: oldInflowTx,
+            after: newInflow,
           })
-          if (srcUpd.count !== 1)
-            throw new Error("Source account not found or access denied!")
+        } else {
+          await auditLog(tx, auditCtx, {
+            action: "create",
+            entityType: "Transaction",
+            entityId: newInflow.id,
+            before: null,
+            after: newInflow,
+          })
+        }
 
-          // Tarik kembali uang dari akun penerima
-          if (inflowTx) {
-            const dstUpd = await tx.account.updateMany({
-              where: { id: inflowTx.accountId, familyId },
-              data: { balance: { decrement: absMoney(inflowTx.amount) } },
-            })
-            if (dstUpd.count !== 1)
-              throw new Error("Destination account not found or access denied!")
-            // Soft delete: inflow transaction (TIDAK PERNAH hard delete — audit trail)
-            await tx.transaction.update({
-              where: { id: inflowTx.id },
-              data: { deletedAt: new Date() },
+        // Tulis audit log Transfer
+        if (oldTransfer) {
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Transfer",
+            entityId: oldTransfer.id,
+            before: oldTransfer,
+            after: createdTransfer,
+          })
+        } else {
+          await auditLog(tx, auditCtx, {
+            action: "create",
+            entityType: "Transfer",
+            entityId: createdTransfer.id,
+            before: null,
+            after: createdTransfer,
+          })
+        }
+      } else {
+        const amountSign: Money =
+          data.type === "expense"
+            ? negateMoney(absMoney(data.amount))
+            : absMoney(data.amount)
+
+        let accountBalanceAfter: bigint | null = null
+        if (data.type === "expense") {
+          const upd = await tx.account.updateMany({
+            where: { id: data.accountId, familyId },
+            data: { balance: { decrement: data.amount } },
+          })
+          if (upd.count !== 1)
+            throw new Error("Account not found or access denied!")
+          const updated = await tx.account.findFirst({
+            where: { id: data.accountId, familyId },
+            select: { balance: true },
+          })
+          accountBalanceAfter = updated!.balance
+        } else {
+          const upd = await tx.account.updateMany({
+            where: { id: data.accountId, familyId },
+            data: { balance: { increment: data.amount } },
+          })
+          if (upd.count !== 1)
+            throw new Error("Account not found or access denied!")
+          const updated = await tx.account.findFirst({
+            where: { id: data.accountId, familyId },
+            select: { balance: true },
+          })
+          accountBalanceAfter = updated!.balance
+        }
+
+        const newTx = await tx.transaction.create({
+          data: {
+            id: data.id,
+            type: data.type,
+            amount: amountSign,
+            description: data.description,
+            date: data.date,
+            notes: data.notes || null,
+            accountId: data.accountId,
+            toAccountId: data.toAccountId || null,
+            categoryId: data.isSplit ? null : data.categoryId || null,
+            merchantId: data.isSplit ? null : data.merchantId || null,
+            isSplit: data.isSplit,
+            userId: user.id,
+            familyId,
+            status: data.status,
+            accountBalanceAfter: accountBalanceAfter,
+            attachmentUrl: data.attachmentUrl,
+          },
+        })
+
+        if (data.isSplit && data.splitEntries?.length) {
+          await Promise.all(
+            data.splitEntries.map((entry) =>
+              tx.splitEntry.create({
+                data: {
+                  transactionId: newTx.id,
+                  description: entry.description,
+                  amount: absMoney(entry.amount),
+                  categoryId: entry.categoryId || null,
+                  merchantId: entry.merchantId || null,
+                },
+              })
+            )
+          )
+        }
+
+        resultTransaction = newTx
+
+        // Re-read data terbaru setelah mutasi
+        const [updatedTx, newAccounts] = await Promise.all([
+          tx.transaction.findUniqueOrThrow({
+            where: { id: newTx.id },
+            include: { splitEntries: true },
+          }),
+          tx.account.findMany({
+            where: { id: { in: Array.from(touchedAccountIds) } },
+          }),
+        ])
+
+        // Tulis audit log Account/update
+        for (const oldAcc of oldAccounts) {
+          const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
+          if (!newAcc || oldAcc.balance === newAcc.balance) continue
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Account",
+            entityId: oldAcc.id,
+            before: oldAcc,
+            after: newAcc,
+          })
+        }
+
+        // Tulis audit log Transaction/update
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Transaction",
+          entityId: oldTx.id,
+          before: oldTx,
+          after: updatedTx,
+        })
+
+        // Split entries logs
+        if (oldTx.splitEntries?.length) {
+          for (const entry of oldTx.splitEntries) {
+            await auditLog(tx, auditCtx, {
+              action: "delete",
+              entityType: "SplitEntry",
+              entityId: entry.id,
+              before: entry,
+              after: null,
             })
           }
-        } else {
-          // Reversal untuk Expense/Income biasa
-          if (oldTx.type === "expense") {
-            const upd = await tx.account.updateMany({
-              where: { id: oldTx.accountId, familyId },
-              data: { balance: { increment: absMoney(oldTx.amount) } },
+        }
+        if (updatedTx.splitEntries?.length) {
+          for (const entry of updatedTx.splitEntries) {
+            await auditLog(tx, auditCtx, {
+              action: "create",
+              entityType: "SplitEntry",
+              entityId: entry.id,
+              before: null,
+              after: entry,
             })
-            if (upd.count !== 1)
-              throw new Error("Account not found or access denied!")
-          } else if (oldTx.type === "income") {
-            const upd = await tx.account.updateMany({
-              where: { id: oldTx.accountId, familyId },
-              data: { balance: { decrement: absMoney(oldTx.amount) } },
-            })
-            if (upd.count !== 1)
-              throw new Error("Account not found or access denied!")
           }
         }
 
-        // 3. Soft Delete Data Utama (GAAP: audit trail tetap ada)
-        await tx.transaction.update({
-          where: { id: oldTx.id },
-          data: { deletedAt: new Date() },
-        })
-
-        return { success: true }
+        if (oldInflowTx) {
+          await auditLog(tx, auditCtx, {
+            action: "delete",
+            entityType: "Transaction",
+            entityId: oldInflowTx.id,
+            before: oldInflowTx,
+            after: null,
+          })
+        }
+        if (oldTransfer) {
+          await auditLog(tx, auditCtx, {
+            action: "delete",
+            entityType: "Transfer",
+            entityId: oldTransfer.id,
+            before: oldTransfer,
+            after: null,
+          })
+        }
       }
-    )
-  })
+
+      return serializeTransaction({
+        ...resultTransaction,
+        amount: absMoney(resultTransaction.amount),
+      })
+    }
+  )
+}
 
 /**
  * BACKEND FUNCTION: Update Transaction (Reversal-and-Replace Pattern)
@@ -871,255 +1484,182 @@ export const updateTransactionFn = createServerFn({ method: "POST" })
   .inputValidator(transactionInputSchema)
   .handler(async ({ data, context }) => {
     if (!data.id) throw new Error("ID is required for updating")
-    const { user, familyId } = context
+    return await updateTransactionForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
 
-    // The Magic: Kita jalankan penghapusan murni dan pembuatan murni secara berurutan
-    // dalam satu ACID Transaction. Zero Balance Mismatch Guaranteed!
-    return await scopedTenantTransaction(
-      familyId,
-      async (tx: TenantTransactionClient) => {
-        // === SPLIT PARITY GUARD (GAAP Compliance) ===
-        // Same authoritative invariant as createTransactionFn — UPDATE flow can
-        // independently violate parity if a client tampers with split entries
-        // without updating the parent amount (or vice versa). Re-validate here.
-        assertSplitParity(data)
+export async function bulkDeleteTransactionsForFamily({
+  ids,
+  familyId,
+  user,
+}: {
+  ids: string[]
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return await scopedTenantTransaction(
+    familyId,
+    async (tx: TenantTransactionClient) => {
+      // 1. Ambil data asli untuk merestore saldo
+      const oldTxs = await tx.transaction.findMany({
+        where: { id: { in: ids } },
+        include: { transferOut: true, splitEntries: true },
+      })
 
-        // --- FASE 1: REVERSAL (HAPUS LAMA) ---
-        // Kita "pinjam" logika delete untuk mengembalikan saldo ke 0
-        const oldTx = await tx.transaction.findUnique({
-          where: { id: data.id },
-          include: { transferOut: true },
-        })
+      const inflowTxIds = oldTxs
+        .filter((t) => t.type === "transfer" && t.transferOut)
+        .map((t) => t.transferOut!.inflowTransactionId)
 
-        if (!oldTx) throw new Error("Original transaction not found")
+      const oldInflowTxs =
+        inflowTxIds.length > 0
+          ? await tx.transaction.findMany({
+              where: { id: { in: inflowTxIds } },
+              include: { splitEntries: true },
+            })
+          : []
 
+      const oldTransfers =
+        oldTxs.length > 0
+          ? await tx.transfer.findMany({
+              where: { outflowTransactionId: { in: oldTxs.map((t) => t.id) } },
+              include: {
+                inflowTransaction: true,
+                outflowTransaction: true,
+              },
+            })
+          : []
+
+      const touchedAccountIds = new Set(oldTxs.map((t) => t.accountId))
+      oldInflowTxs.forEach((t) => touchedAccountIds.add(t.accountId))
+
+      const oldAccounts = await tx.account.findMany({
+        where: { id: { in: Array.from(touchedAccountIds) } },
+      })
+
+      const accountDeltas: Record<string, bigint> = {}
+      const addDelta = (id: string, amount: bigint) => {
+        if (!accountDeltas[id]) accountDeltas[id] = 0n
+        accountDeltas[id] += amount
+      }
+
+      for (const oldTx of oldTxs) {
         if (oldTx.type === "transfer" && oldTx.transferOut) {
-          const inflowTx = await tx.transaction.findUnique({
-            where: {
-              id: oldTx.transferOut.inflowTransactionId,
-            },
-          })
-          // Tenant-safe: update dengan familyId constraint
-          const srcUpd = await tx.account.updateMany({
-            where: { id: oldTx.accountId, familyId },
-            data: { balance: { increment: absMoney(oldTx.amount) } },
-          })
-          if (srcUpd.count !== 1)
-            throw new Error("Source account not found or access denied!")
+          const inflowTx = oldInflowTxs.find(
+            (t) => t.id === oldTx.transferOut!.inflowTransactionId
+          )
+          addDelta(oldTx.accountId, absMoney(oldTx.amount))
           if (inflowTx) {
-            const dstUpd = await tx.account.updateMany({
-              where: { id: inflowTx.accountId, familyId },
-              data: { balance: { decrement: absMoney(inflowTx.amount) } },
+            addDelta(inflowTx.accountId, negateMoney(absMoney(inflowTx.amount)))
+            await tx.transaction.update({
+              where: { id: inflowTx.id },
+              data: { deletedAt: new Date() },
             })
-            if (dstUpd.count !== 1)
-              throw new Error("Destination account not found or access denied!")
-            // INTERNAL REVERSAL: Hard delete OK — bukan user-facing delete
-            await tx.transaction.delete({ where: { id: inflowTx.id } })
           }
-        } else {
+        } else if (oldTx.type !== "transfer") {
           if (oldTx.type === "expense") {
-            const upd = await tx.account.updateMany({
-              where: { id: oldTx.accountId, familyId },
-              data: { balance: { increment: absMoney(oldTx.amount) } },
-            })
-            if (upd.count !== 1)
-              throw new Error("Account not found or access denied!")
+            addDelta(oldTx.accountId, absMoney(oldTx.amount))
           } else if (oldTx.type === "income") {
-            const upd = await tx.account.updateMany({
-              where: { id: oldTx.accountId, familyId },
-              data: { balance: { decrement: absMoney(oldTx.amount) } },
-            })
-            if (upd.count !== 1)
-              throw new Error("Account not found or access denied!")
+            addDelta(oldTx.accountId, negateMoney(absMoney(oldTx.amount)))
           }
-        }
-        // Hapus data lama (Hard delete OK — ID akan dipertahankan via re-create)
-        await tx.transaction.delete({ where: { id: oldTx.id } })
-
-        // --- FASE 2: REPLACE (BUAT BARU DENGAN DATA UPDATE) ---
-        if (data.type === "transfer") {
-          let kind = "funds_movement"
-          // Tenant-safe: verify account ownership
-          const toAccount = await tx.account.findFirst({
-            where: { id: data.toAccountId!, familyId },
-          })
-          if (!toAccount)
-            throw new Error("Destination account not found or access denied!")
-          if (toAccount.type === "CREDIT") kind = "cc_payment"
-          else if (toAccount.type === "LOAN") kind = "loan_payment"
-
-          // Running Balance Snapshot: baca saldo akun setelah update atomik
-          // Tenant-safe: update dengan familyId constraint
-          const srcUpd = await tx.account.updateMany({
-            where: { id: data.accountId, familyId },
-            data: { balance: { decrement: data.amount } },
-          })
-          if (srcUpd.count !== 1)
-            throw new Error("Source account not found or access denied!")
-          const updatedSourceAccount = await tx.account.findFirst({
-            where: { id: data.accountId, familyId },
-            select: { balance: true },
-          })
-          const sourceBalanceAfter = updatedSourceAccount!.balance
-
-          // Multi-currency: gunakan destinationAmount jika tersedia, fallback ke amount
-          const inAmount = data.destinationAmount ?? data.amount
-          const inCurrency = data.destinationCurrency ?? data.currency
-
-          const dstUpd = await tx.account.updateMany({
-            where: { id: data.toAccountId!, familyId },
-            data: { balance: { increment: inAmount } },
-          })
-          if (dstUpd.count !== 1)
-            throw new Error("Destination account not found or access denied!")
-          const updatedDestAccount = await tx.account.findFirst({
-            where: { id: data.toAccountId!, familyId },
-            select: { balance: true },
-          })
-          const destBalanceAfter = updatedDestAccount!.balance
-
-          const outflowTx = await tx.transaction.create({
-            data: {
-              id: data.id, // KITA PERTAHANKAN ID LAMA AGAR UI TIDAK KACAU
-              type: "transfer",
-              kind,
-              currency: data.currency,
-              amount: negateMoney(absMoney(data.amount)),
-              description: data.description,
-              date: data.date,
-              notes: data.notes || null,
-              accountId: data.accountId,
-              toAccountId: data.toAccountId,
-              categoryId: data.categoryId || null,
-              merchantId: data.merchantId || null,
-              userId: user.id,
-              familyId: context.familyId,
-              status: data.status,
-              destinationAmount: data.destinationAmount,
-              destinationCurrency: data.destinationCurrency,
-              accountBalanceAfter: sourceBalanceAfter,
-              attachmentUrl: data.attachmentUrl,
-            },
-          })
-
-          const inflowTx = await tx.transaction.create({
-            data: {
-              type: "transfer",
-              kind,
-              currency: inCurrency,
-              amount: absMoney(inAmount),
-              description: data.description,
-              date: data.date,
-              notes: data.notes || null,
-              accountId: data.toAccountId!,
-              toAccountId: data.accountId,
-              categoryId: data.categoryId || null,
-              merchantId: data.merchantId || null,
-              userId: user.id,
-              familyId: context.familyId,
-              status: data.status,
-              destinationAmount: data.destinationAmount,
-              destinationCurrency: data.destinationCurrency,
-              accountBalanceAfter: destBalanceAfter,
-              attachmentUrl: data.attachmentUrl,
-            },
-          })
-
-          await tx.transfer.create({
-            data: {
-              outflowTransactionId: outflowTx.id,
-              inflowTransactionId: inflowTx.id,
-            },
-          })
-          return serializeTransaction({
-            ...outflowTx,
-            amount: absMoney(outflowTx.amount),
-          })
-        } else {
-          // Re-create Standard Expense/Income (dengan atau tanpa split)
-          const amountSign: Money =
-            data.type === "expense"
-              ? negateMoney(absMoney(data.amount))
-              : absMoney(data.amount)
-
-          // Running Balance Snapshot: baca saldo setelah update atomik
-          // Tenant-safe: update dengan familyId constraint
-          let accountBalanceAfter: bigint | null = null
-          if (data.type === "expense") {
-            const upd = await tx.account.updateMany({
-              where: { id: data.accountId, familyId },
-              data: { balance: { decrement: data.amount } },
-            })
-            if (upd.count !== 1)
-              throw new Error("Account not found or access denied!")
-            const updated = await tx.account.findFirst({
-              where: { id: data.accountId, familyId },
-              select: { balance: true },
-            })
-            accountBalanceAfter = updated!.balance
-          } else {
-            // type is "income" — only possibility after "expense" and "transfer" are handled
-            const upd = await tx.account.updateMany({
-              where: { id: data.accountId, familyId },
-              data: { balance: { increment: data.amount } },
-            })
-            if (upd.count !== 1)
-              throw new Error("Account not found or access denied!")
-            const updated = await tx.account.findFirst({
-              where: { id: data.accountId, familyId },
-              select: { balance: true },
-            })
-            accountBalanceAfter = updated!.balance
-          }
-
-          const newTx = await tx.transaction.create({
-            data: {
-              id: data.id, // PERTAHANKAN ID LAMA
-              type: data.type,
-              amount: amountSign,
-              description: data.description,
-              date: data.date,
-              notes: data.notes || null,
-              accountId: data.accountId,
-              toAccountId: data.toAccountId || null,
-              // Jika split, kategori hidup di entries, bukan parent
-              categoryId: data.isSplit ? null : data.categoryId || null,
-              merchantId: data.isSplit ? null : data.merchantId || null,
-              isSplit: data.isSplit,
-              userId: user.id,
-              familyId: context.familyId,
-              status: data.status,
-              accountBalanceAfter: accountBalanceAfter,
-              attachmentUrl: data.attachmentUrl,
-            },
-          })
-
-          // Recreate split entries satu-satu (parent lama sudah dihapus via CASCADE)
-          // Menggunakan create() agar Prisma generate cuid() untuk id
-          if (data.isSplit && data.splitEntries?.length) {
-            await Promise.all(
-              data.splitEntries.map((entry) =>
-                tx.splitEntry.create({
-                  data: {
-                    transactionId: newTx.id,
-                    description: entry.description,
-                    amount: absMoney(entry.amount),
-                    categoryId: entry.categoryId || null,
-                    merchantId: entry.merchantId || null,
-                  },
-                })
-              )
-            )
-          }
-
-          return serializeTransaction({
-            ...newTx,
-            amount: absMoney(newTx.amount),
-          })
         }
       }
-    )
-  })
+
+      // 2. Terapkan agregasi delta secara masal
+      await Promise.all(
+        Object.entries(accountDeltas).map(([accountId, delta]) =>
+          tx.account.update({
+            where: { id: accountId },
+            data: { balance: { increment: delta } },
+          })
+        )
+      )
+
+      // 3. Soft delete
+      await tx.transaction.updateMany({
+        where: { id: { in: ids } },
+        data: { deletedAt: new Date() },
+      })
+
+      // Re-read data terbaru setelah mutasi
+      const [newOutflowTxs, newInflowTxs, newAccounts, newTransfers] =
+        await Promise.all([
+          tx.transaction.findMany({
+            where: { id: { in: ids } },
+            include: { splitEntries: true },
+          }),
+          inflowTxIds.length > 0
+            ? tx.transaction.findMany({
+                where: { id: { in: inflowTxIds } },
+                include: { splitEntries: true },
+              })
+            : Promise.resolve([]),
+          tx.account.findMany({
+            where: { id: { in: Array.from(touchedAccountIds) } },
+          }),
+          oldTransfers.length > 0
+            ? tx.transfer.findMany({
+                where: { id: { in: oldTransfers.map((t) => t.id) } },
+                include: {
+                  inflowTransaction: true,
+                  outflowTransaction: true,
+                },
+              })
+            : Promise.resolve([]),
+        ])
+
+      // Tulis audit log Account/update (1 per touched Account)
+      for (const oldAcc of oldAccounts) {
+        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
+        if (!newAcc || oldAcc.balance === newAcc.balance) continue
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Account",
+          entityId: oldAcc.id,
+          before: oldAcc,
+          after: newAcc,
+        })
+      }
+
+      // Tulis audit log Transaction/soft_delete
+      for (const oldTx of oldTxs) {
+        const newTx = newOutflowTxs.find((t) => t.id === oldTx.id)
+        await auditLog(tx, auditCtx, {
+          action: "soft_delete",
+          entityType: "Transaction",
+          entityId: oldTx.id,
+          before: oldTx,
+          after: newTx,
+        })
+      }
+      for (const oldInflow of oldInflowTxs) {
+        const newInflow = newInflowTxs.find((t) => t.id === oldInflow.id)
+        await auditLog(tx, auditCtx, {
+          action: "soft_delete",
+          entityType: "Transaction",
+          entityId: oldInflow.id,
+          before: oldInflow,
+          after: newInflow,
+        })
+      }
+      for (const oldTransfer of oldTransfers) {
+        const newTransfer = newTransfers.find((t) => t.id === oldTransfer.id)
+        await auditLog(tx, auditCtx, {
+          action: "soft_delete",
+          entityType: "Transfer",
+          entityId: oldTransfer.id,
+          before: oldTransfer,
+          after: newTransfer,
+        })
+      }
+
+      return { success: true }
+    }
+  )
+}
 
 /**
  * BACKEND FUNCTION: Bulk Delete Transactions (Soft Delete — GAAP Compliance)
@@ -1129,76 +1669,168 @@ export const bulkDeleteTransactionsFn = createServerFn({ method: "POST" })
   .inputValidator(z.object({ ids: z.array(z.string()) }))
   .handler(async ({ data, context }) => {
     if (data.ids.length === 0) return { success: true }
+    return await bulkDeleteTransactionsForFamily({
+      ids: data.ids,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
 
-    return await scopedTenantTransaction(
-      context.familyId,
-      async (tx: TenantTransactionClient) => {
-        // 1. Ambil data asli untuk merestore saldo
-        // (termasuk transfer out/inflow)
-        const oldTxs = await tx.transaction.findMany({
-          where: { id: { in: data.ids } },
-          include: { transferOut: true },
+export async function bulkUpdateTransactionsForFamily({
+  data,
+  familyId,
+  user,
+}: {
+  data: {
+    ids: string[]
+    categoryId?: string | null
+    merchantId?: string | null
+    accountId?: string
+  }
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return await scopedTenantTransaction(
+    familyId,
+    async (tx: TenantTransactionClient) => {
+      // Ambil data before
+      const oldTxs = await tx.transaction.findMany({
+        where: { id: { in: data.ids } },
+        include: { splitEntries: true },
+      })
+
+      const touchedAccountIds = new Set(oldTxs.map((t) => t.accountId))
+      if (data.accountId !== undefined) {
+        touchedAccountIds.add(data.accountId)
+      }
+
+      const oldAccounts = await tx.account.findMany({
+        where: { id: { in: Array.from(touchedAccountIds) } },
+      })
+
+      // 1. Handle Account Change (Requires Balance Shifting)
+      if (data.accountId !== undefined) {
+        const txsToMove = await tx.transaction.findMany({
+          where: {
+            id: { in: data.ids },
+            type: { not: "transfer" },
+            accountId: { not: data.accountId },
+          },
         })
 
         const accountDeltas: Record<string, bigint> = {}
-
         const addDelta = (id: string, amount: bigint) => {
           if (!accountDeltas[id]) accountDeltas[id] = 0n
           accountDeltas[id] += amount
         }
 
-        for (const oldTx of oldTxs) {
-          if (oldTx.type === "transfer" && oldTx.transferOut) {
-            const inflowTx = await tx.transaction.findUnique({
-              where: {
-                id: oldTx.transferOut.inflowTransactionId,
-              },
-            })
-            addDelta(oldTx.accountId, absMoney(oldTx.amount))
-            if (inflowTx) {
-              addDelta(
-                inflowTx.accountId,
-                negateMoney(absMoney(inflowTx.amount))
-              )
-              // Soft delete: inflow transaction (TIDAK PERNAH hard delete — audit trail)
-              await tx.transaction.update({
-                where: { id: inflowTx.id },
-                data: { deletedAt: new Date() },
-              })
-            }
-          } else if (oldTx.type !== "transfer") {
-            if (oldTx.type === "expense") {
-              addDelta(oldTx.accountId, absMoney(oldTx.amount))
-            } else if (oldTx.type === "income") {
-              addDelta(oldTx.accountId, negateMoney(absMoney(oldTx.amount)))
-            }
-          }
+        for (const t of txsToMove) {
+          const magnitude = absMoney(t.amount)
+          const refundSigned: bigint =
+            t.type === "expense" ? magnitude : negateMoney(magnitude)
+          const chargeSigned: bigint =
+            t.type === "expense" ? negateMoney(magnitude) : magnitude
+
+          addDelta(t.accountId, refundSigned)
+          addDelta(data.accountId, chargeSigned)
         }
 
-        // 2. Terapkan agregasi delta secara masal
         await Promise.all(
-          Object.entries(accountDeltas).map(([accountId, delta]) =>
+          Object.entries(accountDeltas).map(([accId, delta]) =>
             tx.account.update({
-              where: { id: accountId },
+              where: { id: accId },
               data: { balance: { increment: delta } },
             })
           )
         )
-
-        // 3. Soft delete: set deletedAt timestamp — TIDAK PERNAH hard delete
-        await tx.transaction.updateMany({
-          where: { id: { in: data.ids } },
-          data: { deletedAt: new Date() },
-        })
-
-        return { success: true }
       }
-    )
-  })
+
+      // 2. Prepare scalar updates payload
+      type CategoryMerchantUpdate = {
+        categoryId?: string | null
+        merchantId?: string | null
+      }
+      type ParentUpdate = CategoryMerchantUpdate & {
+        accountId?: string
+      }
+
+      const updates: CategoryMerchantUpdate = {}
+      if (data.categoryId !== undefined) updates.categoryId = data.categoryId
+      if (data.merchantId !== undefined) updates.merchantId = data.merchantId
+
+      const parentUpdates: ParentUpdate = { ...updates }
+      if (data.accountId !== undefined) parentUpdates.accountId = data.accountId
+
+      // 3. Execute DB Modifications
+      if (Object.keys(parentUpdates).length > 0) {
+        await tx.transaction.updateMany({
+          where: {
+            id: { in: data.ids },
+            ...(data.categoryId !== undefined || data.merchantId !== undefined
+              ? { isSplit: false }
+              : {}),
+          },
+          data: parentUpdates,
+        })
+      }
+
+      const splitUpdates: CategoryMerchantUpdate = {}
+      if (data.categoryId !== undefined)
+        splitUpdates.categoryId = data.categoryId
+      if (data.merchantId !== undefined)
+        splitUpdates.merchantId = data.merchantId
+
+      if (Object.keys(splitUpdates).length > 0) {
+        await tx.splitEntry.updateMany({
+          where: { transactionId: { in: data.ids } },
+          data: splitUpdates,
+        })
+      }
+
+      // Re-read data terbaru setelah mutasi
+      const [newTxs, newAccounts] = await Promise.all([
+        tx.transaction.findMany({
+          where: { id: { in: data.ids } },
+          include: { splitEntries: true },
+        }),
+        tx.account.findMany({
+          where: { id: { in: Array.from(touchedAccountIds) } },
+        }),
+      ])
+
+      // Tulis audit log Account/update (1 per touched Account)
+      for (const oldAcc of oldAccounts) {
+        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
+        if (!newAcc || oldAcc.balance === newAcc.balance) continue
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Account",
+          entityId: oldAcc.id,
+          before: oldAcc,
+          after: newAcc,
+        })
+      }
+
+      // Tulis audit log Transaction/update
+      for (const oldTx of oldTxs) {
+        const newTx = newTxs.find((t) => t.id === oldTx.id)
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Transaction",
+          entityId: oldTx.id,
+          before: oldTx,
+          after: newTx,
+        })
+      }
+
+      return { success: true }
+    }
+  )
+}
 
 /**
  * BACKEND FUNCTION: Bulk Update Transactions
- * Securely handles Category, Merchant, and Account shifts while preserving double-entry ledger logic for account balance transfers.
  */
 export const bulkUpdateTransactionsFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
@@ -1212,98 +1844,114 @@ export const bulkUpdateTransactionsFn = createServerFn({ method: "POST" })
   )
   .handler(async ({ data, context }) => {
     if (data.ids.length === 0) return { success: true }
-
-    return await scopedTenantTransaction(
-      context.familyId,
-      async (tx: TenantTransactionClient) => {
-        // 1. Handle Account Change (Requires Balance Shifting)
-        // We explicitly skip transfers for bulk account edits to prevent complex dual-leg logic breakage.
-        if (data.accountId !== undefined) {
-          const txsToMove = await tx.transaction.findMany({
-            where: {
-              id: { in: data.ids },
-              type: { not: "transfer" },
-              accountId: { not: data.accountId },
-            },
-          })
-
-          const accountDeltas: Record<string, bigint> = {}
-          const addDelta = (id: string, amount: bigint) => {
-            if (!accountDeltas[id]) accountDeltas[id] = 0n
-            accountDeltas[id] += amount
-          }
-
-          for (const t of txsToMove) {
-            // Expense: Reverse old (+), Charge new (-)
-            // Income: Reverse old (-), Charge new (+)
-            const magnitude = absMoney(t.amount)
-            const refundSigned: bigint =
-              t.type === "expense" ? magnitude : negateMoney(magnitude)
-            const chargeSigned: bigint =
-              t.type === "expense" ? negateMoney(magnitude) : magnitude
-
-            addDelta(t.accountId, refundSigned)
-            addDelta(data.accountId, chargeSigned)
-          }
-
-          await Promise.all(
-            Object.entries(accountDeltas).map(([accId, delta]) =>
-              tx.account.update({
-                where: { id: accId },
-                data: { balance: { increment: delta } },
-              })
-            )
-          )
-        }
-
-        // 2. Prepare scalar updates payload (typed — no `any`)
-        type CategoryMerchantUpdate = {
-          categoryId?: string | null
-          merchantId?: string | null
-        }
-        type ParentUpdate = CategoryMerchantUpdate & {
-          accountId?: string
-        }
-
-        const updates: CategoryMerchantUpdate = {}
-        if (data.categoryId !== undefined) updates.categoryId = data.categoryId
-        if (data.merchantId !== undefined) updates.merchantId = data.merchantId
-
-        const parentUpdates: ParentUpdate = { ...updates }
-        if (data.accountId !== undefined)
-          parentUpdates.accountId = data.accountId
-
-        // 3. Execute DB Modifications (Super-Fast Bulk Updates)
-        if (Object.keys(parentUpdates).length > 0) {
-          await tx.transaction.updateMany({
-            // Categories only apply to non-split transactions!
-            where: {
-              id: { in: data.ids },
-              ...(data.categoryId !== undefined || data.merchantId !== undefined
-                ? { isSplit: false }
-                : {}),
-            },
-            data: parentUpdates,
-          })
-        }
-
-        const splitUpdates: CategoryMerchantUpdate = {}
-        if (data.categoryId !== undefined)
-          splitUpdates.categoryId = data.categoryId
-        if (data.merchantId !== undefined)
-          splitUpdates.merchantId = data.merchantId
-
-        if (Object.keys(splitUpdates).length > 0) {
-          await tx.splitEntry.updateMany({
-            where: { transactionId: { in: data.ids } },
-            data: splitUpdates,
-          })
-        }
-
-        return { success: true }
-      }
-    )
+    return await bulkUpdateTransactionsForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
   })
+
+export async function bulkCreateTransactionsForFamily({
+  data,
+  familyId,
+  user,
+}: {
+  data: z.infer<typeof bulkTransactionInputSchema>
+  familyId: string
+  user: { id: string; familyId?: string | null }
+}) {
+  const auditCtx = await createAuditContext({ user })
+  return await scopedTenantTransaction(
+    familyId,
+    async (tx: TenantTransactionClient) => {
+      // Ambil data akun-akun terpengaruh sebelum mutasi
+      const touchedAccountIds = new Set(
+        data.transactions.map((t) => t.accountId)
+      )
+      const oldAccounts = await tx.account.findMany({
+        where: { id: { in: Array.from(touchedAccountIds) } },
+      })
+
+      // 1. Create all transactions
+      await tx.transaction.createMany({
+        data: data.transactions.map((t) => ({
+          id: t.id,
+          userId: user.id,
+          familyId,
+          type: t.type,
+          amount:
+            t.type === "expense"
+              ? negateMoney(absMoney(t.amount))
+              : absMoney(t.amount),
+          description: t.description,
+          accountId: t.accountId,
+          categoryId: t.categoryId,
+          merchantId: t.merchantId,
+          date: t.date,
+          notes: t.notes,
+          status: t.status,
+          attachmentUrl: t.attachmentUrl,
+        })),
+      })
+
+      // 2. Adjust account balances
+      const accountDeltas: Record<string, bigint> = {}
+      for (const t of data.transactions) {
+        if (!accountDeltas[t.accountId]) accountDeltas[t.accountId] = 0n
+        accountDeltas[t.accountId] +=
+          t.type === "expense"
+            ? negateMoney(absMoney(t.amount))
+            : absMoney(t.amount)
+      }
+
+      await Promise.all(
+        Object.entries(accountDeltas).map(([accId, delta]) =>
+          tx.account.update({
+            where: { id: accId },
+            data: { balance: { increment: delta } },
+          })
+        )
+      )
+
+      // Re-read data terbaru setelah mutasi
+      const [newTxs, newAccounts] = await Promise.all([
+        tx.transaction.findMany({
+          where: { id: { in: data.transactions.map((t) => t.id) } },
+          include: { splitEntries: true },
+        }),
+        tx.account.findMany({
+          where: { id: { in: Array.from(touchedAccountIds) } },
+        }),
+      ])
+
+      // Tulis audit log Account/update (1 per touched Account)
+      for (const oldAcc of oldAccounts) {
+        const newAcc = newAccounts.find((a) => a.id === oldAcc.id)
+        if (!newAcc || oldAcc.balance === newAcc.balance) continue
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Account",
+          entityId: oldAcc.id,
+          before: oldAcc,
+          after: newAcc,
+        })
+      }
+
+      // Tulis audit log Transaction/create
+      for (const newTx of newTxs) {
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Transaction",
+          entityId: newTx.id,
+          before: null,
+          after: newTx,
+        })
+      }
+
+      return { success: true, count: data.transactions.length }
+    }
+  )
+}
 
 // ===================================
 // BULK CREATE ENGINES (CSV IMPORT)
@@ -1329,59 +1977,18 @@ const bulkTransactionInputSchema = z.object({
   ),
 })
 
+/**
+ * BACKEND FUNCTION: Bulk Create Transactions
+ */
 export const bulkCreateTransactionsFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
   .inputValidator((data: z.input<typeof bulkTransactionInputSchema>) =>
     bulkTransactionInputSchema.parse(data)
   )
   .handler(async ({ data, context }) => {
-    const { user, familyId } = context
-
-    return await scopedTenantTransaction(
-      familyId,
-      async (tx: TenantTransactionClient) => {
-        // 1. Create all transactions
-        await tx.transaction.createMany({
-          data: data.transactions.map((t) => ({
-            id: t.id,
-            userId: user.id,
-            familyId,
-            type: t.type,
-            amount:
-              t.type === "expense"
-                ? negateMoney(absMoney(t.amount))
-                : absMoney(t.amount),
-            description: t.description,
-            accountId: t.accountId,
-            categoryId: t.categoryId,
-            merchantId: t.merchantId,
-            date: t.date,
-            notes: t.notes,
-            status: t.status,
-            attachmentUrl: t.attachmentUrl,
-          })),
-        })
-
-        // 2. Adjust account balances
-        const accountDeltas: Record<string, bigint> = {}
-        for (const t of data.transactions) {
-          if (!accountDeltas[t.accountId]) accountDeltas[t.accountId] = 0n
-          accountDeltas[t.accountId] +=
-            t.type === "expense"
-              ? negateMoney(absMoney(t.amount))
-              : absMoney(t.amount)
-        }
-
-        await Promise.all(
-          Object.entries(accountDeltas).map(([accId, delta]) =>
-            tx.account.update({
-              where: { id: accId },
-              data: { balance: { increment: delta } },
-            })
-          )
-        )
-
-        return { success: true, count: data.transactions.length }
-      }
-    )
+    return await bulkCreateTransactionsForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
   })

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -1849,22 +1849,23 @@ export async function bulkCreateTransactionsForFamily({
         tx.transaction.createMany({ data: rows }),
         applyAccountDeltas(tx, accountDeltas),
       ])
-
-      // Re-read data terbaru setelah mutasi
-      const [newTxs, newAccounts] = await Promise.all([
-        tx.transaction.findMany({
-          where: { id: { in: transactionIds } },
-          include: { splitEntries: true },
-        }),
-        tx.account.findMany({
-          where: { id: { in: Array.from(touchedAccountIds) } },
-        }),
-      ])
-
-      await auditLogs(tx, auditCtx, [
-        ...accountBalanceAuditEntries(oldAccounts, newAccounts),
-        ...createdAuditEntries("Transaction", newTxs),
-      ])
+        .then(() =>
+          Promise.all([
+            tx.transaction.findMany({
+              where: { id: { in: transactionIds } },
+              include: { splitEntries: true },
+            }),
+            tx.account.findMany({
+              where: { id: { in: Array.from(touchedAccountIds) } },
+            }),
+          ])
+        )
+        .then(([newTxs, newAccounts]) =>
+          auditLogs(tx, auditCtx, [
+            ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+            ...createdAuditEntries("Transaction", newTxs),
+          ])
+        )
 
       return { success: true, count: data.transactions.length }
     }

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -196,6 +196,38 @@ function createdAuditEntries<T extends { id: string }>(
   }))
 }
 
+type AccountDeltaMap = Record<string, bigint>
+
+function addAccountDelta(
+  accountDeltas: AccountDeltaMap,
+  accountId: string,
+  amount: bigint
+): void {
+  if (!accountDeltas[accountId]) accountDeltas[accountId] = 0n
+  accountDeltas[accountId] += amount
+}
+
+async function applyAccountDeltas(
+  tx: TenantTransactionClient,
+  accountDeltas: AccountDeltaMap
+): Promise<void> {
+  await Promise.all(
+    Object.entries(accountDeltas).map(([accountId, delta]) =>
+      tx.account.update({
+        where: { id: accountId },
+        data: { balance: { increment: delta } },
+      })
+    )
+  )
+}
+
+function signedIncomeExpenseAmount(
+  type: "expense" | "income",
+  amount: bigint
+): bigint {
+  return type === "expense" ? negateMoney(absMoney(amount)) : absMoney(amount)
+}
+
 // Schema untuk setiap baris line item dalam split transaction
 const splitEntrySchema = z.object({
   description: z.string().min(1),
@@ -1500,27 +1532,38 @@ export async function bulkDeleteTransactionsForFamily({
         where: { id: { in: Array.from(touchedAccountIds) } },
       })
 
-      const accountDeltas: Record<string, bigint> = {}
-      const addDelta = (id: string, amount: bigint) => {
-        if (!accountDeltas[id]) accountDeltas[id] = 0n
-        accountDeltas[id] += amount
-      }
-
+      const accountDeltas: AccountDeltaMap = {}
       const oldInflowTxsById = indexById(oldInflowTxs)
       for (const oldTx of oldTxs) {
         if (oldTx.type === "transfer" && oldTx.transferOut) {
           const inflowTx = oldInflowTxsById.get(
             oldTx.transferOut.inflowTransactionId
           )
-          addDelta(oldTx.accountId, absMoney(oldTx.amount))
+          addAccountDelta(
+            accountDeltas,
+            oldTx.accountId,
+            absMoney(oldTx.amount)
+          )
           if (inflowTx) {
-            addDelta(inflowTx.accountId, negateMoney(absMoney(inflowTx.amount)))
+            addAccountDelta(
+              accountDeltas,
+              inflowTx.accountId,
+              negateMoney(absMoney(inflowTx.amount))
+            )
           }
         } else if (oldTx.type !== "transfer") {
           if (oldTx.type === "expense") {
-            addDelta(oldTx.accountId, absMoney(oldTx.amount))
+            addAccountDelta(
+              accountDeltas,
+              oldTx.accountId,
+              absMoney(oldTx.amount)
+            )
           } else if (oldTx.type === "income") {
-            addDelta(oldTx.accountId, negateMoney(absMoney(oldTx.amount)))
+            addAccountDelta(
+              accountDeltas,
+              oldTx.accountId,
+              negateMoney(absMoney(oldTx.amount))
+            )
           }
         }
       }
@@ -1533,14 +1576,7 @@ export async function bulkDeleteTransactionsForFamily({
       }
 
       // 2. Terapkan agregasi delta secara masal
-      await Promise.all(
-        Object.entries(accountDeltas).map(([accountId, delta]) =>
-          tx.account.update({
-            where: { id: accountId },
-            data: { balance: { increment: delta } },
-          })
-        )
-      )
+      await applyAccountDeltas(tx, accountDeltas)
 
       // 3. Soft delete
       await tx.transaction.updateMany({
@@ -1660,12 +1696,7 @@ export async function bulkUpdateTransactionsForFamily({
           },
         })
 
-        const accountDeltas: Record<string, bigint> = {}
-        const addDelta = (id: string, amount: bigint) => {
-          if (!accountDeltas[id]) accountDeltas[id] = 0n
-          accountDeltas[id] += amount
-        }
-
+        const accountDeltas: AccountDeltaMap = {}
         for (const t of txsToMove) {
           const magnitude = absMoney(t.amount)
           const refundSigned: bigint =
@@ -1673,18 +1704,11 @@ export async function bulkUpdateTransactionsForFamily({
           const chargeSigned: bigint =
             t.type === "expense" ? negateMoney(magnitude) : magnitude
 
-          addDelta(t.accountId, refundSigned)
-          addDelta(data.accountId, chargeSigned)
+          addAccountDelta(accountDeltas, t.accountId, refundSigned)
+          addAccountDelta(accountDeltas, data.accountId, chargeSigned)
         }
 
-        await Promise.all(
-          Object.entries(accountDeltas).map(([accId, delta]) =>
-            tx.account.update({
-              where: { id: accId },
-              data: { balance: { increment: delta } },
-            })
-          )
-        )
+        await applyAccountDeltas(tx, accountDeltas)
       }
 
       // 2. Prepare scalar updates payload
@@ -1798,17 +1822,18 @@ export async function bulkCreateTransactionsForFamily({
         where: { id: { in: Array.from(touchedAccountIds) } },
       })
 
-      // 1. Create all transactions
-      await tx.transaction.createMany({
-        data: data.transactions.map((t) => ({
+      const transactionIds = data.transactions.map((t) => t.id)
+      const accountDeltas: AccountDeltaMap = {}
+      const rows = data.transactions.map((t) => {
+        const signedAmount = signedIncomeExpenseAmount(t.type, t.amount)
+        addAccountDelta(accountDeltas, t.accountId, signedAmount)
+
+        return {
           id: t.id,
           userId: user.id,
           familyId,
           type: t.type,
-          amount:
-            t.type === "expense"
-              ? negateMoney(absMoney(t.amount))
-              : absMoney(t.amount),
+          amount: signedAmount,
           description: t.description,
           accountId: t.accountId,
           categoryId: t.categoryId,
@@ -1817,32 +1842,18 @@ export async function bulkCreateTransactionsForFamily({
           notes: t.notes,
           status: t.status,
           attachmentUrl: t.attachmentUrl,
-        })),
+        }
       })
 
-      // 2. Adjust account balances
-      const accountDeltas: Record<string, bigint> = {}
-      for (const t of data.transactions) {
-        if (!accountDeltas[t.accountId]) accountDeltas[t.accountId] = 0n
-        accountDeltas[t.accountId] +=
-          t.type === "expense"
-            ? negateMoney(absMoney(t.amount))
-            : absMoney(t.amount)
-      }
-
-      await Promise.all(
-        Object.entries(accountDeltas).map(([accId, delta]) =>
-          tx.account.update({
-            where: { id: accId },
-            data: { balance: { increment: delta } },
-          })
-        )
-      )
+      await Promise.all([
+        tx.transaction.createMany({ data: rows }),
+        applyAccountDeltas(tx, accountDeltas),
+      ])
 
       // Re-read data terbaru setelah mutasi
       const [newTxs, newAccounts] = await Promise.all([
         tx.transaction.findMany({
-          where: { id: { in: data.transactions.map((t) => t.id) } },
+          where: { id: { in: transactionIds } },
           include: { splitEntries: true },
         }),
         tx.account.findMany({

--- a/tests/integration/audit-log.integration.ts
+++ b/tests/integration/audit-log.integration.ts
@@ -1,0 +1,797 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AuditLog } from "@prisma/client"
+type JsonObj = Record<string, unknown>
+import {
+  bulkCreateTransactionsForFamily,
+  bulkDeleteTransactionsForFamily,
+  bulkUpdateTransactionsForFamily,
+  createTransactionForFamily,
+  deleteTransactionForFamily,
+  updateTransactionForFamily,
+} from "../../src/server/transactions"
+import {
+  createSmartRuleForFamily,
+  deleteSmartRuleForFamily,
+} from "../../src/server/smart-rules"
+import { initializeOnboardingForUser } from "../../src/server/onboarding-service"
+import { getAuditLogForFamily } from "../../src/server/audit-log"
+import { auditLog, createAuditContext } from "../../src/server/middleware/audit"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+describe("AuditLog Integration & Security Tests", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // Fixture helper
+  async function createFixture() {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [account, category] = await Promise.all([
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "Test Account",
+      }),
+      factories.createCategory({
+        familyId: owner.family.id,
+        name: "Test Category",
+        type: "expense",
+      }),
+    ])
+    return { owner, account, category }
+  }
+
+  test("1. createTransactionForFamily writes expected AuditLog rows including Account/update", async () => {
+    const { owner, account, category } = await createFixture()
+    const txId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    await createTransactionForFamily({
+      data: {
+        id: txId,
+        idempotencyKey,
+        accountId: account.id,
+        amount: 10_000n,
+        categoryId: category.id,
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "Audit test expense",
+        type: "expense",
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    const logs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      })
+    )
+
+    // Ekspektasikan 2 audit log: 1 untuk Account/update dan 1 untuk Transaction/create
+    expect(logs).toHaveLength(2)
+
+    const accountLog = logs[0]!
+    expect(accountLog.entityType).toBe("Account")
+    expect(accountLog.entityId).toBe(account.id)
+    expect(accountLog.action).toBe("update")
+    expect((accountLog.beforeJson as JsonObj).balance).toBe("100000")
+    expect((accountLog.afterJson as JsonObj).balance).toBe("90000") // 100,000 - 10,000 expense
+
+    const transactionLog = logs[1]!
+    expect(transactionLog.entityType).toBe("Transaction")
+    expect(transactionLog.entityId).toBe(txId)
+    expect(transactionLog.action).toBe("create")
+    expect(transactionLog.beforeJson).toBeNull()
+    expect((transactionLog.afterJson as JsonObj).amount).toBe("-10000")
+  })
+
+  test("2. updateTransactionFn writes full before/after audit snapshots", async () => {
+    const { owner, account, category } = await createFixture()
+    const txId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    // 1. Buat transaksi awal
+    await createTransactionForFamily({
+      data: {
+        id: txId,
+        idempotencyKey,
+        accountId: account.id,
+        amount: 10_000n,
+        categoryId: category.id,
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "Initial expense",
+        type: "expense",
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    // Catat ID log yang sudah ada untuk memisahkan log baru
+    const baselineLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany()
+    )
+    const baselineIds = new Set(baselineLogs.map((l) => l.id))
+
+    // 2. Jalankan updateTransactionForFamily secara langsung
+    await updateTransactionForFamily({
+      data: {
+        id: txId,
+        accountId: account.id,
+        amount: 15_000n, // Naikkan amount
+        categoryId: category.id,
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "Updated expense",
+        type: "expense",
+        currency: "IDR",
+        isSplit: false,
+        status: "CLEARED",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const allLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      })
+    )
+    const logs = allLogs.filter((l) => !baselineIds.has(l.id))
+
+    // Ekspektasikan 2 audit log: 1 untuk Account/update dan 1 untuk Transaction/update
+    expect(logs).toHaveLength(2)
+
+    const accountLog = logs[0]!
+    expect(accountLog.entityType).toBe("Account")
+    expect(accountLog.action).toBe("update")
+    expect((accountLog.beforeJson as JsonObj).balance).toBe("90000")
+    expect((accountLog.afterJson as JsonObj).balance).toBe("85000") // reversal + new amount = 100k - 15k = 85k
+
+    const transactionLog = logs[1]!
+    expect(transactionLog.entityType).toBe("Transaction")
+    expect(transactionLog.action).toBe("update")
+    expect((transactionLog.beforeJson as JsonObj).amount).toBe("-10000")
+    expect((transactionLog.afterJson as JsonObj).amount).toBe("-15000")
+  })
+
+  test("3. deleteTransactionFn writes soft_delete audit logs and Account balance revert", async () => {
+    const { owner, account, category } = await createFixture()
+    const txId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    await createTransactionForFamily({
+      data: {
+        id: txId,
+        idempotencyKey,
+        accountId: account.id,
+        amount: 20_000n,
+        categoryId: category.id,
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "To be deleted",
+        type: "expense",
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    // Catat ID log yang sudah ada untuk memisahkan log baru
+    const baselineLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany()
+    )
+    const baselineIds = new Set(baselineLogs.map((l) => l.id))
+
+    // Jalankan soft delete secara langsung
+    await deleteTransactionForFamily({
+      id: txId,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const allLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      })
+    )
+    const logs = allLogs.filter((l) => !baselineIds.has(l.id))
+
+    expect(logs).toHaveLength(2)
+
+    const accountLog = logs[0]!
+    expect(accountLog.entityType).toBe("Account")
+    expect(accountLog.action).toBe("update")
+    expect((accountLog.beforeJson as JsonObj).balance).toBe("80000")
+    expect((accountLog.afterJson as JsonObj).balance).toBe("100000") // Kembali ke 100k setelah soft delete
+
+    const transactionLog = logs[1]!
+    expect(transactionLog.entityType).toBe("Transaction")
+    expect(transactionLog.action).toBe("soft_delete")
+    expect((transactionLog.beforeJson as JsonObj).deletedAt).toBeNull()
+    expect((transactionLog.afterJson as JsonObj).deletedAt).not.toBeNull()
+  })
+
+  test("transfer create and delete audit the Transfer graph without hard-deleting it", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [sourceAccount, destinationAccount] = await Promise.all([
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "Transfer source",
+      }),
+      factories.createAccount({
+        balance: 25_000n,
+        familyId: owner.family.id,
+        name: "Transfer destination",
+      }),
+    ])
+    const transferTransactionId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    await createTransactionForFamily({
+      data: {
+        id: transferTransactionId,
+        idempotencyKey,
+        accountId: sourceAccount.id,
+        amount: 15_000n,
+        currency: "IDR",
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "Audited transfer",
+        toAccountId: destinationAccount.id,
+        type: "transfer",
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    const transferBeforeDelete = await harness.withFamily(
+      owner.family.id,
+      (tx) =>
+        tx.transfer.findFirstOrThrow({
+          where: { outflowTransactionId: transferTransactionId },
+        })
+    )
+
+    await deleteTransactionForFamily({
+      id: transferTransactionId,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const [transferAfterDelete, transferLogs] = await Promise.all([
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.transfer.findUniqueOrThrow({
+          where: { id: transferBeforeDelete.id },
+          include: {
+            inflowTransaction: true,
+            outflowTransaction: true,
+          },
+        })
+      ),
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.auditLog.findMany({
+          where: {
+            entityId: transferBeforeDelete.id,
+            entityType: "Transfer",
+          },
+          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        })
+      ),
+    ])
+
+    expect(transferAfterDelete.outflowTransaction.deletedAt).not.toBeNull()
+    expect(transferAfterDelete.inflowTransaction.deletedAt).not.toBeNull()
+    expect(transferLogs.map((log) => log.action).sort()).toEqual([
+      "create",
+      "soft_delete",
+    ])
+    const softDeleteLog = transferLogs.find(
+      (log) => log.action === "soft_delete"
+    )
+    expect(softDeleteLog).toBeDefined()
+    const afterJson = softDeleteLog!.afterJson as JsonObj
+    expect((afterJson.outflowTransaction as JsonObj).deletedAt).not.toBeNull()
+    expect((afterJson.inflowTransaction as JsonObj).deletedAt).not.toBeNull()
+  })
+
+  test("transfer update keeps Transfer audit identity stable", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [sourceAccount, destinationAccount] = await Promise.all([
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "Transfer update source",
+      }),
+      factories.createAccount({
+        balance: 10_000n,
+        familyId: owner.family.id,
+        name: "Transfer update destination",
+      }),
+    ])
+    const transferTransactionId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    await createTransactionForFamily({
+      data: {
+        id: transferTransactionId,
+        idempotencyKey,
+        accountId: sourceAccount.id,
+        amount: 10_000n,
+        currency: "IDR",
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "Transfer before update",
+        toAccountId: destinationAccount.id,
+        type: "transfer",
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    const transferBeforeUpdate = await harness.withFamily(
+      owner.family.id,
+      (tx) =>
+        tx.transfer.findFirstOrThrow({
+          where: { outflowTransactionId: transferTransactionId },
+        })
+    )
+    const baselineLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany()
+    )
+    const baselineIds = new Set(baselineLogs.map((log) => log.id))
+
+    await updateTransactionForFamily({
+      data: {
+        id: transferTransactionId,
+        accountId: sourceAccount.id,
+        amount: 12_500n,
+        currency: "IDR",
+        date: new Date("2026-05-24T00:00:00.000Z"),
+        description: "Transfer after update",
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: destinationAccount.id,
+        type: "transfer",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const [transferAfterUpdate, logsAfterUpdate] = await Promise.all([
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.transfer.findFirstOrThrow({
+          where: { outflowTransactionId: transferTransactionId },
+        })
+      ),
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.auditLog.findMany({
+          where: {
+            action: "update",
+            entityId: transferBeforeUpdate.id,
+            entityType: "Transfer",
+          },
+        })
+      ),
+    ])
+    const newLogs = logsAfterUpdate.filter((log) => !baselineIds.has(log.id))
+
+    expect(transferAfterUpdate.id).toBe(transferBeforeUpdate.id)
+    expect(newLogs).toHaveLength(1)
+    expect((newLogs[0]!.beforeJson as JsonObj).id).toBe(transferBeforeUpdate.id)
+    expect((newLogs[0]!.afterJson as JsonObj).id).toBe(transferBeforeUpdate.id)
+  })
+
+  test("bulk transaction helpers audit create, update, and soft_delete paths", async () => {
+    const { owner, account, category } = await createFixture()
+    const secondCategory = await factories.createCategory({
+      familyId: owner.family.id,
+      name: "Bulk updated category",
+      type: "expense",
+    })
+    const [firstId, secondId] = [
+      factories.createIdempotencyKey(),
+      factories.createIdempotencyKey(),
+    ]
+
+    await bulkCreateTransactionsForFamily({
+      data: {
+        transactions: [
+          {
+            id: firstId,
+            accountId: account.id,
+            amount: 1_000n,
+            categoryId: category.id,
+            date: new Date("2026-05-24T00:00:00.000Z"),
+            description: "Bulk first",
+            status: "CLEARED",
+            type: "expense",
+          },
+          {
+            id: secondId,
+            accountId: account.id,
+            amount: 2_000n,
+            categoryId: category.id,
+            date: new Date("2026-05-24T00:00:00.000Z"),
+            description: "Bulk second",
+            status: "CLEARED",
+            type: "expense",
+          },
+        ],
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const createLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        where: { action: "create", entityType: "Transaction" },
+      })
+    )
+    expect(createLogs).toHaveLength(2)
+
+    const baselineAfterCreate = await harness.withFamily(
+      owner.family.id,
+      (tx) => tx.auditLog.findMany()
+    )
+    const baselineAfterCreateIds = new Set(
+      baselineAfterCreate.map((log) => log.id)
+    )
+
+    await bulkUpdateTransactionsForFamily({
+      data: {
+        ids: [firstId, secondId],
+        categoryId: secondCategory.id,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const updateLogs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        where: { action: "update" },
+      })
+    )
+    const newUpdateLogs = updateLogs.filter(
+      (log) => !baselineAfterCreateIds.has(log.id)
+    )
+    expect(
+      newUpdateLogs.filter((log) => log.entityType === "Transaction")
+    ).toHaveLength(2)
+    expect(newUpdateLogs.some((log) => log.entityType === "Account")).toBe(
+      false
+    )
+
+    const baselineAfterUpdate = await harness.withFamily(
+      owner.family.id,
+      (tx) => tx.auditLog.findMany()
+    )
+    const baselineAfterUpdateIds = new Set(
+      baselineAfterUpdate.map((log) => log.id)
+    )
+
+    await bulkDeleteTransactionsForFamily({
+      ids: [firstId, secondId],
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const logsAfterDelete = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany()
+    )
+    const newDeleteLogs = logsAfterDelete.filter(
+      (log) => !baselineAfterUpdateIds.has(log.id)
+    )
+    expect(
+      newDeleteLogs.filter(
+        (log) =>
+          log.action === "soft_delete" && log.entityType === "Transaction"
+      )
+    ).toHaveLength(2)
+    expect(
+      newDeleteLogs.filter(
+        (log) => log.action === "update" && log.entityType === "Account"
+      )
+    ).toHaveLength(1)
+  })
+
+  test("smart rule create and delete write audit rows", async () => {
+    const { owner, category } = await createFixture()
+
+    const rule = await createSmartRuleForFamily({
+      data: {
+        categoryId: category.id,
+        keyword: "Coffee",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    await deleteSmartRuleForFamily({
+      id: rule.id,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const logs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        where: { entityId: rule.id, entityType: "SmartRule" },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      })
+    )
+
+    expect(logs.map((log) => log.action)).toEqual(["create", "delete"])
+    expect(logs[0]!.beforeJson).toBeNull()
+    expect((logs[0]!.afterJson as JsonObj).keyword).toBe("coffee")
+    expect((logs[1]!.beforeJson as JsonObj).keyword).toBe("coffee")
+    expect(logs[1]!.afterJson).toBeNull()
+  })
+
+  test("4. Failed transaction rolls back (rollback) audit log writing", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const auditCtx = await createAuditContext({
+      user: { id: owner.user.id, familyId: owner.family.id },
+    })
+
+    await expect(
+      harness.withFamily(owner.family.id, async (tx) => {
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "CustomTest",
+          entityId: "test-rollback",
+          after: { val: 42 },
+        })
+        // Buat error database yang memicu rollback otomatis
+        throw new Error("Force transactional rollback")
+      })
+    ).rejects.toThrow("Force transactional rollback")
+
+    const logs = await harness.prisma.auditLog.findMany({
+      where: { entityType: "CustomTest" },
+    })
+    expect(logs).toHaveLength(0)
+  })
+
+  test("5. Idempotency replay does not write duplicate audit logs", async () => {
+    const { owner, account, category } = await createFixture()
+    const txId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    const payload = {
+      id: txId,
+      idempotencyKey,
+      accountId: account.id,
+      amount: 5_000n,
+      categoryId: category.id,
+      date: new Date("2026-05-24T00:00:00.000Z"),
+      description: "Idempotency audit check",
+      type: "expense",
+    }
+
+    // Call 1
+    await createTransactionForFamily({
+      data: payload,
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    // Call 2 (Replay)
+    await createTransactionForFamily({
+      data: payload,
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    const logs = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        where: { idempotencyKey },
+      })
+    )
+
+    // Hanya boleh ada 2 entri (1 Account/update dan 1 Transaction/create) bukan berlipat ganda
+    expect(logs).toHaveLength(2)
+  })
+
+  test("6. UPDATE on AuditLog by runtime role is blocked (Postgres constraint)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const auditCtx = await createAuditContext({
+      user: { id: owner.user.id, familyId: owner.family.id },
+    })
+
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "CustomTest",
+        entityId: "test-update-block",
+        after: { val: 1 },
+      })
+    })
+
+    await expect(
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.auditLog.updateMany({
+          where: { entityType: "CustomTest" },
+          data: { action: "update" },
+        })
+      )
+    ).rejects.toThrow(/permission denied/i)
+  })
+
+  test("7. DELETE on AuditLog by runtime role is blocked (Postgres constraint)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const auditCtx = await createAuditContext({
+      user: { id: owner.user.id, familyId: owner.family.id },
+    })
+
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "CustomTest",
+        entityId: "test-delete-block",
+        after: { val: 1 },
+      })
+    })
+
+    await expect(
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.auditLog.deleteMany({
+          where: { entityType: "CustomTest" },
+        })
+      )
+    ).rejects.toThrow(/permission denied/i)
+  })
+
+  test("runtime role cannot TRUNCATE AuditLog", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const auditCtx = await createAuditContext({
+      user: { id: owner.user.id, familyId: owner.family.id },
+    })
+
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "CustomTest",
+        entityId: "test-truncate-block",
+        after: { val: 1 },
+      })
+    })
+
+    await expect(
+      harness.withFamily(owner.family.id, (tx) =>
+        tx.$executeRawUnsafe('TRUNCATE TABLE "AuditLog"')
+      )
+    ).rejects.toThrow(/permission denied|must be owner/i)
+  })
+
+  test("8. Cross-tenant access is blocked by RLS policy", async () => {
+    const [familyA, familyB] = await Promise.all([
+      factories.createAuthenticatedOnboardedUser(),
+      factories.createAuthenticatedOnboardedUser(),
+    ])
+
+    const auditCtxB = await createAuditContext({
+      user: { id: familyB.user.id, familyId: familyB.family.id },
+    })
+    await harness.withFamily(familyB.family.id, async (tx) => {
+      await auditLog(tx, auditCtxB, {
+        action: "create",
+        entityType: "CustomTest",
+        entityId: "secret-tenant-B",
+        after: { val: 999 },
+      })
+    })
+
+    // Coba baca dari Family A
+    const logsForA = await harness.withFamily(familyA.family.id, (tx) =>
+      tx.auditLog.findMany({
+        where: { entityType: "CustomTest" },
+      })
+    )
+    expect(logsForA).toHaveLength(0)
+  })
+
+  test("9. getAuditLogFn works with pagination and filtering", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const auditCtx = await createAuditContext({
+      user: { id: owner.user.id, familyId: owner.family.id },
+    })
+
+    // Buat 5 entri buatan dengan jeda waktu buatan agar urutan stabil
+    await harness.withFamily(owner.family.id, async (tx) => {
+      for (let i = 1; i <= 5; i++) {
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: i % 2 === 0 ? "TypeEven" : "TypeOdd",
+          entityId: `id-${i}`,
+          after: { index: i },
+        })
+        // Sedikit jeda
+        await new Promise((resolve) => setTimeout(resolve, 5))
+      }
+    })
+
+    // Coba query halaman 1 (limit: 3)
+    const page1 = await getAuditLogForFamily({
+      data: { limit: 3 },
+      familyId: owner.family.id,
+    })
+
+    expect(page1.items).toHaveLength(3)
+    expect(page1.hasNextPage).toBe(true)
+    expect(page1.nextCursor).not.toBeNull()
+
+    // Coba query halaman 2 menggunakan cursor dari halaman 1
+    const page2 = await getAuditLogForFamily({
+      data: {
+        limit: 3,
+        cursor: page1.nextCursor!,
+      },
+      familyId: owner.family.id,
+    })
+
+    expect(page2.items).toHaveLength(2) // Total 5 data, page 1 ambil 3, page 2 ambil sisa 2
+    expect(page2.hasNextPage).toBe(false)
+    expect(page2.nextCursor).toBeNull()
+
+    // Coba filter by entityType
+    const filtered = await getAuditLogForFamily({
+      data: {
+        limit: 10,
+        entityType: "TypeEven",
+      },
+      familyId: owner.family.id,
+    })
+    expect(filtered.items).toHaveLength(2) // item 2 & 4
+    expect(
+      filtered.items.every((item: AuditLog) => item.entityType === "TypeEven")
+    ).toBe(true)
+  })
+
+  test("10. onboarding writes a family create audit log", async () => {
+    const user = await factories.createUser({
+      email: "onboard-audit@permoney.local",
+      familyId: null,
+      name: "Audit Onboarding",
+    })
+
+    const result = await initializeOnboardingForUser(harness.prisma, user.id)
+
+    // Cari audit log yang dicatat saat onboarding dengan scoped GUC familyId
+    const logs = await harness.withFamily(result.familyId, (tx) =>
+      tx.auditLog.findMany({
+        where: { familyId: result.familyId },
+      })
+    )
+
+    expect(logs).toHaveLength(1)
+    const log = logs[0]!
+    expect(log.entityType).toBe("Family")
+    expect(log.action).toBe("create")
+    expect(log.entityId).toBe(result.familyId)
+  })
+})

--- a/tests/integration/audit-log.integration.ts
+++ b/tests/integration/audit-log.integration.ts
@@ -21,7 +21,7 @@ import {
   deleteSmartRuleForFamily,
 } from "../../src/server/smart-rules"
 import { initializeOnboardingForUser } from "../../src/server/onboarding-service"
-import { getAuditLogForFamily } from "../../src/server/audit-log"
+import { getAuditLogFn, getAuditLogForFamily } from "../../src/server/audit-log"
 import { auditLog, createAuditContext } from "../../src/server/middleware/audit"
 import {
   createIntegrationHarness,
@@ -32,6 +32,7 @@ import { createTestFactories, type TestFactories } from "./support/factories"
 describe("AuditLog Integration & Security Tests", () => {
   let harness: IntegrationHarness
   let factories: TestFactories
+  const AUDIT_TEST_DATE = new Date("2026-05-24T00:00:00.000Z")
 
   beforeAll(async () => {
     harness = await createIntegrationHarness()
@@ -64,22 +65,234 @@ describe("AuditLog Integration & Security Tests", () => {
     return { owner, account, category }
   }
 
+  async function auditLogBaseline(familyId: string): Promise<Set<string>> {
+    const baselineLogs = await harness.withFamily(familyId, (tx) =>
+      tx.auditLog.findMany({ select: { id: true } })
+    )
+    return new Set(baselineLogs.map((log) => log.id))
+  }
+
+  function logsSince<T extends { id: string }>(
+    logs: readonly T[],
+    baselineIds: ReadonlySet<string>
+  ): T[] {
+    return logs.filter((log) => !baselineIds.has(log.id))
+  }
+
+  async function orderedAuditLogsSince(
+    familyId: string,
+    baselineIds: ReadonlySet<string>
+  ): Promise<AuditLog[]> {
+    const logs = await harness.withFamily(familyId, (tx) =>
+      tx.auditLog.findMany({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      })
+    )
+    return logsSince(logs, baselineIds)
+  }
+
+  function expenseCreatePayload({
+    accountId,
+    amount,
+    categoryId,
+    description,
+    id,
+    idempotencyKey,
+  }: {
+    accountId: string
+    amount: bigint
+    categoryId: string
+    description: string
+    id: string
+    idempotencyKey: string
+  }) {
+    return {
+      id,
+      idempotencyKey,
+      accountId,
+      amount,
+      categoryId,
+      date: AUDIT_TEST_DATE,
+      description,
+      type: "expense" as const,
+    }
+  }
+
+  function expenseUpdatePayload({
+    accountId,
+    amount,
+    categoryId,
+    description,
+    id,
+  }: {
+    accountId: string
+    amount: bigint
+    categoryId: string
+    description: string
+    id: string
+  }) {
+    return {
+      id,
+      accountId,
+      amount,
+      categoryId,
+      date: AUDIT_TEST_DATE,
+      description,
+      currency: "IDR",
+      isSplit: false,
+      status: "CLEARED" as const,
+      type: "expense" as const,
+    }
+  }
+
+  function transferPayload({
+    accountId,
+    amount,
+    description,
+    id,
+    idempotencyKey,
+    toAccountId,
+  }: {
+    accountId: string
+    amount: bigint
+    description: string
+    id: string
+    idempotencyKey?: string
+    toAccountId: string
+  }) {
+    return {
+      id,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+      accountId,
+      amount,
+      currency: "IDR",
+      date: AUDIT_TEST_DATE,
+      description,
+      isSplit: false,
+      status: "CLEARED" as const,
+      toAccountId,
+      type: "transfer" as const,
+    }
+  }
+
+  async function createTransferFixture({
+    amount,
+    description,
+    destinationBalance,
+    destinationName,
+    sourceName,
+  }: {
+    amount: bigint
+    description: string
+    destinationBalance: bigint
+    destinationName: string
+    sourceName: string
+  }) {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [sourceAccount, destinationAccount] = await Promise.all([
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: sourceName,
+      }),
+      factories.createAccount({
+        balance: destinationBalance,
+        familyId: owner.family.id,
+        name: destinationName,
+      }),
+    ])
+    const transferTransactionId = factories.createIdempotencyKey()
+    const idempotencyKey = factories.createIdempotencyKey()
+
+    await createTransactionForFamily({
+      data: transferPayload({
+        id: transferTransactionId,
+        idempotencyKey,
+        accountId: sourceAccount.id,
+        amount,
+        description,
+        toAccountId: destinationAccount.id,
+      }),
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withFamily,
+      user: owner.user,
+    })
+
+    const transfer = await harness.withFamily(owner.family.id, (tx) =>
+      tx.transfer.findFirstOrThrow({
+        where: { outflowTransactionId: transferTransactionId },
+      })
+    )
+
+    return {
+      owner,
+      sourceAccount,
+      destinationAccount,
+      transfer,
+      transferTransactionId,
+    }
+  }
+
+  function bulkExpensePayload({
+    accountId,
+    amount,
+    categoryId,
+    description,
+    id,
+  }: {
+    accountId: string
+    amount: bigint
+    categoryId: string
+    description: string
+    id: string
+  }) {
+    return {
+      id,
+      accountId,
+      amount,
+      categoryId,
+      date: AUDIT_TEST_DATE,
+      description,
+      status: "CLEARED" as const,
+      type: "expense" as const,
+    }
+  }
+
+  async function writeCustomAuditLog({
+    entityId,
+    owner,
+  }: {
+    entityId: string
+    owner: Awaited<ReturnType<typeof createFixture>>["owner"]
+  }): Promise<void> {
+    const auditCtx = await createAuditContext({
+      user: { id: owner.user.id, familyId: owner.family.id },
+    })
+
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "CustomTest",
+        entityId,
+        after: { val: 1 },
+      })
+    })
+  }
+
   test("1. createTransactionForFamily writes expected AuditLog rows including Account/update", async () => {
     const { owner, account, category } = await createFixture()
     const txId = factories.createIdempotencyKey()
     const idempotencyKey = factories.createIdempotencyKey()
 
     await createTransactionForFamily({
-      data: {
+      data: expenseCreatePayload({
         id: txId,
         idempotencyKey,
         accountId: account.id,
         amount: 10_000n,
         categoryId: category.id,
-        date: new Date("2026-05-24T00:00:00.000Z"),
         description: "Audit test expense",
-        type: "expense",
-      },
+      }),
       familyId: owner.family.id,
       runInTenantTransaction: harness.withFamily,
       user: owner.user,
@@ -116,51 +329,36 @@ describe("AuditLog Integration & Security Tests", () => {
 
     // 1. Buat transaksi awal
     await createTransactionForFamily({
-      data: {
+      data: expenseCreatePayload({
         id: txId,
         idempotencyKey,
         accountId: account.id,
         amount: 10_000n,
         categoryId: category.id,
-        date: new Date("2026-05-24T00:00:00.000Z"),
         description: "Initial expense",
-        type: "expense",
-      },
+      }),
       familyId: owner.family.id,
       runInTenantTransaction: harness.withFamily,
       user: owner.user,
     })
 
     // Catat ID log yang sudah ada untuk memisahkan log baru
-    const baselineLogs = await harness.withFamily(owner.family.id, (tx) =>
-      tx.auditLog.findMany()
-    )
-    const baselineIds = new Set(baselineLogs.map((l) => l.id))
+    const baselineIds = await auditLogBaseline(owner.family.id)
 
     // 2. Jalankan updateTransactionForFamily secara langsung
     await updateTransactionForFamily({
-      data: {
+      data: expenseUpdatePayload({
         id: txId,
         accountId: account.id,
         amount: 15_000n, // Naikkan amount
         categoryId: category.id,
-        date: new Date("2026-05-24T00:00:00.000Z"),
         description: "Updated expense",
-        type: "expense",
-        currency: "IDR",
-        isSplit: false,
-        status: "CLEARED",
-      },
+      }),
       familyId: owner.family.id,
       user: owner.user,
     })
 
-    const allLogs = await harness.withFamily(owner.family.id, (tx) =>
-      tx.auditLog.findMany({
-        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-      })
-    )
-    const logs = allLogs.filter((l) => !baselineIds.has(l.id))
+    const logs = await orderedAuditLogsSince(owner.family.id, baselineIds)
 
     // Ekspektasikan 2 audit log: 1 untuk Account/update dan 1 untuk Transaction/update
     expect(logs).toHaveLength(2)
@@ -184,26 +382,21 @@ describe("AuditLog Integration & Security Tests", () => {
     const idempotencyKey = factories.createIdempotencyKey()
 
     await createTransactionForFamily({
-      data: {
+      data: expenseCreatePayload({
         id: txId,
         idempotencyKey,
         accountId: account.id,
         amount: 20_000n,
         categoryId: category.id,
-        date: new Date("2026-05-24T00:00:00.000Z"),
         description: "To be deleted",
-        type: "expense",
-      },
+      }),
       familyId: owner.family.id,
       runInTenantTransaction: harness.withFamily,
       user: owner.user,
     })
 
     // Catat ID log yang sudah ada untuk memisahkan log baru
-    const baselineLogs = await harness.withFamily(owner.family.id, (tx) =>
-      tx.auditLog.findMany()
-    )
-    const baselineIds = new Set(baselineLogs.map((l) => l.id))
+    const baselineIds = await auditLogBaseline(owner.family.id)
 
     // Jalankan soft delete secara langsung
     await deleteTransactionForFamily({
@@ -212,12 +405,7 @@ describe("AuditLog Integration & Security Tests", () => {
       user: owner.user,
     })
 
-    const allLogs = await harness.withFamily(owner.family.id, (tx) =>
-      tx.auditLog.findMany({
-        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-      })
-    )
-    const logs = allLogs.filter((l) => !baselineIds.has(l.id))
+    const logs = await orderedAuditLogsSince(owner.family.id, baselineIds)
 
     expect(logs).toHaveLength(2)
 
@@ -235,46 +423,14 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("transfer create and delete audit the Transfer graph without hard-deleting it", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const [sourceAccount, destinationAccount] = await Promise.all([
-      factories.createAccount({
-        balance: 100_000n,
-        familyId: owner.family.id,
-        name: "Transfer source",
-      }),
-      factories.createAccount({
-        balance: 25_000n,
-        familyId: owner.family.id,
-        name: "Transfer destination",
-      }),
-    ])
-    const transferTransactionId = factories.createIdempotencyKey()
-    const idempotencyKey = factories.createIdempotencyKey()
-
-    await createTransactionForFamily({
-      data: {
-        id: transferTransactionId,
-        idempotencyKey,
-        accountId: sourceAccount.id,
+    const { owner, transfer, transferTransactionId } =
+      await createTransferFixture({
         amount: 15_000n,
-        currency: "IDR",
-        date: new Date("2026-05-24T00:00:00.000Z"),
         description: "Audited transfer",
-        toAccountId: destinationAccount.id,
-        type: "transfer",
-      },
-      familyId: owner.family.id,
-      runInTenantTransaction: harness.withFamily,
-      user: owner.user,
-    })
-
-    const transferBeforeDelete = await harness.withFamily(
-      owner.family.id,
-      (tx) =>
-        tx.transfer.findFirstOrThrow({
-          where: { outflowTransactionId: transferTransactionId },
-        })
-    )
+        destinationBalance: 25_000n,
+        destinationName: "Transfer destination",
+        sourceName: "Transfer source",
+      })
 
     await deleteTransactionForFamily({
       id: transferTransactionId,
@@ -285,7 +441,7 @@ describe("AuditLog Integration & Security Tests", () => {
     const [transferAfterDelete, transferLogs] = await Promise.all([
       harness.withFamily(owner.family.id, (tx) =>
         tx.transfer.findUniqueOrThrow({
-          where: { id: transferBeforeDelete.id },
+          where: { id: transfer.id },
           include: {
             inflowTransaction: true,
             outflowTransaction: true,
@@ -295,7 +451,7 @@ describe("AuditLog Integration & Security Tests", () => {
       harness.withFamily(owner.family.id, (tx) =>
         tx.auditLog.findMany({
           where: {
-            entityId: transferBeforeDelete.id,
+            entityId: transfer.id,
             entityType: "Transfer",
           },
           orderBy: [{ createdAt: "asc" }, { id: "asc" }],
@@ -319,64 +475,29 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("transfer update keeps Transfer audit identity stable", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const [sourceAccount, destinationAccount] = await Promise.all([
-      factories.createAccount({
-        balance: 100_000n,
-        familyId: owner.family.id,
-        name: "Transfer update source",
-      }),
-      factories.createAccount({
-        balance: 10_000n,
-        familyId: owner.family.id,
-        name: "Transfer update destination",
-      }),
-    ])
-    const transferTransactionId = factories.createIdempotencyKey()
-    const idempotencyKey = factories.createIdempotencyKey()
-
-    await createTransactionForFamily({
-      data: {
-        id: transferTransactionId,
-        idempotencyKey,
-        accountId: sourceAccount.id,
-        amount: 10_000n,
-        currency: "IDR",
-        date: new Date("2026-05-24T00:00:00.000Z"),
-        description: "Transfer before update",
-        toAccountId: destinationAccount.id,
-        type: "transfer",
-      },
-      familyId: owner.family.id,
-      runInTenantTransaction: harness.withFamily,
-      user: owner.user,
+    const {
+      destinationAccount,
+      owner,
+      sourceAccount,
+      transfer,
+      transferTransactionId,
+    } = await createTransferFixture({
+      amount: 10_000n,
+      description: "Transfer before update",
+      destinationBalance: 10_000n,
+      destinationName: "Transfer update destination",
+      sourceName: "Transfer update source",
     })
-
-    const transferBeforeUpdate = await harness.withFamily(
-      owner.family.id,
-      (tx) =>
-        tx.transfer.findFirstOrThrow({
-          where: { outflowTransactionId: transferTransactionId },
-        })
-    )
-    const baselineLogs = await harness.withFamily(owner.family.id, (tx) =>
-      tx.auditLog.findMany()
-    )
-    const baselineIds = new Set(baselineLogs.map((log) => log.id))
+    const baselineIds = await auditLogBaseline(owner.family.id)
 
     await updateTransactionForFamily({
-      data: {
+      data: transferPayload({
         id: transferTransactionId,
         accountId: sourceAccount.id,
         amount: 12_500n,
-        currency: "IDR",
-        date: new Date("2026-05-24T00:00:00.000Z"),
         description: "Transfer after update",
-        isSplit: false,
-        status: "CLEARED",
         toAccountId: destinationAccount.id,
-        type: "transfer",
-      },
+      }),
       familyId: owner.family.id,
       user: owner.user,
     })
@@ -391,18 +512,18 @@ describe("AuditLog Integration & Security Tests", () => {
         tx.auditLog.findMany({
           where: {
             action: "update",
-            entityId: transferBeforeUpdate.id,
+            entityId: transfer.id,
             entityType: "Transfer",
           },
         })
       ),
     ])
-    const newLogs = logsAfterUpdate.filter((log) => !baselineIds.has(log.id))
+    const newLogs = logsSince(logsAfterUpdate, baselineIds)
 
-    expect(transferAfterUpdate.id).toBe(transferBeforeUpdate.id)
+    expect(transferAfterUpdate.id).toBe(transfer.id)
     expect(newLogs).toHaveLength(1)
-    expect((newLogs[0]!.beforeJson as JsonObj).id).toBe(transferBeforeUpdate.id)
-    expect((newLogs[0]!.afterJson as JsonObj).id).toBe(transferBeforeUpdate.id)
+    expect((newLogs[0]!.beforeJson as JsonObj).id).toBe(transfer.id)
+    expect((newLogs[0]!.afterJson as JsonObj).id).toBe(transfer.id)
   })
 
   test("bulk transaction helpers audit create, update, and soft_delete paths", async () => {
@@ -420,26 +541,20 @@ describe("AuditLog Integration & Security Tests", () => {
     await bulkCreateTransactionsForFamily({
       data: {
         transactions: [
-          {
+          bulkExpensePayload({
             id: firstId,
             accountId: account.id,
             amount: 1_000n,
             categoryId: category.id,
-            date: new Date("2026-05-24T00:00:00.000Z"),
             description: "Bulk first",
-            status: "CLEARED",
-            type: "expense",
-          },
-          {
+          }),
+          bulkExpensePayload({
             id: secondId,
             accountId: account.id,
             amount: 2_000n,
             categoryId: category.id,
-            date: new Date("2026-05-24T00:00:00.000Z"),
             description: "Bulk second",
-            status: "CLEARED",
-            type: "expense",
-          },
+          }),
         ],
       },
       familyId: owner.family.id,
@@ -453,13 +568,7 @@ describe("AuditLog Integration & Security Tests", () => {
     )
     expect(createLogs).toHaveLength(2)
 
-    const baselineAfterCreate = await harness.withFamily(
-      owner.family.id,
-      (tx) => tx.auditLog.findMany()
-    )
-    const baselineAfterCreateIds = new Set(
-      baselineAfterCreate.map((log) => log.id)
-    )
+    const baselineAfterCreateIds = await auditLogBaseline(owner.family.id)
 
     await bulkUpdateTransactionsForFamily({
       data: {
@@ -475,9 +584,7 @@ describe("AuditLog Integration & Security Tests", () => {
         where: { action: "update" },
       })
     )
-    const newUpdateLogs = updateLogs.filter(
-      (log) => !baselineAfterCreateIds.has(log.id)
-    )
+    const newUpdateLogs = logsSince(updateLogs, baselineAfterCreateIds)
     expect(
       newUpdateLogs.filter((log) => log.entityType === "Transaction")
     ).toHaveLength(2)
@@ -485,13 +592,7 @@ describe("AuditLog Integration & Security Tests", () => {
       false
     )
 
-    const baselineAfterUpdate = await harness.withFamily(
-      owner.family.id,
-      (tx) => tx.auditLog.findMany()
-    )
-    const baselineAfterUpdateIds = new Set(
-      baselineAfterUpdate.map((log) => log.id)
-    )
+    const baselineAfterUpdateIds = await auditLogBaseline(owner.family.id)
 
     await bulkDeleteTransactionsForFamily({
       ids: [firstId, secondId],
@@ -502,9 +603,7 @@ describe("AuditLog Integration & Security Tests", () => {
     const logsAfterDelete = await harness.withFamily(owner.family.id, (tx) =>
       tx.auditLog.findMany()
     )
-    const newDeleteLogs = logsAfterDelete.filter(
-      (log) => !baselineAfterUpdateIds.has(log.id)
-    )
+    const newDeleteLogs = logsSince(logsAfterDelete, baselineAfterUpdateIds)
     expect(
       newDeleteLogs.filter(
         (log) =>
@@ -580,16 +679,14 @@ describe("AuditLog Integration & Security Tests", () => {
     const txId = factories.createIdempotencyKey()
     const idempotencyKey = factories.createIdempotencyKey()
 
-    const payload = {
+    const payload = expenseCreatePayload({
       id: txId,
       idempotencyKey,
       accountId: account.id,
       amount: 5_000n,
       categoryId: category.id,
-      date: new Date("2026-05-24T00:00:00.000Z"),
       description: "Idempotency audit check",
-      type: "expense",
-    }
+    })
 
     // Call 1
     await createTransactionForFamily({
@@ -618,19 +715,8 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("6. UPDATE on AuditLog by runtime role is blocked (Postgres constraint)", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const auditCtx = await createAuditContext({
-      user: { id: owner.user.id, familyId: owner.family.id },
-    })
-
-    await harness.withFamily(owner.family.id, async (tx) => {
-      await auditLog(tx, auditCtx, {
-        action: "create",
-        entityType: "CustomTest",
-        entityId: "test-update-block",
-        after: { val: 1 },
-      })
-    })
+    const { owner } = await createFixture()
+    await writeCustomAuditLog({ entityId: "test-update-block", owner })
 
     await expect(
       harness.withFamily(owner.family.id, (tx) =>
@@ -643,19 +729,8 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("7. DELETE on AuditLog by runtime role is blocked (Postgres constraint)", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const auditCtx = await createAuditContext({
-      user: { id: owner.user.id, familyId: owner.family.id },
-    })
-
-    await harness.withFamily(owner.family.id, async (tx) => {
-      await auditLog(tx, auditCtx, {
-        action: "create",
-        entityType: "CustomTest",
-        entityId: "test-delete-block",
-        after: { val: 1 },
-      })
-    })
+    const { owner } = await createFixture()
+    await writeCustomAuditLog({ entityId: "test-delete-block", owner })
 
     await expect(
       harness.withFamily(owner.family.id, (tx) =>
@@ -667,19 +742,8 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("runtime role cannot TRUNCATE AuditLog", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const auditCtx = await createAuditContext({
-      user: { id: owner.user.id, familyId: owner.family.id },
-    })
-
-    await harness.withFamily(owner.family.id, async (tx) => {
-      await auditLog(tx, auditCtx, {
-        action: "create",
-        entityType: "CustomTest",
-        entityId: "test-truncate-block",
-        after: { val: 1 },
-      })
-    })
+    const { owner } = await createFixture()
+    await writeCustomAuditLog({ entityId: "test-truncate-block", owner })
 
     await expect(
       harness.withFamily(owner.family.id, (tx) =>
@@ -716,6 +780,7 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("9. getAuditLogFn works with pagination and filtering", async () => {
+    expect(getAuditLogFn).toBeDefined()
     const owner = await factories.createAuthenticatedOnboardedUser()
     const auditCtx = await createAuditContext({
       user: { id: owner.user.id, familyId: owner.family.id },

--- a/tests/integration/support/database.ts
+++ b/tests/integration/support/database.ts
@@ -11,6 +11,7 @@ const DEFAULT_ADMIN_DATABASE_URL = "postgres://permoney@localhost:5433/postgres"
 const FIXED_COMMAND_PATH =
   "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 const RESET_TABLES = [
+  "AuditLog",
   "Transfer",
   "SplitEntry",
   "Transaction",
@@ -108,6 +109,10 @@ export async function createIntegrationHarness(
     databaseUrl: runtimeDatabaseUrl,
     prisma,
     reset: async () => {
+      if (runtimeRole) {
+        await resetDatabaseAsOwner(resolved.databaseUrl)
+        return
+      }
       await resetDatabase(prisma)
     },
     teardown: async () => {
@@ -248,6 +253,17 @@ async function resetDatabase(prisma: PrismaClient): Promise<void> {
   )
 }
 
+async function resetDatabaseAsOwner(databaseUrl: string): Promise<void> {
+  const tableList = RESET_TABLES.map(quoteIdentifier).join(", ")
+  const client = new PgClient({ connectionString: databaseUrl })
+  await client.connect()
+  try {
+    await client.query(`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`)
+  } finally {
+    await client.end()
+  }
+}
+
 async function createDatabase(
   adminDatabaseUrl: string,
   databaseName: string
@@ -284,6 +300,7 @@ async function createRuntimeRole(
        GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA public TO ${quoteIdentifier(
          roleName
        )};
+       REVOKE UPDATE, DELETE, TRUNCATE ON "AuditLog" FROM ${quoteIdentifier(roleName)};
        GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${quoteIdentifier(
          roleName
        )};`


### PR DESCRIPTION
## Summary
- add the `AuditLog` schema, migration, RLS policies, and immutable app-role privileges for PER-19
- add audit helpers for request metadata, safe JSON canonicalization, redaction, and append-only audit writes inside mutation transactions
- wire audit logging into ledger mutations, smart rules, and onboarding, including transfer graph, split entries, account balance snapshots, bulk paths, and idempotency replay behavior
- add `getAuditLogFn` / `getAuditLogForFamily` for family-scoped paginated audit reads
- expand real-Postgres integration coverage for transfer, bulk, smart-rule, onboarding, RLS, permission, rollback, pagination, and idempotency audit behavior

## Verification
- `vp check`
- `vp test run`
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration`
- `vp build`
- `vp dlx react-doctor@latest . --verbose --diff`

## Notes
- Build still emits existing TanStack SSR dependency externalization warnings for `node:stream/web` / `node:async_hooks` from framework packages; the audit helper no longer introduces a `node:crypto` client-build warning.
- Integration tests still print the existing `pg@9` deprecation warning from Prisma adapter query concurrency; tests pass and this should be tracked separately if we want zero-warning integration output.
