### PR TITLE
ci: run React Doctor review only on pull requests

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -2,8 +2,6 @@ name: React Doctor
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 permissions:
   checks: write # required to create/update the React Doctor check run
@@ -15,14 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v6
-        if: github.event_name != 'pull_request'
-        with:
-          fetch-depth: 0
       - uses: millionco/react-doctor@30f05ef5320f78a040cc95a7ec30dc573f2d3bce
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove the push trigger from the React Doctor review workflow.
- Simplify checkout because the pinned React Doctor review action requires a pull_request event payload.

## Why
Dependabot merge commits on main made the normal CI workflow green, but the separate React Doctor workflow failed on push with this root cause:

Event payload does not include pull_request; this action only runs on pull_request events.

This PR keeps React Doctor review on PRs, where the action is designed to run, and avoids false red checks on main pushes.

## Verification
- git diff --check
- Before opening this PR, merged Dependabot main was verified locally with:
  - vp run check
  - vp run test:unit
  - PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration
  - PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e
  - vp build