### PR TITLE
PER-45 onboarding demo ledger initializer

### DIFF
--- a/src/components/blocks/onboarding-page.tsx
+++ b/src/components/blocks/onboarding-page.tsx
@@ -1,0 +1,73 @@
+import { useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { useRef, useState, useTransition } from "react"
+import { Button } from "@/components/ui/button"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import { onboardFn } from "@/server/auth-fns"
+
+export function OnboardingPage() {
+  const router = useRouter()
+  const submitOnboarding = useServerFn(onboardFn)
+  const idempotencyKeyRef = useRef<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function getIdempotencyKey() {
+    idempotencyKeyRef.current ??= createUuidV7()
+    return idempotencyKeyRef.current
+  }
+
+  function handleSubmit() {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const result = await submitOnboarding({
+          data: { idempotencyKey: getIdempotencyKey() },
+        })
+        if (result.familyId) {
+          await router.invalidate()
+          await router.navigate({ to: "/dashboard" })
+        }
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Something went wrong. Please try again."
+        )
+      }
+    })
+  }
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-zinc-100 p-6 md:p-10">
+      <div className="w-full max-w-sm text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Welcome to Permoney
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Set up your family workspace to start tracking your finances.
+        </p>
+      </div>
+
+      {error && (
+        <div className="w-full max-w-sm rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <Button
+        onClick={handleSubmit}
+        disabled={isPending}
+        size="lg"
+        className="w-full max-w-sm"
+      >
+        {isPending ? "Setting up your workspace..." : "Get Started"}
+      </Button>
+
+      <p className="text-xs text-muted-foreground">
+        This creates your private family workspace. You can invite members
+        later.
+      </p>
+    </div>
+  )
+}

--- a/src/routes/onboarding.tsx
+++ b/src/routes/onboarding.tsx
@@ -1,9 +1,7 @@
-import { createFileRoute, redirect, useRouter } from "@tanstack/react-router"
-import { onboardFn, getSessionGuardFn } from "@/server/auth-fns"
+import { createFileRoute, redirect } from "@tanstack/react-router"
+import { getSessionGuardFn } from "@/server/auth-fns"
 import { getOnboardingRouteRedirect } from "@/server/onboarding-contract"
-import { Button } from "@/components/ui/button"
-import { useServerFn } from "@tanstack/react-start"
-import { useState, useTransition } from "react"
+import { OnboardingPage } from "@/components/blocks/onboarding-page"
 
 export const Route = createFileRoute("/onboarding")({
   beforeLoad: async () => {
@@ -13,62 +11,3 @@ export const Route = createFileRoute("/onboarding")({
   },
   component: OnboardingPage,
 })
-
-function OnboardingPage() {
-  const router = useRouter()
-  const submitOnboarding = useServerFn(onboardFn)
-  const [error, setError] = useState<string | null>(null)
-  const [isPending, startTransition] = useTransition()
-
-  function handleSubmit() {
-    setError(null)
-    startTransition(async () => {
-      try {
-        const result = await submitOnboarding()
-        if (result.familyId) {
-          await router.invalidate()
-          await router.navigate({ to: "/dashboard" })
-        }
-      } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Something went wrong. Please try again."
-        )
-      }
-    })
-  }
-
-  return (
-    <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-zinc-100 p-6 md:p-10">
-      <div className="w-full max-w-sm text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Welcome to Permoney
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Set up your family workspace to start tracking your finances.
-        </p>
-      </div>
-
-      {error && (
-        <div className="w-full max-w-sm rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400">
-          {error}
-        </div>
-      )}
-
-      <Button
-        onClick={handleSubmit}
-        disabled={isPending}
-        size="lg"
-        className="w-full max-w-sm"
-      >
-        {isPending ? "Setting up your workspace..." : "Get Started"}
-      </Button>
-
-      <p className="text-xs text-muted-foreground">
-        This creates your private family workspace. You can invite members
-        later.
-      </p>
-    </div>
-  )
-}

--- a/src/server/auth-fns.ts
+++ b/src/server/auth-fns.ts
@@ -5,6 +5,7 @@ import {
   getPostAuthRedirectPath,
   hasFamilyIdValue,
 } from "./onboarding-contract"
