### PR TITLE
PER-107: Fix auth hydration redirects

### DIFF
--- a/src/components/blocks/login-route-shell.tsx
+++ b/src/components/blocks/login-route-shell.tsx
@@ -1,0 +1,11 @@
+import { LoginForm } from "@/components/login-form"
+
+export function LoginRouteShell() {
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-zinc-100 p-6 md:p-10">
+      <div className="w-full max-w-sm md:max-w-4xl">
+        <LoginForm />
+      </div>
+    </div>
+  )
+}

--- a/src/routes/_protected.tsx
+++ b/src/routes/_protected.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from "@tanstack/react-router"
+import { getSessionGuardFn } from "@/server/auth-fns"
+import { getProtectedRouteRedirect } from "@/server/onboarding-contract"
+
+export const Route = createFileRoute("/_protected")({
+  // PER-107: protected app routes share one SSR-eligible guard boundary. This
+  // lets the server redirect before client-only children such as /transactions
+  // render their pending UI, keeping the first server tree aligned with the
+  // first hydrated client route.
+  beforeLoad: async () => {
+    const guard = await getSessionGuardFn()
+    const redirectTo = getProtectedRouteRedirect(guard)
+    if (redirectTo) throw redirect({ to: redirectTo })
+  },
+})

--- a/src/routes/_protected/dashboard.tsx
+++ b/src/routes/_protected/dashboard.tsx
@@ -1,24 +1,17 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { AppSidebar } from "@/components/app-sidebar"
 import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 import { DataTable } from "@/components/data-table"
 import { SectionCards } from "@/components/section-cards"
 import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import { getSessionGuardFn } from "@/server/auth-fns"
-import { getProtectedRouteRedirect } from "@/server/onboarding-contract"
 // KITA IMPORT TOOLTIP PROVIDER DI SINI
 import { TooltipProvider } from "@/components/ui/tooltip"
 
-import data from "./data.json"
+import data from "../data.json"
 
