### PR TITLE
PER-73 account class/type/subtype taxonomy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,8 @@ Transactions are the heart of Permoney. This is not a CRUD module. It is the can
 
 The canonical domain boundary is documented in [`docs/adr/0008-core-domain-model-and-ledger-boundaries.md`](./docs/adr/0008-core-domain-model-and-ledger-boundaries.md). Read it before adding or changing import staging, valuation snapshots, AI enrichment, reconciliation, asset tracking, or other systems that touch money-shaped data.
 
+The account taxonomy contract is documented in [`docs/account-taxonomy.md`](./docs/account-taxonomy.md). Use `accountClass`, `accountType`, and `accountSubtype` for account classification; do not introduce new ledger behavior through ad hoc account product strings.
+
 ### A. Data Integrity & Double-Entry (Server-Side)
 
 - **ACID Transactions**: Every financial mutation (create/update/delete/bulk/import/onboarding demo data) MUST be wrapped in an interactive `prisma.$transaction(async (tx) => ...)` block so reads, writes, RLS GUC setup, balance updates, idempotency checks, and audit logs share the same transaction.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ All Prisma + Node-only modules use the **`.server.ts` hard fence** convention en
 
 `Transaction` is the canonical ledger center. Metadata, import staging, AI enrichment, valuation snapshots, reconciliation records, and derived views attach to the ledger; they do not replace it. See [`docs/adr/0008-core-domain-model-and-ledger-boundaries.md`](./docs/adr/0008-core-domain-model-and-ledger-boundaries.md).
 
+### Account Taxonomy
+
+Accounts use explicit `accountClass`, `accountType`, and `accountSubtype` fields so new financial products usually fit as subtype/capability metadata instead of new ledger semantics. See [`docs/account-taxonomy.md`](./docs/account-taxonomy.md).
+
 ### Reactive Ledger
 
 - Server functions (`createServerFn`) are the only way to mutate persistent data.

