### PR TITLE
PER-93: idempotent update/delete semantics — soft-delete + new-row replaces hard-delete reversal

### DIFF
--- a/docs/adr/0032-idempotent-update-delete.md
+++ b/docs/adr/0032-idempotent-update-delete.md
@@ -1,0 +1,266 @@
+# ADR-0032 — Idempotent update/delete semantics: soft-delete + new-row supersession
+
+|                   |                |
+| ----------------- | -------------- |
+| **Status**        | Accepted       |
+| **Date**          | 2026-05-31     |
+| **Accepted**      | 2026-05-31     |
+| **Deciders**      | Hendri Permana |
+| **Supersedes**    | —              |
+| **Superseded by** | —              |
+
+## Context
+
+PER-93 closes the remaining M2 gap in ledger mutation idempotency. PER-17 /
+ADR-0006 made create-style transaction writes replay-safe. PER-20 / ADR-0012
+made user-facing delete a soft-delete and made transfer soft-delete symmetric.
+PER-18 / ADR-0013 put every scoped mutation behind Serializable retry and
+version-checked balance updates. PER-103 / ADR-0031 made transfer graph shape a
+database invariant.
+
+`updateTransactionForFamily` is the outlier. It still uses an internal
+reversal-and-replace pattern:
+
+1. reverse the old balance effect;
+2. hard-delete the old `Transfer` row when present;
+3. hard-delete the old `Transaction` row(s);
+4. create replacement rows using the same primary transaction id;
+5. apply the new balance effect;
+6. audit the before/after graph.
+
+This kept URL continuity but now conflicts with the stronger M2 standard:
+ledger history must not be erased as the correctness mechanism. With
+`Transfer` FKs now `ON DELETE RESTRICT`, the handler also carries an explicit
+interim hard-delete dependency that PER-93 is meant to remove.
+
+Delete has a different gap. The current handler is balance-safe because
+`deletedAt IS NOT NULL` returns no-op, but it is not yet ADR-0006 idempotency:
+there is no endpoint-scoped key, no payload comparison, and no replay record
+that lets a network retry return the original response without re-reading and
+re-interpreting mutable ledger state.
+
+## Decision
+
+**Replace update hard-delete reversal with soft-delete + new-row supersession,
+and make update/delete replay through endpoint-scoped `IdempotencyRecord`
+rows.**
+
+### 1. Update creates a new canonical row id
+
+Updating a transaction is represented as:
+
+1. read the active old graph under `scopedTenantTransaction`;
+2. reject if the target row is already soft-deleted;
+3. soft-delete the old canonical row(s);
+4. create replacement row(s) with new primary ids;
+5. apply the aggregate account delta exactly once per touched account;
+6. write audit rows for the old soft-delete and new create graph in the same
+   transaction;
+7. store an idempotency replay record whose response contains the new outflow
+   transaction id.
+
+The replacement row does **not** reuse the old primary id. The old id remains a
+historical ledger id. UI continuity is explicit through supersession links:
+
+```prisma
+model Transaction {
+  supersededBy String? @unique
+  supersedes   String? @unique
+}
+```
+
+`supersededBy` points from an old, soft-deleted row to its immediate successor.
+`supersedes` points from the successor back to the row it replaced. The chain is
+one-to-one at each edge, so a transaction can be updated repeatedly without
+erasing the intermediate states:
+
+```text
+T1(deletedAt, supersededBy=T2) <- T2(deletedAt, supersedes=T1, supersededBy=T3) <- T3(active, supersedes=T2)
+```
+
+The database enforces two structural checks:
+
+- a row with `supersededBy IS NOT NULL` must also have `deletedAt IS NOT NULL`;
+- a row cannot supersede itself or be superseded by itself.
+
+Self-referential foreign keys use `ON DELETE RESTRICT` so future hard-delete
+paths cannot silently erase a supersession chain.
+
+### 2. New id over versioned same id
+
+PER-93 locks the **new-id-per-update** strategy.
+
+Keeping the same id with a hidden version number was rejected. It would make
+URLs stable, but it makes history ambiguous: one id would refer to multiple
+financial meanings over time, and every audit/log/debug tool would need a
+version dimension to say which transaction it means. That trades a small UI
+convenience for permanent ledger ambiguity.
+
+A new id per update is stricter and easier to audit. The active list shows the
+latest non-deleted row. Audit history can show "this transaction was superseded
+by X" using the explicit link. Reports that need historical reconstruction can
+walk the chain instead of inferring identity from mutable rows.
+
+### 3. Transfer update keeps graph symmetry
+
+Updating a transfer supersedes the entire money movement:
+
+1. soft-delete old outflow `Transaction`;
+2. soft-delete old inflow `Transaction`;
+3. soft-delete old `Transfer`;
+4. create new outflow `Transaction`;
+5. create new inflow `Transaction`;
+6. create a new `Transfer` linking the new legs.
+
+The old `Transfer` remains in the database so ADR-0031 inverse-pairing still
+sees each old transfer-typed leg paired by exactly one transfer row. Soft-delete
+does not remove the pair; it only closes it. The new legs are paired by the new
+`Transfer` before commit. Every step runs in one Serializable transaction.
+
+The supersession link is stored on the transaction legs:
+
+- old outflow `supersededBy = newOutflow.id`, new outflow `supersedes = oldOutflow.id`;
+- old inflow `supersededBy = newInflow.id`, new inflow `supersedes = oldInflow.id`.
+
+No `Transfer.supersedes` column is introduced in PER-93. The transfer update
+relationship is derivable from the leg supersession links plus audit rows. A
+future UI that needs transfer-level history can add a transfer-specific link in
+a narrow follow-up without changing transaction identity.
+
+### 4. Idempotency for update/delete uses `IdempotencyRecord`
+
+Update and delete are endpoint-scoped mutations, so they use ADR-0006
+`IdempotencyRecord` instead of `Transaction.idempotencyKey`:
+
+| Endpoint              | Replay key scope                    | Response source                     |
+| --------------------- | ----------------------------------- | ----------------------------------- |
+| `updateTransactionFn` | `(familyId, "updateTransactionFn")` | cached serialized replacement row   |
+| `deleteTransactionFn` | `(familyId, "deleteTransactionFn")` | cached `{ success: true }` response |
+
+The existing `Transaction.idempotencyKey` unique index remains the create-flow
+dedupe mechanism. Replacement rows created by update do not store the update
+idempotency key in that column because the key is endpoint-scoped by contract
+while the existing unique index is only `(familyId, idempotencyKey)`. Audit rows
+and `IdempotencyRecord` rows still carry the key, preserving replay and forensic
+correlation without introducing a cross-endpoint false conflict.
+
+Each update/delete transaction attempt starts by reading the replay record. If
+the key exists:
+
+- same canonical payload returns the stored response without mutating balances,
+  rows, or audit logs;
+- different canonical payload throws `IdempotencyConflictError` (`409`).
+
+If no record exists, the mutation proceeds and writes the replay record before
+commit. A concurrent same-key request may race to the same unique record. The
+loser rolls back its attempted mutation on the unique conflict, re-reads the
+record, and replays or conflicts from the committed payload.
+
+Replay records keep ADR-0006's 24-hour TTL. Transaction history and audit rows
+are not purged for idempotency TTL.
+
+### 5. Deleted-row semantics
+
+An update against a soft-deleted transaction returns **410 Gone** and never
+resurrects the row.
+
+A delete against an already-soft-deleted transaction also returns **410 Gone**
+when it is a new logical request. The same idempotency key that performed the
+original delete replays the prior `{ success: true }` response before row-state
+inspection. This preserves retry safety while refusing to treat a new delete
+intent against closed ledger history as a success.
+
+### 6. Bulk paths
+
+PER-93 does not redesign bulk update/delete. PER-95 owns bulk parity. Existing
+bulk handlers must keep passing their current tests, but they are not allowed
+to silently become the new canonical update/delete model. PER-95 will adopt the
+same principles:
+
+- no hard delete for ledger history;
+- explicit idempotency key per logical bulk mutation;
+- update as soft-delete + new-row supersession where financial meaning changes;
+- same tenant validation, audit, RLS GUC, and Serializable retry boundary as
+  the single-row paths.
+
+### 7. Migration guard
+
+The migration adds the supersession columns and indexes only after fail-loud
+drift checks:
+
+- any existing `Transaction.deletedAt IS NOT NULL` row must have a soft-delete
+  audit row with non-null before/after JSON;
+- malformed pre-existing transfer soft-delete drift aborts rather than letting
+  supersession links be added over ambiguous history.
+
+The development database was audited before the ADR: zero soft-deleted
+transactions, zero missing soft-delete audit rows, and zero hard-delete-style
+transaction audit rows.
+
+## Consequences
+
+### Positive
+
+- Update no longer erases canonical ledger rows or relies on hard delete to
+  correct balances.
+- Every update/delete retry has an explicit endpoint-scoped replay contract.
+  Replays do not mutate balances, create rows, or duplicate audit evidence.
+- Transaction identity becomes historically precise: old rows stay old, new
+  financial meaning gets a new id, and continuity is represented by explicit
+  links.
+- Transfer updates preserve ADR-0012 soft-delete symmetry and ADR-0031 pairing
+  invariants because old and new transfer graphs both remain paired.
+- Same-key/different-payload conflicts fail before mutation when a replay
+  record exists, and roll back cleanly when detected by the unique replay record
+  race.
+
+### Negative
+
+- The UI can no longer assume an update response has the same transaction id as
+  the submitted row. Clients must replace the old local row with the new id and
+  refetch TanStack DB collections after mutation.
+- Repeated updates create more rows than in-place mutation. This is the
+  intentional storage cost of auditability; a financial ledger is optimized for
+  explainable history, not row reuse.
+- `IdempotencyRecord` and `Transaction.idempotencyKey` now have distinct
+  responsibilities. Future agents must not "simplify" update replay by storing
+  endpoint-scoped update keys on `Transaction.idempotencyKey` unless the unique
+  constraint is redesigned in a separate ADR.
+- Bulk paths remain temporarily asymmetric until PER-95. The tests in PER-93
+  guard that they keep existing behavior; they do not certify them as the final
+  bulk design.
+
+### Alternatives considered
+
+1. **Reuse the old transaction id and add a version column.** Rejected. It
+   preserves URL stability but makes one id represent multiple ledger meanings.
+   Audit, support, imports, and future reconciliation would need to qualify
+   every reference with a version to avoid ambiguity.
+2. **Keep hard-delete reversal and rely on `AuditLog` snapshots.** Rejected.
+   Audit snapshots help explain a historical change, but they are not a
+   substitute for durable canonical ledger rows. ADR-0012 explicitly named
+   PER-93 as the point where the interim hard-delete pattern ends.
+3. **Make delete of an already-deleted transaction always return 200.** Rejected
+   for new logical requests. It is safe for balance arithmetic, but it hides a
+   state-machine error from callers and weakens "closed ledger row" semantics.
+   Same-key retries still replay 200 through idempotency.
+4. **Store update idempotency keys on replacement `Transaction` rows only.**
+   Rejected because ADR-0006 scopes keys by endpoint, while the existing
+   transaction unique index does not. `IdempotencyRecord` is the correct
+   endpoint-scoped replay surface for update/delete.
+5. **Add transfer-level supersession columns now.** Deferred. Transaction-leg
+   supersession plus audit rows is enough to explain PER-93. Adding
+   `Transfer.supersedes` can be done later if the audit UI needs direct
+   transfer-chain navigation.
+
+## References
+
+- PER-93 (M2-15 — Idempotent update and delete semantics for ledger mutations)
+- PER-95 (bulk update/delete parity follow-up)
+- ADR-0006 (idempotency keys and audit-log architecture)
+- ADR-0011 (app-level tenant reference validation)
+- ADR-0012 (transfer soft-delete symmetry and `onDelete: Restrict`)
+- ADR-0013 (optimistic locking and Serializable retry)
+- ADR-0031 (transfer graph database invariants)
+- `prisma/migrations/20260601020000_idempotent_update_delete/migration.sql`
+- `tests/integration/idempotent-mutations.integration.ts`