-export const Route = createFileRoute("/dashboard")({
+export const Route = createFileRoute("/_protected/dashboard")({
   component: DashboardPage,
-  beforeLoad: async () => {
-    const guard = await getSessionGuardFn()
-    const redirectTo = getProtectedRouteRedirect(guard)
-    if (redirectTo) throw redirect({ to: redirectTo })
-  },
   // Metadata halaman — digunakan oleh SiteHeader untuk judul dinamis
   staticData: { title: "Dashboard" },
 })

--- a/src/routes/_protected/import.tsx
+++ b/src/routes/_protected/import.tsx
@@ -48,7 +48,7 @@ import {
 import { formatCurrency } from "@/lib/currency"
 import { createUuidV7 } from "@/lib/uuid-v7"
 
-export const Route = createFileRoute("/import")({
+export const Route = createFileRoute("/_protected/import")({
   component: ImportPage,
   staticData: {
     title: "Import & Rules Engine",

--- a/src/routes/_protected/transactions.tsx
+++ b/src/routes/_protected/transactions.tsx
@@ -16,7 +16,6 @@ import { useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
 import {
   createFileRoute,
-  redirect,
   type ErrorComponentProps,
 } from "@tanstack/react-router"
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table"
@@ -46,7 +45,6 @@ import {
   bulkUpdateTransactionsFn,
   getTransactionFormData,
 } from "@/server/transactions"
-import { getSessionGuardFn } from "@/server/auth-fns"
 import { formatCurrency } from "@/lib/currency"
 import { ZERO_MONEY, type Money } from "@/lib/money"
 import {
@@ -75,21 +73,15 @@ type VirtualRow =
 type TransactionArray = Array<TransactionData>
 type GroupedRecord = Record<string, TransactionArray>
 
-export const Route = createFileRoute("/transactions")({
+export const Route = createFileRoute("/_protected/transactions")({
   // URL search params divalidasi otomatis oleh Zod via TanStack Router.
   // PENTING: validateSearch HARUS dideklarasikan SEBELUM loader agar
   // search params sudah ter-validasi saat loader dijalankan.
   validateSearch: zodValidator(transactionSearchSchema),
   // TanStack DB (useLiveQuery) hanya hidup di browser, tidak bisa di-render di server.
   ssr: false,
-  // === AUTH GUARD: redirect sebelum loader jalan ===
-  // Tanpa ini, unauthenticated user langsung hit transactionCollection.preload()
-  // → getTransactionsFn → familyMiddleware → server error (bukan redirect).
-  beforeLoad: async () => {
-    const guard = await getSessionGuardFn()
-    if (!guard.authenticated) throw redirect({ to: "/login" })
-    if (!guard.hasFamilyId) throw redirect({ to: "/onboarding" })
-  },
+  // Auth guard lives in /_protected so SSR redirects run before this
+  // client-only TanStack DB route can render its pending collection UI.
   // === PRELOAD COLLECTION DURING NAVIGATION ===
   // Wajib per skill `@tanstack/db/skills/meta-framework`: tanpa preload,
   // `startSyncImmediate()` di dalam `useLiveQuery` akan fire saat render,

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,23 +1,19 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
-import { LoginForm } from "@/components/login-form"
+import { LoginRouteShell } from "@/components/blocks/login-route-shell"
 import { getSessionGuardFn } from "@/server/auth-fns"
 import { getPublicAuthRouteRedirect } from "@/server/onboarding-contract"
 
 export const Route = createFileRoute("/login")({
+  // PER-107: keep the auth shell in the critical route module. In dev SSR the
+  // server can render while `beforeLoad` is pending, while hydration may already
+  // have the guard result. Rendering the same shell for both states prevents a
+  // route Suspense fallback from becoming the hydratable server tree.
+  codeSplitGroupings: [],
+  pendingComponent: LoginRouteShell,
   beforeLoad: async () => {
     const guard = await getSessionGuardFn()
     const redirectTo = getPublicAuthRouteRedirect(guard)
     if (redirectTo) throw redirect({ to: redirectTo })
   },
-  component: RouteComponent,
+  component: LoginRouteShell,
 })
-
-function RouteComponent() {
-  return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-zinc-100 p-6 md:p-10">
-      <div className="w-full max-w-sm md:max-w-4xl">
-        <LoginForm />
-      </div>
-    </div>
-  )
-}

--- a/src/routes/onboarding.tsx
+++ b/src/routes/onboarding.tsx
@@ -4,6 +4,12 @@ import { getOnboardingRouteRedirect } from "@/server/onboarding-contract"
 import { OnboardingPage } from "@/components/blocks/onboarding-page"
 
 export const Route = createFileRoute("/onboarding")({
+  // PER-107: keep the onboarding shell in the critical route module. In dev SSR
+  // the server can render while `beforeLoad` is pending, while hydration may
+  // already have the guard result. Rendering the same shell for both states
+  // prevents a route Suspense fallback from becoming the hydratable server tree.
+  codeSplitGroupings: [],
+  pendingComponent: OnboardingPage,
   beforeLoad: async () => {
     const result = await getSessionGuardFn()
     const redirectTo = getOnboardingRouteRedirect(result)

--- a/tests/e2e/support/fixtures.ts
+++ b/tests/e2e/support/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base } from "@playwright/test"
 
 const FORBIDDEN_CONSOLE_FRAGMENTS = [
+  "Hydration failed because the server rendered HTML didn't match the client",
   "react-dom/server.browser.js",
   "renderRouterToString",
   "node:stream/web",


### PR DESCRIPTION
## Summary

- Added a pathless `/_protected` route boundary for protected app pages so SSR auth redirects happen before client-only child routes render pending UI.
- Moved `/dashboard`, `/transactions`, and `/import` under that protected boundary while preserving their public URLs.
- Kept `/login` and `/onboarding` auth shells in the critical route module and added an E2E console gate for React hydration mismatch errors.

## Testing

- [x] `vp check`
- [x] `vp run test:unit:coverage`
- [x] `vp run test:integration` — passed in GitHub Actions; local attempt was blocked by missing Postgres password env (`SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string`)
- [x] `env -u DATABASE_URL PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e`
- [x] `vp build`
- [x] `vp dlx react-doctor@latest . --verbose --diff` — 100/100, no issues

## Critical Finance Impact

- [ ] This PR does not touch ledger mutation, balance updates, RLS, idempotency, audit logging, or auth guards.
- [x] This PR touches a critical finance/auth path and includes deterministic tests in the relevant suite.
- [x] Existing tests already cover this change.

If existing tests cover the change, name them and state the invariant they prove:

- `tests/e2e/auth-routes.e2e.ts` proves logged-out and authenticated-without-family users are redirected before protected app UI or transaction preload can render.
- `tests/e2e/support/fixtures.ts` now fails the suite if React reports a hydration mismatch, preventing recurrence of the PER-107 regression.
- GitHub Actions `test:integration` stayed green, proving the protected-route restructure did not regress the existing Postgres-backed ledger/onboarding invariants.