--- a/docs/account-taxonomy.md
+++ b/docs/account-taxonomy.md
@@ -1,0 +1,154 @@
+# Account Taxonomy
+
+Permoney accounts use a three-layer taxonomy:
+
+1. `accountClass`: the normal-balance class that controls sign semantics.
+2. `accountType`: the stable ledger capability family.
+3. `accountSubtype`: the product family label. This is intentionally flexible
+   so new account products can be added without rewriting ledger semantics.
+
+This document is the public schema/API contract for account classification. It
+extends the core domain boundary in
+[`ADR-0008`](./adr/0008-core-domain-model-and-ledger-boundaries.md).
+
+## Schema Fields
+
+| Field               | Required | Purpose                                                                 |
+| ------------------- | -------- | ----------------------------------------------------------------------- |
+| `accountClass`      | Yes      | Normal-balance class: `ASSET` or `LIABILITY`.                           |
+| `accountType`       | Yes      | Ledger capability family such as `DEPOSITORY`, `CREDIT`, or `LOAN`.     |
+| `accountSubtype`    | Yes      | Product family label such as `checking`, `bnpl`, `mortgage`, or `gold`. |
+| `institutionName`   | No       | Human-readable bank, lender, broker, provider, or custodian name.       |
+| `externalProvider`  | No       | Integration provider key, for example a future bank API connector.      |
+| `externalAccountId` | No       | Provider-side account identifier.                                       |
+| `mask`              | No       | Non-sensitive account mask, such as the final 4 digits.                 |
+| `isImportable`      | Yes      | Whether this account may receive provider/import feed data.             |
+| `creditLimit`       | No       | Product limit in minor units for cards, BNPL, or credit lines.          |
+| `statementDay`      | No       | Statement cycle day, 1 through 31.                                      |
+| `dueDay`            | No       | Payment due day, 1 through 31.                                          |
+| `interestRateBps`   | No       | Interest rate in basis points.                                          |
+| `archivedAt`        | No       | Archive timestamp. If present, `status` must be `closed`.               |
+
+Provider and capability metadata never changes ledger semantics by itself. It
+helps imports, reminders, reconciliation, and UI workflows decide what the
+account can do.
+
+## Account Classes
+
+| `accountClass` | Normal balance | Balance sign rule | Use for                               |
+| -------------- | -------------- | ----------------- | ------------------------------------- |
+| `ASSET`        | Debit          | `balance >= 0`    | Cash, deposits, wallets, investments. |
+| `LIABILITY`    | Credit         | `balance <= 0`    | Credit cards, BNPL, loans, mortgages. |
+
+`EQUITY` and `TRACKING` are intentionally not in the M2.5 schema. Tracked real
+assets still use `ASSET` with `accountType = TRACKED_ASSET`. Future equity or
+off-ledger tracking classes require a separate ADR because they would change
+normal-balance and reporting semantics.
+
+## Account Types
+
+| `accountType`   | `accountClass` | Default subtype | Ledger meaning                                     |
+| --------------- | -------------- | --------------- | -------------------------------------------------- |
+| `CASH`          | `ASSET`        | `cash`          | Physical cash or petty-cash wallet.                |
+| `DEPOSITORY`    | `ASSET`        | `checking`      | Bank deposit accounts: checking, savings, payroll. |
+| `E_WALLET`      | `ASSET`        | `cash`          | Stored-value wallets and payment apps.             |
+| `CREDIT`        | `LIABILITY`    | `credit_card`   | Revolving credit products and credit cards.        |
+| `LOAN`          | `LIABILITY`    | `personal_loan` | Installment debt: BNPL, KPR, bank loans, pinjol.   |
+| `INVESTMENT`    | `ASSET`        | `brokerage`     | Brokerage, retirement, crypto custody accounts.    |
+| `RECEIVABLE`    | `ASSET`        | `receivable`    | Money owed to the family by another party.         |
+| `TRACKED_ASSET` | `ASSET`        | `generic_asset` | Gold, silver, vehicles, real estate, collectibles. |
+
+New products should usually be modeled as a new `accountSubtype` or capability
+field under one of these `accountType` values. Add a new `accountType` only when
+the product needs different ledger capabilities or normal-balance rules.
+
+## Subtypes
+
+Known subtypes in code are:
+
+- `cash`
+- `checking`
+- `savings`
+- `payroll`
+- `credit_card`
+- `bnpl`
+- `mortgage`
+- `personal_loan`
+- `payday_loan`
+- `brokerage`
+- `retirement`
+- `crypto_wallet`
+- `receivable`
+- `gold`
+- `silver`
+- `vehicle`
+- `real_estate`
+- `generic_asset`
+
+The database enforces subtype shape as lowercase snake case. It does not enforce
+a closed subtype enum. This is deliberate: adding `student_loan`, `term_deposit`,
+or `kpr_subsidized` should not require a ledger migration as long as the product
+fits an existing `accountType`.
+
+## Normal-Balance Examples
+
+### Checking account
+
+```text
+accountClass    ASSET
+accountType     DEPOSITORY
+accountSubtype  checking
+balance         >= 0
+```
+
+Expenses decrease the balance. Income increases it.
+
+### Credit card
+
+```text
+accountClass    LIABILITY
+accountType     CREDIT
+accountSubtype  credit_card
+balance         <= 0
+```
+
+Card spending makes the balance more negative. Payments toward the card move it
+toward zero. Transfers into a `CREDIT` account are classified as `cc_payment`.
+
+### BNPL or mortgage
+
+```text
+accountClass    LIABILITY
+accountType     LOAN
+accountSubtype  bnpl | mortgage
+balance         <= 0
+```
+
+Payments toward the loan move the balance toward zero. Transfers into a `LOAN`
+account are classified as `loan_payment`.
+
+### Gold, vehicle, or real estate tracking
+
+```text
+accountClass    ASSET
+accountType     TRACKED_ASSET
+accountSubtype  gold | vehicle | real_estate
+balance         >= 0
+```
+
+The account balance represents the tracked ledger value in minor units. Market
+price movement belongs in future valuation snapshots unless a realized
+transaction occurs.
+
+## Implementation Contract
+
+- Server and client code should use `accountClass`, `accountType`, and
+  `accountSubtype`. Do not add new writes to the old `type` name.
+- `src/lib/accounts.ts` is the TypeScript source for taxonomy constants,
+  default subtypes, class/type mapping, and normal-balance helpers.
+- The database is the backstop: class domain, type domain, class/type
+  consistency, normal-balance sign, subtype shape, due-day ranges, credit-limit
+  sign, and archive/status consistency are enforced by checks.
+- Import providers and AI enrichment may suggest institution metadata,
+  provider IDs, masks, limits, rates, and subtype refinements. The final account
+  write still uses the canonical account API and database constraints.

--- a/docs/adr/0008-core-domain-model-and-ledger-boundaries.md
+++ b/docs/adr/0008-core-domain-model-and-ledger-boundaries.md
@@ -80,8 +80,9 @@ core domain entity, but it is not a separate transaction ledger.
 - `Account.balance` is a durable materialized state updated by canonical
   `Transaction` mutations.
 - `Account.version` protects concurrent balance updates.
-- Account type, currency, display name, and institution metadata describe where
-  transactions post.
+- Account class/type/subtype, currency, display name, and institution metadata
+  describe where transactions post. The taxonomy contract lives in
+  [`docs/account-taxonomy.md`](../account-taxonomy.md).
 
 No code path may compute a new balance from memory and save it as a shortcut.
 Balances change through atomic increments/decrements in the same transaction