+import { initializeOnboardingInputSchema } from "./onboarding-input"
 
 export { signupSchema, loginSchema }
 
@@ -101,28 +102,32 @@ export const logoutFn = createServerFn({ method: "POST" }).handler(async () => {
 /**
  * M1-7: Guided onboarding initializer.
  *
- * Callable when the session exists. If the user already has a family, this is
- * an idempotent replay and returns the existing familyId.
+ * Callable when the session exists with a client-supplied idempotency key. If
+ * the user already has a family, matching replays return the stored response.
  *
  * Inside one Prisma $transaction:
  *   1. Lock the User row so concurrent onboarding requests serialize.
  *   2. Create a Family row with a safe default name if familyId is still null.
  *   3. Set the Postgres app.family_id GUC on the same transaction client.
  *   4. Update User.familyId to the new Family's id.
+ *   5. Create the starter Account, sample Transaction, idempotency record, and
+ *      audit rows in the same transaction.
  *
  * Returns the new familyId so the client can redirect to the dashboard.
  */
-export const onboardFn = createServerFn({ method: "POST" }).handler(
-  async () => {
+export const onboardFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    initializeOnboardingInputSchema.parse(data)
+  )
+  .handler(async ({ data }) => {
     const [{ user }, { prisma }, { initializeOnboardingForUser }] =
       await Promise.all([
         requireSession(),
         import("./db.server"),
         import("./onboarding-service"),
       ])
-    return await initializeOnboardingForUser(prisma, user.id)
-  }
-)
+    return await initializeOnboardingForUser(prisma, user.id, data)
+  })
 
 function readAuthFamilyId(user: unknown): string | null {
   if (typeof user !== "object" || user === null || !("familyId" in user)) {

--- a/src/server/idempotency.ts
+++ b/src/server/idempotency.ts
@@ -1,0 +1,43 @@
+export class IdempotencyConflictError extends Error {
+  statusCode = 409
+
+  constructor(message = "Idempotency key reused with a different payload") {
+    super(message)
+    this.name = "IdempotencyConflictError"
+  }
+}
+
+export const IDEMPOTENCY_RECORD_TTL_MS = 24 * 60 * 60 * 1000
+
+export async function hashCanonicalPayload(payload: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(
+    JSON.stringify(toCanonicalJson(payload))
+  )
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("")
+}
+
+export function toCanonicalJson(value: unknown): unknown {
+  if (value === null || value === undefined) return null
+  if (typeof value === "bigint") return value.toString()
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map((item) => toCanonicalJson(item))
+  if (typeof value === "object") {
+    const source = value as Record<string, unknown>
+    const result: Record<string, unknown> = {}
+    for (const key of Object.keys(source).sort(compareStableText)) {
+      const item = source[key]
+      if (item !== undefined) {
+        result[key] = toCanonicalJson(item)
+      }
+    }
+    return result
+  }
+  return value
+}
+
+function compareStableText(left: string, right: string): number {
+  return left.localeCompare(right)
+}

--- a/src/server/onboarding-input.ts
+++ b/src/server/onboarding-input.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const onboardingIdempotencyKeySchema = z
+  .string()
+  .trim()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    "idempotencyKey must be a UUIDv7"
+  )
+  .transform((value) => value.toLowerCase())
+
+export const initializeOnboardingInputSchema = z.object({
+  idempotencyKey: onboardingIdempotencyKeySchema,
+})
+
+export type InitializeOnboardingInput = z.infer<
+  typeof initializeOnboardingInputSchema
+>

--- a/src/server/onboarding-service.ts
+++ b/src/server/onboarding-service.ts
@@ -1,7 +1,17 @@
 import type { Prisma, PrismaClient } from "@prisma/client"
-import { auditLog, createAuditContext } from "./middleware/audit"
+import { auditLogs, createAuditContext } from "./middleware/audit"
 import { setTenantGuc } from "./middleware/with-family"
 import { withSerializableRetry } from "./middleware/with-retry"
+import {
+  initializeOnboardingInputSchema,
+  type InitializeOnboardingInput,
+} from "./onboarding-input"
+import {
+  IDEMPOTENCY_RECORD_TTL_MS,
+  IdempotencyConflictError,
+  hashCanonicalPayload,
+  toCanonicalJson,
+} from "./idempotency"
 
 interface LockedOnboardingUser {
   email: string
@@ -11,17 +21,32 @@ interface LockedOnboardingUser {
 }
 
 export interface OnboardingInitializationResult {
+  accountId: string | null
   created: boolean
   familyId: string
+  sampleTransactionId: string | null
 }
+
+const INITIALIZE_ONBOARDING_ENDPOINT = "initializeOnboardingForUser"
+const STARTER_ACCOUNT_OPENING_BALANCE = 10_000_000n
+const SAMPLE_TRANSACTION_AMOUNT = -1_250_000n
+const STARTER_ACCOUNT_NAME = "Everyday Cash"
+const SAMPLE_TRANSACTION_DESCRIPTION = "Welcome coffee"
+const STARTER_ACCOUNT_COLOR = "#2563eb"
 
 export async function initializeOnboardingForUser(
   client: PrismaClient,
-  userId: string
+  userId: string,
+  input: InitializeOnboardingInput
 ): Promise<OnboardingInitializationResult> {
-  const auditCtx = await createAuditContext({
-    user: { id: userId, familyId: null },
-  })
+  const data = initializeOnboardingInputSchema.parse(input)
+  const requestHash = await hashCanonicalPayload({ userId })
+  const auditCtx = await createAuditContext(
+    {
+      user: { id: userId, familyId: null },
+    },
+    data.idempotencyKey
+  )
 
   return await withSerializableRetry(client, async (tx) => {
     const user = await lockUserForOnboarding(tx, userId)
@@ -34,8 +59,19 @@ export async function initializeOnboardingForUser(
     }
 
     if (user.familyId) {
-      await setTenantGuc(tx, user.familyId)
-      return { created: false, familyId: user.familyId }
+      const scopedFamilyId = await setTenantGuc(tx, user.familyId)
+      const replay = await replayOnboardingResponse(tx, {
+        familyId: scopedFamilyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+      if (replay) return replay
+      return {
+        accountId: null,
+        created: false,
+        familyId: scopedFamilyId,
+        sampleTransactionId: null,
+      }
     }
 
     const family = await tx.family.create({
@@ -51,18 +87,197 @@ export async function initializeOnboardingForUser(
       data: { familyId: scopedFamilyId },
     })
 
-    // Catat audit log untuk pembuatan Family baru (onboarding)
-    await auditLog(tx, auditCtx, {
-      action: "create",
-      entityType: "Family",
-      entityId: family.id,
-      before: null,
-      after: family,
-      familyId: family.id,
+    const account = await tx.account.create({
+      data: {
+        balance: STARTER_ACCOUNT_OPENING_BALANCE,
+        color: STARTER_ACCOUNT_COLOR,
+        currency: family.currency,
+        familyId: scopedFamilyId,
+        name: STARTER_ACCOUNT_NAME,
+        status: "active",
+        type: "DEPOSITORY",
+      },
     })
 
-    return { created: true, familyId: scopedFamilyId }
+    const finalBalance =
+      STARTER_ACCOUNT_OPENING_BALANCE + SAMPLE_TRANSACTION_AMOUNT
+    const balanceUpdate = await tx.account.updateMany({
+      where: {
+        familyId: scopedFamilyId,
+        id: account.id,
+        version: account.version,
+      },
+      data: {
+        balance: { increment: SAMPLE_TRANSACTION_AMOUNT },
+        version: { increment: 1 },
+      },
+    })
+    if (balanceUpdate.count !== 1) {
+      throw new Error("Starter account balance version drift detected")
+    }
+
+    const finalAccount = await tx.account.findFirstOrThrow({
+      where: { familyId: scopedFamilyId, id: account.id },
+    })
+    if (finalAccount.balance !== finalBalance) {
+      throw new Error("Starter account balance did not reflect sample expense")
+    }
+
+    const sampleTransaction = await tx.transaction.create({
+      data: {
+        accountBalanceAfter: finalAccount.balance,
+        accountId: finalAccount.id,
+        amount: SAMPLE_TRANSACTION_AMOUNT,
+        categoryId: null,
+        currency: family.currency,
+        date: new Date(),
+        description: SAMPLE_TRANSACTION_DESCRIPTION,
+        familyId: scopedFamilyId,
+        idempotencyKey: data.idempotencyKey,
+        isSplit: false,
+        kind: "standard",
+        merchantId: null,
+        notes: null,
+        status: "CLEARED",
+        toAccountId: null,
+        type: "expense",
+        userId: user.id,
+      },
+    })
+
+    const scopedAuditCtx = {
+      ...auditCtx,
+      session: {
+        user: {
+          id: user.id,
+          familyId: scopedFamilyId,
+        },
+      },
+    }
+
+    await auditLogs(tx, scopedAuditCtx, [
+      {
+        action: "create",
+        after: family,
+        before: null,
+        entityId: family.id,
+        entityType: "Family",
+        familyId: scopedFamilyId,
+      },
+      {
+        action: "create",
+        after: finalAccount,
+        before: null,
+        entityId: finalAccount.id,
+        entityType: "Account",
+        familyId: scopedFamilyId,
+      },
+      {
+        action: "create",
+        after: sampleTransaction,
+        before: null,
+        entityId: sampleTransaction.id,
+        entityType: "Transaction",
+        familyId: scopedFamilyId,
+      },
+    ])
+
+    const result: OnboardingInitializationResult = {
+      accountId: finalAccount.id,
+      created: true,
+      familyId: scopedFamilyId,
+      sampleTransactionId: sampleTransaction.id,
+    }
+
+    await persistOnboardingResponse(tx, {
+      familyId: scopedFamilyId,
+      key: data.idempotencyKey,
+      requestHash,
+      response: result,
+    })
+
+    return result
   })
+}
+
+async function replayOnboardingResponse(
+  tx: Prisma.TransactionClient,
+  {
+    familyId,
+    key,
+    requestHash,
+  }: {
+    familyId: string
+    key: string
+    requestHash: string
+  }
+): Promise<OnboardingInitializationResult | null> {
+  const record = await tx.idempotencyRecord.findUnique({
+    where: {
+      familyId_endpoint_key: {
+        endpoint: INITIALIZE_ONBOARDING_ENDPOINT,
+        familyId,
+        key,
+      },
+    },
+  })
+  if (!record) return null
+  if (record.requestHash !== requestHash) {
+    throw new IdempotencyConflictError()
+  }
+  return parseStoredOnboardingResult(record.responseJson)
+}
+
+async function persistOnboardingResponse(
+  tx: Prisma.TransactionClient,
+  {
+    familyId,
+    key,
+    requestHash,
+    response,
+  }: {
+    familyId: string
+    key: string
+    requestHash: string
+    response: OnboardingInitializationResult
+  }
+): Promise<void> {
+  await tx.idempotencyRecord.create({
+    data: {
+      endpoint: INITIALIZE_ONBOARDING_ENDPOINT,
+      expiresAt: new Date(Date.now() + IDEMPOTENCY_RECORD_TTL_MS),
+      familyId,
+      key,
+      requestHash,
+      responseJson: toCanonicalJson(response) as Prisma.InputJsonValue,
+      statusCode: 200,
+    },
+  })
+}
+
+function parseStoredOnboardingResult(
+  value: Prisma.JsonValue
+): OnboardingInitializationResult {
+  if (!isRecord(value)) {
+    throw new TypeError("Stored onboarding idempotency response is invalid")
+  }
+
+  const { accountId, created, familyId, sampleTransactionId } = value
+  if (typeof created !== "boolean" || typeof familyId !== "string") {
+    throw new TypeError("Stored onboarding idempotency response is invalid")
+  }
+
+  return {
+    accountId: typeof accountId === "string" ? accountId : null,
+    created,
+    familyId,
+    sampleTransactionId:
+      typeof sampleTransactionId === "string" ? sampleTransactionId : null,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function deriveDefaultFamilyName(

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -19,6 +19,14 @@ import {
   validateTenantReferences,
 } from "./validation/tenant-references"
 import { VersionDriftError } from "./middleware/with-retry"
+import {
+  IDEMPOTENCY_RECORD_TTL_MS,
+  IdempotencyConflictError,
+  hashCanonicalPayload,
+  toCanonicalJson,
+} from "./idempotency"
+
+export { IdempotencyConflictError } from "./idempotency"
 
 /**
  * BACKEND FUNCTION: Fetch reference data for the Transaction Form Dropdowns
@@ -741,15 +749,6 @@ interface CreateTransactionForFamilyArgs {
   user: { id: string }
 }
 
-export class IdempotencyConflictError extends Error {
-  statusCode = 409
-
-  constructor(message = "Idempotency key reused with a different payload") {
-    super(message)
-    this.name = "IdempotencyConflictError"
-  }
-}
-
 export class TransactionGoneError extends Error {
   statusCode = 410
 
@@ -759,7 +758,6 @@ export class TransactionGoneError extends Error {
   }
 }
 
-const IDEMPOTENCY_RECORD_TTL_MS = 24 * 60 * 60 * 1000
 const UPDATE_TRANSACTION_ENDPOINT = "updateTransactionFn"
 const DELETE_TRANSACTION_ENDPOINT = "deleteTransactionFn"
 const BULK_CREATE_TRANSACTIONS_ENDPOINT = "bulkCreateTransactionsFn"
@@ -796,35 +794,6 @@ interface BulkUpdateTransactionsResult {
 interface BulkDeleteTransactionsResult {
   count: number
   success: boolean
-}
-
-async function hashCanonicalPayload(payload: unknown): Promise<string> {
-  const bytes = new TextEncoder().encode(
-    JSON.stringify(toCanonicalJson(payload))
-  )
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes)
-  return Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, "0")
-  ).join("")
-}
-
-function toCanonicalJson(value: unknown): unknown {
-  if (value === null || value === undefined) return null
-  if (typeof value === "bigint") return value.toString()
-  if (value instanceof Date) return value.toISOString()
-  if (Array.isArray(value)) return value.map((item) => toCanonicalJson(item))
-  if (typeof value === "object") {
-    const source = value as Record<string, unknown>
-    const result: Record<string, unknown> = {}
-    for (const key of Object.keys(source).sort()) {
-      const item = source[key]
-      if (item !== undefined) {
-        result[key] = toCanonicalJson(item)
-      }
-    }
-    return result
-  }
-  return value
 }
 
 async function replayIdempotentEndpointResponse<TResponse>(

--- a/tests/integration/audit-log.integration.ts
+++ b/tests/integration/audit-log.integration.ts
@@ -864,25 +864,42 @@ describe("AuditLog Integration & Security Tests", () => {
   })
 
   test("10. onboarding writes a family create audit log", async () => {
+    const idempotencyKey = factories.createIdempotencyKey()
     const user = await factories.createUser({
       email: "onboard-audit@permoney.local",
       familyId: null,
       name: "Audit Onboarding",
     })
 
-    const result = await initializeOnboardingForUser(harness.prisma, user.id)
+    const result = await initializeOnboardingForUser(harness.prisma, user.id, {
+      idempotencyKey,
+    })
 
     // Cari audit log yang dicatat saat onboarding dengan scoped GUC familyId
     const logs = await harness.withFamily(result.familyId, (tx) =>
       tx.auditLog.findMany({
         where: { familyId: result.familyId },
+        orderBy: { entityType: "asc" },
       })
     )
 
-    expect(logs).toHaveLength(1)
-    const log = logs[0]!
-    expect(log.entityType).toBe("Family")
-    expect(log.action).toBe("create")
-    expect(log.entityId).toBe(result.familyId)
+    expect(logs.map((log) => log.entityType)).toEqual([
+      "Account",
+      "Family",
+      "Transaction",
+    ])
+    expect(logs.every((log) => log.action === "create")).toBe(true)
+    expect(logs.every((log) => log.idempotencyKey === idempotencyKey)).toBe(
+      true
+    )
+    expect(logs.find((log) => log.entityType === "Family")?.entityId).toBe(
+      result.familyId
+    )
+    expect(logs.find((log) => log.entityType === "Account")?.entityId).toBe(
+      result.accountId
+    )
+    expect(logs.find((log) => log.entityType === "Transaction")?.entityId).toBe(
+      result.sampleTransactionId
+    )
   })
 })

--- a/tests/integration/onboarding-contract.integration.ts
+++ b/tests/integration/onboarding-contract.integration.ts
@@ -58,35 +58,122 @@ describe("onboarding contract", () => {
   })
 
   test("onboarding initialization creates one family and replay returns it", async () => {
+    const idempotencyKey = factories.createIdempotencyKey()
     const user = await factories.createUser({
       email: "onboarding-replay@permoney.local",
       familyId: null,
       name: "Onboarding Replay",
     })
 
-    const first = await initializeOnboardingForUser(harness.prisma, user.id)
+    const first = await initializeOnboardingForUser(harness.prisma, user.id, {
+      idempotencyKey,
+    })
     const storedAfterFirst = await harness.prisma.user.findFirstOrThrow({
       where: { familyId: first.familyId, id: user.id },
     })
     const second = await initializeOnboardingForUser(
       harness.prisma,
-      storedAfterFirst.id
+      storedAfterFirst.id,
+      { idempotencyKey }
     )
 
-    const [storedUser, families] = await Promise.all([
-      harness.prisma.user.findUniqueOrThrow({ where: { id: user.id } }),
-      harness.prisma.family.findMany(),
-    ])
+    const storedUser = await harness.prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+    })
+    const families = await harness.prisma.family.findMany()
+    const scopedRows = await harness.withFamily(first.familyId, async (tx) => {
+      const accounts = await tx.account.findMany({
+        where: { familyId: first.familyId },
+      })
+      const transactions = await tx.transaction.findMany({
+        where: { familyId: first.familyId },
+      })
+      const auditLogs = await tx.auditLog.findMany({
+        where: { familyId: first.familyId },
+        orderBy: { entityType: "asc" },
+      })
+      const idempotencyRecords = await tx.idempotencyRecord.findMany({
+        where: {
+          endpoint: "initializeOnboardingForUser",
+          familyId: first.familyId,
+          key: idempotencyKey,
+        },
+      })
+      return { accounts, auditLogs, idempotencyRecords, transactions }
+    })
 
     expect(first.created).toBe(true)
-    expect(second.created).toBe(false)
-    expect(second.familyId).toBe(first.familyId)
+    expect(second).toEqual(first)
     expect(storedUser.familyId).toBe(first.familyId)
     expect(families).toHaveLength(1)
     expect(families[0]?.name).toBe("Onboarding Replay's Family")
+
+    expect(scopedRows.accounts).toHaveLength(1)
+    expect(scopedRows.transactions).toHaveLength(1)
+    expect(scopedRows.idempotencyRecords).toHaveLength(1)
+
+    const account = scopedRows.accounts[0]!
+    const transaction = scopedRows.transactions[0]!
+
+    expect(first.accountId).toBe(account.id)
+    expect(first.sampleTransactionId).toBe(transaction.id)
+    expect(account.familyId).toBe(first.familyId)
+    expect(transaction.familyId).toBe(first.familyId)
+    expect(transaction.accountId).toBe(account.id)
+    expect(transaction.userId).toBe(user.id)
+    expect(transaction.type).toBe("expense")
+    expect(transaction.amount).toBeLessThan(0n)
+    expect(transaction.idempotencyKey).toBe(idempotencyKey)
+    expect(transaction.accountBalanceAfter).toBe(account.balance)
+
+    const replayRows = await harness.withFamily(first.familyId, async (tx) => {
+      const accountAfterReplay = await tx.account.findUniqueOrThrow({
+        where: { id: account.id },
+      })
+      const transactionCount = await tx.transaction.count({
+        where: { familyId: first.familyId },
+      })
+      const auditCount = await tx.auditLog.count({
+        where: { familyId: first.familyId },
+      })
+      return { accountAfterReplay, auditCount, transactionCount }
+    })
+
+    expect(replayRows.accountAfterReplay.balance).toBe(account.balance)
+    expect(replayRows.transactionCount).toBe(1)
+    expect(replayRows.auditCount).toBe(3)
+
+    expect(
+      scopedRows.auditLogs.map((log) => ({
+        action: log.action,
+        entityId: log.entityId,
+        entityType: log.entityType,
+        idempotencyKey: log.idempotencyKey,
+      }))
+    ).toEqual([
+      {
+        action: "create",
+        entityId: account.id,
+        entityType: "Account",
+        idempotencyKey,
+      },
+      {
+        action: "create",
+        entityId: first.familyId,
+        entityType: "Family",
+        idempotencyKey,
+      },
+      {
+        action: "create",
+        entityId: transaction.id,
+        entityType: "Transaction",
+        idempotencyKey,
+      },
+    ])
   })
 
   test("concurrent onboarding initialization does not duplicate families", async () => {
+    const idempotencyKey = factories.createIdempotencyKey()
     const user = await factories.createUser({
       email: "onboarding-concurrent@permoney.local",
       familyId: null,
@@ -94,19 +181,52 @@ describe("onboarding contract", () => {
     })
 
     const [first, second] = await Promise.all([
-      initializeOnboardingForUser(harness.prisma, user.id),
-      initializeOnboardingForUser(harness.prisma, user.id),
-    ])
-
-    const [storedUser, familyCount] = await Promise.all([
-      harness.prisma.user.findFirstOrThrow({
-        where: { familyId: first.familyId, id: user.id },
+      initializeOnboardingForUser(harness.prisma, user.id, {
+        idempotencyKey,
       }),
-      harness.prisma.family.count(),
+      initializeOnboardingForUser(harness.prisma, user.id, {
+        idempotencyKey,
+      }),
     ])
 
-    expect(first.familyId).toBe(second.familyId)
+    const storedUser = await harness.prisma.user.findFirstOrThrow({
+      where: { familyId: first.familyId, id: user.id },
+    })
+    const familyCount = await harness.prisma.family.count()
+    const scopedCounts = await harness.withFamily(
+      first.familyId,
+      async (tx) => {
+        const accountCount = await tx.account.count({
+          where: { familyId: first.familyId },
+        })
+        const transactionCount = await tx.transaction.count({
+          where: { familyId: first.familyId },
+        })
+        const auditCount = await tx.auditLog.count({
+          where: { familyId: first.familyId },
+        })
+        const idempotencyRecordCount = await tx.idempotencyRecord.count({
+          where: {
+            endpoint: "initializeOnboardingForUser",
+            familyId: first.familyId,
+            key: idempotencyKey,
+          },
+        })
+        return {
+          accountCount,
+          auditCount,
+          idempotencyRecordCount,
+          transactionCount,
+        }
+      }
+    )
+
+    expect(second).toEqual(first)
     expect(storedUser.familyId).toBe(first.familyId)
     expect(familyCount).toBe(1)
+    expect(scopedCounts.accountCount).toBe(1)
+    expect(scopedCounts.transactionCount).toBe(1)
+    expect(scopedCounts.auditCount).toBe(3)
+    expect(scopedCounts.idempotencyRecordCount).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

- Extend onboarding initialization to create the Family, User assignment, starter Account, sample expense Transaction, AuditLog rows, and IdempotencyRecord inside one Serializable Prisma transaction.
- Require a client-supplied UUIDv7 idempotency key from the onboarding page and replay the stored onboarding result for duplicate submissions.
- Add real Postgres integration coverage for sequential and concurrent onboarding replay, audit rows, idempotency records, and account balance stability.
- Move the onboarding page component out of the route file so React Doctor diff stays clean.

## Verification

- `vp run check`
- `vp test run`
- `env -u DATABASE_URL PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration`
- `vp build`
- `vp dlx react-doctor@latest . --verbose --diff`
- `env -u DATABASE_URL PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e -- tests/e2e/auth-routes.e2e.ts`

Note: the first E2E attempt only failed because the Playwright Chromium binary was missing locally. I installed it with `vp exec playwright install chromium` and reran the same targeted E2E successfully.