--- a/prisma/migrations/20260601020000_idempotent_update_delete/migration.sql
+++ b/prisma/migrations/20260601020000_idempotent_update_delete/migration.sql
@@ -1,0 +1,84 @@
+-- PER-93 / ADR-0032: Idempotent update/delete semantics.
+--
+-- Update stops hard-deleting ledger rows. A replacement transaction now gets a
+-- new primary id and links to the old, soft-deleted row through a one-to-one
+-- supersession edge. Delete and update replay through IdempotencyRecord rows at
+-- the application layer; this migration owns the durable Transaction links.
+
+-- ============================================================================
+-- 1. Fail-loud drift guard.
+-- ============================================================================
+-- If an environment already contains soft-deleted Transaction rows, they must
+-- have a soft-delete audit row with before/after JSON before supersession links
+-- are added over the same history. The development database was audited clean:
+-- deleted transactions = 0, missing soft-delete audit = 0, hard-delete-style
+-- Transaction audit rows = 0.
+DO $$
+DECLARE
+  deleted_without_audit INT;
+  half_deleted_transfers INT;
+BEGIN
+  SELECT COUNT(*)
+    INTO deleted_without_audit
+    FROM "Transaction" t
+    WHERE t."deletedAt" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+          FROM "AuditLog" a
+          WHERE a."entityType" = 'Transaction'
+            AND a."entityId" = t.id
+            AND a.action = 'soft_delete'
+            AND a."beforeJson" IS NOT NULL
+            AND a."afterJson" IS NOT NULL
+      );
+
+  SELECT COUNT(*)
+    INTO half_deleted_transfers
+    FROM "Transfer" tr
+    JOIN "Transaction" tout ON tout.id = tr."outflowTransactionId"
+    JOIN "Transaction" tin  ON tin.id  = tr."inflowTransactionId"
+    WHERE (tr."deletedAt" IS NULL) <> (tout."deletedAt" IS NULL)
+       OR (tr."deletedAt" IS NULL) <> (tin."deletedAt" IS NULL);
+
+  IF deleted_without_audit > 0 OR half_deleted_transfers > 0 THEN
+    RAISE EXCEPTION
+      'PER-93 migration aborted: soft-delete drift detected (deleted-without-audit=%, transfer-symmetry=%). Manual reconciliation required before re-running.',
+      deleted_without_audit, half_deleted_transfers;
+  END IF;
+END
+$$;
+
+-- ============================================================================
+-- 2. Supersession columns and one-to-one indexes.
+-- ============================================================================
+ALTER TABLE "Transaction"
+  ADD COLUMN "supersededBy" TEXT,
+  ADD COLUMN "supersedes" TEXT;
+
+CREATE UNIQUE INDEX "Transaction_supersededBy_key"
+  ON "Transaction"("supersededBy");
+
+CREATE UNIQUE INDEX "Transaction_supersedes_key"
+  ON "Transaction"("supersedes");
+
+ALTER TABLE "Transaction"
+  ADD CONSTRAINT "Transaction_supersededBy_fkey"
+    FOREIGN KEY ("supersededBy")
+    REFERENCES "Transaction"(id)
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Transaction"
+  ADD CONSTRAINT "Transaction_supersedes_fkey"
+    FOREIGN KEY ("supersedes")
+    REFERENCES "Transaction"(id)
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- A row that points to its successor is historical and must already be closed.
+-- The replacement row points backward through supersedes and may remain active.
+ALTER TABLE "Transaction"
+  ADD CONSTRAINT "transaction_superseded_rows_are_soft_deleted"
+    CHECK ("supersededBy" IS NULL OR "deletedAt" IS NOT NULL),
+  ADD CONSTRAINT "transaction_superseded_by_not_self"
+    CHECK ("supersededBy" IS NULL OR "supersededBy" <> id),
+  ADD CONSTRAINT "transaction_supersedes_not_self"
+    CHECK ("supersedes" IS NULL OR "supersedes" <> id);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,8 +194,14 @@ model Transaction {
 
   // Soft Delete (GAAP Compliance): Transaksi tidak pernah benar-benar dihapus
   // NULL = aktif, ada timestamp = soft-deleted (audit trail tetap ada)
-  deletedAt DateTime?
-  idempotencyKey String?
+  deletedAt               DateTime?
+  supersededBy            String?       @unique
+  supersededByTransaction Transaction?  @relation("TransactionSupersededBy", fields: [supersededBy], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  supersedes              String?       @unique
+  supersedesTransaction   Transaction?  @relation("TransactionSupersedes", fields: [supersedes], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  supersededTransactions  Transaction[] @relation("TransactionSupersedes")
+  supersedingTransactions Transaction[] @relation("TransactionSupersededBy")
+  idempotencyKey          String?
 
   merchantId String?
   merchant   Merchant? @relation(fields: [merchantId, familyId], references: [id, familyId], onDelete: Restrict, onUpdate: Cascade, map: "Transaction_merchantId_familyId_fkey")

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1466,6 +1466,8 @@ function useTransactionFormModalController({
             ...payload,
             id: optimisticId,
             idempotencyKey,
+            supersededBy: null,
+            supersedes: null,
             createdAt: new Date(),
             familyId: "",
             // splitEntries di optimistic payload adalah versi ringkas (tanpa relasi Prisma)

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -2,6 +2,7 @@ import { createCollection } from "@tanstack/react-db"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import { decodeMoney, encodeMoney, type Money } from "./money"
 import { getQueryClient } from "./query-client"
+import { createUuidV7 } from "./uuid-v7"
 import {
   createTransactionFn,
   deleteTransactionFn,
@@ -189,6 +190,7 @@ export const transactionCollection = createCollection(
         await updateTransactionFn({
           data: {
             id: payload.id as string,
+            idempotencyKey: createUuidV7(),
             type: payload.type as "expense" | "income" | "transfer",
             amount: encodeMoney(payload.amount as Money),
             description: payload.description as string,
@@ -238,7 +240,7 @@ export const transactionCollection = createCollection(
       try {
         const id = transaction.mutations[0].original.id
         await deleteTransactionFn({
-          data: { id: id as string },
+          data: { id: id as string, idempotencyKey: createUuidV7() },
         })
         // WAJIB: Sync ulang setelah hapus agar UI konsisten dengan server
         await transactionCollection.utils.refetch()

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -1,4 +1,5 @@
 import { createServerFn } from "@tanstack/react-start"
+import type { Prisma } from "@prisma/client"
 import { z } from "zod"
 import { absMoney, encodeMoney, negateMoney, type Money } from "@/lib/money"
 import { assertSplitParity } from "@/lib/split-parity"
@@ -695,7 +696,29 @@ const createTransactionInputSchema =
     idempotencyKey: true,
   })
 
+const updateTransactionTransportInputSchema = transactionInputSchema.extend({
+  id: z.string().min(1),
+  idempotencyKey: uuidV7Schema.optional(),
+})
+
+const updateTransactionInputSchema =
+  updateTransactionTransportInputSchema.required({
+    idempotencyKey: true,
+  })
+
+const deleteTransactionTransportInputSchema = z.object({
+  id: z.string().min(1),
+  idempotencyKey: uuidV7Schema.optional(),
+})
+
+const deleteTransactionInputSchema =
+  deleteTransactionTransportInputSchema.required({
+    idempotencyKey: true,
+  })
+
 type CreateTransactionInput = z.infer<typeof createTransactionInputSchema>
+type UpdateTransactionInput = z.infer<typeof updateTransactionInputSchema>
+type DeleteTransactionInput = z.infer<typeof deleteTransactionInputSchema>
 type RunInTenantTransaction = <T>(
   familyId: string,
   callback: (tx: TenantTransactionClient) => Promise<T>
@@ -715,6 +738,115 @@ export class IdempotencyConflictError extends Error {
     super(message)
     this.name = "IdempotencyConflictError"
   }
+}
+
+export class TransactionGoneError extends Error {
+  statusCode = 410
+
+  constructor(message = "Transaction has been deleted and cannot be mutated") {
+    super(message)
+    this.name = "TransactionGoneError"
+  }
+}
+
+const IDEMPOTENCY_RECORD_TTL_MS = 24 * 60 * 60 * 1000
+const UPDATE_TRANSACTION_ENDPOINT = "updateTransactionFn"
+const DELETE_TRANSACTION_ENDPOINT = "deleteTransactionFn"
+
+type IdempotentMutationEndpoint =
+  | typeof UPDATE_TRANSACTION_ENDPOINT
+  | typeof DELETE_TRANSACTION_ENDPOINT
+
+interface SerializedTransactionResult {
+  id: string
+}
+
+async function hashCanonicalPayload(payload: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(
+    JSON.stringify(toCanonicalJson(payload))
+  )
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("")
+}
+
+function toCanonicalJson(value: unknown): unknown {
+  if (value === null || value === undefined) return null
+  if (typeof value === "bigint") return value.toString()
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map((item) => toCanonicalJson(item))
+  if (typeof value === "object") {
+    const source = value as Record<string, unknown>
+    const result: Record<string, unknown> = {}
+    for (const key of Object.keys(source).sort()) {
+      const item = source[key]
+      if (item !== undefined) {
+        result[key] = toCanonicalJson(item)
+      }
+    }
+    return result
+  }
+  return value
+}
+
+async function replayIdempotentEndpointResponse<TResponse>(
+  tx: TenantTransactionClient,
+  {
+    endpoint,
+    familyId,
+    key,
+    requestHash,
+  }: {
+    endpoint: IdempotentMutationEndpoint
+    familyId: string
+    key: string
+    requestHash: string
+  }
+): Promise<TResponse | null> {
+  const record = await tx.idempotencyRecord.findUnique({
+    where: {
+      familyId_endpoint_key: {
+        endpoint,
+        familyId,
+        key,
+      },
+    },
+  })
+  if (!record) return null
+  if (record.requestHash !== requestHash) {
+    throw new IdempotencyConflictError()
+  }
+  return record.responseJson as TResponse
+}
+
+async function persistIdempotentEndpointResponse(
+  tx: TenantTransactionClient,
+  {
+    endpoint,
+    familyId,
+    key,
+    requestHash,
+    response,
+  }: {
+    endpoint: IdempotentMutationEndpoint
+    familyId: string
+    key: string
+    requestHash: string
+    response: unknown
+  }
+): Promise<void> {
+  await tx.idempotencyRecord.create({
+    data: {
+      endpoint,
+      expiresAt: new Date(Date.now() + IDEMPOTENCY_RECORD_TTL_MS),
+      familyId,
+      key,
+      requestHash,
+      responseJson: toCanonicalJson(response) as Prisma.InputJsonValue,
+      statusCode: 200,
+    },
+  })
 }
 
 interface PersistedSplitEntryForIdempotency {
@@ -834,6 +966,17 @@ function canonicalRequestPayload(data: CreateTransactionInput) {
         : null,
     type: data.type,
   }
+}
+
+function canonicalUpdateRequestPayload(data: UpdateTransactionInput) {
+  return {
+    id: data.id,
+    replacement: canonicalRequestPayload(data),
+  }
+}
+
+function canonicalDeleteRequestPayload(data: DeleteTransactionInput) {
+  return { id: data.id }
 }
 
 function canonicalPersistedPayload(tx: PersistedTransactionForIdempotency) {
@@ -1000,6 +1143,38 @@ async function normalizeCreateTransactionTransportInput(
 
   // Normalisasi data dengan menyertakan idempotencyKey dari header jika ada
   return createTransactionInputSchema.parse({
+    ...data,
+    idempotencyKey: headerKey ?? data.idempotencyKey,
+  })
+}
+
+async function normalizeUpdateTransactionTransportInput(
+  data: z.infer<typeof updateTransactionTransportInputSchema>
+): Promise<UpdateTransactionInput> {
+  const rawHeaderKey = await readIdempotencyHeader()
+  const headerKey =
+    rawHeaderKey == null ? null : uuidV7Schema.parse(rawHeaderKey)
+  if (headerKey && data.idempotencyKey && headerKey !== data.idempotencyKey) {
+    throw new Error("Idempotency-Key header does not match idempotencyKey")
+  }
+
+  return updateTransactionInputSchema.parse({
+    ...data,
+    idempotencyKey: headerKey ?? data.idempotencyKey,
+  })
+}
+
+async function normalizeDeleteTransactionTransportInput(
+  data: z.infer<typeof deleteTransactionTransportInputSchema>
+): Promise<DeleteTransactionInput> {
+  const rawHeaderKey = await readIdempotencyHeader()
+  const headerKey =
+    rawHeaderKey == null ? null : uuidV7Schema.parse(rawHeaderKey)
+  if (headerKey && data.idempotencyKey && headerKey !== data.idempotencyKey) {
+    throw new Error("Idempotency-Key header does not match idempotencyKey")
+  }
+
+  return deleteTransactionInputSchema.parse({
     ...data,
     idempotencyKey: headerKey ?? data.idempotencyKey,
   })
@@ -1319,188 +1494,242 @@ export const getTransactionsFn = createServerFn({ method: "GET" })
 
 export async function deleteTransactionForFamily({
   id,
+  idempotencyKey,
   familyId,
   user,
 }: {
   id: string
+  idempotencyKey: string
   familyId: string
   user: { id: string; familyId?: string | null }
 }) {
-  const auditCtx = await createAuditContext({ user })
-  return await scopedTenantTransaction(
-    familyId,
-    async (tx: TenantTransactionClient) => {
-      // 1. Cari transaksi lama beserta relasi transfernya dan split entries
-      let oldTx = await findTransactionAuditGraph(tx, id)
+  const data = deleteTransactionInputSchema.parse({ id, idempotencyKey })
+  const requestHash = await hashCanonicalPayload(
+    canonicalDeleteRequestPayload(data)
+  )
+  const auditCtx = await createAuditContext({ user }, data.idempotencyKey)
 
-      if (!oldTx) throw new Error("Transaction not found!")
-
-      // PER-20 / ADR-0012: replaying a soft-delete on an already-soft-deleted
-      // transaction (or a leg of a transfer whose Transfer is already
-      // soft-deleted) is a no-op. We return success without re-reversing
-      // balances or writing duplicate audit rows. AGENTS.md § 5.A "Delete
-      // Must Be Idempotent". PER-93 will introduce explicit idempotency-key
-      // replay semantics; this guard preserves correctness in the meantime.
-      if (oldTx.deletedAt !== null) {
-        return { success: true }
-      }
-
-      // PER-20 / ADR-0012: a transfer is one money movement. If the user
-      // clicked the inflow leg, redirect to the outflow leg so the symmetric
-      // handler logic below treats outflow as the source of truth. Soft-
-      // deleting either leg deletes the entire transfer; there is no
-      // "delete one leg only" operation.
-      if (oldTx.type === "transfer" && oldTx.transferIn && !oldTx.transferOut) {
-        const outflowAuditGraph = await findTransactionAuditGraph(
-          tx,
-          oldTx.transferIn.outflowTransactionId
-        )
-        if (!outflowAuditGraph) {
-          throw new Error("Transfer outflow leg missing for inflow soft-delete")
-        }
-        if (outflowAuditGraph.deletedAt !== null) {
-          return { success: true }
-        }
-        oldTx = outflowAuditGraph
-      }
-
-      const oldTransferGraph =
-        oldTx.type === "transfer" && oldTx.transferOut
-          ? await findTransferGraph(tx, oldTx.transferOut.id)
-          : null
-
-      // Cari inflow transaction jika ini transfer
-      const inflowTx =
-        oldTx.type === "transfer" && oldTx.transferOut
-          ? await findOptionalTransactionWithSplitEntries(
-              tx,
-              oldTx.transferOut.inflowTransactionId
-            )
-          : null
-
-      // Ambil akun-akun yang terpengaruh sebelum mutasi
-      const affectedAccountIds = [oldTx.accountId]
-      if (inflowTx) {
-        affectedAccountIds.push(inflowTx.accountId)
-      }
-      const oldAccounts = await tx.account.findMany({
-        where: { id: { in: affectedAccountIds } },
-      })
-
-      // 2. REVERSE BALANCES (Kembalikan Saldo)
-      if (oldTx.type === "transfer" && oldTx.transferOut) {
-        await applyAccountBalanceDelta(tx, {
-          accountId: oldTx.accountId,
-          delta: absMoney(oldTx.amount),
+  const deleteOrReplay = async () =>
+    await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) => {
+        const replay = await replayIdempotentEndpointResponse<{
+          success: boolean
+        }>(tx, {
+          endpoint: DELETE_TRANSACTION_ENDPOINT,
           familyId,
-          notFoundMessage: "Source account not found or access denied!",
+          key: data.idempotencyKey,
+          requestHash,
+        })
+        if (replay) return replay
+
+        // 1. Cari transaksi lama beserta relasi transfernya dan split entries
+        let oldTx = await findTransactionAuditGraph(tx, data.id)
+
+        if (!oldTx) throw new Error("Transaction not found!")
+
+        if (oldTx.deletedAt !== null) {
+          throw new TransactionGoneError()
+        }
+
+        // PER-20 / ADR-0012: a transfer is one money movement. If the user
+        // clicked the inflow leg, redirect to the outflow leg so the symmetric
+        // handler logic below treats outflow as the source of truth. Soft-
+        // deleting either leg deletes the entire transfer; there is no
+        // "delete one leg only" operation.
+        if (
+          oldTx.type === "transfer" &&
+          oldTx.transferIn &&
+          !oldTx.transferOut
+        ) {
+          const outflowAuditGraph = await findTransactionAuditGraph(
+            tx,
+            oldTx.transferIn.outflowTransactionId
+          )
+          if (!outflowAuditGraph) {
+            throw new Error(
+              "Transfer outflow leg missing for inflow soft-delete"
+            )
+          }
+          if (outflowAuditGraph.deletedAt !== null) {
+            throw new TransactionGoneError()
+          }
+          oldTx = outflowAuditGraph
+        }
+
+        const oldTransferGraph =
+          oldTx.type === "transfer" && oldTx.transferOut
+            ? await findTransferGraph(tx, oldTx.transferOut.id)
+            : null
+        if (oldTransferGraph?.deletedAt !== null && oldTransferGraph) {
+          throw new TransactionGoneError()
+        }
+
+        // Cari inflow transaction jika ini transfer
+        const inflowTx =
+          oldTx.type === "transfer" && oldTx.transferOut
+            ? await findOptionalTransactionWithSplitEntries(
+                tx,
+                oldTx.transferOut.inflowTransactionId
+              )
+            : null
+
+        // Ambil akun-akun yang terpengaruh sebelum mutasi
+        const affectedAccountIds = [oldTx.accountId]
+        if (inflowTx) {
+          affectedAccountIds.push(inflowTx.accountId)
+        }
+        const oldAccounts = await tx.account.findMany({
+          where: { id: { in: affectedAccountIds } },
         })
 
-        if (inflowTx) {
+        // 2. REVERSE BALANCES (Kembalikan Saldo)
+        if (oldTx.type === "transfer" && oldTx.transferOut) {
           await applyAccountBalanceDelta(tx, {
-            accountId: inflowTx.accountId,
-            delta: negateMoney(absMoney(inflowTx.amount)),
+            accountId: oldTx.accountId,
+            delta: absMoney(oldTx.amount),
             familyId,
-            notFoundMessage: "Destination account not found or access denied!",
+            notFoundMessage: "Source account not found or access denied!",
+          })
+
+          if (inflowTx) {
+            await applyAccountBalanceDelta(tx, {
+              accountId: inflowTx.accountId,
+              delta: negateMoney(absMoney(inflowTx.amount)),
+              familyId,
+              notFoundMessage:
+                "Destination account not found or access denied!",
+            })
+          }
+        } else {
+          await applyAccountBalanceDelta(tx, {
+            accountId: oldTx.accountId,
+            delta: negateMoney(oldTx.amount),
+            familyId,
+            notFoundMessage: "Account not found or access denied!",
           })
         }
-      } else {
-        await applyAccountBalanceDelta(tx, {
-          accountId: oldTx.accountId,
-          delta: negateMoney(oldTx.amount),
+
+        // 3. SOFT DELETE (GAAP Compliance)
+        // PER-20 / ADR-0012: a transfer is one money movement. Soft-deleting
+        // either leg also soft-deletes the opposite leg and the Transfer row
+        // itself, all in this same `$transaction`. The audit trail of "was
+        // money moved? when? who?" survives.
+        if (oldTx.type === "transfer" && oldTx.transferOut && inflowTx) {
+          // Soft delete outflow
+          const outflowUpdate = await tx.transaction.updateMany({
+            where: { id: oldTx.id, familyId, deletedAt: null },
+            data: { deletedAt: new Date() },
+          })
+          if (outflowUpdate.count !== 1) throw new TransactionGoneError()
+
+          // Soft delete inflow
+          const inflowUpdate = await tx.transaction.updateMany({
+            where: { id: inflowTx.id, familyId, deletedAt: null },
+            data: { deletedAt: new Date() },
+          })
+          if (inflowUpdate.count !== 1) throw new TransactionGoneError()
+
+          // Soft delete the Transfer shadow row
+          await tx.transfer.update({
+            where: { id: oldTx.transferOut.id },
+            data: { deletedAt: new Date() },
+          })
+        } else {
+          const update = await tx.transaction.updateMany({
+            where: { id: oldTx.id, familyId, deletedAt: null },
+            data: { deletedAt: new Date() },
+          })
+          if (update.count !== 1) throw new TransactionGoneError()
+        }
+
+        // Ambil data terbaru setelah mutasi selesai diaplikasikan
+        const [
+          updatedOutflowTx,
+          updatedInflowTx,
+          newAccounts,
+          updatedTransferGraph,
+        ] = await runTenantTransactionQueriesInOrder([
+          () => findTransactionWithSplitEntries(tx, oldTx.id),
+          () =>
+            inflowTx
+              ? findTransactionWithSplitEntries(tx, inflowTx.id)
+              : Promise.resolve(null),
+          () =>
+            tx.account.findMany({
+              where: { id: { in: affectedAccountIds } },
+            }),
+          () =>
+            oldTransferGraph
+              ? findTransferGraph(tx, oldTransferGraph.id)
+              : Promise.resolve(null),
+        ] as const)
+
+        await auditLogs(tx, auditCtx, [
+          ...accountBalanceAuditEntries(oldAccounts, newAccounts),
+          {
+            action: "soft_delete",
+            entityType: "Transaction",
+            entityId: oldTx.id,
+            before: oldTx,
+            after: updatedOutflowTx,
+          },
+          ...(updatedInflowTx && inflowTx
+            ? [
+                {
+                  action: "soft_delete" as const,
+                  entityType: "Transaction",
+                  entityId: inflowTx.id,
+                  before: inflowTx,
+                  after: updatedInflowTx,
+                },
+              ]
+            : []),
+          ...(oldTransferGraph && updatedTransferGraph
+            ? [
+                {
+                  action: "soft_delete" as const,
+                  entityType: "Transfer",
+                  entityId: oldTransferGraph.id,
+                  before: oldTransferGraph,
+                  after: updatedTransferGraph,
+                },
+              ]
+            : []),
+        ])
+
+        const response = { success: true }
+        await persistIdempotentEndpointResponse(tx, {
+          endpoint: DELETE_TRANSACTION_ENDPOINT,
           familyId,
-          notFoundMessage: "Account not found or access denied!",
+          key: data.idempotencyKey,
+          requestHash,
+          response,
         })
+
+        return response
       }
+    )
 
-      // 3. SOFT DELETE (GAAP Compliance)
-      // PER-20 / ADR-0012: a transfer is one money movement. Soft-deleting
-      // either leg also soft-deletes the opposite leg and the Transfer row
-      // itself, all in this same `$transaction`. The audit trail of "was
-      // money moved? when? who?" survives.
-      if (oldTx.type === "transfer" && oldTx.transferOut && inflowTx) {
-        // Soft delete outflow
-        await tx.transaction.update({
-          where: { id: oldTx.id },
-          data: { deletedAt: new Date() },
+  try {
+    return await deleteOrReplay()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+
+    const replay = await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) =>
+        await replayIdempotentEndpointResponse<{ success: boolean }>(tx, {
+          endpoint: DELETE_TRANSACTION_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
         })
+    )
+    if (replay) return replay
 
-        // Soft delete inflow
-        await tx.transaction.update({
-          where: { id: inflowTx.id },
-          data: { deletedAt: new Date() },
-        })
-
-        // Soft delete the Transfer shadow row
-        await tx.transfer.update({
-          where: { id: oldTx.transferOut.id },
-          data: { deletedAt: new Date() },
-        })
-      } else {
-        await tx.transaction.update({
-          where: { id: oldTx.id },
-          data: { deletedAt: new Date() },
-        })
-      }
-
-      // Ambil data terbaru setelah mutasi selesai diaplikasikan
-      const [
-        updatedOutflowTx,
-        updatedInflowTx,
-        newAccounts,
-        updatedTransferGraph,
-      ] = await runTenantTransactionQueriesInOrder([
-        () => findTransactionWithSplitEntries(tx, oldTx.id),
-        () =>
-          inflowTx
-            ? findTransactionWithSplitEntries(tx, inflowTx.id)
-            : Promise.resolve(null),
-        () =>
-          tx.account.findMany({
-            where: { id: { in: affectedAccountIds } },
-          }),
-        () =>
-          oldTransferGraph
-            ? findTransferGraph(tx, oldTransferGraph.id)
-            : Promise.resolve(null),
-      ] as const)
-
-      await auditLogs(tx, auditCtx, [
-        ...accountBalanceAuditEntries(oldAccounts, newAccounts),
-        {
-          action: "soft_delete",
-          entityType: "Transaction",
-          entityId: oldTx.id,
-          before: oldTx,
-          after: updatedOutflowTx,
-        },
-        ...(updatedInflowTx && inflowTx
-          ? [
-              {
-                action: "soft_delete" as const,
-                entityType: "Transaction",
-                entityId: inflowTx.id,
-                before: inflowTx,
-                after: updatedInflowTx,
-              },
-            ]
-          : []),
-        ...(oldTransferGraph && updatedTransferGraph
-          ? [
-              {
-                action: "soft_delete" as const,
-                entityType: "Transfer",
-                entityId: oldTransferGraph.id,
-                before: oldTransferGraph,
-                after: updatedTransferGraph,
-              },
-            ]
-          : []),
-      ])
-
-      return { success: true }
-    }
-  )
+    throw error
+  }
 }
 
 /**
@@ -1509,370 +1738,456 @@ export async function deleteTransactionForFamily({
  */
 export const deleteTransactionFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
-  .inputValidator(z.object({ id: z.string() }))
+  .inputValidator(
+    (data: z.input<typeof deleteTransactionTransportInputSchema>) =>
+      deleteTransactionTransportInputSchema.parse(data)
+  )
   .handler(async ({ data, context }) => {
+    const normalized = await normalizeDeleteTransactionTransportInput(data)
     return await deleteTransactionForFamily({
-      id: data.id,
+      id: normalized.id,
+      idempotencyKey: normalized.idempotencyKey,
       familyId: context.familyId,
       user: context.user,
     })
   })
 
 export async function updateTransactionForFamily({
-  data,
+  data: rawData,
   familyId,
   user,
 }: {
-  data: z.infer<typeof transactionInputSchema>
+  data: unknown
   familyId: string
   user: { id: string; familyId?: string | null }
 }) {
-  const auditCtx = await createAuditContext({ user })
-  return await scopedTenantTransaction(
-    familyId,
-    async (tx: TenantTransactionClient) => {
-      // PER-94: validate updated foreign references before reversal/replace.
-      await validateTenantReferences(tx, familyId, {
-        accountId: data.accountId,
-        toAccountId: data.toAccountId,
-        merchantId: data.merchantId,
-        categoryId: data.categoryId,
-        splitEntries: data.splitEntries,
-      })
+  const data = updateTransactionInputSchema.parse(rawData)
+  const requestHash = await hashCanonicalPayload(
+    canonicalUpdateRequestPayload(data)
+  )
+  const auditCtx = await createAuditContext({ user }, data.idempotencyKey)
 
-      assertSplitParity(data)
-
-      // --- FASE 1: REVERSAL (HAPUS LAMA) ---
-      // Ambil snapshot graph lengkap sebelum mutasi dilakukan
-      const oldTx = await findTransactionAuditGraph(tx, data.id!)
-
-      if (!oldTx) throw new Error("Original transaction not found")
-
-      const oldInflowTx =
-        oldTx.type === "transfer" && oldTx.transferOut
-          ? await findTransactionWithSplitEntries(
-              tx,
-              oldTx.transferOut.inflowTransactionId
-            )
-          : null
-      const oldTransfer =
-        oldTx.type === "transfer" && oldTx.transferOut
-          ? {
-              id: oldTx.transferOut.id,
-              outflowTransactionId: oldTx.transferOut.outflowTransactionId,
-              inflowTransactionId: oldTx.transferOut.inflowTransactionId,
-              createdAt: oldTx.transferOut.createdAt,
+  const updateOrReplay = async () =>
+    await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) => {
+        const replay =
+          await replayIdempotentEndpointResponse<SerializedTransactionResult>(
+            tx,
+            {
+              endpoint: UPDATE_TRANSACTION_ENDPOINT,
+              familyId,
+              key: data.idempotencyKey,
+              requestHash,
             }
-          : null
+          )
+        if (replay) return replay
 
-      // Kumpulkan semua akun yang terpengaruh (sebelum dan sesudah)
-      const touchedAccountIds = new Set([oldTx.accountId, data.accountId])
-      if (oldInflowTx) touchedAccountIds.add(oldInflowTx.accountId)
-      if (data.toAccountId) touchedAccountIds.add(data.toAccountId)
-
-      const oldAccounts = await tx.account.findMany({
-        where: { id: { in: Array.from(touchedAccountIds) } },
-      })
-
-      if (oldTx.type === "transfer" && oldTx.transferOut) {
-        const inflowTx = await tx.transaction.findUnique({
-          where: {
-            id: oldTx.transferOut.inflowTransactionId,
-          },
+        // PER-94: validate updated foreign references before reversal/replace.
+        await validateTenantReferences(tx, familyId, {
+          accountId: data.accountId,
+          toAccountId: data.toAccountId,
+          merchantId: data.merchantId,
+          categoryId: data.categoryId,
+          splitEntries: data.splitEntries,
         })
-        await applyAccountBalanceDelta(tx, {
-          accountId: oldTx.accountId,
-          delta: absMoney(oldTx.amount),
-          familyId,
-          notFoundMessage: "Source account not found or access denied!",
-        })
-        if (inflowTx) {
-          await applyAccountBalanceDelta(tx, {
-            accountId: inflowTx.accountId,
-            delta: negateMoney(absMoney(inflowTx.amount)),
-            familyId,
-            notFoundMessage: "Destination account not found or access denied!",
-          })
-          // PER-20 / ADR-0012: Transfer FK is now ON DELETE RESTRICT. The
-          // hard-delete below would fail with a restrict_violation unless we
-          // first hard-delete the Transfer row that references both legs.
-          // PER-93 will replace this whole reversal-and-replace pattern with
-          // soft-delete + new-row; in the meantime, the dependency on the
-          // Transfer row is explicit instead of inherited from `Cascade`.
-          await tx.transfer.delete({
-            where: { id: oldTx.transferOut.id },
-          })
-          await tx.transaction.delete({ where: { id: inflowTx.id } })
+
+        assertSplitParity(data)
+
+        // Ambil snapshot graph lengkap sebelum mutasi dilakukan
+        let oldTx = await findTransactionAuditGraph(tx, data.id)
+
+        if (!oldTx) throw new Error("Original transaction not found")
+        if (oldTx.deletedAt !== null) throw new TransactionGoneError()
+
+        if (
+          oldTx.type === "transfer" &&
+          oldTx.transferIn &&
+          !oldTx.transferOut
+        ) {
+          const outflowAuditGraph = await findTransactionAuditGraph(
+            tx,
+            oldTx.transferIn.outflowTransactionId
+          )
+          if (!outflowAuditGraph) {
+            throw new Error("Transfer outflow leg missing for update")
+          }
+          if (outflowAuditGraph.deletedAt !== null) {
+            throw new TransactionGoneError()
+          }
+          oldTx = outflowAuditGraph
         }
-      } else {
-        await applyAccountBalanceDelta(tx, {
-          accountId: oldTx.accountId,
-          delta: negateMoney(oldTx.amount),
-          familyId,
-          notFoundMessage: "Account not found or access denied!",
-        })
-      }
-      await tx.transaction.delete({ where: { id: oldTx.id } })
 
-      // --- FASE 2: REPLACE (BUAT BARU DENGAN DATA UPDATE) ---
-      let resultTransaction
+        const oldInflowTx =
+          oldTx.type === "transfer" && oldTx.transferOut
+            ? await findTransactionWithSplitEntries(
+                tx,
+                oldTx.transferOut.inflowTransactionId
+              )
+            : null
+        const oldTransferGraph =
+          oldTx.type === "transfer" && oldTx.transferOut
+            ? await findTransferGraph(tx, oldTx.transferOut.id)
+            : null
+        if (oldTransferGraph?.deletedAt !== null && oldTransferGraph) {
+          throw new TransactionGoneError()
+        }
 
-      if (data.type === "transfer") {
-        let kind = "funds_movement"
-        const toAccount = await tx.account.findFirst({
-          where: { id: data.toAccountId!, familyId },
-        })
-        if (!toAccount)
-          throw new Error("Destination account not found or access denied!")
-        if (toAccount.type === "CREDIT") kind = "cc_payment"
-        else if (toAccount.type === "LOAN") kind = "loan_payment"
+        // Kumpulkan semua akun yang terpengaruh (sebelum dan sesudah)
+        const touchedAccountIds = new Set([oldTx.accountId, data.accountId])
+        if (oldInflowTx) touchedAccountIds.add(oldInflowTx.accountId)
+        if (data.toAccountId) touchedAccountIds.add(data.toAccountId)
 
-        const sourceMutation = await applyAccountBalanceDelta(tx, {
-          accountId: data.accountId,
-          delta: negateMoney(absMoney(data.amount)),
-          familyId,
-          notFoundMessage: "Source account not found or access denied!",
-        })
-        const sourceBalanceAfter = sourceMutation.after.balance
-
-        const inAmount = data.destinationAmount ?? data.amount
-        const inCurrency = data.destinationCurrency ?? data.currency
-
-        const destMutation = await applyAccountBalanceDelta(tx, {
-          accountId: data.toAccountId!,
-          delta: absMoney(inAmount),
-          familyId,
-          notFoundMessage: "Destination account not found or access denied!",
-        })
-        const destBalanceAfter = destMutation.after.balance
-
-        const outflowTx = await tx.transaction.create({
-          data: {
-            id: data.id,
-            type: "transfer",
-            kind,
-            currency: data.currency,
-            amount: negateMoney(absMoney(data.amount)),
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.accountId,
-            toAccountId: data.toAccountId,
-            categoryId: data.categoryId || null,
-            merchantId: data.merchantId || null,
-            userId: user.id,
-            familyId,
-            status: data.status,
-            destinationAmount: data.destinationAmount,
-            destinationCurrency: data.destinationCurrency,
-            accountBalanceAfter: sourceBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
+        const oldAccounts = await tx.account.findMany({
+          where: { id: { in: Array.from(touchedAccountIds) } },
         })
 
-        const inflowTx = await tx.transaction.create({
-          data: {
-            type: "transfer",
-            kind,
-            currency: inCurrency,
-            amount: absMoney(inAmount),
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.toAccountId!,
-            toAccountId: data.accountId,
-            categoryId: data.categoryId || null,
-            merchantId: data.merchantId || null,
-            userId: user.id,
-            familyId,
-            status: data.status,
-            destinationAmount: data.destinationAmount,
-            destinationCurrency: data.destinationCurrency,
-            accountBalanceAfter: destBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
-        })
-
-        const createdTransfer = await tx.transfer.create({
-          data: {
-            ...(oldTransfer ? { id: oldTransfer.id } : {}),
-            outflowTransactionId: outflowTx.id,
-            inflowTransactionId: inflowTx.id,
-          },
-        })
-
-        resultTransaction = outflowTx
-
-        // Re-read data terbaru setelah mutasi
-        const [newOutflow, newInflow, newAccounts] =
-          await runTenantTransactionQueriesInOrder([
-            () => findTransactionWithSplitEntries(tx, outflowTx.id),
-            () => findTransactionWithSplitEntries(tx, inflowTx.id),
-            () =>
-              tx.account.findMany({
-                where: { id: { in: Array.from(touchedAccountIds) } },
-              }),
-          ] as const)
-
-        await auditLogs(tx, auditCtx, [
-          ...accountBalanceAuditEntries(oldAccounts, newAccounts),
-          {
-            action: "update",
-            entityType: "Transaction",
-            entityId: oldTx.id,
-            before: oldTx,
-            after: newOutflow,
-          },
-          ...(oldInflowTx
-            ? [
-                {
-                  action: "update" as const,
-                  entityType: "Transaction",
-                  entityId: oldInflowTx.id,
-                  before: oldInflowTx,
-                  after: newInflow,
-                },
-              ]
-            : createdAuditEntries("Transaction", [newInflow])),
-          oldTransfer
-            ? {
-                action: "update",
-                entityType: "Transfer",
-                entityId: oldTransfer.id,
-                before: oldTransfer,
-                after: createdTransfer,
-              }
-            : createdAuditEntries("Transfer", [createdTransfer])[0]!,
-        ])
-      } else {
-        const amountSign: Money =
-          data.type === "expense"
-            ? negateMoney(absMoney(data.amount))
-            : absMoney(data.amount)
-
-        const accountMutation = await applyAccountBalanceDelta(tx, {
-          accountId: data.accountId,
-          delta: amountSign,
-          familyId,
-          notFoundMessage: "Account not found or access denied!",
-        })
-        const accountBalanceAfter = accountMutation.after.balance
-
-        const newTx = await tx.transaction.create({
-          data: {
-            id: data.id,
-            type: data.type,
-            amount: amountSign,
-            description: data.description,
-            date: data.date,
-            notes: data.notes || null,
-            accountId: data.accountId,
-            toAccountId: data.toAccountId || null,
-            categoryId: data.isSplit ? null : data.categoryId || null,
-            merchantId: data.isSplit ? null : data.merchantId || null,
-            isSplit: data.isSplit,
-            userId: user.id,
-            familyId,
-            status: data.status,
-            accountBalanceAfter: accountBalanceAfter,
-            attachmentUrl: data.attachmentUrl,
-          },
-        })
-
-        let createdSplitEntries: Awaited<
-          ReturnType<TenantTransactionClient["splitEntry"]["create"]>
-        >[] = []
-        if (data.isSplit && data.splitEntries?.length) {
-          createdSplitEntries = await runTenantTransactionQueriesInOrder(
-            data.splitEntries.map(
-              (entry) => () =>
-                tx.splitEntry.create({
-                  data: {
-                    transactionId: newTx.id,
-                    description: entry.description,
-                    amount: absMoney(entry.amount),
-                    categoryId: entry.categoryId || null,
-                    merchantId: entry.merchantId || null,
-                  },
-                })
-            )
+        const accountDeltas: AccountDeltaMap = {}
+        if (oldTx.type === "transfer" && oldTx.transferOut) {
+          if (!oldInflowTx) {
+            throw new Error("Transfer inflow leg missing for update")
+          }
+          addAccountDelta(
+            accountDeltas,
+            oldTx.accountId,
+            absMoney(oldTx.amount)
+          )
+          addAccountDelta(
+            accountDeltas,
+            oldInflowTx.accountId,
+            negateMoney(absMoney(oldInflowTx.amount))
+          )
+        } else {
+          addAccountDelta(
+            accountDeltas,
+            oldTx.accountId,
+            negateMoney(oldTx.amount)
           )
         }
 
-        resultTransaction = newTx
+        let resultTransaction: Awaited<
+          ReturnType<TenantTransactionClient["transaction"]["create"]>
+        >
+        let createdInflowTx: Awaited<
+          ReturnType<TenantTransactionClient["transaction"]["create"]>
+        > | null = null
+        let createdTransfer: Awaited<
+          ReturnType<TenantTransactionClient["transfer"]["create"]>
+        > | null = null
+        let createdSplitEntries: Awaited<
+          ReturnType<TenantTransactionClient["splitEntry"]["create"]>
+        >[] = []
 
-        // Re-read data terbaru setelah mutasi
-        const [updatedTx, newAccounts] =
-          await runTenantTransactionQueriesInOrder([
-            () => findTransactionWithSplitEntries(tx, newTx.id),
-            () =>
-              tx.account.findMany({
-                where: { id: { in: Array.from(touchedAccountIds) } },
-              }),
-          ] as const)
+        if (data.type === "transfer") {
+          if (!data.toAccountId)
+            throw new Error("Transfer requires a destination account!")
+          const toAccountId = data.toAccountId
+          let kind = "funds_movement"
+          const toAccount = await tx.account.findFirst({
+            where: { id: toAccountId, familyId },
+          })
+          if (!toAccount)
+            throw new Error("Destination account not found or access denied!")
+          if (toAccount.type === "CREDIT") kind = "cc_payment"
+          else if (toAccount.type === "LOAN") kind = "loan_payment"
+
+          const inAmount = data.destinationAmount ?? data.amount
+          const inCurrency = data.destinationCurrency ?? data.currency
+
+          addAccountDelta(
+            accountDeltas,
+            data.accountId,
+            negateMoney(absMoney(data.amount))
+          )
+          addAccountDelta(accountDeltas, toAccountId, absMoney(inAmount))
+          await applyAccountDeltas(tx, familyId, accountDeltas)
+
+          const sourceBalanceAfter = (
+            await findAccountBalanceVersion(
+              tx,
+              data.accountId,
+              familyId,
+              "Source account not found or access denied!"
+            )
+          ).balance
+          const destBalanceAfter = (
+            await findAccountBalanceVersion(
+              tx,
+              toAccountId,
+              familyId,
+              "Destination account not found or access denied!"
+            )
+          ).balance
+
+          const outflowTx = await tx.transaction.create({
+            data: {
+              type: "transfer",
+              kind,
+              currency: data.currency,
+              amount: negateMoney(absMoney(data.amount)),
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.accountId,
+              toAccountId,
+              categoryId: data.categoryId || null,
+              merchantId: data.merchantId || null,
+              userId: user.id,
+              familyId,
+              status: data.status,
+              destinationAmount: data.destinationAmount,
+              destinationCurrency: data.destinationCurrency,
+              accountBalanceAfter: sourceBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+              supersedes: oldTx.id,
+            },
+          })
+
+          const inflowTx = await tx.transaction.create({
+            data: {
+              type: "transfer",
+              kind,
+              currency: inCurrency,
+              amount: absMoney(inAmount),
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: toAccountId,
+              toAccountId: data.accountId,
+              categoryId: data.categoryId || null,
+              merchantId: data.merchantId || null,
+              userId: user.id,
+              familyId,
+              status: data.status,
+              destinationAmount: data.destinationAmount,
+              destinationCurrency: data.destinationCurrency,
+              accountBalanceAfter: destBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+              ...(oldInflowTx ? { supersedes: oldInflowTx.id } : {}),
+            },
+          })
+
+          createdTransfer = await tx.transfer.create({
+            data: {
+              outflowTransactionId: outflowTx.id,
+              inflowTransactionId: inflowTx.id,
+            },
+          })
+
+          resultTransaction = outflowTx
+          createdInflowTx = inflowTx
+        } else {
+          const amountSign: Money =
+            data.type === "expense"
+              ? negateMoney(absMoney(data.amount))
+              : absMoney(data.amount)
+
+          addAccountDelta(accountDeltas, data.accountId, amountSign)
+          await applyAccountDeltas(tx, familyId, accountDeltas)
+          const accountBalanceAfter = (
+            await findAccountBalanceVersion(
+              tx,
+              data.accountId,
+              familyId,
+              "Account not found or access denied!"
+            )
+          ).balance
+
+          const newTx = await tx.transaction.create({
+            data: {
+              type: data.type,
+              amount: amountSign,
+              description: data.description,
+              date: data.date,
+              notes: data.notes || null,
+              accountId: data.accountId,
+              toAccountId: data.toAccountId || null,
+              categoryId: data.isSplit ? null : data.categoryId || null,
+              merchantId: data.isSplit ? null : data.merchantId || null,
+              isSplit: data.isSplit,
+              userId: user.id,
+              familyId,
+              status: data.status,
+              accountBalanceAfter: accountBalanceAfter,
+              attachmentUrl: data.attachmentUrl,
+              supersedes: oldTx.id,
+            },
+          })
+
+          if (data.isSplit && data.splitEntries?.length) {
+            createdSplitEntries = await runTenantTransactionQueriesInOrder(
+              data.splitEntries.map(
+                (entry) => () =>
+                  tx.splitEntry.create({
+                    data: {
+                      transactionId: newTx.id,
+                      description: entry.description,
+                      amount: absMoney(entry.amount),
+                      categoryId: entry.categoryId || null,
+                      merchantId: entry.merchantId || null,
+                    },
+                  })
+              )
+            )
+          }
+
+          resultTransaction = newTx
+        }
+
+        const deletedAt = new Date()
+        const outflowUpdate = await tx.transaction.updateMany({
+          where: { id: oldTx.id, familyId, deletedAt: null },
+          data: { deletedAt, supersededBy: resultTransaction.id },
+        })
+        if (outflowUpdate.count !== 1) throw new TransactionGoneError()
+
+        if (oldInflowTx) {
+          const inflowUpdate = await tx.transaction.updateMany({
+            where: { id: oldInflowTx.id, familyId, deletedAt: null },
+            data: {
+              deletedAt,
+              ...(createdInflowTx ? { supersededBy: createdInflowTx.id } : {}),
+            },
+          })
+          if (inflowUpdate.count !== 1) throw new TransactionGoneError()
+        }
+
+        if (oldTransferGraph) {
+          const transferUpdate = await tx.transfer.updateMany({
+            where: { id: oldTransferGraph.id, deletedAt: null },
+            data: { deletedAt },
+          })
+          if (transferUpdate.count !== 1) throw new TransactionGoneError()
+        }
+
+        const [
+          updatedOldOutflow,
+          updatedOldInflow,
+          newOutflow,
+          newInflow,
+          updatedOldTransfer,
+          newTransferGraph,
+          newAccounts,
+        ] = await runTenantTransactionQueriesInOrder([
+          () => findTransactionWithSplitEntries(tx, oldTx.id),
+          () =>
+            oldInflowTx
+              ? findTransactionWithSplitEntries(tx, oldInflowTx.id)
+              : Promise.resolve(null),
+          () => findTransactionWithSplitEntries(tx, resultTransaction.id),
+          () =>
+            createdInflowTx
+              ? findTransactionWithSplitEntries(tx, createdInflowTx.id)
+              : Promise.resolve(null),
+          () =>
+            oldTransferGraph
+              ? findTransferGraph(tx, oldTransferGraph.id)
+              : Promise.resolve(null),
+          () =>
+            createdTransfer
+              ? findTransferGraph(tx, createdTransfer.id)
+              : Promise.resolve(null),
+          () =>
+            tx.account.findMany({
+              where: { id: { in: Array.from(touchedAccountIds) } },
+            }),
+        ] as const)
 
         await auditLogs(tx, auditCtx, [
           ...accountBalanceAuditEntries(oldAccounts, newAccounts),
           {
-            action: "update",
+            action: "soft_delete",
             entityType: "Transaction",
             entityId: oldTx.id,
             before: oldTx,
-            after: updatedTx,
+            after: updatedOldOutflow,
           },
-          ...oldTx.splitEntries.map((entry) => ({
-            action: "delete" as const,
-            entityType: "SplitEntry",
-            entityId: entry.id,
-            before: entry,
-            after: null,
-          })),
-          ...createdAuditEntries("SplitEntry", createdSplitEntries),
-          ...(oldInflowTx
+          ...(oldInflowTx && updatedOldInflow
             ? [
                 {
-                  action: "delete" as const,
+                  action: "soft_delete" as const,
                   entityType: "Transaction",
                   entityId: oldInflowTx.id,
                   before: oldInflowTx,
-                  after: null,
+                  after: updatedOldInflow,
                 },
               ]
             : []),
-          ...(oldTransfer
+          ...(oldTransferGraph && updatedOldTransfer
             ? [
                 {
-                  action: "delete" as const,
+                  action: "soft_delete" as const,
                   entityType: "Transfer",
-                  entityId: oldTransfer.id,
-                  before: oldTransfer,
-                  after: null,
+                  entityId: oldTransferGraph.id,
+                  before: oldTransferGraph,
+                  after: updatedOldTransfer,
                 },
               ]
             : []),
+          ...createdAuditEntries("Transaction", [
+            newOutflow,
+            ...(newInflow ? [newInflow] : []),
+          ]),
+          ...(newTransferGraph
+            ? createdAuditEntries("Transfer", [newTransferGraph])
+            : []),
+          ...createdAuditEntries("SplitEntry", createdSplitEntries),
         ])
-      }
 
-      return serializeTransaction({
-        ...resultTransaction,
-        amount: absMoney(resultTransaction.amount),
-      })
-    }
-  )
+        const response = serializeTransaction({
+          ...resultTransaction,
+          amount: absMoney(resultTransaction.amount),
+        })
+
+        await persistIdempotentEndpointResponse(tx, {
+          endpoint: UPDATE_TRANSACTION_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+          response,
+        })
+
+        return response
+      }
+    )
+
+  try {
+    return await updateOrReplay()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+
+    const replay = await scopedTenantTransaction(
+      familyId,
+      async (tx: TenantTransactionClient) =>
+        await replayIdempotentEndpointResponse<SerializedTransactionResult>(
+          tx,
+          {
+            endpoint: UPDATE_TRANSACTION_ENDPOINT,
+            familyId,
+            key: data.idempotencyKey,
+            requestHash,
+          }
+        )
+    )
+    if (replay) return replay
+
+    throw error
+  }
 }
 
 /**
- * BACKEND FUNCTION: Update Transaction (Reversal-and-Replace Pattern)
- * FASE 1 menggunakan hard delete (internal reversal, bukan user-facing delete).
- * FASE 2 membuat record baru dengan ID yang sama — continuity terjaga.
+ * BACKEND FUNCTION: Update Transaction (soft-delete + new-row supersession)
  */
 export const updateTransactionFn = createServerFn({ method: "POST" })
   .middleware([familyMiddleware])
-  .inputValidator(transactionInputSchema)
+  .inputValidator(
+    (data: z.input<typeof updateTransactionTransportInputSchema>) =>
+      updateTransactionTransportInputSchema.parse(data)
+  )
   .handler(async ({ data, context }) => {
-    if (!data.id) throw new Error("ID is required for updating")
+    const normalized = await normalizeUpdateTransactionTransportInput(data)
     return await updateTransactionForFamily({
-      data,
+      data: normalized,
       familyId: context.familyId,
       user: context.user,
     })

--- a/tests/integration/audit-log.integration.ts
+++ b/tests/integration/audit-log.integration.ts
@@ -133,6 +133,7 @@ describe("AuditLog Integration & Security Tests", () => {
   }) {
     return {
       id,
+      idempotencyKey: factories.createIdempotencyKey(),
       accountId,
       amount,
       categoryId,
@@ -162,7 +163,7 @@ describe("AuditLog Integration & Security Tests", () => {
   }) {
     return {
       id,
-      ...(idempotencyKey ? { idempotencyKey } : {}),
+      idempotencyKey: idempotencyKey ?? factories.createIdempotencyKey(),
       accountId,
       amount,
       currency: "IDR",
@@ -360,8 +361,9 @@ describe("AuditLog Integration & Security Tests", () => {
 
     const logs = await orderedAuditLogsSince(owner.family.id, baselineIds)
 
-    // Ekspektasikan 2 audit log: 1 untuk Account/update dan 1 untuk Transaction/update
-    expect(logs).toHaveLength(2)
+    // PER-93: update is represented as Account/update, old Transaction
+    // soft_delete, and replacement Transaction/create.
+    expect(logs).toHaveLength(3)
 
     const accountLog = logs[0]!
     expect(accountLog.entityType).toBe("Account")
@@ -371,9 +373,14 @@ describe("AuditLog Integration & Security Tests", () => {
 
     const transactionLog = logs[1]!
     expect(transactionLog.entityType).toBe("Transaction")
-    expect(transactionLog.action).toBe("update")
+    expect(transactionLog.action).toBe("soft_delete")
     expect((transactionLog.beforeJson as JsonObj).amount).toBe("-10000")
-    expect((transactionLog.afterJson as JsonObj).amount).toBe("-15000")
+    expect((transactionLog.afterJson as JsonObj).deletedAt).not.toBeNull()
+
+    const replacementLog = logs[2]!
+    expect(replacementLog.entityType).toBe("Transaction")
+    expect(replacementLog.action).toBe("create")
+    expect((replacementLog.afterJson as JsonObj).amount).toBe("-15000")
   })
 
   test("3. deleteTransactionFn writes soft_delete audit logs and Account balance revert", async () => {
@@ -401,6 +408,7 @@ describe("AuditLog Integration & Security Tests", () => {
     // Jalankan soft delete secara langsung
     await deleteTransactionForFamily({
       id: txId,
+      idempotencyKey: factories.createIdempotencyKey(),
       familyId: owner.family.id,
       user: owner.user,
     })
@@ -434,6 +442,7 @@ describe("AuditLog Integration & Security Tests", () => {
 
     await deleteTransactionForFamily({
       id: transferTransactionId,
+      idempotencyKey: factories.createIdempotencyKey(),
       familyId: owner.family.id,
       user: owner.user,
     })
@@ -474,7 +483,7 @@ describe("AuditLog Integration & Security Tests", () => {
     expect((afterJson.inflowTransaction as JsonObj).deletedAt).not.toBeNull()
   })
 
-  test("transfer update keeps Transfer audit identity stable", async () => {
+  test("transfer update audits old Transfer soft-delete and replacement create", async () => {
     const {
       destinationAccount,
       owner,
@@ -490,7 +499,7 @@ describe("AuditLog Integration & Security Tests", () => {
     })
     const baselineIds = await auditLogBaseline(owner.family.id)
 
-    await updateTransactionForFamily({
+    const updatedTransfer = await updateTransactionForFamily({
       data: transferPayload({
         id: transferTransactionId,
         accountId: sourceAccount.id,
@@ -502,28 +511,35 @@ describe("AuditLog Integration & Security Tests", () => {
       user: owner.user,
     })
 
-    const [transferAfterUpdate, logsAfterUpdate] = await Promise.all([
-      harness.withFamily(owner.family.id, (tx) =>
-        tx.transfer.findFirstOrThrow({
-          where: { outflowTransactionId: transferTransactionId },
-        })
-      ),
-      harness.withFamily(owner.family.id, (tx) =>
-        tx.auditLog.findMany({
-          where: {
-            action: "update",
-            entityId: transfer.id,
-            entityType: "Transfer",
-          },
-        })
-      ),
-    ])
+    const [oldTransferAfterUpdate, replacementTransfer, logsAfterUpdate] =
+      await Promise.all([
+        harness.withFamily(owner.family.id, (tx) =>
+          tx.transfer.findUniqueOrThrow({
+            where: { id: transfer.id },
+          })
+        ),
+        harness.withFamily(owner.family.id, (tx) =>
+          tx.transfer.findFirstOrThrow({
+            where: { outflowTransactionId: updatedTransfer.id },
+          })
+        ),
+        harness.withFamily(owner.family.id, (tx) =>
+          tx.auditLog.findMany({
+            where: {
+              entityType: "Transfer",
+            },
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          })
+        ),
+      ])
     const newLogs = logsSince(logsAfterUpdate, baselineIds)
 
-    expect(transferAfterUpdate.id).toBe(transfer.id)
-    expect(newLogs).toHaveLength(1)
+    expect(oldTransferAfterUpdate.deletedAt).not.toBeNull()
+    expect(replacementTransfer.id).not.toBe(transfer.id)
+    expect(newLogs.map((log) => log.action)).toEqual(["soft_delete", "create"])
     expect((newLogs[0]!.beforeJson as JsonObj).id).toBe(transfer.id)
-    expect((newLogs[0]!.afterJson as JsonObj).id).toBe(transfer.id)
+    expect((newLogs[0]!.afterJson as JsonObj).deletedAt).not.toBeNull()
+    expect((newLogs[1]!.afterJson as JsonObj).id).toBe(replacementTransfer.id)
   })
 
   test("bulk transaction helpers audit create, update, and soft_delete paths", async () => {

--- a/tests/integration/concurrency.integration.ts
+++ b/tests/integration/concurrency.integration.ts
@@ -330,6 +330,7 @@ describe("ledger concurrency and retry policy (PER-18)", () => {
             currency: "IDR",
             date: new Date("2026-05-30T00:03:01.000Z"),
             description: "Updated transfer during delete",
+            idempotencyKey: factories.createIdempotencyKey(),
             isSplit: false,
             status: "CLEARED",
             toAccountId: fixture.destinationTwo.id,
@@ -340,6 +341,7 @@ describe("ledger concurrency and retry policy (PER-18)", () => {
         }),
         deleteTransactionForFamily({
           id: transfer.id,
+          idempotencyKey: factories.createIdempotencyKey(),
           familyId: fixture.owner.family.id,
           user: fixture.owner.user,
         }),

--- a/tests/integration/idempotent-mutations.integration.ts
+++ b/tests/integration/idempotent-mutations.integration.ts
@@ -1,0 +1,631 @@
+import { Prisma } from "@prisma/client"
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import {
+  bulkUpdateTransactionsForFamily,
+  createTransactionForFamily,
+  deleteTransactionForFamily,
+  updateTransactionForFamily,
+} from "@/server/transactions"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+type TransactionKind = "expense" | "income" | "transfer"
+type TransactionStatus = "PENDING" | "CLEARED" | "RECONCILED"
+
+interface MutationUser {
+  familyId?: string | null
+  id: string
+}
+
+interface SerializedTransactionResult {
+  id: string
+}
+
+interface UpdateMutationPayload {
+  accountId: string
+  amount: bigint
+  attachmentUrl?: string | null
+  categoryId?: string | null
+  currency?: string
+  date: Date
+  description: string
+  destinationAmount?: bigint | null
+  destinationCurrency?: string | null
+  id: string
+  idempotencyKey: string
+  isSplit?: boolean
+  merchantId?: string | null
+  notes?: string | null
+  splitEntries?: Array<{
+    amount: bigint
+    categoryId?: string | null
+    description: string
+    merchantId?: string | null
+  }>
+  status?: TransactionStatus
+  toAccountId?: string | null
+  type: TransactionKind
+}
+
+interface UpdateMutationArgs {
+  data: UpdateMutationPayload
+  familyId: string
+  user: MutationUser
+}
+
+interface DeleteMutationArgs {
+  familyId: string
+  id: string
+  idempotencyKey: string
+  user: MutationUser
+}
+
+interface SupersessionRow {
+  amount: bigint
+  deletedAt: Date | null
+  id: string
+  supersededBy: string | null
+  supersedes: string | null
+  type: string
+}
+
+interface AccountBalanceRow {
+  balance: bigint
+  id: string
+}
+
+const updateMutation = updateTransactionForFamily as unknown as (
+  args: UpdateMutationArgs
+) => Promise<SerializedTransactionResult>
+
+const deleteMutation = deleteTransactionForFamily as unknown as (
+  args: DeleteMutationArgs
+) => Promise<{ success: boolean }>
+
+describe("idempotent update/delete ledger mutations (PER-93)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  test("update soft-deletes the old transaction, creates a new id, links supersession, and applies one balance delta", async () => {
+    const fixture = await createExpenseFixture()
+    const original = await createExpense(fixture, {
+      amount: 10_000n,
+      description: "Original expense",
+    })
+    const updateKey = factories.createIdempotencyKey()
+
+    const updated = await updateMutation({
+      data: {
+        id: original.id,
+        idempotencyKey: updateKey,
+        accountId: fixture.account.id,
+        amount: 25_000n,
+        categoryId: fixture.category.id,
+        currency: "IDR",
+        date: new Date("2026-06-01T02:00:00.000Z"),
+        description: "Updated expense",
+        isSplit: false,
+        status: "CLEARED",
+        type: "expense",
+      },
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+
+    expect(updated.id).not.toBe(original.id)
+
+    const rows = await readSupersessionRows(fixture.owner.family.id, [
+      original.id,
+      updated.id,
+    ])
+    expect(rows.get(original.id)).toMatchObject({
+      amount: -10_000n,
+      supersededBy: updated.id,
+      supersedes: null,
+    })
+    expect(rows.get(original.id)?.deletedAt).toBeInstanceOf(Date)
+    expect(rows.get(updated.id)).toMatchObject({
+      amount: -25_000n,
+      deletedAt: null,
+      supersededBy: null,
+      supersedes: original.id,
+    })
+
+    await expectAccountBalances(fixture.owner.family.id, {
+      [fixture.account.id]: 75_000n,
+    })
+
+    const auditRows = await harness.withFamily(fixture.owner.family.id, (tx) =>
+      tx.auditLog.findMany({
+        where: {
+          entityType: "Transaction",
+          idempotencyKey: updateKey,
+        },
+        orderBy: { createdAt: "asc" },
+        select: {
+          action: true,
+          afterJson: true,
+          beforeJson: true,
+          entityId: true,
+        },
+      })
+    )
+    expect(auditRows.map((row) => [row.action, row.entityId])).toEqual([
+      ["soft_delete", original.id],
+      ["create", updated.id],
+    ])
+    expect(auditRows.every((row) => row.beforeJson !== null)).toBe(false)
+    expect(auditRows.every((row) => row.afterJson !== null)).toBe(true)
+  })
+
+  test("replaying update with the same idempotency key returns the same new id without duplicate balance or audit effects", async () => {
+    const fixture = await createExpenseFixture()
+    const original = await createExpense(fixture, {
+      amount: 10_000n,
+      description: "Replay update original",
+    })
+    const payload: UpdateMutationPayload = {
+      id: original.id,
+      idempotencyKey: factories.createIdempotencyKey(),
+      accountId: fixture.account.id,
+      amount: 25_000n,
+      categoryId: fixture.category.id,
+      currency: "IDR",
+      date: new Date("2026-06-01T02:01:00.000Z"),
+      description: "Replay update replacement",
+      isSplit: false,
+      status: "CLEARED",
+      type: "expense",
+    }
+
+    const first = await updateMutation({
+      data: payload,
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+    const replay = await updateMutation({
+      data: payload,
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+
+    expect(replay.id).toBe(first.id)
+    await expectAccountBalances(fixture.owner.family.id, {
+      [fixture.account.id]: 75_000n,
+    })
+
+    const transactionAudits = await harness.withFamily(
+      fixture.owner.family.id,
+      (tx) =>
+        tx.auditLog.findMany({
+          where: {
+            entityType: "Transaction",
+            idempotencyKey: payload.idempotencyKey,
+          },
+          select: { action: true, entityId: true },
+        })
+    )
+    expect(transactionAudits).toHaveLength(2)
+    expect(transactionAudits.map((row) => row.action).sort()).toEqual([
+      "create",
+      "soft_delete",
+    ])
+  })
+
+  test("update transfer soft-deletes both old legs and old transfer, then creates a new paired transfer graph", async () => {
+    const fixture = await createTransferFixture()
+    const transfer = await createTransfer(fixture, {
+      amount: 100_000n,
+      description: "Original transfer",
+      toAccountId: fixture.destinationOne.id,
+    })
+    const oldTransfer = await readTransferByOutflow(
+      fixture.owner.family.id,
+      transfer.id
+    )
+    const updateKey = factories.createIdempotencyKey()
+
+    const updated = await updateMutation({
+      data: {
+        id: transfer.id,
+        idempotencyKey: updateKey,
+        accountId: fixture.source.id,
+        amount: 150_000n,
+        currency: "IDR",
+        date: new Date("2026-06-01T02:02:00.000Z"),
+        description: "Updated transfer",
+        destinationAmount: null,
+        destinationCurrency: null,
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fixture.destinationTwo.id,
+        type: "transfer",
+      },
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+
+    expect(updated.id).not.toBe(transfer.id)
+    const newTransfer = await readTransferByOutflow(
+      fixture.owner.family.id,
+      updated.id
+    )
+    expect(newTransfer.id).not.toBe(oldTransfer.id)
+
+    const rows = await readSupersessionRows(fixture.owner.family.id, [
+      oldTransfer.outflowTransactionId,
+      oldTransfer.inflowTransactionId,
+      newTransfer.outflowTransactionId,
+      newTransfer.inflowTransactionId,
+    ])
+    expect(
+      rows.get(oldTransfer.outflowTransactionId)?.deletedAt
+    ).toBeInstanceOf(Date)
+    expect(rows.get(oldTransfer.inflowTransactionId)?.deletedAt).toBeInstanceOf(
+      Date
+    )
+    expect(rows.get(oldTransfer.outflowTransactionId)?.supersededBy).toBe(
+      newTransfer.outflowTransactionId
+    )
+    expect(rows.get(oldTransfer.inflowTransactionId)?.supersededBy).toBe(
+      newTransfer.inflowTransactionId
+    )
+    expect(rows.get(newTransfer.outflowTransactionId)).toMatchObject({
+      amount: -150_000n,
+      deletedAt: null,
+      supersedes: oldTransfer.outflowTransactionId,
+    })
+    expect(rows.get(newTransfer.inflowTransactionId)).toMatchObject({
+      amount: 150_000n,
+      deletedAt: null,
+      supersedes: oldTransfer.inflowTransactionId,
+    })
+
+    const oldTransferAfter = await readTransferById(
+      fixture.owner.family.id,
+      oldTransfer.id
+    )
+    expect(oldTransferAfter.deletedAt).toBeInstanceOf(Date)
+    expect(newTransfer.deletedAt).toBeNull()
+
+    await expectAccountBalances(fixture.owner.family.id, {
+      [fixture.source.id]: 850_000n,
+      [fixture.destinationOne.id]: 100_000n,
+      [fixture.destinationTwo.id]: 250_000n,
+    })
+  })
+
+  test("delete replay with the same idempotency key returns prior success without double reversal or duplicate audit", async () => {
+    const fixture = await createExpenseFixture()
+    const original = await createExpense(fixture, {
+      amount: 20_000n,
+      description: "Delete replay expense",
+    })
+    const deleteKey = factories.createIdempotencyKey()
+
+    await deleteMutation({
+      id: original.id,
+      idempotencyKey: deleteKey,
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+    const replay = await deleteMutation({
+      id: original.id,
+      idempotencyKey: deleteKey,
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+
+    expect(replay).toEqual({ success: true })
+    await expectAccountBalances(fixture.owner.family.id, {
+      [fixture.account.id]: 100_000n,
+    })
+
+    const transactionAudits = await harness.withFamily(
+      fixture.owner.family.id,
+      (tx) =>
+        tx.auditLog.findMany({
+          where: {
+            action: "soft_delete",
+            entityId: original.id,
+            entityType: "Transaction",
+            idempotencyKey: deleteKey,
+          },
+        })
+    )
+    expect(transactionAudits).toHaveLength(1)
+  })
+
+  test("updating a soft-deleted transaction fails with 410 Gone and does not mutate balances", async () => {
+    const fixture = await createExpenseFixture()
+    const original = await createExpense(fixture, {
+      amount: 15_000n,
+      description: "Gone update expense",
+    })
+    await deleteMutation({
+      id: original.id,
+      idempotencyKey: factories.createIdempotencyKey(),
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+
+    await expect(
+      updateMutation({
+        data: {
+          id: original.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+          accountId: fixture.account.id,
+          amount: 30_000n,
+          categoryId: fixture.category.id,
+          currency: "IDR",
+          date: new Date("2026-06-01T02:03:00.000Z"),
+          description: "Should not resurrect",
+          isSplit: false,
+          status: "CLEARED",
+          type: "expense",
+        },
+        familyId: fixture.owner.family.id,
+        user: fixture.owner.user,
+      })
+    ).rejects.toMatchObject({ statusCode: 410 })
+
+    await expectAccountBalances(fixture.owner.family.id, {
+      [fixture.account.id]: 100_000n,
+    })
+    const activeCount = await harness.withFamily(
+      fixture.owner.family.id,
+      (tx) =>
+        tx.transaction.count({
+          where: { accountId: fixture.account.id, deletedAt: null },
+        })
+    )
+    expect(activeCount).toBe(0)
+  })
+
+  test("concurrent update and delete on the same transaction settle with exactly one winner and a coherent balance", async () => {
+    const fixture = await createExpenseFixture()
+    const original = await createExpense(fixture, {
+      amount: 10_000n,
+      description: "Race original",
+    })
+
+    const results = await Promise.allSettled([
+      updateMutation({
+        data: {
+          id: original.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+          accountId: fixture.account.id,
+          amount: 20_000n,
+          categoryId: fixture.category.id,
+          currency: "IDR",
+          date: new Date("2026-06-01T02:04:00.000Z"),
+          description: "Race update",
+          isSplit: false,
+          status: "CLEARED",
+          type: "expense",
+        },
+        familyId: fixture.owner.family.id,
+        user: fixture.owner.user,
+      }),
+      deleteMutation({
+        id: original.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+        familyId: fixture.owner.family.id,
+        user: fixture.owner.user,
+      }),
+    ])
+
+    expect(
+      results.filter((result) => result.status === "fulfilled")
+    ).toHaveLength(1)
+    expect(
+      results.filter((result) => result.status === "rejected")
+    ).toHaveLength(1)
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected"
+    )
+    expect(rejected?.reason).toMatchObject({ statusCode: 410 })
+
+    const balances = await readAccountBalances(fixture.owner.family.id, [
+      fixture.account.id,
+    ])
+    expect([80_000n, 100_000n]).toContain(balances.get(fixture.account.id))
+  })
+
+  test("existing bulk update path remains compatible until PER-95 redesigns bulk parity", async () => {
+    const fixture = await createExpenseFixture()
+    const secondCategory = await factories.createCategory({
+      familyId: fixture.owner.family.id,
+      name: "Bulk updated category",
+      type: "expense",
+    })
+    const first = await createExpense(fixture, {
+      amount: 5_000n,
+      description: "Bulk update first",
+    })
+    const second = await createExpense(fixture, {
+      amount: 7_000n,
+      description: "Bulk update second",
+    })
+
+    await bulkUpdateTransactionsForFamily({
+      data: {
+        ids: [first.id, second.id],
+        categoryId: secondCategory.id,
+      },
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+
+    await expectAccountBalances(fixture.owner.family.id, {
+      [fixture.account.id]: 88_000n,
+    })
+    const categories = await harness.withFamily(fixture.owner.family.id, (tx) =>
+      tx.transaction.findMany({
+        where: { id: { in: [first.id, second.id] } },
+        select: { categoryId: true },
+      })
+    )
+    expect(categories.map((row) => row.categoryId)).toEqual([
+      secondCategory.id,
+      secondCategory.id,
+    ])
+  })
+
+  async function createExpenseFixture() {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [account, category] = await Promise.all([
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "PER-93 expense account",
+      }),
+      factories.createCategory({
+        familyId: owner.family.id,
+        name: "PER-93 expense category",
+        type: "expense",
+      }),
+    ])
+
+    return { account, category, owner }
+  }
+
+  async function createTransferFixture() {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const [source, destinationOne, destinationTwo] = await Promise.all([
+      factories.createAccount({
+        balance: 1_000_000n,
+        familyId: owner.family.id,
+        name: "PER-93 source",
+      }),
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "PER-93 destination one",
+      }),
+      factories.createAccount({
+        balance: 100_000n,
+        familyId: owner.family.id,
+        name: "PER-93 destination two",
+      }),
+    ])
+
+    return { destinationOne, destinationTwo, owner, source }
+  }
+
+  async function createExpense(
+    fixture: Awaited<ReturnType<typeof createExpenseFixture>>,
+    input: { amount: bigint; description: string }
+  ) {
+    return await createTransactionForFamily({
+      data: {
+        id: factories.createIdempotencyKey(),
+        idempotencyKey: factories.createIdempotencyKey(),
+        accountId: fixture.account.id,
+        amount: input.amount,
+        categoryId: fixture.category.id,
+        currency: "IDR",
+        date: new Date("2026-06-01T01:00:00.000Z"),
+        description: input.description,
+        isSplit: false,
+        status: "CLEARED",
+        type: "expense",
+      },
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+  }
+
+  async function createTransfer(
+    fixture: Awaited<ReturnType<typeof createTransferFixture>>,
+    input: { amount: bigint; description: string; toAccountId: string }
+  ) {
+    return await createTransactionForFamily({
+      data: {
+        id: factories.createIdempotencyKey(),
+        idempotencyKey: factories.createIdempotencyKey(),
+        accountId: fixture.source.id,
+        amount: input.amount,
+        currency: "IDR",
+        date: new Date("2026-06-01T01:30:00.000Z"),
+        description: input.description,
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: input.toAccountId,
+        type: "transfer",
+      },
+      familyId: fixture.owner.family.id,
+      user: fixture.owner.user,
+    })
+  }
+
+  async function readSupersessionRows(familyId: string, ids: string[]) {
+    const rows = await harness.withFamily(
+      familyId,
+      (tx) =>
+        tx.$queryRaw<SupersessionRow[]>`
+        SELECT id, amount, type, "deletedAt", "supersededBy", "supersedes"
+        FROM "Transaction"
+        WHERE id IN (${Prisma.join(ids)})
+      `
+    )
+    return new Map(rows.map((row) => [row.id, row]))
+  }
+
+  async function readTransferByOutflow(familyId: string, outflowId: string) {
+    return await harness.withFamily(familyId, (tx) =>
+      tx.transfer.findUniqueOrThrow({
+        where: { outflowTransactionId: outflowId },
+      })
+    )
+  }
+
+  async function readTransferById(familyId: string, id: string) {
+    return await harness.withFamily(familyId, (tx) =>
+      tx.transfer.findUniqueOrThrow({
+        where: { id },
+      })
+    )
+  }
+
+  async function readAccountBalances(familyId: string, accountIds: string[]) {
+    const rows = await harness.withFamily(familyId, (tx) =>
+      tx.account.findMany({
+        where: { id: { in: accountIds } },
+        select: { balance: true, id: true },
+      })
+    )
+    return new Map(rows.map((row: AccountBalanceRow) => [row.id, row.balance]))
+  }
+
+  async function expectAccountBalances(
+    familyId: string,
+    expected: Record<string, bigint>
+  ) {
+    const balances = await readAccountBalances(familyId, Object.keys(expected))
+    expect(Object.fromEntries(balances)).toEqual(expected)
+  }
+})

--- a/tests/integration/pg-client-query-deprecation.integration.ts
+++ b/tests/integration/pg-client-query-deprecation.integration.ts
@@ -74,6 +74,7 @@ describe("pg client query usage", () => {
     const deleteWarnings = await capturePgOverlappingQueryWarnings(async () => {
       await deleteTransactionForFamily({
         id: transactionId,
+        idempotencyKey: factories.createIdempotencyKey(),
         familyId: owner.family.id,
         user: owner.user,
       })

--- a/tests/integration/tenant-reference-validation.integration.ts
+++ b/tests/integration/tenant-reference-validation.integration.ts
@@ -327,6 +327,7 @@ describe("App-level tenant reference validation (PER-94)", () => {
             date: new Date("2026-03-07T00:00:00.000Z"),
             description: "Cross-tenant accountId on update",
             isSplit: false,
+            idempotencyKey: getFactories().createIdempotencyKey(),
             status: "CLEARED",
             type: "expense",
           },

--- a/tests/integration/transfer-graph-invariants.integration.ts
+++ b/tests/integration/transfer-graph-invariants.integration.ts
@@ -208,6 +208,7 @@ describe("PER-103 — Transfer graph DB invariants", () => {
       deleteTransactionForFamily({
         familyId: fx.familyId,
         id: outflowId,
+        idempotencyKey: getFactories().createIdempotencyKey(),
         user: fx.user,
       })
     ).resolves.toBeDefined()
@@ -219,7 +220,7 @@ describe("PER-103 — Transfer graph DB invariants", () => {
     expect(transfers[0]?.deletedAt).not.toBeNull()
   })
 
-  test("update transfer reversal-and-replace passes the deferred trigger at commit", async () => {
+  test("update transfer soft-delete supersession passes the deferred trigger at commit", async () => {
     const fx = await createAccountsFixture({ sourceBalance: 200_000n })
     const replacementDest = await getFactories().createAccount({
       balance: 0n,
@@ -254,6 +255,7 @@ describe("PER-103 — Transfer graph DB invariants", () => {
           date: TEST_DATE,
           description: "Updated transfer",
           id: outflowId,
+          idempotencyKey: getFactories().createIdempotencyKey(),
           isSplit: false,
           status: "CLEARED",
           toAccountId: replacementDest.id,
@@ -267,7 +269,10 @@ describe("PER-103 — Transfer graph DB invariants", () => {
     const transfers = await getHarness().withFamily(fx.familyId, (tx) =>
       tx.transfer.findMany()
     )
-    expect(transfers).toHaveLength(1)
+    expect(transfers).toHaveLength(2)
+    expect(
+      transfers.filter((transfer) => transfer.deletedAt === null)
+    ).toHaveLength(1)
   })
 })
 

--- a/tests/integration/transfer-soft-delete.integration.ts
+++ b/tests/integration/transfer-soft-delete.integration.ts
@@ -65,6 +65,7 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
     await deleteTransactionForFamily({
       familyId: fixture.owner.family.id,
       id: fixture.outflowTransactionId,
+      idempotencyKey: getFactories().createIdempotencyKey(),
       user: fixture.owner.user,
     })
 
@@ -104,6 +105,7 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
     await deleteTransactionForFamily({
       familyId: fixture.owner.family.id,
       id: fixture.inflowTransactionId,
+      idempotencyKey: getFactories().createIdempotencyKey(),
       user: fixture.owner.user,
     })
 
@@ -158,6 +160,7 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
     await deleteTransactionForFamily({
       familyId: owner.family.id,
       id: transferA.outflowTransactionId,
+      idempotencyKey: getFactories().createIdempotencyKey(),
       user: owner.user,
     })
 
@@ -174,10 +177,12 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
 
   test("soft-delete is idempotent: replay does not double-reverse balances", async () => {
     const fixture = await createTransferFixture()
+    const idempotencyKey = getFactories().createIdempotencyKey()
 
     await deleteTransactionForFamily({
       familyId: fixture.owner.family.id,
       id: fixture.outflowTransactionId,
+      idempotencyKey,
       user: fixture.owner.user,
     })
     const balancesAfterFirstDelete = await readBalances(fixture)
@@ -186,6 +191,7 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
       deleteTransactionForFamily({
         familyId: fixture.owner.family.id,
         id: fixture.outflowTransactionId,
+        idempotencyKey,
         user: fixture.owner.user,
       })
     ).resolves.toBeDefined()
@@ -287,7 +293,7 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
       toAccountId: originalDest.id,
     })
 
-    await updateTransactionForFamily({
+    const updated = await updateTransactionForFamily({
       data: {
         accountId: sourceAccount.id,
         amount: 75_000n,
@@ -295,6 +301,7 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
         date: TEST_DATE,
         description: "Updated transfer",
         id: fixture.outflowTransactionId,
+        idempotencyKey: getFactories().createIdempotencyKey(),
         isSplit: false,
         status: "CLEARED",
         toAccountId: replacementDest.id,
@@ -304,16 +311,21 @@ describe("PER-20 — Transfer soft-delete symmetry", () => {
       user: owner.user,
     })
 
-    // The Transfer row tied to the old transactions must be gone (hard-deleted
-    // as part of the reversal phase). A new Transfer row points at the new
-    // outflow + inflow Transactions.
+    // PER-93 keeps the old Transfer as soft-deleted history and creates a new
+    // Transfer row for the replacement legs.
     const transfersAfter = await getHarness().withFamily(
       owner.family.id,
       (tx) => tx.transfer.findMany({})
     )
-    expect(transfersAfter).toHaveLength(1)
-    const newTransfer = transfersAfter[0]
-    expect(newTransfer?.outflowTransactionId).toBe(fixture.outflowTransactionId)
+    expect(transfersAfter).toHaveLength(2)
+    const oldTransfer = transfersAfter.find(
+      (row) => row.id === fixture.transferId
+    )
+    const newTransfer = transfersAfter.find(
+      (row) => row.id !== fixture.transferId
+    )
+    expect(oldTransfer?.deletedAt).not.toBeNull()
+    expect(newTransfer?.outflowTransactionId).toBe(updated.id)
     expect(newTransfer?.inflowTransactionId).not.toBe(
       fixture.inflowTransactionId
     )


### PR DESCRIPTION
## Summary

Implements PER-93 ledger-safe update/delete semantics for transaction mutations:

- Documents the final design in `docs/adr/0032-idempotent-update-delete.md`.
- Adds `Transaction.supersededBy` / `Transaction.supersedes` one-to-one links with fail-loud migration guards.
- Replaces single-update hard-delete reversal with soft-delete plus new canonical transaction rows.
- Adds endpoint-scoped `IdempotencyRecord` replay for `updateTransactionFn` and `deleteTransactionFn`.
- Preserves transfer graph auditability by soft-deleting old transfer legs and the old `Transfer`, then creating a new paired graph.
- Requires client-side update/delete idempotency keys and keeps TanStack DB collection refetch behavior after mutations.

## Ledger Semantics

- Same update/delete key + same canonical payload replays the original response without duplicate balance, row, or audit effects.
- Same key + different payload returns the existing idempotency conflict behavior.
- Updating a soft-deleted transaction returns `410 Gone` and does not mutate balances.
- A new logical delete against a soft-deleted transaction returns `410 Gone`; the original delete key still replays `{ success: true }`.
- Bulk update/delete remain existing behavior and are explicitly left for PER-95 parity.

## Migration

Adds migration `20260601020000_idempotent_update_delete` with drift guards for:

- soft-deleted transactions missing soft-delete audit evidence;
- malformed transfer soft-delete symmetry.

The local dev database drift audit before implementation was clean: deleted transactions `0`, deleted-without-soft-delete-audit `0`, hard-delete-style audit rows `0`.

## Validation

RED gate before implementation:

```bash
env -u DATABASE_URL PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration -- tests/integration/idempotent-mutations.integration.ts
```

Expected failures: 6 failed, 116 passed.

GREEN / final checks:

```bash
vp check
vp test run
env -u DATABASE_URL PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration -- tests/integration/idempotent-mutations.integration.ts
env -u DATABASE_URL PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration
vp build
vp run db:deploy
git diff --check
```

Final results:

- `vp check` passed.
- `vp test run` passed: 9 files, 210 tests.
- Integration suite passed: 15 files, 122 tests.
- `vp build` passed. Remaining warnings are existing TanStack/node built-in externalization warnings, not introduced by PER-93.
- Migration applied locally with `vp run db:deploy`.
- Pre-commit staged check passed during commit.