--- a/prisma/migrations/20260601140000_account_taxonomy/migration.sql
+++ b/prisma/migrations/20260601140000_account_taxonomy/migration.sql
@@ -1,0 +1,185 @@
+-- PER-73: account class/type/subtype taxonomy and capability metadata.
+--
+-- `accountClass` controls normal-balance behaviour. `accountType` controls the
+-- stable ledger capability family. `accountSubtype` is intentionally flexible
+-- so new product families can be added without rewriting ledger semantics.
+
+CREATE OR REPLACE FUNCTION _per73_account_class_for_type(account_type TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN account_type IN ('CREDIT', 'LOAN') THEN 'LIABILITY'
+    WHEN account_type IN (
+      'CASH',
+      'DEPOSITORY',
+      'E_WALLET',
+      'INVESTMENT',
+      'RECEIVABLE',
+      'TRACKED_ASSET'
+    ) THEN 'ASSET'
+    ELSE NULL
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION _per73_default_account_subtype(account_type TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE account_type
+    WHEN 'CASH' THEN 'cash'
+    WHEN 'DEPOSITORY' THEN 'checking'
+    WHEN 'E_WALLET' THEN 'cash'
+    WHEN 'CREDIT' THEN 'credit_card'
+    WHEN 'LOAN' THEN 'personal_loan'
+    WHEN 'INVESTMENT' THEN 'brokerage'
+    WHEN 'RECEIVABLE' THEN 'receivable'
+    WHEN 'TRACKED_ASSET' THEN 'generic_asset'
+    ELSE NULL
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION _per73_account_balance_sign_is_valid(
+  account_class TEXT,
+  balance BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE account_class
+    WHEN 'ASSET' THEN balance >= 0
+    WHEN 'LIABILITY' THEN balance <= 0
+    ELSE false
+  END
+$$;
+
+DO $$
+DECLARE
+  null_type_rows INT;
+  invalid_type_rows INT;
+  invalid_balance_rows INT;
+BEGIN
+  SELECT COUNT(*)
+    INTO null_type_rows
+    FROM "Account"
+   WHERE "type" IS NULL;
+
+  SELECT COUNT(*)
+    INTO invalid_type_rows
+    FROM "Account"
+   WHERE _per73_account_class_for_type("type") IS NULL;
+
+  SELECT COUNT(*)
+    INTO invalid_balance_rows
+    FROM "Account"
+   WHERE NOT _per73_account_balance_sign_is_valid(
+     _per73_account_class_for_type("type"),
+     balance
+   );
+
+  IF null_type_rows > 0
+     OR invalid_type_rows > 0
+     OR invalid_balance_rows > 0 THEN
+    RAISE EXCEPTION
+      'PER-73 migration aborted: % null Account.type row(s), % invalid type row(s), % invalid balance sign row(s). Manual reconciliation required.',
+      null_type_rows,
+      invalid_type_rows,
+      invalid_balance_rows
+      USING ERRCODE = 'check_violation';
+  END IF;
+END $$;
+
+ALTER TABLE "Account"
+  DROP CONSTRAINT IF EXISTS account_type_domain;
+
+ALTER TABLE "Account"
+  DROP CONSTRAINT IF EXISTS balance_nonneg_for_asset_accounts;
+
+ALTER TABLE "Account"
+  RENAME COLUMN "type" TO "accountType";
+
+ALTER TABLE "Account"
+  ADD COLUMN "accountClass" TEXT,
+  ADD COLUMN "accountSubtype" TEXT,
+  ADD COLUMN "archivedAt" TIMESTAMP(3),
+  ADD COLUMN "institutionName" TEXT,
+  ADD COLUMN "externalProvider" TEXT,
+  ADD COLUMN "externalAccountId" TEXT,
+  ADD COLUMN "mask" TEXT,
+  ADD COLUMN "isImportable" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "creditLimit" BIGINT,
+  ADD COLUMN "statementDay" INTEGER,
+  ADD COLUMN "dueDay" INTEGER,
+  ADD COLUMN "interestRateBps" INTEGER;
+
+UPDATE "Account"
+   SET "accountClass" = _per73_account_class_for_type("accountType"),
+       "accountSubtype" = _per73_default_account_subtype("accountType")
+ WHERE "accountClass" IS NULL
+    OR "accountSubtype" IS NULL;
+
+ALTER TABLE "Account"
+  ALTER COLUMN "accountClass" SET NOT NULL,
+  ALTER COLUMN "accountSubtype" SET NOT NULL;
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_class_domain CHECK (
+    "accountClass" IN ('ASSET', 'LIABILITY')
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_type_domain CHECK (
+    _per73_account_class_for_type("accountType") IS NOT NULL
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_type_class_consistency CHECK (
+    _per73_account_class_for_type("accountType") = "accountClass"
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_normal_balance_sign CHECK (
+    _per73_account_balance_sign_is_valid("accountClass", balance)
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_subtype_shape CHECK (
+    "accountSubtype" ~ '^[a-z][a-z0-9_]{0,63}$'
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_statement_day_range CHECK (
+    "statementDay" IS NULL OR "statementDay" BETWEEN 1 AND 31
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_due_day_range CHECK (
+    "dueDay" IS NULL OR "dueDay" BETWEEN 1 AND 31
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_credit_limit_nonnegative CHECK (
+    "creditLimit" IS NULL OR "creditLimit" >= 0
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_interest_rate_bps_nonnegative CHECK (
+    "interestRateBps" IS NULL OR "interestRateBps" >= 0
+  );
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_archive_status_consistency CHECK (
+    "archivedAt" IS NULL OR status = 'closed'
+  );
+
+CREATE INDEX "Account_familyId_accountClass_accountType_idx"
+  ON "Account"("familyId", "accountClass", "accountType");
+
+CREATE INDEX "Account_familyId_status_idx"
+  ON "Account"("familyId", status);
+
+CREATE INDEX "Account_familyId_externalProvider_externalAccountId_idx"
+  ON "Account"("familyId", "externalProvider", "externalAccountId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,8 +89,12 @@ model Account {
   id   String @id @default(cuid())
   name String
 
-  // Tipe makin pro: "DEPOSITORY" (Bank/Dompet), "CREDIT" (Kartu Kredit), "LOAN" (Hutang), "RECEIVABLE" (Piutang/Uang dipinjam orang), "INVESTMENT" (Saham)
-  type             String
+  // Taxonomy contract: class controls normal balance, type controls ledger
+  // capabilities, subtype describes product family without rewriting ledger
+  // semantics. See docs/account-taxonomy.md.
+  accountClass   String
+  accountType    String
+  accountSubtype String
   // Stored in MINOR UNITS (sen for IDR, cents for USD, satoshi for BTC).
   // Per-currency scale is driven by `CURRENCIES[code].minorUnitConversion`
   // in src/lib/data/currencies.ts. See docs/adr/0001-money-type-migration.md.
@@ -100,8 +104,21 @@ model Account {
   currencyRegistry Iso4217Currency @relation("AccountCurrency", fields: [currency], references: [code], onDelete: Restrict, onUpdate: Cascade, map: "account_currency_is_iso_4217")
 
   // Fitur Enterprise: Visual & Status
-  color  String? // Hex color misal "#3b82f6"
-  status String  @default("active") // "active" atau "closed"
+  color      String? // Hex color misal "#3b82f6"
+  status     String    @default("active") // "active" atau "closed"
+  archivedAt DateTime?
+
+  // Optional provider/capability metadata. These fields describe integrations
+  // and product behaviour; they do not change ledger semantics.
+  institutionName   String?
+  externalProvider  String?
+  externalAccountId String?
+  mask              String?
+  isImportable      Boolean @default(false)
+  creditLimit       BigInt?
+  statementDay      Int?
+  dueDay            Int?
+  interestRateBps   Int?
 
   familyId String
   family   Family @relation(fields: [familyId], references: [id])
@@ -113,6 +130,9 @@ model Account {
   // ADR-0004 lands; cheap to add now). See ADR-0003.
   @@unique([id, familyId], map: "Account_id_familyId_key")
   @@index([familyId])
+  @@index([familyId, accountClass, accountType])
+  @@index([familyId, status])
+  @@index([familyId, externalProvider, externalAccountId])
 }
 
 model Merchant {

--- a/prisma/seed/app-tenant.ts
+++ b/prisma/seed/app-tenant.ts
@@ -91,22 +91,28 @@ export async function seedAppTenant(
         tx.account.createMany({
           data: [
             {
+              accountClass: "ASSET",
+              accountSubtype: "checking",
+              accountType: "DEPOSITORY",
               name: "BCA Utama",
-              type: "DEPOSITORY",
               balance: 1_500_000_000n,
               familyId: family.id,
               color: "#0066AE",
             },
             {
+              accountClass: "ASSET",
+              accountSubtype: "cash",
+              accountType: "CASH",
               name: "Dompet Cash",
-              type: "DEPOSITORY",
               balance: 50_000_000n,
               familyId: family.id,
               color: "#22C55E",
             },
             {
+              accountClass: "ASSET",
+              accountSubtype: "receivable",
+              accountType: "RECEIVABLE",
               name: "Piutang Teman",
-              type: "RECEIVABLE",
               balance: 0n,
               familyId: family.id,
               color: "#F59E0B",

--- a/src/components/transaction-bulk-fab.tsx
+++ b/src/components/transaction-bulk-fab.tsx
@@ -30,9 +30,9 @@ interface MerchantOption {
 }
 
 interface AccountOption {
+  accountType: string
   id: string
   name: string
-  type: string
 }
 
 interface TransactionBulkFABProps {
@@ -169,7 +169,7 @@ export function TransactionBulkFAB({
                 <div className="flex flex-col">
                   <span className="text-sm font-medium">{a.name}</span>
                   <span className="text-xs text-muted-foreground uppercase">
-                    {a.type}
+                    {a.accountType}
                   </span>
                 </div>
               </DropdownMenuItem>

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1355,6 +1355,34 @@ function useTransactionFormModalController({
           value.destinationAmount != null && destCurrency
             ? toMoney(value.destinationAmount, destCurrency)
             : null
+        const selectedAccount = formData?.accounts.find(
+          (a) => a.id === value.accountId
+        )
+        const selectedToAccount =
+          value.toAccountId && value.type === "transfer"
+            ? formData?.accounts.find((a) => a.id === value.toAccountId)
+            : null
+        const accountRelation = selectedAccount
+          ? {
+              accountType: selectedAccount.accountType,
+              color: selectedAccount.color,
+              name: selectedAccount.name,
+              type: selectedAccount.accountType,
+            }
+          : {
+              accountType: "",
+              color: null,
+              name: "...",
+              type: "",
+            }
+        const toAccountRelation = selectedToAccount
+          ? {
+              accountType: selectedToAccount.accountType,
+              color: selectedToAccount.color,
+              name: selectedToAccount.name,
+              type: selectedToAccount.accountType,
+            }
+          : null
 
         const payload = {
           type: value.type,
@@ -1397,15 +1425,8 @@ function useTransactionFormModalController({
           attachmentUrl: value.attachmentUrl || null,
           deletedAt: null,
           userId: "",
-          account: formData?.accounts.find((a) => a.id === value.accountId) ?? {
-            name: "...",
-            type: "",
-            color: null,
-          },
-          toAccount: value.toAccountId
-            ? (formData?.accounts.find((a) => a.id === value.toAccountId) ??
-              null)
-            : null,
+          account: accountRelation,
+          toAccount: toAccountRelation,
           // Jika split, category di parent null
           category:
             !isSplit && value.categoryId

--- a/src/lib/accounts.test.ts
+++ b/src/lib/accounts.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vite-plus/test"
+import {
+  ACCOUNT_CLASS_VALUES,
+  ACCOUNT_SUBTYPE_VALUES,
+  ACCOUNT_TYPE_VALUES,
+  getAccountClassForType,
+  getAccountNormalBalance,
+  getDefaultAccountSubtype,
+  isLiabilityAccountType,
+  normalizeAccountTaxonomy,
+} from "./accounts"
+
+describe("account taxonomy", () => {
+  test("defines stable class, type, and subtype vocabularies", () => {
+    expect(ACCOUNT_CLASS_VALUES).toEqual(["ASSET", "LIABILITY"])
+    expect(ACCOUNT_TYPE_VALUES).toEqual([
+      "CASH",
+      "DEPOSITORY",
+      "E_WALLET",
+      "CREDIT",
+      "LOAN",
+      "INVESTMENT",
+      "RECEIVABLE",
+      "TRACKED_ASSET",
+    ])
+    expect(ACCOUNT_SUBTYPE_VALUES).toContain("checking")
+    expect(ACCOUNT_SUBTYPE_VALUES).toContain("bnpl")
+    expect(ACCOUNT_SUBTYPE_VALUES).toContain("mortgage")
+    expect(ACCOUNT_SUBTYPE_VALUES).toContain("crypto_wallet")
+    expect(ACCOUNT_SUBTYPE_VALUES).toContain("real_estate")
+  })
+
+  test("maps account types to explicit account classes and normal balances", () => {
+    expect(getAccountClassForType("DEPOSITORY")).toBe("ASSET")
+    expect(getAccountClassForType("E_WALLET")).toBe("ASSET")
+    expect(getAccountClassForType("RECEIVABLE")).toBe("ASSET")
+    expect(getAccountClassForType("CREDIT")).toBe("LIABILITY")
+    expect(getAccountClassForType("LOAN")).toBe("LIABILITY")
+
+    expect(getAccountNormalBalance("ASSET")).toEqual({
+      balanceSign: "positive",
+      side: "DEBIT",
+    })
+    expect(getAccountNormalBalance("LIABILITY")).toEqual({
+      balanceSign: "negative",
+      side: "CREDIT",
+    })
+    expect(isLiabilityAccountType("CREDIT")).toBe(true)
+    expect(isLiabilityAccountType("INVESTMENT")).toBe(false)
+  })
+
+  test("normalizes subtype defaults without changing ledger semantics", () => {
+    expect(getDefaultAccountSubtype("CASH")).toBe("cash")
+    expect(getDefaultAccountSubtype("DEPOSITORY")).toBe("checking")
+    expect(getDefaultAccountSubtype("CREDIT")).toBe("credit_card")
+    expect(getDefaultAccountSubtype("LOAN")).toBe("personal_loan")
+    expect(getDefaultAccountSubtype("TRACKED_ASSET")).toBe("generic_asset")
+
+    expect(
+      normalizeAccountTaxonomy({
+        accountSubtype: "mortgage",
+        accountType: "LOAN",
+      })
+    ).toEqual({
+      accountClass: "LIABILITY",
+      accountSubtype: "mortgage",
+      accountType: "LOAN",
+    })
+  })
+
+  test("rejects class/type mismatches at the domain boundary", () => {
+    expect(() =>
+      normalizeAccountTaxonomy({
+        accountClass: "ASSET",
+        accountType: "CREDIT",
+      })
+    ).toThrow(/belongs to accountClass LIABILITY/i)
+
+    expect(() =>
+      normalizeAccountTaxonomy({
+        accountSubtype: "Mortgage",
+        accountType: "LOAN",
+      })
+    ).toThrow(/lowercase snake case/i)
+  })
+})

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -1,0 +1,155 @@
+export const ACCOUNT_CLASS_VALUES = ["ASSET", "LIABILITY"] as const
+
+export type AccountClass = (typeof ACCOUNT_CLASS_VALUES)[number]
+
+export const ACCOUNT_TYPE_VALUES = [
+  "CASH",
+  "DEPOSITORY",
+  "E_WALLET",
+  "CREDIT",
+  "LOAN",
+  "INVESTMENT",
+  "RECEIVABLE",
+  "TRACKED_ASSET",
+] as const
+
+export type AccountType = (typeof ACCOUNT_TYPE_VALUES)[number]
+
+export const ACCOUNT_SUBTYPE_VALUES = [
+  "cash",
+  "checking",
+  "savings",
+  "payroll",
+  "credit_card",
+  "bnpl",
+  "mortgage",
+  "personal_loan",
+  "payday_loan",
+  "brokerage",
+  "retirement",
+  "crypto_wallet",
+  "receivable",
+  "gold",
+  "silver",
+  "vehicle",
+  "real_estate",
+  "generic_asset",
+] as const
+
+export type AccountSubtype = (typeof ACCOUNT_SUBTYPE_VALUES)[number]
+
+export type AccountNormalBalance = {
+  balanceSign: "negative" | "positive"
+  side: "CREDIT" | "DEBIT"
+}
+
+export type AccountTaxonomy = {
+  accountClass: AccountClass
+  accountSubtype: string
+  accountType: AccountType
+}
+
+export type AccountTaxonomyInput = {
+  accountClass?: AccountClass
+  accountSubtype?: string | null
+  accountType: AccountType
+}
+
+const ASSET_ACCOUNT_TYPES = [
+  "CASH",
+  "DEPOSITORY",
+  "E_WALLET",
+  "INVESTMENT",
+  "RECEIVABLE",
+  "TRACKED_ASSET",
+] as const satisfies readonly AccountType[]
+
+const LIABILITY_ACCOUNT_TYPES = [
+  "CREDIT",
+  "LOAN",
+] as const satisfies readonly AccountType[]
+const LIABILITY_ACCOUNT_TYPE_SET = new Set<AccountType>(LIABILITY_ACCOUNT_TYPES)
+const ASSET_ACCOUNT_TYPE_SET = new Set<AccountType>(ASSET_ACCOUNT_TYPES)
+
+const ACCOUNT_TYPE_TO_CLASS = {
+  CASH: "ASSET",
+  CREDIT: "LIABILITY",
+  DEPOSITORY: "ASSET",
+  E_WALLET: "ASSET",
+  INVESTMENT: "ASSET",
+  LOAN: "LIABILITY",
+  RECEIVABLE: "ASSET",
+  TRACKED_ASSET: "ASSET",
+} as const satisfies Record<AccountType, AccountClass>
+
+const DEFAULT_ACCOUNT_SUBTYPE_BY_TYPE = {
+  CASH: "cash",
+  CREDIT: "credit_card",
+  DEPOSITORY: "checking",
+  E_WALLET: "cash",
+  INVESTMENT: "brokerage",
+  LOAN: "personal_loan",
+  RECEIVABLE: "receivable",
+  TRACKED_ASSET: "generic_asset",
+} as const satisfies Record<AccountType, AccountSubtype>
+
+const NORMAL_BALANCE_BY_CLASS = {
+  ASSET: {
+    balanceSign: "positive",
+    side: "DEBIT",
+  },
+  LIABILITY: {
+    balanceSign: "negative",
+    side: "CREDIT",
+  },
+} as const satisfies Record<AccountClass, AccountNormalBalance>
+
+const ACCOUNT_SUBTYPE_PATTERN = /^[a-z][a-z0-9_]{0,63}$/
+
+export function getAccountClassForType(accountType: AccountType): AccountClass {
+  return ACCOUNT_TYPE_TO_CLASS[accountType]
+}
+
+export function getAccountNormalBalance(
+  accountClass: AccountClass
+): AccountNormalBalance {
+  return NORMAL_BALANCE_BY_CLASS[accountClass]
+}
+
+export function getDefaultAccountSubtype(
+  accountType: AccountType
+): AccountSubtype {
+  return DEFAULT_ACCOUNT_SUBTYPE_BY_TYPE[accountType]
+}
+
+export function isLiabilityAccountType(accountType: AccountType): boolean {
+  return LIABILITY_ACCOUNT_TYPE_SET.has(accountType)
+}
+
+export function isAssetAccountType(accountType: AccountType): boolean {
+  return ASSET_ACCOUNT_TYPE_SET.has(accountType)
+}
+
+export function normalizeAccountTaxonomy(
+  input: AccountTaxonomyInput
+): AccountTaxonomy {
+  const expectedClass = getAccountClassForType(input.accountType)
+  if (input.accountClass && input.accountClass !== expectedClass) {
+    throw new Error(
+      `Account type ${input.accountType} belongs to accountClass ${expectedClass}, not ${input.accountClass}`
+    )
+  }
+  const accountSubtype =
+    input.accountSubtype?.trim() || getDefaultAccountSubtype(input.accountType)
+  if (!ACCOUNT_SUBTYPE_PATTERN.test(accountSubtype)) {
+    throw new Error(
+      `Account subtype ${accountSubtype} must be lowercase snake case`
+    )
+  }
+
+  return {
+    accountClass: expectedClass,
+    accountSubtype,
+    accountType: input.accountType,
+  }
+}

--- a/src/server/onboarding-service.ts
+++ b/src/server/onboarding-service.ts
@@ -89,13 +89,15 @@ export async function initializeOnboardingForUser(
 
     const account = await tx.account.create({
       data: {
+        accountClass: "ASSET",
+        accountSubtype: "checking",
+        accountType: "DEPOSITORY",
         balance: STARTER_ACCOUNT_OPENING_BALANCE,
         color: STARTER_ACCOUNT_COLOR,
         currency: family.currency,
         familyId: scopedFamilyId,
         name: STARTER_ACCOUNT_NAME,
         status: "active",
-        type: "DEPOSITORY",
       },
     })
 

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -351,11 +351,16 @@ async function findTransactionsWithTransferOutAndSplitEntries(
 }
 
 function accountListRelation(account: {
+  accountType: string
   color: string | null
   name: string
-  type: string
 }) {
-  return { name: account.name, type: account.type, color: account.color }
+  return {
+    accountType: account.accountType,
+    color: account.color,
+    name: account.name,
+    type: account.accountType,
+  }
 }
 
 function categoryListRelation(category: {
@@ -422,7 +427,7 @@ export async function findLedgerTransactionsForFamily(
         accountIds.size > 0
           ? tx.account.findMany({
               where: { id: { in: Array.from(accountIds) } },
-              select: { id: true, name: true, type: true, color: true },
+              select: { id: true, name: true, accountType: true, color: true },
             })
           : Promise.resolve([]),
       () =>
@@ -1350,8 +1355,8 @@ export async function createTransactionForFamily({
             throw new Error("Destination account not found or access denied!")
 
           let kind = "funds_movement"
-          if (toAccount.type === "CREDIT") kind = "cc_payment"
-          else if (toAccount.type === "LOAN") kind = "loan_payment"
+          if (toAccount.accountType === "CREDIT") kind = "cc_payment"
+          else if (toAccount.accountType === "LOAN") kind = "loan_payment"
 
           const [oldSrcAcc, oldDstAcc] =
             await runTenantTransactionQueriesInOrder([
@@ -1975,8 +1980,8 @@ async function replaceTransactionWithinTenantTransaction(
     })
     if (!toAccount)
       throw new Error("Destination account not found or access denied!")
-    if (toAccount.type === "CREDIT") kind = "cc_payment"
-    else if (toAccount.type === "LOAN") kind = "loan_payment"
+    if (toAccount.accountType === "CREDIT") kind = "cc_payment"
+    else if (toAccount.accountType === "LOAN") kind = "loan_payment"
 
     const inAmount = data.destinationAmount ?? data.amount
     const inCurrency = data.destinationCurrency ?? data.currency

--- a/tests/integration/db-constraints.integration.ts
+++ b/tests/integration/db-constraints.integration.ts
@@ -216,7 +216,9 @@ describe("M2 data-integrity database constraints", () => {
             familyId: owner.family.id,
             name: "Invalid account type",
             status: "active",
-            type: "VAULT",
+            accountClass: "ASSET",
+            accountSubtype: "checking",
+            accountType: "VAULT",
           },
         })
       )
@@ -232,14 +234,119 @@ describe("M2 data-integrity database constraints", () => {
             familyId: owner.family.id,
             name: "Invalid account status",
             status: "archived",
-            type: "DEPOSITORY",
+            accountClass: "ASSET",
+            accountSubtype: "checking",
+            accountType: "DEPOSITORY",
           },
         })
       )
     )
   })
 
-  test("rejects negative balances for non-credit account types", async () => {
+  test("rejects malformed account taxonomy and normal-balance drift", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+
+    await expectDatabaseRejection(() =>
+      harness.withFamily(
+        owner.family.id,
+        (tx) =>
+          tx.$executeRaw`
+          INSERT INTO "Account" (
+            id,
+            name,
+            "accountClass",
+            "accountType",
+            "accountSubtype",
+            balance,
+            currency,
+            color,
+            status,
+            "familyId"
+          )
+          VALUES (
+            'invalid-account-class',
+            'Invalid account class',
+            'EXPENSE',
+            'DEPOSITORY',
+            'checking',
+            0,
+            'IDR',
+            '#2563eb',
+            'active',
+            ${owner.family.id}
+          )
+        `
+      )
+    )
+
+    await expectDatabaseRejection(() =>
+      harness.withFamily(
+        owner.family.id,
+        (tx) =>
+          tx.$executeRaw`
+          INSERT INTO "Account" (
+            id,
+            name,
+            "accountClass",
+            "accountType",
+            "accountSubtype",
+            balance,
+            currency,
+            color,
+            status,
+            "familyId"
+          )
+          VALUES (
+            'invalid-account-class-type-pair',
+            'Invalid account class type pair',
+            'ASSET',
+            'CREDIT',
+            'credit_card',
+            0,
+            'IDR',
+            '#2563eb',
+            'active',
+            ${owner.family.id}
+          )
+        `
+      )
+    )
+
+    await expectDatabaseRejection(() =>
+      harness.withFamily(
+        owner.family.id,
+        (tx) =>
+          tx.$executeRaw`
+          INSERT INTO "Account" (
+            id,
+            name,
+            "accountClass",
+            "accountType",
+            "accountSubtype",
+            balance,
+            currency,
+            color,
+            status,
+            "familyId"
+          )
+          VALUES (
+            'invalid-positive-liability-balance',
+            'Invalid positive liability balance',
+            'LIABILITY',
+            'LOAN',
+            'personal_loan',
+            100,
+            'IDR',
+            '#2563eb',
+            'active',
+            ${owner.family.id}
+          )
+        `
+      )
+    )
+  })
+
+  test("rejects negative balances for asset account classes", async () => {
     const owner = await factories.createAuthenticatedOnboardedUser()
 
     await expectDatabaseRejection(() =>
@@ -252,7 +359,9 @@ describe("M2 data-integrity database constraints", () => {
             familyId: owner.family.id,
             name: "Invalid negative depository",
             status: "active",
-            type: "DEPOSITORY",
+            accountClass: "ASSET",
+            accountSubtype: "checking",
+            accountType: "DEPOSITORY",
           },
         })
       )
@@ -272,7 +381,9 @@ describe("M2 data-integrity database constraints", () => {
             familyId: owner.family.id,
             name: "Invalid account currency",
             status: "active",
-            type: "DEPOSITORY",
+            accountClass: "ASSET",
+            accountSubtype: "checking",
+            accountType: "DEPOSITORY",
           },
         })
       )
@@ -426,16 +537,16 @@ describe("M2 data-integrity database constraints", () => {
     const owner = await factories.createAuthenticatedOnboardedUser()
     const [assetAccount, creditAccount] = await Promise.all([
       factories.createAccount({
+        accountType: "DEPOSITORY",
         balance: 10_000n,
         familyId: owner.family.id,
         name: "Valid asset account",
-        type: "DEPOSITORY",
       }),
       factories.createAccount({
+        accountType: "CREDIT",
         balance: -10_000n,
         familyId: owner.family.id,
         name: "Valid credit account",
-        type: "CREDIT",
       }),
     ])
 

--- a/tests/integration/rls-guc-scoping.integration.ts
+++ b/tests/integration/rls-guc-scoping.integration.ts
@@ -113,7 +113,9 @@ describe("transaction-scoped RLS GUC", () => {
             familyId: familyB.family.id,
             name: "Illegal cross-tenant insert",
             status: "active",
-            type: "DEPOSITORY",
+            accountClass: "ASSET",
+            accountSubtype: "checking",
+            accountType: "DEPOSITORY",
           },
         })
       )
@@ -166,7 +168,9 @@ describe("transaction-scoped RLS GUC", () => {
             familyId: owner.family.id,
             name: "Single connection account",
             status: "active",
-            type: "DEPOSITORY",
+            accountClass: "ASSET",
+            accountSubtype: "checking",
+            accountType: "DEPOSITORY",
           },
         })
         const selected = await tx.account.findUniqueOrThrow({

--- a/tests/integration/support/factories.ts
+++ b/tests/integration/support/factories.ts
@@ -13,14 +13,13 @@ import type {
 import { betterAuth } from "better-auth"
 import { testUtils } from "better-auth/plugins"
 import { tanstackStartCookies } from "better-auth/tanstack-start"
+import {
+  normalizeAccountTaxonomy,
+  type AccountClass,
+  type AccountType,
+} from "../../../src/lib/accounts"
 import type { IntegrationHarness } from "./database"
 
-type AccountType =
-  | "DEPOSITORY"
-  | "CREDIT"
-  | "LOAN"
-  | "RECEIVABLE"
-  | "INVESTMENT"
 type CategoryType = "expense" | "income"
 type TransactionType = "expense" | "income" | "transfer"
 
@@ -58,13 +57,15 @@ interface CreateUserInput {
 }
 
 interface CreateAccountInput {
+  accountClass?: AccountClass
+  accountSubtype?: string | null
+  accountType?: AccountType
   balance?: bigint
   color?: string | null
   currency?: string
   familyId: string
   name?: string
   status?: string
-  type?: AccountType
 }
 
 interface CreateCategoryInput {
@@ -196,16 +197,24 @@ export function createTestFactories(
     }
 
   const createAccount = async (input: CreateAccountInput): Promise<Account> => {
+    const taxonomy = normalizeAccountTaxonomy({
+      accountClass: input.accountClass,
+      accountSubtype: input.accountSubtype,
+      accountType: input.accountType ?? "DEPOSITORY",
+    })
+
     return await harness.withFamily(input.familyId, async (tx) => {
       return await tx.account.create({
         data: {
+          accountClass: taxonomy.accountClass,
+          accountSubtype: taxonomy.accountSubtype,
+          accountType: taxonomy.accountType,
           balance: input.balance ?? 0n,
           color: input.color ?? "#2563eb",
           currency: input.currency ?? "IDR",
           familyId: input.familyId,
           name: input.name ?? nextValue("Test account"),
           status: input.status ?? "active",
-          type: input.type ?? "DEPOSITORY",
         },
       })
     })


### PR DESCRIPTION
## Summary

- Add the explicit Account taxonomy contract: `accountClass`, `accountType`, and `accountSubtype`, plus provider/capability metadata fields.
- Add a Postgres migration that renames legacy `Account.type` to `accountType`, backfills class/subtype, and enforces class domain, type domain, class/type consistency, normal-balance sign, subtype shape, due-day ranges, credit-limit sign, and archive/status consistency.
- Add `src/lib/accounts.ts` domain helpers and tests for class/type/subtype mapping and normal-balance semantics.
- Update seed, onboarding, transaction transfer-kind logic, integration factories, and account UI payloads to use `accountType`.
- Document the taxonomy in `docs/account-taxonomy.md` and link it from README, AGENTS, and ADR-0008.

## Validation

- `vp fmt`
- `vp check`
- `vp test run`
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration`
- `vp build`
- `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e`
- `git diff --check`