### PR TITLE
chore: update skills-lock.json (matpocok skills)

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -101,7 +101,8 @@
     "frontend-design": {
       "source": "anthropics/skills",
       "sourceType": "github",
-      "computedHash": "063a0e6448123cd359ad0044cc46b0e490cc7964d45ef4bb9fd842bd2ffbca67"
+      "skillPath": "skills/frontend-design/SKILL.md",
+      "computedHash": "4eabc66183767153e404b39d1b839b1c37f2d82d86f0a0d7e880a579d8d62336"
     },
     "gemini-api": {
       "source": "google/skills",


### PR DESCRIPTION
Commits the working-tree change to `skills-lock.json`: adds `skillPath` + refreshed hash for the `frontend-design` skill (matpocok skills set). Tooling/config only — no app code. Separated out so it does not pollute the PER-143 (#103) PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)