### PR TITLE
feat(reporting): R2 — income statement / cash-flow engine (PER-155)

### DIFF
--- a/src/lib/cash-flow.test.ts
+++ b/src/lib/cash-flow.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from "vite-plus/test"
+import { convertMinor, encodeRate, IDENTITY_RATE } from "./fx"
+import {
+  MAX_CASH_FLOW_BUCKETS,
+  computeCashFlowReport,
+  generateCashFlowBuckets,
+  type CashFlowLedgerRowInput,
+} from "./cash-flow"
+
+// =============================================================================
+// PER-155 / R2 — pure income-statement / cash-flow engine.
+//
+// All math is Prisma-free and exercised here without a database (the real
+// Postgres boundary — transfer exclusion, RLS, split persistence — is proven in
+// tests/integration/cash-flow-report.integration.ts). Flow value basis is the
+// frozen per-row `baseAmount` (ADR-0038 §2); split children re-derive base from
+// the parent's stored rate, exactly as budget-progress does.
+// =============================================================================
+
+const TZ = "UTC"
+const D = (iso: string) => new Date(iso)
+
+const expenseRow = (
+  partial: Partial<CashFlowLedgerRowInput> & { baseAmount: bigint | null }
+): CashFlowLedgerRowInput => ({
+  type: "expense",
+  currency: "IDR",
+  baseCurrency: partial.baseAmount === null ? null : "IDR",
+  fxRateScaled: partial.baseAmount === null ? null : IDENTITY_RATE,
+  date: D("2026-06-15T00:00:00.000Z"),
+  isSplit: false,
+  categoryId: null,
+  merchantId: null,
+  splitEntries: [],
+  ...partial,
+})
+
+const incomeRow = (
+  partial: Partial<CashFlowLedgerRowInput> & { baseAmount: bigint | null }
+): CashFlowLedgerRowInput =>
+  expenseRow({ ...partial, type: "income" }) as CashFlowLedgerRowInput
+
+const report = (transactions: CashFlowLedgerRowInput[]) =>
+  computeCashFlowReport({
+    from: "2026-06-01",
+    to: "2026-06-30",
+    interval: "month",
+    timezone: TZ,
+    transactions,
+  })
+
+const cat = (r: ReturnType<typeof report>, id: string | null) =>
+  r.byCategory.find((g) => g.categoryId === id)
+const merchant = (r: ReturnType<typeof report>, id: string | null) =>
+  r.byMerchant.find((g) => g.merchantId === id)
+
+describe("computeCashFlowReport — aggregation", () => {
+  test("separates income and expense; net = income − expense", () => {
+    const r = report([
+      incomeRow({ baseAmount: 200_000n, categoryId: "salary" }),
+      expenseRow({
+        baseAmount: -50_000n,
+        categoryId: "food",
+        merchantId: "m1",
+      }),
+      expenseRow({ baseAmount: -30_000n, categoryId: "fun", merchantId: "m2" }),
+    ])
+
+    expect(r.totals.income).toBe(200_000n)
+    expect(r.totals.expense).toBe(80_000n)
+    expect(r.totals.net).toBe(120_000n)
+    expect(r.totals.net).toBe(r.totals.income - r.totals.expense)
+  })
+
+  test("groups by category and by merchant independently", () => {
+    const r = report([
+      incomeRow({ baseAmount: 200_000n, categoryId: "salary" }),
+      expenseRow({
+        baseAmount: -50_000n,
+        categoryId: "food",
+        merchantId: "m1",
+      }),
+      expenseRow({
+        baseAmount: -30_000n,
+        categoryId: "food",
+        merchantId: "m2",
+      }),
+    ])
+
+    expect(cat(r, "food")?.expense).toBe(80_000n)
+    expect(cat(r, "food")?.income).toBe(0n)
+    expect(cat(r, "salary")?.income).toBe(200_000n)
+    expect(merchant(r, "m1")?.expense).toBe(50_000n)
+    expect(merchant(r, "m2")?.expense).toBe(30_000n)
+    // income row had no merchant: it lands in the read-only no-merchant line.
+    expect(merchant(r, null)?.income).toBe(200_000n)
+  })
+
+  test("null categoryId is the read-only uncategorized line", () => {
+    const r = report([
+      expenseRow({ baseAmount: -25_000n, categoryId: null, merchantId: "m1" }),
+    ])
+    expect(cat(r, null)?.expense).toBe(25_000n)
+  })
+
+  test("the series totals reconcile with the range totals (decomposition)", () => {
+    const r = computeCashFlowReport({
+      from: "2026-06-01",
+      to: "2026-08-31",
+      interval: "month",
+      timezone: TZ,
+      transactions: [
+        incomeRow({ baseAmount: 100_000n, date: D("2026-06-10T00:00:00Z") }),
+        expenseRow({ baseAmount: -40_000n, date: D("2026-07-10T00:00:00Z") }),
+        expenseRow({ baseAmount: -10_000n, date: D("2026-08-10T00:00:00Z") }),
+      ],
+    })
+    const sum = (pick: (b: { income: bigint; expense: bigint }) => bigint) =>
+      r.series.reduce((acc, b) => acc + pick(b), 0n)
+    expect(sum((b) => b.income)).toBe(r.totals.income)
+    expect(sum((b) => b.expense)).toBe(r.totals.expense)
+    // Each series bucket is itself net-consistent.
+    for (const b of r.series) expect(b.net).toBe(b.income - b.expense)
+  })
+})
+
+describe("computeCashFlowReport — split attribution", () => {
+  test("split children attribute to their own category and merchant", () => {
+    const r = report([
+      expenseRow({
+        baseAmount: -100_000n,
+        isSplit: true,
+        categoryId: null,
+        merchantId: null,
+        splitEntries: [
+          { categoryId: "food", merchantId: "m1", amount: 60_000n },
+          { categoryId: "fun", merchantId: null, amount: 40_000n },
+        ],
+      }),
+    ])
+    expect(cat(r, "food")?.expense).toBe(60_000n)
+    expect(cat(r, "fun")?.expense).toBe(40_000n)
+    expect(merchant(r, "m1")?.expense).toBe(60_000n)
+    expect(merchant(r, null)?.expense).toBe(40_000n)
+    expect(r.totals.expense).toBe(100_000n)
+  })
+
+  test("split children take their income/expense sign from the parent type", () => {
+    const r = report([
+      incomeRow({
+        baseAmount: 90_000n,
+        isSplit: true,
+        categoryId: null,
+        splitEntries: [
+          { categoryId: "salary", merchantId: null, amount: 50_000n },
+          { categoryId: "bonus", merchantId: null, amount: 40_000n },
+        ],
+      }),
+    ])
+    expect(cat(r, "salary")?.income).toBe(50_000n)
+    expect(cat(r, "bonus")?.income).toBe(40_000n)
+    expect(r.totals.income).toBe(90_000n)
+    expect(r.totals.expense).toBe(0n)
+  })
+})
+
+describe("computeCashFlowReport — multi-currency via frozen baseAmount", () => {
+  test("non-split foreign row uses its stored baseAmount verbatim", () => {
+    const usdConverted = convertMinor(
+      1_000n,
+      "USD",
+      "IDR",
+      encodeRate("16000")
+    ) as bigint
+    const r = report([
+      expenseRow({
+        currency: "USD",
+        baseCurrency: "IDR",
+        fxRateScaled: encodeRate("16000"),
+        baseAmount: -usdConverted, // signed, frozen at write time
+        categoryId: "food",
+      }),
+    ])
+    expect(cat(r, "food")?.expense).toBe(usdConverted)
+    expect(r.totals.expense).toBe(usdConverted)
+  })
+
+  test("split children re-derive base from the parent's stored rate (sums to parent)", () => {
+    const rate = encodeRate("16000")
+    const parentBase = -(convertMinor(1_000n, "USD", "IDR", rate) as bigint)
+    const r = report([
+      expenseRow({
+        currency: "USD",
+        baseCurrency: "IDR",
+        fxRateScaled: rate,
+        baseAmount: parentBase,
+        isSplit: true,
+        categoryId: null,
+        splitEntries: [
+          { categoryId: "food", merchantId: null, amount: 600n },
+          { categoryId: "fun", merchantId: null, amount: 400n },
+        ],
+      }),
+    ])
+    const food = convertMinor(600n, "USD", "IDR", rate)
+    const fun = convertMinor(400n, "USD", "IDR", rate)
+    expect(cat(r, "food")?.expense).toBe(food)
+    expect(cat(r, "fun")?.expense).toBe(fun)
+    expect(food + fun).toBe(-parentBase) // children reconcile with parent base
+  })
+})
+
+describe("computeCashFlowReport — FX-pending", () => {
+  test("a pending row is excluded from totals and flagged, never zeroed", () => {
+    const r = report([
+      expenseRow({ baseAmount: -50_000n, categoryId: "food" }),
+      expenseRow({
+        currency: "USD",
+        baseAmount: null, // FX-pending
+        categoryId: "food",
+      }),
+    ])
+    expect(r.totals.expense).toBe(50_000n) // pending USD excluded, not zeroed
+    expect(r.totals.unconvertedCount).toBe(1)
+    expect(cat(r, "food")?.expense).toBe(50_000n)
+    expect(cat(r, "food")?.unconvertedCount).toBe(1)
+    expect(r.series.some((b) => b.isPartial)).toBe(true)
+  })
+
+  test("a split whose parent is FX-pending flags every child, counts the tx once", () => {
+    const r = report([
+      expenseRow({
+        currency: "USD",
+        baseAmount: null,
+        fxRateScaled: null,
+        baseCurrency: null,
+        isSplit: true,
+        splitEntries: [
+          { categoryId: "food", merchantId: null, amount: 600n },
+          { categoryId: "fun", merchantId: null, amount: 400n },
+        ],
+      }),
+    ])
+    expect(r.totals.expense).toBe(0n)
+    expect(r.totals.unconvertedCount).toBe(1) // one distinct pending transaction
+    expect(cat(r, "food")?.unconvertedCount).toBe(1)
+    expect(cat(r, "fun")?.unconvertedCount).toBe(1)
+  })
+})
+
+describe("computeCashFlowReport — period bucketing (family timezone)", () => {
+  test("places a row by its family-tz calendar date, not raw UTC", () => {
+    // 2026-06-30 19:00 UTC == 2026-07-01 02:00 in Asia/Jakarta (+07).
+    const r = computeCashFlowReport({
+      from: "2026-07-01",
+      to: "2026-07-01",
+      interval: "day",
+      timezone: "Asia/Jakarta",
+      transactions: [
+        expenseRow({
+          baseAmount: -10_000n,
+          date: D("2026-06-30T19:00:00.000Z"),
+        }),
+      ],
+    })
+    expect(r.totals.expense).toBe(10_000n)
+    expect(r.series).toHaveLength(1)
+    expect(r.series[0].expense).toBe(10_000n)
+  })
+
+  test("rows outside [from,to] (family-tz) do not count", () => {
+    const r = report([
+      expenseRow({ baseAmount: -10_000n, date: D("2026-05-31T00:00:00Z") }),
+      expenseRow({ baseAmount: -20_000n, date: D("2026-07-01T00:00:00Z") }),
+    ])
+    expect(r.totals.expense).toBe(0n)
+  })
+})
+
+describe("generateCashFlowBuckets", () => {
+  test("daily buckets are contiguous single days covering [from,to]", () => {
+    const buckets = generateCashFlowBuckets("2026-06-01", "2026-06-03", "day")
+    expect(buckets).toEqual([
+      { periodStart: "2026-06-01", periodEnd: "2026-06-01" },
+      { periodStart: "2026-06-02", periodEnd: "2026-06-02" },
+      { periodStart: "2026-06-03", periodEnd: "2026-06-03" },
+    ])
+  })
+
+  test("the final bucket is clamped to `to`", () => {
+    const buckets = generateCashFlowBuckets("2026-06-01", "2026-06-10", "week")
+    expect(buckets).toEqual([
+      { periodStart: "2026-06-01", periodEnd: "2026-06-07" },
+      { periodStart: "2026-06-08", periodEnd: "2026-06-10" },
+    ])
+  })
+
+  test("from > to throws", () => {
+    expect(() =>
+      generateCashFlowBuckets("2026-06-10", "2026-06-01", "day")
+    ).toThrow(RangeError)
+  })
+
+  test(`more than ${MAX_CASH_FLOW_BUCKETS} buckets throws`, () => {
+    expect(() =>
+      generateCashFlowBuckets("2026-01-01", "2027-12-31", "day")
+    ).toThrow(RangeError)
+  })
+})

