### PR TITLE
feat(reporting): R3 — dashboard realization (net worth, cash flow, top categories, budget) (PER-156)

### DIFF
--- a/src/components/blocks/dashboard-cards.test.tsx
+++ b/src/components/blocks/dashboard-cards.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vite-plus/test"
+import { cleanup, render, screen } from "@testing-library/react"
+
+import {
+  BudgetProgressCard,
+  CashFlowCard,
+  NetWorthCard,
+  TopCategoriesCard,
+  selectTopExpenseCategories,
+  type TopCategoryRow,
+} from "./dashboard-cards"
+import type {
+  CashFlowReportResult,
+  NetWorthSeriesResult,
+  SerializedCashFlowCategoryGroup,
+} from "@/server/reporting"
+import type {
+  SerializedBudgetProgress,
+  SerializedExpenseCategory,
+} from "@/server/budgets"
+
+// recharts' ResponsiveContainer relies on ResizeObserver, which jsdom lacks.
+// The cards still render their headline KPIs (outside the chart) regardless.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver =
+  ResizeObserverStub as unknown as typeof ResizeObserver
+
+afterEach(() => cleanup())
+
+const netWorthBase: NetWorthSeriesResult = {
+  baseCurrency: "USD",
+  timezone: "UTC",
+  from: "2026-01-01",
+  to: "2026-06-01",
+  interval: "month",
+  points: [
+    {
+      date: "2026-01-01",
+      netWorth: "100000",
+      assets: "100000",
+      liabilities: "0",
+      unconverted: [],
+      isPartial: false,
+    },
+    {
+      date: "2026-06-01",
+      netWorth: "123456",
+      assets: "123456",
+      liabilities: "0",
+      unconverted: [],
+      isPartial: false,
+    },
+  ],
+}
+
+const cashFlowBase: CashFlowReportResult = {
+  baseCurrency: "USD",
+  timezone: "UTC",
+  from: "2026-05-01",
+  to: "2026-05-31",
+  interval: "month",
+  totals: {
+    income: "500000",
+    expense: "320000",
+    net: "180000",
+    unconvertedCount: 2,
+  },
+  byCategory: [
+    {
+      categoryId: "c1",
+      income: "0",
+      expense: "200000",
+      net: "-200000",
+      unconvertedCount: 0,
+    },
+    {
+      categoryId: null,
+      income: "0",
+      expense: "50000",
+      net: "-50000",
+      unconvertedCount: 0,
+    },
+    {
+      categoryId: "c2",
+      income: "100000",
+      expense: "0",
+      net: "100000",
+      unconvertedCount: 0,
+    },
+  ],
+  byMerchant: [],
+  series: [
+    {
+      periodStart: "2026-05-01",
+      periodEnd: "2026-05-31",
+      isPartial: false,
+      income: "500000",
+      expense: "320000",
+      net: "180000",
+      unconvertedCount: 0,
+    },
+  ],
+}
+
+const expenseCategories: SerializedExpenseCategory[] = [
+  { id: "c1", name: "Groceries", color: "#10b981", icon: "shopping-cart" },
+  { id: "c2", name: "Salary", color: "#6172F3", icon: "briefcase" },
+]
+
+const budgetBase: SerializedBudgetProgress = {
+  budgetId: "b1",
+  name: "June 2026",
+  month: "2026-06",
+  periodKind: "monthly",
+  periodStart: "2026-06-01",
+  periodEnd: "2026-06-30",
+  currency: "USD",
+  baseCurrency: "USD",
+  timezone: "UTC",
+  archivedAt: null,
+  categories: [
+    {
+      categoryId: "c1",
+      categoryName: "Groceries",
+      categoryColor: "#10b981",
+      categoryIcon: "shopping-cart",
+      allocatedAmount: "300000",
+      actualAmount: "320000",
+      remainingAmount: "-20000",
+      isOver: true,
+      pendingCount: 0,
+    },
+  ],
+  uncategorized: { actualAmount: "0", pendingCount: 0 },
+  totals: {
+    allocatedAmount: "300000",
+    actualAmount: "320000",
+    remainingAmount: "-20000",
+    isOver: true,
+    pendingTransactionCount: 0,
+  },
+}
+
+describe("selectTopExpenseCategories", () => {
+  const groups: SerializedCashFlowCategoryGroup[] = cashFlowBase.byCategory
+  const nameById = new Map(expenseCategories.map((c) => [c.id, c.name]))
+
+  it("orders by expense descending, maps names, and drops zero-expense groups", () => {
+    const rows: TopCategoryRow[] = selectTopExpenseCategories(
+      groups,
+      nameById,
+      5
+    )
+    expect(rows.map((r) => r.name)).toEqual(["Groceries", "Uncategorized"])
+    expect(rows[0]?.expense).toBe("200000")
+  })
+
+  it("respects the limit", () => {
+    expect(selectTopExpenseCategories(groups, nameById, 1)).toHaveLength(1)
+  })
+
+  it("renders an unknown id as 'Unknown category'", () => {
+    const rows = selectTopExpenseCategories(
+      [
+        {
+          categoryId: "ghost",
+          income: "0",
+          expense: "999",
+          net: "-999",
+          unconvertedCount: 0,
+        },
+      ],
+      new Map(),
+      5
+    )
+    expect(rows[0]?.name).toBe("Unknown category")
+  })
+})
+
+describe("NetWorthCard", () => {
+  it("shows the last point as the headline net worth", () => {
+    render(<NetWorthCard data={netWorthBase} />)
+    expect(screen.getByText(/1,234\.56/)).toBeTruthy()
+  })
+
+  it("shows an empty state when there are no points", () => {
+    render(<NetWorthCard data={{ ...netWorthBase, points: [] }} />)
+    expect(screen.getByText(/No balances in this range/i)).toBeTruthy()
+  })
+
+  it("surfaces a partial badge when the latest point is FX-pending", () => {
+    render(
+      <NetWorthCard
+        data={{
+          ...netWorthBase,
+          points: [
+            {
+              date: "2026-06-01",
+              netWorth: "123456",
+              assets: "123456",
+              liabilities: "0",
+              unconverted: [{ currency: "EUR", native: "5000" }],
+              isPartial: true,
+            },
+          ],
+        }}
+      />
+    )
+    expect(screen.getByText(/1 unconverted/i)).toBeTruthy()
+  })
+})
+
+describe("CashFlowCard", () => {
+  it("renders income, expense, and net cash flow headlines", () => {
+    render(<CashFlowCard data={cashFlowBase} />)
+    expect(screen.getByText(/5,000\.00/)).toBeTruthy() // income
+    expect(screen.getByText(/3,200\.00/)).toBeTruthy() // expense
+    expect(screen.getByText(/1,800\.00/)).toBeTruthy() // net
+  })
+
+  it("shows the unconverted badge from the totals", () => {
+    render(<CashFlowCard data={cashFlowBase} />)
+    expect(screen.getByText(/2 unconverted/i)).toBeTruthy()
+  })
+})
+
+describe("TopCategoriesCard", () => {
+  it("lists top expense categories and excludes income-only ones", () => {
+    render(
+      <TopCategoriesCard data={cashFlowBase} categories={expenseCategories} />
+    )
+    expect(screen.getByText("Groceries")).toBeTruthy()
+    expect(screen.getByText("Uncategorized")).toBeTruthy()
+    expect(screen.queryByText("Salary")).toBeNull()
+  })
+
+  it("shows an empty state when there is no categorized spend", () => {
+    render(
+      <TopCategoriesCard
+        data={{ ...cashFlowBase, byCategory: [] }}
+        categories={expenseCategories}
+      />
+    )
+    expect(screen.getByText(/No categorized spending/i)).toBeTruthy()
+  })
+})
+
+describe("BudgetProgressCard", () => {
+  it("renders totals and an over-budget badge", () => {
+    render(<BudgetProgressCard progress={budgetBase} />)
+    expect(screen.getByText("$3,000.00")).toBeTruthy() // budgeted total stat
+    expect(screen.getByText("Over budget")).toBeTruthy()
+    expect(screen.getByText("Groceries")).toBeTruthy()
+  })
+})