--- a/src/lib/cash-flow.ts
+++ b/src/lib/cash-flow.ts
@@ -1,0 +1,342 @@
+/**
+ * Cash-flow / income-statement engine — the pure income-vs-expense + cash-flow
+ * core (PER-155 / R2). =========================================================
+ *
+ * Single source of truth for "what flowed in and out over a period, by category
+ * and by merchant, and as a trend." A PURE function over already-fetched ledger
+ * rows: no DB, no I/O, no `now`. The flow value basis is each transaction's
+ * frozen, materialized base-currency projection (`baseAmount`, ADR-0035 /
+ * ADR-0038 §2) — never re-resolved here — so historical periods are stable as
+ * later FX rates arrive.
+ *
+ * Counting rules (consistent with the budget engine, `budget-progress.ts`):
+ *   - Only flow rows are passed in: `type ∈ {income, expense}`. Transfers
+ *     (`funds_movement`/`cc_payment`/`loan_payment`/`liability_draw`) are
+ *     `type='transfer'` and excluded UPSTREAM by the server query — they are
+ *     movements, not flow. `liability_interest`/`liability_fee`/`fx_fee` are
+ *     genuine `type='expense'` finance costs and DO count; keying on `type`
+ *     means they can never be dropped by mistake. (See docs/liability-semantics.)
+ *   - Income vs expense is taken from `type`; magnitudes are positive, `net =
+ *     income − expense ≡ Σ signed base` by construction.
+ *   - Splits contribute per child `categoryId`/`merchantId` (the parent's are
+ *     null); the child's base is the parent's stored rate applied to the child's
+ *     native amount (`convertMinor`), so the children reconcile with the parent
+ *     `baseAmount`. The child's income/expense sign comes from the parent type.
+ *   - FX-pending rows (`baseAmount === null`, or a split whose parent is pending)
+ *     are EXCLUDED from base totals and counted separately (`unconvertedCount`)
+ *     so the UI can badge "N unconverted" — never silently zeroed.
+ *   - `categoryId === null` (resp. `merchantId === null`) is the read-only
+ *     uncategorized / no-merchant line.
+ *   - Period membership and trend bucketing use the transaction's calendar date
+ *     in the FAMILY timezone (ADR-0037 / R1 convention), not raw UTC.
+ *
+ * Amounts in and out are signed `bigint` minor units; `income`/`expense` are
+ * reported as positive magnitudes, `net` is signed.
+ */
+
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { calendarDateInZone } from "./budget-progress"
+import { convertMinor } from "./fx"
+
+export const MAX_CASH_FLOW_BUCKETS = 366
+
+export type CashFlowInterval = "day" | "week" | "month"
+
+// ---- inputs -----------------------------------------------------------------
+
+export interface CashFlowSplitEntryInput {
+  categoryId: string | null
+  merchantId: string | null
+  /** Positive native minor units (parent currency). */
+  amount: bigint
+}
+
+export interface CashFlowLedgerRowInput {
+  /** Already filtered to flow rows by the server query. */
+  type: "income" | "expense"
+  /** Native currency of the transaction. */
+  currency: string
+  /** Family base currency captured at write time; null when FX-pending. */
+  baseCurrency: string | null
+  /** 1e12-scaled rate used at write time; null when FX-pending. */
+  fxRateScaled: bigint | null
+  /** Materialized base projection (signed); null when FX-pending. */
+  baseAmount: bigint | null
+  /** Wall-clock instant of the transaction (stored UTC). */
+  date: Date
+  isSplit: boolean
+  /** Null when split (lives on children) or genuinely uncategorized. */
+  categoryId: string | null
+  /** Null when split (lives on children) or genuinely merchant-less. */
+  merchantId: string | null
+  splitEntries: CashFlowSplitEntryInput[]
+}
+
+export interface CashFlowReportInput {
+  /** Inclusive range bounds as family-tz calendar dates (YYYY-MM-DD). */
+  from: string
+  to: string
+  interval: CashFlowInterval
+  /** IANA timezone, e.g. "Asia/Jakarta". */
+  timezone: string
+  transactions: ReadonlyArray<CashFlowLedgerRowInput>
+}
+
+// ---- outputs ----------------------------------------------------------------
+
+export interface CashFlowAmounts {
+  /** Positive base magnitude that flowed in. */
+  income: bigint
+  /** Positive base magnitude that flowed out. */
+  expense: bigint
+  /** Signed: `income − expense`. */
+  net: bigint
+  /** FX-pending contributions excluded from the figures above. */
+  unconvertedCount: number
+}
+
+export interface CashFlowCategoryGroup extends CashFlowAmounts {
+  categoryId: string | null
+}
+
+export interface CashFlowMerchantGroup extends CashFlowAmounts {
+  merchantId: string | null
+}
+
+export interface CashFlowSeriesBucket extends CashFlowAmounts {
+  periodStart: string
+  periodEnd: string
+  isPartial: boolean
+}
+
+export interface CashFlowReport {
+  totals: CashFlowAmounts
+  byCategory: CashFlowCategoryGroup[]
+  byMerchant: CashFlowMerchantGroup[]
+  series: CashFlowSeriesBucket[]
+}
+
+// ---- bucket generation (pure calendar math) ---------------------------------
+
+export interface CashFlowBucket {
+  periodStart: string
+  periodEnd: string
+}
+
+function parseDate(date: string): { year: number; month: number; day: number } {
+  const [year, month, day] = date.split("-").map(Number)
+  return { year, month, day }
+}
+
+function formatUtc(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+/** Advance a YYYY-MM-DD by one interval step (start of the next bucket). */
+function stepDate(date: string, interval: CashFlowInterval): string {
+  const { year, month, day } = parseDate(date)
+  if (interval === "day") return formatUtc(Date.UTC(year, month - 1, day + 1))
+  if (interval === "week") return formatUtc(Date.UTC(year, month - 1, day + 7))
+  // month: advance one calendar month, clamping the day to the new month's last.
+  const nextMonth = month === 12 ? 1 : month + 1
+  const nextYear = month === 12 ? year + 1 : year
+  const lastDay = new Date(Date.UTC(nextYear, nextMonth, 0)).getUTCDate()
+  return formatUtc(Date.UTC(nextYear, nextMonth - 1, Math.min(day, lastDay)))
+}
+
+/** The calendar date one day before `date` (inclusive bucket end). */
+function dayBefore(date: string): string {
+  const { year, month, day } = parseDate(date)
+  return formatUtc(Date.UTC(year, month - 1, day - 1))
+}
+
+/**
+ * Contiguous, gap-free `[periodStart, periodEnd]` buckets (YYYY-MM-DD) stepped
+ * by `interval` across `[from, to]`. The first bucket starts at `from`; the last
+ * bucket's end is clamped to `to`. Throws `RangeError` when `from > to` or the
+ * bucket count would exceed `MAX_CASH_FLOW_BUCKETS` (strict, bounded contract).
+ */
+export function generateCashFlowBuckets(
+  from: string,
+  to: string,
+  interval: CashFlowInterval
+): CashFlowBucket[] {
+  if (from > to) {
+    throw new RangeError(`cash-flow: from (${from}) must be <= to (${to})`)
+  }
+  const buckets: CashFlowBucket[] = []
+  let cursor = from
+  while (cursor <= to) {
+    const nextStart = stepDate(cursor, interval)
+    const end = nextStart > to ? to : dayBefore(nextStart)
+    buckets.push({ periodStart: cursor, periodEnd: end })
+    if (buckets.length > MAX_CASH_FLOW_BUCKETS) {
+      throw new RangeError(
+        `cash-flow exceeds ${MAX_CASH_FLOW_BUCKETS} buckets; narrow the range or widen the interval`
+      )
+    }
+    cursor = nextStart
+  }
+  return buckets
+}
+
+// ---- the fold ---------------------------------------------------------------
+
+interface Accumulator {
+  income: bigint
+  expense: bigint
+  unconvertedCount: number
+}
+
+function emptyAccumulator(): Accumulator {
+  return { income: 0n, expense: 0n, unconvertedCount: 0 }
+}
+
+/** Add one signed base contribution (positive => income, negative => expense). */
+function addContribution(acc: Accumulator, signedBase: bigint): void {
+  if (signedBase >= 0n) acc.income += signedBase
+  else acc.expense += -signedBase
+}
+
+/** Largest bucket index whose periodStart <= cd. Buckets are ascending. */
+function findBucketIndex(buckets: CashFlowBucket[], cd: string): number {
+  let lo = 0
+  let hi = buckets.length - 1
+  let found = 0
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    if (buckets[mid].periodStart <= cd) {
+      found = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  return found
+}
+
+/** Positive base magnitude of one split child via the parent's stored rate. */
+function splitChildBase(
+  row: CashFlowLedgerRowInput,
+  entry: CashFlowSplitEntryInput
+): bigint {
+  // Caller guarantees the parent is non-pending (rate + base currency present).
+  const base = convertMinor(
+    entry.amount,
+    row.currency as CurrencyCode,
+    row.baseCurrency as CurrencyCode,
+    row.fxRateScaled as bigint
+  ) as bigint
+  return base < 0n ? -base : base
+}
+
+function finalize(acc: Accumulator): CashFlowAmounts {
+  return {
+    income: acc.income,
+    expense: acc.expense,
+    net: acc.income - acc.expense,
+    unconvertedCount: acc.unconvertedCount,
+  }
+}
+
+/** Deterministic group ordering: real ids ascending, the null line last. */
+function compareNullableId(a: string | null, b: string | null): number {
+  if (a === b) return 0
+  if (a === null) return 1
+  if (b === null) return -1
+  return a < b ? -1 : 1
+}
+
+/**
+ * Compute the income/expense + cash-flow report for one range. Pure; safe to
+ * unit-test exhaustively. Single pass over the rows; `O(rows · log buckets)`.
+ */
+export function computeCashFlowReport(
+  input: CashFlowReportInput
+): CashFlowReport {
+  const buckets = generateCashFlowBuckets(input.from, input.to, input.interval)
+
+  const totals = emptyAccumulator()
+  const bucketAcc = buckets.map(emptyAccumulator)
+  const byCategory = new Map<string | null, Accumulator>()
+  const byMerchant = new Map<string | null, Accumulator>()
+
+  const categoryAcc = (id: string | null): Accumulator => {
+    let acc = byCategory.get(id)
+    if (!acc) {
+      acc = emptyAccumulator()
+      byCategory.set(id, acc)
+    }
+    return acc
+  }
+  const merchantAcc = (id: string | null): Accumulator => {
+    let acc = byMerchant.get(id)
+    if (!acc) {
+      acc = emptyAccumulator()
+      byMerchant.set(id, acc)
+    }
+    return acc
+  }
+
+  for (const row of input.transactions) {
+    const cd = calendarDateInZone(row.date, input.timezone)
+    if (cd < input.from || cd > input.to) continue
+    const bucket = bucketAcc[findBucketIndex(buckets, cd)]
+
+    if (row.isSplit) {
+      const parentPending =
+        row.baseAmount === null ||
+        row.fxRateScaled === null ||
+        row.baseCurrency === null
+      if (parentPending) {
+        // One distinct pending transaction at the period/bucket level; a flagged
+        // contribution at each touched category/merchant line.
+        totals.unconvertedCount += 1
+        bucket.unconvertedCount += 1
+        for (const entry of row.splitEntries) {
+          categoryAcc(entry.categoryId).unconvertedCount += 1
+          merchantAcc(entry.merchantId).unconvertedCount += 1
+        }
+        continue
+      }
+      for (const entry of row.splitEntries) {
+        const magnitude = splitChildBase(row, entry)
+        const signed = row.type === "expense" ? -magnitude : magnitude
+        addContribution(totals, signed)
+        addContribution(bucket, signed)
+        addContribution(categoryAcc(entry.categoryId), signed)
+        addContribution(merchantAcc(entry.merchantId), signed)
+      }
+      continue
+    }
+
+    if (row.baseAmount === null) {
+      totals.unconvertedCount += 1
+      bucket.unconvertedCount += 1
+      categoryAcc(row.categoryId).unconvertedCount += 1
+      merchantAcc(row.merchantId).unconvertedCount += 1
+      continue
+    }
+
+    addContribution(totals, row.baseAmount)
+    addContribution(bucket, row.baseAmount)
+    addContribution(categoryAcc(row.categoryId), row.baseAmount)
+    addContribution(merchantAcc(row.merchantId), row.baseAmount)
+  }
+
+  return {
+    totals: finalize(totals),
+    byCategory: [...byCategory.entries()]
+      .sort(([a], [b]) => compareNullableId(a, b))
+      .map(([categoryId, acc]) => ({ categoryId, ...finalize(acc) })),
+    byMerchant: [...byMerchant.entries()]
+      .sort(([a], [b]) => compareNullableId(a, b))
+      .map(([merchantId, acc]) => ({ merchantId, ...finalize(acc) })),
+    series: buckets.map((bucket, index) => ({
+      periodStart: bucket.periodStart,
+      periodEnd: bucket.periodEnd,
+      ...finalize(bucketAcc[index]),
+      isPartial: bucketAcc[index].unconvertedCount > 0,
+    })),
+  }
+}

--- a/src/server/reporting.ts
+++ b/src/server/reporting.ts
@@ -6,6 +6,13 @@ import {
   type NetWorthPoint,
   type SeriesInterval,
 } from "@/lib/net-worth"
+import {
+  computeCashFlowReport,
+  generateCashFlowBuckets,
+  type CashFlowAmounts,
+  type CashFlowInterval,
+  type CashFlowReport,
+} from "@/lib/cash-flow"
 import { getFamilyBaseCurrency } from "./fx"
 import {
   familyMiddleware,
@@ -207,6 +214,226 @@ export const getNetWorthSeriesFn = createServerFn({ method: "GET" })
   )
   .handler(async ({ data, context }) => {
     return await getNetWorthSeriesForFamily({
+      data,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+// =============================================================================
+// PER-155 / R2 — Income statement / cash-flow engine.
+//
+// Income vs expense + cash flow over a range, grouped by category and merchant,
+// plus a per-period trend. Computed-on-read from the canonical ledger using each
+// row's FROZEN base-currency projection (`baseAmount`, ADR-0035 / ADR-0038 §2),
+// so historical periods are stable as later FX rates arrive (the net-worth
+// _stock_ line marks-to-market; this _flow_ line does not — same columns, two
+// correct uses).
+//
+// The flow/transfer boundary keys on `type`: only `type ∈ {income, expense}`
+// rows are loaded, so every transfer kind (funds_movement / cc_payment /
+// loan_payment / liability_draw — all `type='transfer'`) is excluded as a
+// movement, while `liability_interest` / `liability_fee` / `fx_fee` (genuine
+// `type='expense'` finance costs) are retained. `excluded`/soft-deleted rows are
+// dropped, exactly as the budget engine does. The full kind×report matrix
+// (refund, holds, asset sale, …) is owned by PER-80; R2 classifies only the
+// kinds that exist today. The heavy lifting is the pure `computeCashFlowReport`
+// fold in `src/lib/cash-flow.ts`. Read-only: one `scopedTenantTransaction`, no
+// idempotency, no AuditLog; `familyMiddleware` alone (viewer holds `*:read`).
+// =============================================================================
+
+export const getCashFlowReportInputSchema = z
+  .object({
+    from: dateOnlySchema,
+    to: dateOnlySchema,
+    interval: z.enum(["day", "week", "month"]),
+  })
+  .superRefine((data, ctx) => {
+    // Reuse the single source of truth for bounds (from ≤ to, ≤ MAX buckets).
+    try {
+      generateCashFlowBuckets(data.from, data.to, data.interval)
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: (error as Error).message,
+      })
+    }
+  })
+
+export type GetCashFlowReportInput = z.infer<
+  typeof getCashFlowReportInputSchema
+>
+
+export interface SerializedCashFlowAmounts {
+  income: string
+  expense: string
+  net: string
+  unconvertedCount: number
+}
+
+export interface SerializedCashFlowCategoryGroup extends SerializedCashFlowAmounts {
+  categoryId: string | null
+}
+
+export interface SerializedCashFlowMerchantGroup extends SerializedCashFlowAmounts {
+  merchantId: string | null
+}
+
+export interface SerializedCashFlowBucket extends SerializedCashFlowAmounts {
+  periodStart: string
+  periodEnd: string
+  isPartial: boolean
+}
+
+export interface CashFlowReportResult {
+  baseCurrency: string
+  timezone: string
+  from: string
+  to: string
+  interval: CashFlowInterval
+  totals: SerializedCashFlowAmounts
+  byCategory: SerializedCashFlowCategoryGroup[]
+  byMerchant: SerializedCashFlowMerchantGroup[]
+  series: SerializedCashFlowBucket[]
+}
+
+function serializeAmounts(amounts: CashFlowAmounts): SerializedCashFlowAmounts {
+  return {
+    income: amounts.income.toString(),
+    expense: amounts.expense.toString(),
+    net: amounts.net.toString(),
+    unconvertedCount: amounts.unconvertedCount,
+  }
+}
+
+function serializeCashFlowReport(
+  report: CashFlowReport,
+  meta: {
+    baseCurrency: string
+    timezone: string
+    from: string
+    to: string
+    interval: CashFlowInterval
+  }
+): CashFlowReportResult {
+  return {
+    ...meta,
+    totals: serializeAmounts(report.totals),
+    byCategory: report.byCategory.map((group) => ({
+      categoryId: group.categoryId,
+      ...serializeAmounts(group),
+    })),
+    byMerchant: report.byMerchant.map((group) => ({
+      merchantId: group.merchantId,
+      ...serializeAmounts(group),
+    })),
+    series: report.series.map((bucket) => ({
+      periodStart: bucket.periodStart,
+      periodEnd: bucket.periodEnd,
+      isPartial: bucket.isPartial,
+      ...serializeAmounts(bucket),
+    })),
+  }
+}
+
+// Generous inclusive bounds: ±2 days UTC covers any family timezone offset
+// (±14h). The fold localizes each instant precisely and filters to [from, to]
+// in the family timezone, so over-fetching at most a day's rows is harmless.
+function queryRange(from: string, to: string): { gte: Date; lt: Date } {
+  const startOfFrom = Date.parse(`${from}T00:00:00.000Z`)
+  const startOfTo = Date.parse(`${to}T00:00:00.000Z`)
+  const day = 24 * 60 * 60 * 1000
+  return {
+    gte: new Date(startOfFrom - 2 * day),
+    lt: new Date(startOfTo + 2 * day),
+  }
+}
+
+export async function getCashFlowReportForFamily({
+  data: rawData,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: GetCashFlowReportInput
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<CashFlowReportResult> {
+  const data = getCashFlowReportInputSchema.parse(rawData)
+  const range = queryRange(data.from, data.to)
+
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+    const timezone = await getFamilyTimezone(tx, familyId)
+
+    // One query — the flow rows. Transfers are excluded by `type`; `excluded`
+    // and soft-deleted rows never count (ADR-0037 / budget-engine parity).
+    const transactions = await tx.transaction.findMany({
+      where: {
+        familyId,
+        deletedAt: null,
+        excluded: false,
+        type: { in: ["income", "expense"] },
+        date: range,
+      },
+      select: {
+        type: true,
+        currency: true,
+        baseCurrency: true,
+        fxRateScaled: true,
+        baseAmount: true,
+        date: true,
+        isSplit: true,
+        categoryId: true,
+        merchantId: true,
+        splitEntries: {
+          select: { categoryId: true, merchantId: true, amount: true },
+        },
+      },
+    })
+
+    const report = computeCashFlowReport({
+      from: data.from,
+      to: data.to,
+      interval: data.interval,
+      timezone,
+      transactions: transactions.map((row) => ({
+        // Narrowed by the `type` filter above; the DB CHECK guarantees the domain.
+        type: row.type as "income" | "expense",
+        currency: row.currency,
+        baseCurrency: row.baseCurrency,
+        fxRateScaled: row.fxRateScaled,
+        baseAmount: row.baseAmount,
+        date: row.date,
+        isSplit: row.isSplit,
+        categoryId: row.categoryId,
+        merchantId: row.merchantId,
+        splitEntries: row.splitEntries.map((entry) => ({
+          categoryId: entry.categoryId,
+          merchantId: entry.merchantId,
+          amount: entry.amount,
+        })),
+      })),
+    })
+
+    return serializeCashFlowReport(report, {
+      baseCurrency,
+      timezone,
+      from: data.from,
+      to: data.to,
+      interval: data.interval,
+    })
+  })
+}
+
+export const getCashFlowReportFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: GetCashFlowReportInput) =>
+    getCashFlowReportInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await getCashFlowReportForFamily({
       data,
       familyId: context.familyId,
       userId: context.user.id,

--- a/tests/integration/cash-flow-report.integration.ts
+++ b/tests/integration/cash-flow-report.integration.ts
@@ -1,0 +1,396 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { convertMinor, encodeRate } from "@/lib/fx"
+import { upsertFxRateSnapshotForFamily } from "@/server/fx"
+import {
+  getCashFlowReportForFamily,
+  type CashFlowReportResult,
+} from "@/server/reporting"
+import { createTransactionForFamily } from "@/server/transactions"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-155 / R2 — Real-Postgres proof of the cash-flow contract over rows written
+// by the REAL ledger path (`createTransactionForFamily`): transfers excluded by
+// `type` while liability interest/fee stay counted as finance-cost expenses,
+// split attribution per child, multi-currency via the frozen `baseAmount`
+// projection (stable as later rates arrive), FX-pending exclusion+flag, and RLS
+// tenant isolation.
+
+const FROM = "2026-06-01"
+const TO = "2026-06-30"
+const ON = (d = "2026-06-15") => new Date(`${d}T03:00:00.000Z`)
+
+describe("cash-flow report (PER-155 / R2)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // ---- helpers ---------------------------------------------------------------
+
+  const setFamilyDefaults = (
+    owner: AuthenticatedOnboardedUser,
+    currency: string,
+    timezone: string
+  ) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.family.update({
+        where: { id: owner.family.id },
+        data: { currency, timezone },
+      })
+    )
+
+  // Seed a generous opening balance with the correct normal-balance sign
+  // (ASSET >= 0, LIABILITY <= 0) so posting flow/transfers never trips the
+  // account_normal_balance_sign CHECK.
+  const account = (
+    owner: AuthenticatedOnboardedUser,
+    name: string,
+    accountType: AccountType = "DEPOSITORY",
+    currency = "IDR"
+  ) => {
+    const isLiability = accountType === "CREDIT" || accountType === "LOAN"
+    return factories.createAccount({
+      familyId: owner.family.id,
+      name,
+      accountType,
+      currency,
+      balance: isLiability ? -100_000_000n : 100_000_000n,
+    })
+  }
+
+  const create = (
+    owner: AuthenticatedOnboardedUser,
+    data: Omit<
+      Parameters<typeof createTransactionForFamily>[0]["data"],
+      "idempotencyKey"
+    >
+  ) =>
+    createTransactionForFamily({
+      data: { idempotencyKey: factories.createIdempotencyKey(), ...data },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const seedRate = (
+    owner: AuthenticatedOnboardedUser,
+    fromCurrency: string,
+    rate: string,
+    asOfDate: string
+  ) =>
+    upsertFxRateSnapshotForFamily({
+      data: { fromCurrency, toCurrency: "IDR", rate, asOfDate, source: "seed" },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const report = (
+    owner: AuthenticatedOnboardedUser,
+    userId = owner.user.id
+  ): Promise<CashFlowReportResult> =>
+    getCashFlowReportForFamily({
+      data: { from: FROM, to: TO, interval: "month" },
+      familyId: owner.family.id,
+      userId,
+    })
+
+  const cat = (r: CashFlowReportResult, id: string | null) =>
+    r.byCategory.find((g) => g.categoryId === id)
+  const merch = (r: CashFlowReportResult, id: string | null) =>
+    r.byMerchant.find((g) => g.merchantId === id)
+
+  // ---- aggregation + grouping ------------------------------------------------
+
+  test("aggregates income vs expense and groups by category and merchant", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+    const wallet = await account(owner, "Wallet")
+    const food = await factories.createCategory({
+      familyId: owner.family.id,
+      type: "expense",
+      name: "Food",
+    })
+    const salary = await factories.createCategory({
+      familyId: owner.family.id,
+      type: "income",
+      name: "Salary",
+    })
+    const store = await factories.createMerchant({
+      familyId: owner.family.id,
+      name: "Store",
+    })
+
+    await create(owner, {
+      type: "expense",
+      amount: 50_000n,
+      currency: "IDR",
+      accountId: wallet.id,
+      categoryId: food.id,
+      merchantId: store.id,
+      description: "groceries",
+      date: ON(),
+    })
+    await create(owner, {
+      type: "income",
+      amount: 200_000n,
+      currency: "IDR",
+      accountId: wallet.id,
+      categoryId: salary.id,
+      description: "payday",
+      date: ON(),
+    })
+
+    const r = await report(owner)
+    expect(r.baseCurrency).toBe("IDR")
+    expect(r.totals.income).toBe("200000")
+    expect(r.totals.expense).toBe("50000")
+    expect(r.totals.net).toBe("150000")
+    expect(cat(r, food.id)?.expense).toBe("50000")
+    expect(cat(r, salary.id)?.income).toBe("200000")
+    expect(merch(r, store.id)?.expense).toBe("50000")
+    // the income row had no merchant => no-merchant line
+    expect(merch(r, null)?.income).toBe("200000")
+  })
+
+  // ---- transfer exclusion vs liability-cost retention (the core invariant) ----
+
+  test("excludes transfers but keeps liability interest/fee as expenses", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+    const a = await account(owner, "Checking")
+    const b = await account(owner, "Savings")
+    const card = await account(owner, "Card", "CREDIT")
+
+    // Pure money movement: asset->asset transfer (funds_movement). Excluded.
+    await create(owner, {
+      type: "transfer",
+      amount: 100_000n,
+      currency: "IDR",
+      accountId: a.id,
+      toAccountId: b.id,
+      description: "move to savings",
+      date: ON(),
+    })
+    // Credit-card principal payment (cc_payment, kind derived). Excluded.
+    await create(owner, {
+      type: "transfer",
+      amount: 40_000n,
+      currency: "IDR",
+      accountId: a.id,
+      toAccountId: card.id,
+      description: "card payment",
+      date: ON(),
+    })
+    // Finance costs: liability interest + fee ARE real expenses. Counted.
+    await create(owner, {
+      type: "expense",
+      kind: "liability_interest",
+      amount: 7_000n,
+      currency: "IDR",
+      accountId: a.id,
+      toAccountId: card.id,
+      description: "card interest",
+      date: ON(),
+    })
+    await create(owner, {
+      type: "expense",
+      kind: "liability_fee",
+      amount: 3_000n,
+      currency: "IDR",
+      accountId: a.id,
+      toAccountId: card.id,
+      description: "late fee",
+      date: ON(),
+    })
+    // Ordinary spending on the card. Counted.
+    await create(owner, {
+      type: "expense",
+      amount: 50_000n,
+      currency: "IDR",
+      accountId: card.id,
+      description: "dinner on card",
+      date: ON(),
+    })
+
+    const r = await report(owner)
+    // 7,000 interest + 3,000 fee + 50,000 spending; the two transfers excluded.
+    expect(r.totals.expense).toBe("60000")
+    expect(r.totals.income).toBe("0")
+    expect(r.totals.net).toBe("-60000")
+  })
+
+  // ---- split attribution -----------------------------------------------------
+
+  test("attributes split entries to their child categories and merchants", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+    const wallet = await account(owner, "Wallet")
+    const food = await factories.createCategory({
+      familyId: owner.family.id,
+      type: "expense",
+      name: "Food",
+    })
+    const fun = await factories.createCategory({
+      familyId: owner.family.id,
+      type: "expense",
+      name: "Fun",
+    })
+
+    await create(owner, {
+      type: "expense",
+      amount: 100_000n,
+      currency: "IDR",
+      accountId: wallet.id,
+      description: "split receipt",
+      date: ON(),
+      isSplit: true,
+      splitEntries: [
+        { description: "groceries", amount: 60_000n, categoryId: food.id },
+        { description: "movie", amount: 40_000n, categoryId: fun.id },
+      ],
+    })
+
+    const r = await report(owner)
+    expect(cat(r, food.id)?.expense).toBe("60000")
+    expect(cat(r, fun.id)?.expense).toBe("40000")
+    expect(r.totals.expense).toBe("100000")
+    // Parent category is null on a split; it must not double-count.
+    expect(cat(r, null)).toBeUndefined()
+  })
+
+  // ---- multi-currency via frozen baseAmount, stable over time ----------------
+
+  test("normalizes foreign rows via baseAmount; a later rate does not move history", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+    const usd = await account(owner, "USD wallet", "DEPOSITORY", "USD")
+    const food = await factories.createCategory({
+      familyId: owner.family.id,
+      type: "expense",
+      name: "Food",
+    })
+    await seedRate(owner, "USD", "16000", "2026-06-01")
+
+    await create(owner, {
+      type: "expense",
+      amount: 1_000n, // 10.00 USD
+      currency: "USD",
+      accountId: usd.id,
+      categoryId: food.id,
+      description: "usd lunch",
+      date: ON(),
+    })
+
+    const expected = (
+      convertMinor(1_000n, "USD", "IDR", encodeRate("16000")) as bigint
+    ).toString()
+
+    const before = await report(owner)
+    expect(before.totals.expense).toBe(expected)
+    expect(before.totals.unconvertedCount).toBe(0)
+
+    // A later-dated rate must NOT change the already-frozen historical value.
+    await seedRate(owner, "USD", "17000", "2026-06-20")
+    const after = await report(owner)
+    expect(after.totals.expense).toBe(expected)
+  })
+
+  test("FX-pending foreign row is excluded from totals and flagged", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+    const usd = await account(owner, "USD wallet", "DEPOSITORY", "USD")
+    // No USD rate seeded => baseAmount is null (FX-pending).
+    await create(owner, {
+      type: "expense",
+      amount: 1_000n,
+      currency: "USD",
+      accountId: usd.id,
+      description: "unconverted",
+      date: ON(),
+    })
+
+    const r = await report(owner)
+    expect(r.totals.expense).toBe("0") // excluded, not zeroed into the figure
+    expect(r.totals.unconvertedCount).toBe(1)
+    expect(r.series.some((b) => b.isPartial)).toBe(true)
+  })
+
+  // ---- tenant isolation ------------------------------------------------------
+
+  test("a non-member reading the family sees an all-zero report", async () => {
+    const ownerA = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(ownerA, "IDR", "UTC")
+    const wallet = await account(ownerA, "Wallet")
+    await create(ownerA, {
+      type: "expense",
+      amount: 50_000n,
+      currency: "IDR",
+      accountId: wallet.id,
+      description: "groceries",
+      date: ON(),
+    })
+    const ownerB = await factories.createAuthenticatedOnboardedUser()
+
+    const leaked = await report(ownerA, ownerB.user.id)
+    expect(leaked.totals.income).toBe("0")
+    expect(leaked.totals.expense).toBe("0")
+    expect(leaked.byCategory).toHaveLength(0)
+    expect(leaked.byMerchant).toHaveLength(0)
+  })
+
+  test("family B's report reflects only B's ledger", async () => {
+    const ownerA = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(ownerA, "IDR", "UTC")
+    const aWallet = await account(ownerA, "A wallet")
+    await create(ownerA, {
+      type: "expense",
+      amount: 99_999n,
+      currency: "IDR",
+      accountId: aWallet.id,
+      description: "A spend",
+      date: ON(),
+    })
+
+    const ownerB = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(ownerB, "IDR", "UTC")
+    const bWallet = await account(ownerB, "B wallet")
+    await create(ownerB, {
+      type: "income",
+      amount: 42_000n,
+      currency: "IDR",
+      accountId: bWallet.id,
+      description: "B income",
+      date: ON(),
+    })
+
+    const r = await report(ownerB)
+    expect(r.totals.income).toBe("42000")
+    expect(r.totals.expense).toBe("0")
+  })
+})


### PR DESCRIPTION
## PER-155 — R2: Income statement / cash-flow engine

Decomposed from PER-119; **blocks PER-156** (R3 dashboard). Blocked-by **PER-147** (F3 base currency/FX) — merged.

Income vs expense + cash flow over a date range, grouped by **category** and **merchant**, with a per-period **trend**. Computed-on-read from the canonical ledger using each row's **frozen `baseAmount`** projection (ADR-0035 / ADR-0038 §2), so historical periods stay stable as later FX rates arrive — the net-worth *stock* line marks-to-market, this *flow* line does not. Same columns, two correct uses → **no new ADR**.

### Decision contract (derivable from existing docs)
- **Flow = `type ∈ {income, expense}`.** Every transfer kind (`funds_movement`/`cc_payment`/`loan_payment`/`liability_draw`, all `type='transfer'`) is excluded as a *movement*, while `liability_interest`/`liability_fee`/`fx_fee` (genuine `type='expense'` finance costs) stay counted. Keying on `type` means costs can never be dropped by mistake. `excluded`/soft-deleted rows never count (budget-engine parity). The full kind×report matrix (refund, holds, asset sale…) stays owned by **PER-80**; R2 classifies only today's kinds.
- **Split attribution** per child category/merchant (parent ids null); child base re-derives from the parent's stored rate via `convertMinor`, reconciling with the parent `baseAmount`; child sign comes from the parent `type`.
- **FX-pending** rows (`baseAmount === null`, or a split whose parent is pending) are excluded from totals and flagged (`unconvertedCount`), never zeroed.
- `net = income − expense ≡ Σ signed base` by construction; income/expense are positive magnitudes. Period bucketing uses the **family-tz** calendar date (ADR-0037 / R1 convention).

### Implementation
- **Pure, Prisma-free** `src/lib/cash-flow.ts` (`computeCashFlowReport` + `generateCashFlowBuckets`), exhaustively unit-tested (16 cases).
- **One deep read fn** `getCashFlowReportFn` in `src/server/reporting.ts`: single `scopedTenantTransaction` (transaction-scoped RLS GUCs), **single query, single in-memory pass** (no N+1), no idempotency/audit (read-only), `familyMiddleware` alone (`viewer` holds `*:read`). Returns `{ totals, byCategory, byMerchant, series }`; bigints serialized as minor-unit strings. **No UI** (R3 owns rendering).

### Acceptance criteria
- [x] Income/expense + cash-flow read fn over a date range, grouped by category/merchant
- [x] Transfers excluded from income/expense; split entries attributed to child categories/merchants
- [x] Base-currency normalization via F3 `baseAmount`; stable historical values (proven: a later-dated rate does not move history)
- [x] Tenant isolation enforced; reads scoped to `context.familyId`
- [x] Unit (aggregation/attribution math) + real-Postgres integration tests (transfer exclusion, liability-cost retention, split attribution, multi-currency, FX-pending, tenant isolation)
- [x] `vp run check && vp test run && vp build` clean

### Verification
- `vp run check` ✅ · `vp test run` → 281 ✅ · `vp build` ✅ · full integration → **26 files / 233 tests** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