--- a/src/components/blocks/dashboard-cards.tsx
+++ b/src/components/blocks/dashboard-cards.tsx
@@ -1,0 +1,567 @@
+import * as React from "react"
+import {
+  PiggyBank,
+  Tags,
+  TrendingDown,
+  TrendingUp,
+  TriangleAlert,
+  Wallet,
+} from "lucide-react"
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis } from "recharts"
+
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { decodeMoney, formatMoney, toDisplayNumber } from "@/lib/money"
+import type {
+  CashFlowReportResult,
+  NetWorthSeriesResult,
+  SerializedCashFlowCategoryGroup,
+} from "@/server/reporting"
+import type {
+  SerializedBudgetProgress,
+  SerializedExpenseCategory,
+} from "@/server/budgets"
+
+// =============================================================================
+// PER-156 / R3 — Dashboard realization.
+//
+// PURE rendering layer over the reporting engines: R1 net-worth series, R2
+// cash-flow report, P1 budget progress. NO analytics math lives here — every
+// figure is read from the server-fn output. The only client-side work is
+// presentation: decoding wire money (minor-unit bigint strings) for display,
+// mapping series to chart-friendly display numbers (memoized), and ordering the
+// top expense categories. KPIs come straight off `totals`, so there is no heavy
+// per-render recompute (CLAUDE.md §5C). FX-pending rows are surfaced via
+// "unconverted / partial" badges, never hidden.
+// =============================================================================
+
+/** Exact display string from a wire money value (minor-unit bigint string). */
+function formatWire(wire: string, currency: CurrencyCode): string {
+  return formatMoney(decodeMoney(wire), currency)
+}
+
+/** Wire money → display number (major units) for plotting on a chart axis. */
+function toChartNumber(wire: string, currency: CurrencyCode): number {
+  return toDisplayNumber(decodeMoney(wire), currency)
+}
+
+function formatDay(value: string): string {
+  const date = new Date(`${value}T00:00:00Z`)
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  })
+}
+
+// ─── Top expense categories — pure ordering helper (unit-tested) ─────────────
+export interface TopCategoryRow {
+  categoryId: string | null
+  name: string
+  /** Positive expense magnitude as a wire string (minor-unit bigint). */
+  expense: string
+}
+
+/**
+ * Top expense categories for the period, ordered by spend descending. Pure
+ * presentation ordering over R2's `byCategory` — no money math, only a bigint
+ * compare and a name lookup. `categoryId === null` renders as "Uncategorized".
+ */
+export function selectTopExpenseCategories(
+  byCategory: ReadonlyArray<SerializedCashFlowCategoryGroup>,
+  nameById: ReadonlyMap<string, string>,
+  limit: number
+): TopCategoryRow[] {
+  return byCategory
+    .filter((group) => decodeMoney(group.expense) > 0n)
+    .sort((a, b) => {
+      const delta = decodeMoney(b.expense) - decodeMoney(a.expense)
+      return delta > 0n ? 1 : delta < 0n ? -1 : 0
+    })
+    .slice(0, limit)
+    .map((group) => ({
+      categoryId: group.categoryId,
+      name:
+        group.categoryId === null
+          ? "Uncategorized"
+          : (nameById.get(group.categoryId) ?? "Unknown category"),
+      expense: group.expense,
+    }))
+}
+
+// ─── Shared bits ─────────────────────────────────────────────────────────────
+function PartialBadge({ count }: { count?: number }) {
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 text-amber-600 dark:text-amber-400"
+    >
+      <TriangleAlert className="size-3" aria-hidden />
+      {typeof count === "number" && count > 0
+        ? `${count} unconverted`
+        : "Partial — FX pending"}
+    </Badge>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string
+  value: string
+  tone?: "default" | "positive" | "negative"
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "text-lg font-semibold tabular-nums",
+          tone === "negative" && "text-destructive",
+          tone === "positive" && "text-emerald-600 dark:text-emerald-400"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function EmptyHint({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-muted-foreground">{children}</p>
+}
+
+// ─── Net worth (R1) ──────────────────────────────────────────────────────────
+const netWorthChartConfig = {
+  netWorth: { label: "Net worth", color: "var(--chart-2)" },
+} satisfies ChartConfig
+
+export function NetWorthCard({ data }: { data: NetWorthSeriesResult }) {
+  const base = data.baseCurrency as CurrencyCode
+  const points = data.points
+  const last = points.at(-1)
+  const first = points.at(0)
+
+  const chartData = React.useMemo(
+    () =>
+      points.map((point) => ({
+        date: point.date,
+        netWorth: toChartNumber(point.netWorth, base),
+      })),
+    [points, base]
+  )
+
+  // Headline KPIs derived from the already-computed endpoints (no recompute).
+  const { headline, delta } = React.useMemo(() => {
+    if (!last) return { headline: null as string | null, delta: 0 }
+    const lastNum = toChartNumber(last.netWorth, base)
+    const firstNum = first ? toChartNumber(first.netWorth, base) : lastNum
+    return {
+      headline: formatWire(last.netWorth, base),
+      delta: lastNum - firstNum,
+    }
+  }, [last, first, base])
+
+  const isPartial =
+    (last?.isPartial ?? false) || (last?.unconverted.length ?? 0) > 0
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardDescription className="flex items-center gap-2">
+          <Wallet className="size-4" aria-hidden />
+          Net worth in base currency ({data.baseCurrency})
+        </CardDescription>
+        <CardTitle
+          className="text-3xl tabular-nums"
+          data-testid="dashboard-net-worth-value"
+        >
+          {headline ?? "—"}
+        </CardTitle>
+        {headline ? (
+          <CardAction>
+            <Badge
+              variant="outline"
+              className={cn(
+                "gap-1",
+                delta >= 0
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-destructive"
+              )}
+            >
+              {delta >= 0 ? (
+                <TrendingUp className="size-3" aria-hidden />
+              ) : (
+                <TrendingDown className="size-3" aria-hidden />
+              )}
+              {formatSignedNumber(delta, base)}
+            </Badge>
+          </CardAction>
+        ) : null}
+      </CardHeader>
+      <CardContent className="px-2 pt-2 sm:px-6">
+        {points.length === 0 ? (
+          <EmptyHint>
+            No balances in this range yet. Add accounts and transactions to see
+            your net worth over time.
+          </EmptyHint>
+        ) : (
+          <>
+            {isPartial ? (
+              <div className="mb-2 px-2 sm:px-0">
+                <PartialBadge count={last?.unconverted.length} />
+              </div>
+            ) : null}
+            <ChartContainer
+              config={netWorthChartConfig}
+              className="aspect-auto h-[220px] w-full"
+            >
+              <AreaChart data={chartData}>
+                <defs>
+                  <linearGradient id="fillNetWorth" x1="0" y1="0" x2="0" y2="1">
+                    <stop
+                      offset="5%"
+                      stopColor="var(--color-netWorth)"
+                      stopOpacity={0.8}
+                    />
+                    <stop
+                      offset="95%"
+                      stopColor="var(--color-netWorth)"
+                      stopOpacity={0.1}
+                    />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="date"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                  minTickGap={32}
+                  tickFormatter={formatDay}
+                />
+                <ChartTooltip
+                  cursor={false}
+                  content={
+                    <ChartTooltipContent
+                      labelFormatter={(value) => formatDay(String(value))}
+                      indicator="dot"
+                    />
+                  }
+                />
+                <Area
+                  dataKey="netWorth"
+                  type="natural"
+                  fill="url(#fillNetWorth)"
+                  stroke="var(--color-netWorth)"
+                />
+              </AreaChart>
+            </ChartContainer>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Signed, human display of a delta number in the given currency. */
+function formatSignedNumber(value: number, currency: CurrencyCode): string {
+  const sign = value > 0 ? "+" : ""
+  try {
+    return `${sign}${new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      currencyDisplay: "narrowSymbol",
+      notation: "compact",
+    }).format(value)}`
+  } catch {
+    return `${sign}${value.toFixed(2)}`
+  }
+}
+
+// ─── Cash flow (R2) ──────────────────────────────────────────────────────────
+const cashFlowChartConfig = {
+  income: { label: "Income", color: "var(--chart-2)" },
+  expense: { label: "Expense", color: "var(--chart-4)" },
+} satisfies ChartConfig
+
+export function CashFlowCard({ data }: { data: CashFlowReportResult }) {
+  const base = data.baseCurrency as CurrencyCode
+  const { totals, series } = data
+
+  const chartData = React.useMemo(
+    () =>
+      series.map((bucket) => ({
+        label: bucket.periodStart,
+        income: toChartNumber(bucket.income, base),
+        expense: toChartNumber(bucket.expense, base),
+      })),
+    [series, base]
+  )
+
+  const netIsNegative = decodeMoney(totals.net) < 0n
+  const hasData = series.length > 0
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <TrendingUp className="size-5 text-emerald-500" aria-hidden />
+          Cash flow
+        </CardTitle>
+        <CardDescription>
+          Income vs expense for the selected period · base {data.baseCurrency}
+        </CardDescription>
+        {totals.unconvertedCount > 0 ? (
+          <CardAction>
+            <PartialBadge count={totals.unconvertedCount} />
+          </CardAction>
+        ) : null}
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Stat
+            label="Income"
+            value={formatWire(totals.income, base)}
+            tone="positive"
+          />
+          <Stat label="Expense" value={formatWire(totals.expense, base)} />
+          <Stat
+            label="Net cash flow"
+            value={formatWire(totals.net, base)}
+            tone={netIsNegative ? "negative" : "positive"}
+          />
+        </div>
+
+        {hasData ? (
+          <ChartContainer
+            config={cashFlowChartConfig}
+            className="aspect-auto h-[220px] w-full"
+          >
+            <BarChart data={chartData}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="label"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={24}
+                tickFormatter={formatDay}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(value) => formatDay(String(value))}
+                    indicator="dot"
+                  />
+                }
+              />
+              <Bar dataKey="income" fill="var(--color-income)" radius={4} />
+              <Bar dataKey="expense" fill="var(--color-expense)" radius={4} />
+            </BarChart>
+          </ChartContainer>
+        ) : (
+          <EmptyHint>No income or expense recorded in this period.</EmptyHint>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Top categories (R2 byCategory) ──────────────────────────────────────────
+export function TopCategoriesCard({
+  data,
+  categories,
+  limit = 5,
+}: {
+  data: CashFlowReportResult
+  categories: ReadonlyArray<SerializedExpenseCategory> | undefined
+  limit?: number
+}) {
+  const base = data.baseCurrency as CurrencyCode
+
+  const rows = React.useMemo(() => {
+    const nameById = new Map<string, string>()
+    for (const category of categories ?? [])
+      nameById.set(category.id, category.name)
+    return selectTopExpenseCategories(data.byCategory, nameById, limit)
+  }, [data.byCategory, categories, limit])
+
+  const max = React.useMemo(
+    () =>
+      rows.reduce(
+        (acc, row) =>
+          decodeMoney(row.expense) > acc ? decodeMoney(row.expense) : acc,
+        0n
+      ),
+    [rows]
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Tags className="size-5 text-emerald-500" aria-hidden />
+          Top spending categories
+        </CardTitle>
+        <CardDescription>
+          Where your money went this period · base {data.baseCurrency}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <EmptyHint>No categorized spending in this period yet.</EmptyHint>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {rows.map((row) => {
+              const pct =
+                max > 0n ? Number((decodeMoney(row.expense) * 100n) / max) : 0
+              return (
+                <li
+                  key={row.categoryId ?? "uncategorized"}
+                  className="flex flex-col gap-1.5"
+                >
+                  <div className="flex items-center justify-between gap-2 text-sm">
+                    <span className="font-medium">{row.name}</span>
+                    <span className="text-muted-foreground tabular-nums">
+                      {formatWire(row.expense, base)}
+                    </span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-emerald-500"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Budget progress (P1) ────────────────────────────────────────────────────
+function spendPercent(actualWire: string, allocatedWire: string): number {
+  const allocated = Number(allocatedWire)
+  if (allocated <= 0) return 0
+  return Math.min(100, Math.round((Number(actualWire) / allocated) * 100))
+}
+
+export function BudgetProgressCard({
+  progress,
+  limit = 5,
+}: {
+  progress: SerializedBudgetProgress
+  limit?: number
+}) {
+  const currency = progress.currency as CurrencyCode
+  const { totals, categories } = progress
+  const topCategories = React.useMemo(
+    () => categories.slice(0, limit),
+    [categories, limit]
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <PiggyBank className="size-5 text-emerald-500" aria-hidden />
+          Budget progress
+          {totals.isOver ? (
+            <Badge variant="destructive">Over budget</Badge>
+          ) : null}
+        </CardTitle>
+        <CardDescription>
+          {progress.name} · {progress.periodStart} → {progress.periodEnd}
+        </CardDescription>
+        {totals.pendingTransactionCount > 0 ? (
+          <CardAction>
+            <PartialBadge count={totals.pendingTransactionCount} />
+          </CardAction>
+        ) : null}
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Stat
+            label="Budgeted"
+            value={formatWire(totals.allocatedAmount, currency)}
+          />
+          <Stat
+            label="Spent"
+            value={formatWire(totals.actualAmount, currency)}
+          />
+          <Stat
+            label="Remaining"
+            value={formatWire(totals.remainingAmount, currency)}
+            tone={totals.isOver ? "negative" : "default"}
+          />
+        </div>
+
+        {topCategories.length === 0 ? (
+          <EmptyHint>
+            No category allocations yet. Set some on the Budgets page to start
+            tracking.
+          </EmptyHint>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {topCategories.map((category) => (
+              <li key={category.categoryId} className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between gap-2 text-sm">
+                  <span className="flex items-center gap-2 font-medium">
+                    <span
+                      className="size-2.5 rounded-full"
+                      style={{ backgroundColor: category.categoryColor }}
+                      aria-hidden
+                    />
+                    {category.categoryName}
+                  </span>
+                  <span
+                    className={cn(
+                      "text-muted-foreground tabular-nums",
+                      category.isOver && "text-destructive"
+                    )}
+                  >
+                    {formatWire(category.actualAmount, currency)} /{" "}
+                    {formatWire(category.allocatedAmount, currency)}
+                  </span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className={cn(
+                      "h-full rounded-full",
+                      category.isOver ? "bg-destructive" : "bg-emerald-500"
+                    )}
+                    style={{
+                      width: `${spendPercent(category.actualAmount, category.allocatedAmount)}%`,
+                    }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/_protected/dashboard.tsx
+++ b/src/routes/_protected/dashboard.tsx
@@ -1,49 +1,304 @@
+import * as React from "react"
 import { createFileRoute } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { z } from "zod"
+import { LayoutDashboard, RefreshCw, TriangleAlert } from "lucide-react"
+
 import { AppSidebar } from "@/components/app-sidebar"
-import { ChartAreaInteractive } from "@/components/chart-area-interactive"
-import { DataTable } from "@/components/data-table"
-import { SectionCards } from "@/components/section-cards"
 import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-// KITA IMPORT TOOLTIP PROVIDER DI SINI
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { PermoneyDateRangePicker } from "@/components/ui/date-range-picker"
+import {
+  BudgetProgressCard,
+  CashFlowCard,
+  NetWorthCard,
+  TopCategoriesCard,
+} from "@/components/blocks/dashboard-cards"
+import { getCashFlowReportFn, getNetWorthSeriesFn } from "@/server/reporting"
+import { getBudgetForPeriodFn, listExpenseCategoriesFn } from "@/server/budgets"
 
-import data from "../data.json"
+// =============================================================================
+// PER-156 / R3 — Dashboard realization (rendering layer only).
+//
+// `/dashboard` wires the reporting engines (R1 net worth, R2 cash flow, P1
+// budget progress) to one shared period selector that is the single source of
+// truth for every card. The selection (`from` / `to` / `interval`) lives in the
+// TanStack Router search params, so the view is persistent on reload and
+// shareable by URL. `ssr: false` — these reads call server fns from the client
+// via TanStack Query, mirroring the budgets route; no TanStack DB collection is
+// touched here, so no loader preload is required. Budget progress is monthly, so
+// it tracks the month of the period's end date.
+// =============================================================================
+
+const intervalSchema = z.enum(["day", "week", "month"])
+type Interval = z.infer<typeof intervalSchema>
+
+const dateOnly = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
+
+const dashboardSearchSchema = z.object({
+  from: dateOnly.optional(),
+  to: dateOnly.optional(),
+  interval: intervalSchema.optional(),
+})
+type DashboardSearch = z.infer<typeof dashboardSearchSchema>
 
 export const Route = createFileRoute("/_protected/dashboard")({
-  component: DashboardPage,
-  // Metadata halaman — digunakan oleh SiteHeader untuk judul dinamis
+  ssr: false,
   staticData: { title: "Dashboard" },
+  validateSearch: (search: Record<string, unknown>): DashboardSearch => {
+    const parsed = dashboardSearchSchema.safeParse(search)
+    return parsed.success ? parsed.data : {}
+  },
+  component: DashboardPage,
 })
 
+/** Local-calendar YYYY-MM-DD (the user's clock, matching the date picker). */
+function toDateOnly(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function parseDateOnly(value: string): Date {
+  const [year, month, day] = value.split("-").map(Number)
+  return new Date(year, month - 1, day)
+}
+
 function DashboardPage() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  // Anchor the defaults once per mount so the query keys (and thus the fetched
+  // range) stay stable across renders: last 6 months ending today.
+  const [defaults] = React.useState(() => {
+    const now = new Date()
+    const fromDate = new Date(now)
+    fromDate.setMonth(fromDate.getMonth() - 6)
+    return { from: toDateOnly(fromDate), to: toDateOnly(now) }
+  })
+
+  const from = search.from ?? defaults.from
+  const to = search.to ?? defaults.to
+  const interval: Interval = search.interval ?? "month"
+  // Budget periods are monthly; track the month the selected range ends in.
+  const month = to.slice(0, 7)
+
+  const netWorth = useQuery({
+    queryKey: ["dashboard", "net-worth", from, to, interval],
+    queryFn: async () =>
+      await getNetWorthSeriesFn({ data: { from, to, interval } }),
+  })
+  const cashFlow = useQuery({
+    queryKey: ["dashboard", "cash-flow", from, to, interval],
+    queryFn: async () =>
+      await getCashFlowReportFn({ data: { from, to, interval } }),
+  })
+  const budget = useQuery({
+    queryKey: ["dashboard", "budget", month],
+    queryFn: async () => await getBudgetForPeriodFn({ data: { month } }),
+  })
+  const categories = useQuery({
+    queryKey: ["dashboard", "expense-categories"],
+    queryFn: async () => await listExpenseCategoriesFn(),
+  })
+
   return (
-    // KITA BUNGKUS SELURUH DASHBOARD DENGAN TOOLTIP PROVIDER
     <TooltipProvider>
       <SidebarProvider
         style={
           {
-            "--sidebar-width": "calc(var(--spacing) * 64)",
-            "--header-height": "calc(var(--spacing) * 14)",
+            "--sidebar-width": "calc(var(--spacing) * 72)",
           } as React.CSSProperties
         }
       >
         <AppSidebar variant="inset" />
         <SidebarInset>
           <SiteHeader />
-          <div className="flex flex-1 flex-col">
-            <div className="@container/main flex flex-1 flex-col gap-2">
-              <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-                <SectionCards />
-                <div className="px-4 lg:px-6">
-                  <ChartAreaInteractive />
+          <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <LayoutDashboard
+                  className="size-6 text-emerald-500"
+                  aria-hidden
+                />
+                <div>
+                  <h1 className="text-xl font-semibold">Dashboard</h1>
+                  <p className="text-sm text-muted-foreground">
+                    Your net worth, cash flow, and budget — all in your base
+                    currency for the selected period.
+                  </p>
                 </div>
-                <DataTable data={data} />
+              </div>
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="grid gap-1.5">
+                  <Label>Period</Label>
+                  <PermoneyDateRangePicker
+                    date={{ from: parseDateOnly(from), to: parseDateOnly(to) }}
+                    onUpdate={(range) => {
+                      if (!range?.from || !range?.to) return
+                      void navigate({
+                        search: {
+                          from: toDateOnly(range.from),
+                          to: toDateOnly(range.to),
+                          interval,
+                        },
+                      })
+                    }}
+                    className="w-[260px]"
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label>Interval</Label>
+                  <ToggleGroup
+                    type="single"
+                    variant="outline"
+                    value={interval}
+                    onValueChange={(value) => {
+                      if (!value) return
+                      void navigate({
+                        search: { from, to, interval: value as Interval },
+                      })
+                    }}
+                  >
+                    <ToggleGroupItem value="day">Day</ToggleGroupItem>
+                    <ToggleGroupItem value="week">Week</ToggleGroupItem>
+                    <ToggleGroupItem value="month">Month</ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
               </div>
             </div>
+
+            <Section
+              query={netWorth}
+              skeletonHeight="h-[300px]"
+              label="net worth"
+            >
+              {(data) => <NetWorthCard data={data} />}
+            </Section>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Section
+                query={cashFlow}
+                skeletonHeight="h-[360px]"
+                label="cash flow"
+              >
+                {(data) => <CashFlowCard data={data} />}
+              </Section>
+              <Section
+                query={cashFlow}
+                skeletonHeight="h-[360px]"
+                label="top categories"
+              >
+                {(data) => (
+                  <TopCategoriesCard data={data} categories={categories.data} />
+                )}
+              </Section>
+            </div>
+
+            <Section
+              query={budget}
+              skeletonHeight="h-[360px]"
+              label="budget progress"
+            >
+              {(data) => <BudgetProgressCard progress={data} />}
+            </Section>
           </div>
         </SidebarInset>
       </SidebarProvider>
     </TooltipProvider>
+  )
+}
+
+interface SectionQuery<TData> {
+  data: TData | undefined
+  isLoading: boolean
+  isError: boolean
+  isFetching: boolean
+  error: unknown
+  refetch: () => void
+}
+
+function Section<TData>({
+  query,
+  children,
+  skeletonHeight,
+  label,
+}: {
+  query: SectionQuery<TData>
+  children: (data: TData) => React.ReactNode
+  skeletonHeight: string
+  label: string
+}) {
+  if (query.isLoading) {
+    return <Skeleton className={`w-full ${skeletonHeight} rounded-xl`} />
+  }
+  if (query.isError || query.data === undefined) {
+    return (
+      <SectionError
+        label={label}
+        message={
+          query.error instanceof Error
+            ? query.error.message
+            : `Something went wrong loading ${label}.`
+        }
+        isRetrying={query.isFetching}
+        onRetry={query.refetch}
+      />
+    )
+  }
+  return <>{children(query.data)}</>
+}
+
+function SectionError({
+  label,
+  message,
+  isRetrying,
+  onRetry,
+}: {
+  label: string
+  message: string
+  isRetrying: boolean
+  onRetry: () => void
+}) {
+  return (
+    <Card className="border-destructive/50">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-destructive">
+          <TriangleAlert className="size-5" aria-hidden />
+          Couldn&apos;t load {label}
+        </CardTitle>
+        <CardDescription>
+          If you just pulled this branch, make sure the database migrations have
+          run (<code>vp run db:migrate</code>).
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-3 rounded-md bg-destructive/10 p-3 font-mono text-sm text-destructive">
+          {message}
+        </p>
+        <Button
+          variant="outline"
+          className="w-fit"
+          disabled={isRetrying}
+          onClick={onRetry}
+        >
+          <RefreshCw className="size-4" aria-hidden />
+          {isRetrying ? "Retrying…" : "Retry"}
+        </Button>
+      </CardContent>
+    </Card>
   )
 }

--- a/tests/e2e/auth-routes.e2e.ts
+++ b/tests/e2e/auth-routes.e2e.ts
@@ -135,7 +135,11 @@ async function expectDashboardRoute(page: Page): Promise<void> {
     expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/),
     waitForHydration(page),
   ])
-  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible()
+  // The route renders the title in the SiteHeader chrome AND as the page body
+  // heading (PER-156). Scope to the header so the assertion stays unambiguous.
+  await expect(
+    page.locator("header").getByRole("heading", { name: "Dashboard" })
+  ).toBeVisible()
 }
 
 async function expectTransactionsRoute(page: Page): Promise<void> {

--- a/tests/e2e/budgets.e2e.ts
+++ b/tests/e2e/budgets.e2e.ts
@@ -1,51 +1,10 @@
-import { randomUUID } from "node:crypto"
-import type { Page } from "@playwright/test"
 import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
 
 // PER-148 — the route was shipped without ever being opened in a browser. This
 // drives the real path (browser -> server-fn -> react-query -> render) that the
 // integration tests bypass, and asserts the page actually renders content
 // instead of being stuck on "Loading budget…".
-
-interface Identity {
-  email: string
-  fullName: string
-  password: string
-  username: string
-}
-
-function createIdentity(): Identity {
-  const suffix = randomUUID().replaceAll("-", "").slice(0, 12)
-  const password = randomUUID().replaceAll("-", "")
-  return {
-    email: `e2e-${suffix}@permoney.test`,
-    fullName: `E2E User ${suffix}`,
-    password: `${password.slice(0, 12)}A1a`,
-    username: `e2e_${suffix}`,
-  }
-}
-
-async function waitForHydration(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => document.documentElement.dataset.permoneyHydrated === "true"
-  )
-}
-
-async function onboard(page: Page): Promise<void> {
-  const identity = createIdentity()
-  await page.goto("/signup")
-  await waitForHydration(page)
-  await page.getByLabel("Full Name").fill(identity.fullName)
-  await page.getByLabel("Username").fill(identity.username)
-  await page.getByLabel("Email").fill(identity.email)
-  await page.getByLabel("Password").fill(identity.password)
-  await page.getByRole("button", { name: "Create Account" }).click()
-  await expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/)
-  await waitForHydration(page)
-  await page.getByRole("button", { name: "Get Started" }).click()
-  await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
-  await waitForHydration(page)
-}
 
 test.describe("budgets route", () => {
   test("onboarded user can open /budgets and see content, not a stuck loader", async ({

--- a/tests/e2e/dashboard.e2e.ts
+++ b/tests/e2e/dashboard.e2e.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto"
+import type { Page } from "@playwright/test"
+import { expect, test } from "./support/fixtures"
+
+// PER-156 — R3 dashboard realization. Drives the real path
+// (browser -> server-fn -> react-query -> render) for the three reporting
+// engines (R1 net worth, R2 cash flow + top categories, P1 budget progress)
+// against the data a freshly onboarded family already has: a starter account
+// with a non-zero opening balance (so R1 renders a real net-worth headline).
+// Asserts the page renders headline content instead of being stuck on a
+// skeleton or error.
+
+interface Identity {
+  email: string
+  fullName: string
+  password: string
+  username: string
+}
+
+function createIdentity(): Identity {
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 12)
+  const password = randomUUID().replaceAll("-", "")
+  return {
+    email: `e2e-${suffix}@permoney.test`,
+    fullName: `E2E User ${suffix}`,
+    password: `${password.slice(0, 12)}A1a`,
+    username: `e2e_${suffix}`,
+  }
+}
+
+async function waitForHydration(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.permoneyHydrated === "true"
+  )
+}
+
+async function onboard(page: Page): Promise<void> {
+  const identity = createIdentity()
+  await page.goto("/signup")
+  await waitForHydration(page)
+  await page.getByLabel("Full Name").fill(identity.fullName)
+  await page.getByLabel("Username").fill(identity.username)
+  await page.getByLabel("Email").fill(identity.email)
+  await page.getByLabel("Password").fill(identity.password)
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/)
+  await waitForHydration(page)
+  await page.getByRole("button", { name: "Get Started" }).click()
+  await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
+  await waitForHydration(page)
+}
+
+test.describe("dashboard route", () => {
+  test("onboarded user sees net worth, cash flow, top categories, and budget", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    await page.goto("/dashboard")
+    await waitForHydration(page)
+
+    // Each section title only renders once its server-fn data has resolved.
+    await expect(
+      page.getByText("Net worth in base currency", { exact: false })
+    ).toBeVisible()
+    await expect(page.getByText("Cash flow", { exact: true })).toBeVisible()
+    await expect(page.getByText("Net cash flow")).toBeVisible()
+    await expect(page.getByText("Top spending categories")).toBeVisible()
+    await expect(page.getByText("Budget progress")).toBeVisible()
+
+    // R1 produced a real net-worth headline from the seeded starter account —
+    // a formatted figure (contains a digit), never the "—" empty placeholder.
+    const netWorthValue = page.getByTestId("dashboard-net-worth-value")
+    await expect(netWorthValue).toBeVisible()
+    await expect(netWorthValue).toHaveText(/\d/)
+
+    // Not stuck loading / not errored.
+    await expect(page.getByText(/Couldn't load/)).toHaveCount(0)
+  })
+})

--- a/tests/e2e/dashboard.e2e.ts
+++ b/tests/e2e/dashboard.e2e.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from "node:crypto"
-import type { Page } from "@playwright/test"
 import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
 
 // PER-156 — R3 dashboard realization. Drives the real path
 // (browser -> server-fn -> react-query -> render) for the three reporting
@@ -9,46 +8,6 @@ import { expect, test } from "./support/fixtures"
 // with a non-zero opening balance (so R1 renders a real net-worth headline).
 // Asserts the page renders headline content instead of being stuck on a
 // skeleton or error.
-
-interface Identity {
-  email: string
-  fullName: string
-  password: string
-  username: string
-}
-
-function createIdentity(): Identity {
-  const suffix = randomUUID().replaceAll("-", "").slice(0, 12)
-  const password = randomUUID().replaceAll("-", "")
-  return {
-    email: `e2e-${suffix}@permoney.test`,
-    fullName: `E2E User ${suffix}`,
-    password: `${password.slice(0, 12)}A1a`,
-    username: `e2e_${suffix}`,
-  }
-}
-
-async function waitForHydration(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => document.documentElement.dataset.permoneyHydrated === "true"
-  )
-}
-
-async function onboard(page: Page): Promise<void> {
-  const identity = createIdentity()
-  await page.goto("/signup")
-  await waitForHydration(page)
-  await page.getByLabel("Full Name").fill(identity.fullName)
-  await page.getByLabel("Username").fill(identity.username)
-  await page.getByLabel("Email").fill(identity.email)
-  await page.getByLabel("Password").fill(identity.password)
-  await page.getByRole("button", { name: "Create Account" }).click()
-  await expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/)
-  await waitForHydration(page)
-  await page.getByRole("button", { name: "Get Started" }).click()
-  await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
-  await waitForHydration(page)
-}
 
 test.describe("dashboard route", () => {
   test("onboarded user sees net worth, cash flow, top categories, and budget", async ({

--- a/tests/e2e/support/onboarding.ts
+++ b/tests/e2e/support/onboarding.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "node:crypto"
+import type { Page } from "@playwright/test"
+import { expect } from "./fixtures"
+
+// Shared onboarding helpers for e2e specs: spin up a unique identity, sign up,
+// complete onboarding, and land on /dashboard. Kept in one place so route specs
+// (budgets, dashboard, …) drive the real signup→onboard→protected path without
+// re-copying the flow.
+
+export interface Identity {
+  email: string
+  fullName: string
+  password: string
+  username: string
+}
+
+export function createIdentity(): Identity {
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 12)
+  const password = randomUUID().replaceAll("-", "")
+  return {
+    email: `e2e-${suffix}@permoney.test`,
+    fullName: `E2E User ${suffix}`,
+    password: `${password.slice(0, 12)}A1a`,
+    username: `e2e_${suffix}`,
+  }
+}
+
+export async function waitForHydration(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.permoneyHydrated === "true"
+  )
+}
+
+/** Sign up a fresh user and complete onboarding, ending on /dashboard. */
+export async function onboard(page: Page): Promise<void> {
+  const identity = createIdentity()
+  await page.goto("/signup")
+  await waitForHydration(page)
+  await page.getByLabel("Full Name").fill(identity.fullName)
+  await page.getByLabel("Username").fill(identity.username)
+  await page.getByLabel("Email").fill(identity.email)
+  await page.getByLabel("Password").fill(identity.password)
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/)
+  await waitForHydration(page)
+  await page.getByRole("button", { name: "Get Started" }).click()
+  await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
+  await waitForHydration(page)
+}


### PR DESCRIPTION
## What & why

Closes **PER-156** (R3 — Dashboard realization). The final reporting slice: wires `/dashboard` to the engines shipped in R1 (PER-154), R2 (PER-155), and P1 (PER-148) as a **pure rendering layer** — no analytics math lives here. Every figure is read from the existing server fns; nothing is recomputed.

## What's built

- **One shared period selector** (date range + day/week/month interval) is the single source of truth for all cards, persisted in **TanStack Router search params** → the view survives reload and is shareable by URL. Budget progress (monthly) tracks the month the selected range ends in.
- **Net worth** (R1 `getNetWorthSeriesFn`): area chart + headline derived from the series' last point.
- **Cash flow** (R2 `getCashFlowReportFn`): income / expense / net-cash-flow KPIs + income-vs-expense bar chart.
- **Top spending categories** (R2 `byCategory` + `listExpenseCategoriesFn` for names): pure, unit-tested ordering by spend.
- **Budget progress** (P1 `getBudgetForPeriodFn`): budgeted / spent / remaining + per-category bars.
- KPIs via `useMemo` from already-computed output (no heavy per-render recompute); **no `useEffect`**.
- `ssr: false`; reads go through server fns via TanStack Query (mirrors the budgets route). No TanStack DB collection is touched, so no loader preload needed.
- Empty / loading / error states per section; **base-currency** display; FX-pending rows surfaced via "N unconverted / partial" badges (never hidden).

## Tests

- Component/unit tests (`dashboard-cards.test.tsx`): headline figures correct, empty + partial states, and the `selectTopExpenseCategories` pure selector.
- Playwright e2e smoke (`dashboard.e2e.ts`): an onboarded user sees all four sections render with a real net-worth headline, not a stuck skeleton/error.

## Verification

`vp run check` ✅ · `vp test run` (292 passed) ✅ · `vp build` ✅. e2e + integration run in CI.

## Scope

PER-156 only — no changes to R1/R2/P1 engines or onboarding. Note: a freshly onboarded family's sample "Welcome coffee" expense has a null `baseAmount`, so R2 correctly treats it as FX-pending (excluded from totals, shown via the unconverted badge); the e2e asserts the net-worth headline rather than that row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)