### PR TITLE
feat(imports): PER-151 — CSV/QIF import wizard (column mapping, Mint/YNAB/QIF)

### DIFF
--- a/docs/adr/0040-csv-import-parser-and-wizard-contract.md
+++ b/docs/adr/0040-csv-import-parser-and-wizard-contract.md
@@ -1,0 +1,193 @@
+# ADR-0040 — CSV/QIF import parser and wizard contract
+
+|                   |                                                     |
+| ----------------- | --------------------------------------------------- |
+| **Status**        | Accepted                                            |
+| **Date**          | 2026-06-24                                          |
+| **Accepted**      | 2026-06-24                                          |
+| **Deciders**      | Hendri Permana                                      |
+| **Supersedes**    | —                                                   |
+| **Superseded by** | —                                                   |
+| **Builds on**     | ADR-0039 (import staging, deduplication, promotion) |
+
+## Context
+
+ADR-0039 locked the durable **staging spine**: `StagedRowInput`, the row state
+machine, deterministic dedup, three-layer idempotency, atomic audited promotion,
+and the four server functions (`createImportBatchFn`, `getImportBatchFn`,
+`reviewImportRowsFn`, `promoteImportBatchFn`). It deliberately ships **no CSV
+parser and no UI** — §10 names that the seam input is already-field-extracted
+`StagedRowInput[]`, and states "PER-151's wizard does CSV→`StagedRowInput`
+(including resolving each row's account)."
+
+PER-151 is that wizard. The only genuinely new, durable decisions it introduces
+are about **turning an opaque file into `StagedRowInput[]` deterministically** —
+how columns map to fields, how an absolute magnitude + `income|expense` type is
+derived from the many ways exporters encode sign, how ambiguous dates are
+resolved without silent corruption, and how the non-columnar QIF format fits the
+same seam. None of these touch ledger correctness, tenant isolation, balances, or
+money invariants — those are all enforced **server-side** by ADR-0039 at staging
+and promotion. A mis-mapped column at worst produces a wrong-looking preview row
+that the user rejects before promotion; it can never silently corrupt the ledger.
+
+This ADR documents the parser/wizard contract so a future agent adding a new
+preset (Revolut, OFX, a local bank export) extends a known shape instead of
+reinventing one.
+
+## Decision
+
+**The CSV/QIF parser is a pure, DB-free module (`src/lib/csv-import.ts`) that
+deterministically maps a file + an explicit column/format mapping into client
+`ParsedImportRow`s, which the wizard stamps with one chosen target account and
+submits as `StagedRowInput[]`. All money/ledger correctness stays in ADR-0039.**
+
+### 1. Pure module boundary
+
+`src/lib/csv-import.ts` contains only pure functions and types — no Prisma, no
+React, no server fns, no network. It is unit-tested in isolation
+(`src/lib/csv-import.test.ts`). The wizard route imports it, adds the chosen
+`accountId` and `rawPayload`, and calls the existing server fns. This mirrors the
+`src/lib/import-staging.ts` (pure) ↔ `src/server/imports.ts` (server) split from
+ADR-0039 §10.
+
+### 2. The three-mode amount model
+
+`StagedRowInput.amount` is **positive minor units** (`absAmountSchema`) plus a
+separate `type ∈ {income, expense}`. Exporters encode this three different ways,
+so the mapping's amount config is a discriminated union — the minimal set that
+covers the named formats without per-format special-casing:
+
+- **`signed`** — one amount column; the sign decides the type. Config carries
+  `negativeMeans: "expense" | "income"` because banks disagree on whether a
+  debit is negative. → generic bank CSV.
+- **`split`** — two columns (outflow/debit, inflow/credit), each a positive
+  magnitude; whichever is non-empty/non-zero sets both type and amount. →
+  **YNAB** (`Outflow`/`Inflow`).
+- **`typed`** — one positive-magnitude amount column plus a separate type column
+  whose values map (case-insensitively) to expense/income. → **Mint**
+  (`Amount` + `Transaction Type`: `debit`→expense, `credit`→income).
+
+Magnitudes are parsed with the canonical, currency-aware `parseUserInput(raw,
+currency)` from `src/lib/money.ts` (tolerant of locale thousands/decimal
+separators and currency symbols; returns `null` on garbage), then reduced to
+absolute minor units. **Currency is the chosen target account's currency** — the
+same single-source-of-truth rule ADR-0039 §4 applies at normalize/promote.
+
+### 3. Explicit date format — never heuristic
+
+CSV dates are ambiguous (`03/04/2026` is Mar 4 US or Apr 3 elsewhere). Silent
+month/day flips would corrupt ledger dates, so the wizard requires an **explicit
+date-format choice** from a small supported set
+(`YYYY-MM-DD`, `DD/MM/YYYY`, `MM/DD/YYYY`, `DD-MM-YYYY`); presets pre-select a
+sensible default but the user can override. The parsed date is shown in the
+preview before promotion. A cell that does not parse under the chosen format
+makes the row an **error row** with a reason — it is surfaced and excluded from
+submission, never silently dropped or guessed.
+
+### 4. Presets
+
+Presets pre-fill the column mapping + amount mode + date default; the user can
+adjust every field afterward. Shipped: **generic** (user maps everything),
+**Mint** (`typed`), **YNAB** (`split`). A preset is data, not code — adding one
+is a new entry in the preset table, the reason this lives behind an explicit
+mapping contract.
+
+### 5. QIF is a separate parser, same seam
+
+QIF is line-oriented (`!Type:Bank`, `D`=date, `T`=signed amount, `P`=payee,
+`M`=memo, `^`=record end), not columnar, so it cannot share the column-mapping
+UI. It gets its own pure parser that emits the same `ParsedImportRow[]`; the
+`T` sign maps to type (negative→expense). It still needs the explicit date-format
+choice (QIF dates are equally ambiguous) and the target account. The wizard
+detects `.qif`, skips column-mapping, and goes straight to account selection,
+date-format, then preview.
+
+### 6. Single target account per file (this slice)
+
+ADR-0039 §1 makes `accountId` authoritative **per row** so one file can fan out
+across many accounts (a full Sure export). PER-151 ships the common case: the
+user picks **one** Permoney account and every row is stamped with it. Per-row
+account-column resolution (and the full multi-account Sure migration) is
+**reserved** for PER-163 / a follow-up; it does not change this contract, it only
+populates `accountId` differently.
+
+### 7. Review default verdicts (preview → confirm/reject)
+
+`promoteImportBatchFn` only promotes `rowStatus === "confirmed"` rows
+(ADR-0039 §9), so the review step is mandatory and its **defaults decide what
+lands**. The wizard pre-selects:
+
+- `normalized` (clean) → **Confirm**.
+- `normalized` + `possibleDuplicate` (near-dup) → **Confirm**, badged amber so
+  the user notices.
+- `duplicate` (exact canonical/in-batch match) → **Reject**, badged — opt back in
+  deliberately.
+
+The user can flip any verdict before promoting; this is a UI default only, never
+a server invariant — the server's per-row promotion idempotency key still makes a
+true canonical double-book impossible regardless of the choice.
+
+### 8. Error and scope boundaries
+
+Rows failing client validation (unparseable date/amount under the chosen format,
+empty description, zero amount) are shown as **won't-import** with a reason and
+excluded from the `StagedRowInput[]` payload, because `stagedRowInputSchema`
+requires a valid positive amount, date, and non-empty description. Like ADR-0039
+§9, the wizard handles **income/expense flat single-account rows only**;
+transfers, splits, and multi-currency rows (row currency ≠ account currency) are
+out of scope here.
+
+## Consequences
+
+### Positive
+
+- Adding a new file format is a new pure preset/parser entry feeding the same
+  seam — no new server code, no ledger risk.
+- Deterministic date handling removes a whole class of silent date-corruption
+  bugs; the preview makes every transformation visible before promotion.
+- The wizard reuses ADR-0039's four server fns unchanged; all money invariants
+  (dedup, idempotency, atomic balance, audit, RLS, FX projection) stay in one
+  place.
+
+### Negative / costs
+
+- The explicit mapping/date UI is more steps than blind auto-detect, traded for
+  correctness and visibility.
+- Per-row account mapping and QIF's investment/split records are deferred; a Sure
+  full-family import (PER-163) needs more than this contract provides.
+
+## Alternatives considered
+
+1. **Auto-detect date format heuristically.** Rejected — ambiguous all-≤12 dates
+   can silently flip month/day in a ledger; explicit choice + preview is safe.
+2. **Two amount modes (special-case Mint inside its preset).** Rejected — the
+   `typed` mode generalizes the abs-amount-plus-type-column pattern for future
+   exporters instead of hiding it in one preset.
+3. **Fold QIF into the column mapper.** Rejected — QIF is not columnar; forcing it
+   into column mapping is leakier than a small dedicated parser to the same seam.
+4. **No ADR (pure client code).** Rejected — the amount model, date set, and
+   preset shape are durable decisions future format work builds on; ADR-0039
+   explicitly left the parser contract to this slice.
+
+## Testing
+
+- **Pure units (`src/lib/csv-import.test.ts`):** CSV header parsing; each amount
+  mode (`signed` sign→type, `split` outflow/inflow→type, `typed` value→type);
+  locale amount parsing → minor units for 0- and 2-decimal currencies; each
+  supported date format + rejection of an unparseable date; Mint and YNAB preset
+  mappings end-to-end; QIF record parsing; error rows surfaced not dropped.
+- **E2E (`tests/e2e`):** upload a small CSV → preview shows normalized rows →
+  promote → the transaction appears in the ledger (real route + server fns).
+- **Server-side ledger correctness** (idempotent replay, promotion parity, tenant
+  isolation, dedup) is already covered by ADR-0039 / PER-82's real-Postgres
+  integration suite, which this wizard calls unchanged.
+
+## References
+
+- ADR-0039 (Import staging, deduplication, and promotion — the seam this consumes)
+- ADR-0035 (Currency/FX — base projection at promote; account currency authority)
+- ADR-0006 (Idempotency keys and audit-log architecture)
+- ADR-0036 (`ledger:write` capability covers import)
+- `src/lib/money.ts` (`parseUserInput`, `toMinorUnits` — canonical amount parsing)
+- PER-151 (P4 — CSV import wizard), PER-82 (M2.5-11 — import staging)
+- PER-163 (Sure full-family migration — per-row multi-account import, reserved)

--- a/src/lib/csv-import.test.ts
+++ b/src/lib/csv-import.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import {
+  DATE_FORMATS,
+  IMPORT_PRESETS,
+  getPreset,
+  mapCsvRow,
+  mapCsvRows,
+  parseCsv,
+  parseImportDate,
+  parseQif,
+  toStagedRows,
+  type ColumnMapping,
+} from "./csv-import"
+
+function ymd(date: Date | null): string | null {
+  if (!date) return null
+  return [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+  ].join("-")
+}
+
+describe("parseCsv", () => {
+  test("returns headers and row objects", () => {
+    const { headers, rows } = parseCsv(
+      "Date,Description,Amount\n2026-01-15,Coffee,-12.34\n2026-01-16,Salary,1000\n"
+    )
+    expect(headers).toEqual(["Date", "Description", "Amount"])
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      Date: "2026-01-15",
+      Description: "Coffee",
+      Amount: "-12.34",
+    })
+  })
+
+  test("skips blank lines and trims headers", () => {
+    const { rows } = parseCsv("Date,Amount\n\n2026-01-15,10\n\n")
+    expect(rows).toHaveLength(1)
+  })
+})
+
+describe("parseImportDate", () => {
+  test("supports the documented format set", () => {
+    expect(DATE_FORMATS).toEqual([
+      "YYYY-MM-DD",
+      "DD/MM/YYYY",
+      "MM/DD/YYYY",
+      "DD-MM-YYYY",
+    ])
+  })
+
+  test("parses each format to the same calendar day", () => {
+    expect(ymd(parseImportDate("2026-01-15", "YYYY-MM-DD"))).toBe("2026-01-15")
+    expect(ymd(parseImportDate("15/01/2026", "DD/MM/YYYY"))).toBe("2026-01-15")
+    expect(ymd(parseImportDate("01/15/2026", "MM/DD/YYYY"))).toBe("2026-01-15")
+    expect(ymd(parseImportDate("15-01-2026", "DD-MM-YYYY"))).toBe("2026-01-15")
+  })
+
+  test("rejects ambiguous/invalid values rather than guessing", () => {
+    expect(parseImportDate("32/01/2026", "DD/MM/YYYY")).toBeNull()
+    expect(parseImportDate("2026-13-01", "YYYY-MM-DD")).toBeNull()
+    expect(parseImportDate("01/15/2026", "DD/MM/YYYY")).toBeNull() // 15 is not a month
+    expect(parseImportDate("", "YYYY-MM-DD")).toBeNull()
+    expect(parseImportDate("not-a-date", "YYYY-MM-DD")).toBeNull()
+  })
+})
+
+const SIGNED_MAPPING: ColumnMapping = {
+  dateColumn: "Date",
+  descriptionColumn: "Description",
+  dateFormat: "YYYY-MM-DD",
+  amount: { kind: "signed", column: "Amount", negativeMeans: "expense" },
+}
+
+describe("mapCsvRow — signed amount mode", () => {
+  test("negative means expense, positive means income (abs minor units)", () => {
+    const expense = mapCsvRow(
+      { Date: "2026-01-15", Description: "Coffee", Amount: "-12.34" },
+      SIGNED_MAPPING,
+      "USD"
+    )
+    expect(expense.error).toBeNull()
+    expect(expense.type).toBe("expense")
+    expect(expense.amountMinor).toBe(1234n)
+    expect(ymd(expense.date)).toBe("2026-01-15")
+    expect(expense.description).toBe("Coffee")
+
+    const income = mapCsvRow(
+      { Date: "2026-01-16", Description: "Salary", Amount: "1000" },
+      SIGNED_MAPPING,
+      "USD"
+    )
+    expect(income.type).toBe("income")
+    expect(income.amountMinor).toBe(100000n)
+  })
+
+  test("negativeMeans income flips the convention", () => {
+    const row = mapCsvRow(
+      { Date: "2026-01-15", Description: "Refund", Amount: "-50" },
+      {
+        ...SIGNED_MAPPING,
+        amount: { kind: "signed", column: "Amount", negativeMeans: "income" },
+      },
+      "USD"
+    )
+    expect(row.type).toBe("income")
+    expect(row.amountMinor).toBe(5000n)
+  })
+
+  test("honours per-currency minor units (IDR locale separators)", () => {
+    const row = mapCsvRow(
+      { Date: "2026-01-15", Description: "Makan", Amount: "-15.000,50" },
+      SIGNED_MAPPING,
+      "IDR"
+    )
+    expect(row.type).toBe("expense")
+    expect(row.amountMinor).toBe(1500050n)
+  })
+
+  test("zero, empty, and malformed amounts become error rows (not dropped)", () => {
+    const zero = mapCsvRow(
+      { Date: "2026-01-15", Description: "X", Amount: "0" },
+      SIGNED_MAPPING,
+      "USD"
+    )
+    expect(zero.error).not.toBeNull()
+    expect(zero.amountMinor).toBeNull()
+
+    const bad = mapCsvRow(
+      { Date: "2026-01-15", Description: "X", Amount: "abc" },
+      SIGNED_MAPPING,
+      "USD"
+    )
+    expect(bad.error).not.toBeNull()
+  })
+
+  test("empty description is an error row", () => {
+    const row = mapCsvRow(
+      { Date: "2026-01-15", Description: "  ", Amount: "-1" },
+      SIGNED_MAPPING,
+      "USD"
+    )
+    expect(row.error).not.toBeNull()
+  })
+
+  test("unparseable date is an error row", () => {
+    const row = mapCsvRow(
+      { Date: "31/31/2026", Description: "X", Amount: "-1" },
+      SIGNED_MAPPING,
+      "USD"
+    )
+    expect(row.error).not.toBeNull()
+    expect(row.date).toBeNull()
+  })
+
+  test("preserves the full raw record as provenance", () => {
+    const raw = {
+      Date: "2026-01-15",
+      Description: "Coffee",
+      Amount: "-12.34",
+      Extra: "x",
+    }
+    const row = mapCsvRow(raw, SIGNED_MAPPING, "USD")
+    expect(row.rawPayload).toEqual(raw)
+  })
+})
+
+describe("mapCsvRow — split amount mode (YNAB shape)", () => {
+  const mapping: ColumnMapping = {
+    dateColumn: "Date",
+    descriptionColumn: "Payee",
+    dateFormat: "DD/MM/YYYY",
+    amount: { kind: "split", outflowColumn: "Outflow", inflowColumn: "Inflow" },
+  }
+
+  test("outflow → expense, inflow → income", () => {
+    const out = mapCsvRow(
+      { Date: "15/01/2026", Payee: "Store", Outflow: "50.00", Inflow: "0.00" },
+      mapping,
+      "USD"
+    )
+    expect(out.type).toBe("expense")
+    expect(out.amountMinor).toBe(5000n)
+
+    const inflow = mapCsvRow(
+      { Date: "16/01/2026", Payee: "Job", Outflow: "0.00", Inflow: "100.00" },
+      mapping,
+      "USD"
+    )
+    expect(inflow.type).toBe("income")
+    expect(inflow.amountMinor).toBe(10000n)
+  })
+
+  test("both columns zero/empty → error row", () => {
+    const row = mapCsvRow(
+      { Date: "15/01/2026", Payee: "Store", Outflow: "0.00", Inflow: "0.00" },
+      mapping,
+      "USD"
+    )
+    expect(row.error).not.toBeNull()
+  })
+})
+
+describe("mapCsvRow — typed amount mode (Mint shape)", () => {
+  const mapping: ColumnMapping = {
+    dateColumn: "Date",
+    descriptionColumn: "Description",
+    dateFormat: "MM/DD/YYYY",
+    amount: {
+      kind: "typed",
+      amountColumn: "Amount",
+      typeColumn: "Transaction Type",
+      expenseValues: ["debit"],
+      incomeValues: ["credit"],
+    },
+  }
+
+  test("type column maps debit→expense, credit→income (case-insensitive)", () => {
+    const debit = mapCsvRow(
+      {
+        Date: "01/15/2026",
+        Description: "Coffee",
+        Amount: "12.34",
+        "Transaction Type": "debit",
+      },
+      mapping,
+      "USD"
+    )
+    expect(debit.type).toBe("expense")
+    expect(debit.amountMinor).toBe(1234n)
+
+    const credit = mapCsvRow(
+      {
+        Date: "01/16/2026",
+        Description: "Pay",
+        Amount: "1000",
+        "Transaction Type": "CREDIT",
+      },
+      mapping,
+      "USD"
+    )
+    expect(credit.type).toBe("income")
+  })
+
+  test("unknown type value → error row", () => {
+    const row = mapCsvRow(
+      {
+        Date: "01/15/2026",
+        Description: "X",
+        Amount: "1",
+        "Transaction Type": "weird",
+      },
+      mapping,
+      "USD"
+    )
+    expect(row.error).not.toBeNull()
+  })
+})
+
+describe("presets", () => {
+  test("ships generic, mint, ynab", () => {
+    expect(IMPORT_PRESETS.map((p) => p.id)).toEqual(["generic", "mint", "ynab"])
+  })
+
+  test("Mint preset maps a Mint export end-to-end", () => {
+    const csv =
+      "Date,Description,Original Description,Amount,Transaction Type,Category,Account Name\n" +
+      "1/15/2026,Starbucks,STARBUCKS #123,12.34,debit,Coffee,Checking\n" +
+      "1/16/2026,Payroll,ACME PAYROLL,2000.00,credit,Income,Checking\n"
+    const { headers, rows } = parseCsv(csv)
+    const mapping = getPreset("mint").suggestMapping(headers)
+    const mapped = mapCsvRows(rows, mapping, "USD")
+    expect(mapped.every((r) => r.error === null)).toBe(true)
+    expect(mapped[0]).toMatchObject({ type: "expense", amountMinor: 1234n })
+    expect(ymd(mapped[0].date)).toBe("2026-01-15")
+    expect(mapped[1]).toMatchObject({ type: "income", amountMinor: 200000n })
+  })
+
+  test("YNAB preset maps a YNAB register export end-to-end", () => {
+    const csv =
+      "Account,Flag,Date,Payee,Category,Memo,Outflow,Inflow,Cleared\n" +
+      "Checking,,15/01/2026,Store,Food,,50.00,0.00,Cleared\n" +
+      "Checking,,16/01/2026,Job,Income,,0.00,1000.00,Cleared\n"
+    const { headers, rows } = parseCsv(csv)
+    const mapping = getPreset("ynab").suggestMapping(headers)
+    const mapped = mapCsvRows(rows, mapping, "USD")
+    expect(mapped.every((r) => r.error === null)).toBe(true)
+    expect(mapped[0]).toMatchObject({ type: "expense", amountMinor: 5000n })
+    expect(mapped[1]).toMatchObject({ type: "income", amountMinor: 100000n })
+    expect(mapped[0].description).toBe("Store")
+  })
+})
+
+describe("parseQif", () => {
+  test("parses Bank records with signed T amounts", () => {
+    const qif = [
+      "!Type:Bank",
+      "D01/15/2026",
+      "T-50.00",
+      "PStarbucks",
+      "MCoffee run",
+      "^",
+      "D01/16/2026",
+      "T1200.00",
+      "PSalary",
+      "^",
+    ].join("\n")
+    const rows = parseQif(qif, { dateFormat: "MM/DD/YYYY", currency: "USD" })
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      type: "expense",
+      amountMinor: 5000n,
+      description: "Starbucks",
+    })
+    expect(ymd(rows[0].date)).toBe("2026-01-15")
+    expect(rows[1]).toMatchObject({ type: "income", amountMinor: 120000n })
+  })
+
+  test("falls back to memo when payee missing; flags bad records", () => {
+    const qif = [
+      "!Type:Bank",
+      "D01/15/2026",
+      "T-5.00",
+      "Mjust a memo",
+      "^",
+    ].join("\n")
+    const rows = parseQif(qif, { dateFormat: "MM/DD/YYYY", currency: "USD" })
+    expect(rows[0].description).toBe("just a memo")
+    expect(rows[0].error).toBeNull()
+  })
+})
+
+describe("toStagedRows", () => {
+  test("drops error rows, stamps account, emits string minor units + ISO date", () => {
+    const parsed = mapCsvRows(
+      [
+        { Date: "2026-01-15", Description: "Coffee", Amount: "-12.34" },
+        { Date: "bad", Description: "X", Amount: "-1" },
+        { Date: "2026-01-16", Description: "Pay", Amount: "1000" },
+      ],
+      SIGNED_MAPPING,
+      "USD"
+    )
+    const staged = toStagedRows(parsed, "acc_1")
+    expect(staged).toHaveLength(2)
+    expect(staged[0]).toMatchObject({
+      accountId: "acc_1",
+      amount: "1234",
+      type: "expense",
+      date: "2026-01-15",
+      description: "Coffee",
+    })
+    expect(typeof staged[0].amount).toBe("string")
+  })
+})

--- a/src/lib/csv-import.ts
+++ b/src/lib/csv-import.ts
@@ -1,0 +1,500 @@
+/**
+ * Pure CSV/QIF import parser & mapper (ADR-0040).
+ *
+ * This module is DB-free, React-free, and server-free: it turns an uploaded
+ * file plus an explicit column/format mapping into client `ParsedImportRow`s.
+ * The wizard stamps a single chosen target account and submits the valid rows
+ * as `StagedRowInput[]` to the ADR-0039 staging server functions, where ALL
+ * money/ledger correctness (dedup, idempotency, balance, audit, RLS, FX) lives.
+ */
+import Papa from "papaparse"
+
+import { type CurrencyCode } from "@/lib/data/currencies"
+import { parseUserInput } from "@/lib/money"
+
+export type ImportRowType = "income" | "expense"
+
+// ---------------------------------------------------------------------------
+// Date formats — explicit, never heuristic (ADR-0040 §3).
+// ---------------------------------------------------------------------------
+
+export type DateFormat =
+  | "YYYY-MM-DD"
+  | "DD/MM/YYYY"
+  | "MM/DD/YYYY"
+  | "DD-MM-YYYY"
+
+export const DATE_FORMATS: readonly DateFormat[] = [
+  "YYYY-MM-DD",
+  "DD/MM/YYYY",
+  "MM/DD/YYYY",
+  "DD-MM-YYYY",
+]
+
+const DATE_PATTERNS: Record<
+  DateFormat,
+  {
+    re: RegExp
+    order: readonly ["y" | "m" | "d", "y" | "m" | "d", "y" | "m" | "d"]
+  }
+> = {
+  "YYYY-MM-DD": { re: /^(\d{4})-(\d{1,2})-(\d{1,2})$/, order: ["y", "m", "d"] },
+  "DD/MM/YYYY": {
+    re: /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/,
+    order: ["d", "m", "y"],
+  },
+  "MM/DD/YYYY": {
+    re: /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/,
+    order: ["m", "d", "y"],
+  },
+  "DD-MM-YYYY": { re: /^(\d{1,2})-(\d{1,2})-(\d{4})$/, order: ["d", "m", "y"] },
+}
+
+/**
+ * Parse a date string under an explicit format. Returns a UTC-midnight `Date`
+ * for the calendar day, or `null` if the value does not unambiguously parse
+ * (the wizard surfaces such rows as errors rather than guessing).
+ */
+export function parseImportDate(
+  value: string,
+  format: DateFormat
+): Date | null {
+  const trimmed = value.trim()
+  if (trimmed === "") return null
+  const spec = DATE_PATTERNS[format]
+  const match = spec.re.exec(trimmed)
+  if (!match) return null
+
+  const parts: Record<"y" | "m" | "d", number> = { y: 0, m: 0, d: 0 }
+  spec.order.forEach((key, index) => {
+    parts[key] = Number(match[index + 1])
+  })
+
+  if (parts.m < 1 || parts.m > 12) return null
+  if (parts.d < 1 || parts.d > 31) return null
+
+  const date = new Date(Date.UTC(parts.y, parts.m - 1, parts.d))
+  // Reject impossible days (e.g. 31 Feb rolls over to March).
+  if (
+    date.getUTCFullYear() !== parts.y ||
+    date.getUTCMonth() !== parts.m - 1 ||
+    date.getUTCDate() !== parts.d
+  ) {
+    return null
+  }
+  return date
+}
+
+// ---------------------------------------------------------------------------
+// Column mapping — the three-mode amount model (ADR-0040 §2).
+// ---------------------------------------------------------------------------
+
+export type AmountMapping =
+  | { kind: "signed"; column: string; negativeMeans: ImportRowType }
+  | { kind: "split"; outflowColumn: string; inflowColumn: string }
+  | {
+      kind: "typed"
+      amountColumn: string
+      typeColumn: string
+      expenseValues: readonly string[]
+      incomeValues: readonly string[]
+    }
+
+export interface ColumnMapping {
+  dateColumn: string
+  descriptionColumn: string
+  amount: AmountMapping
+  dateFormat: DateFormat
+  externalIdColumn?: string | null
+}
+
+export interface ParsedImportRow {
+  date: Date | null
+  type: ImportRowType
+  /** Positive minor units; `null` when the amount could not be parsed. */
+  amountMinor: bigint | null
+  description: string
+  externalId: string | null
+  rawPayload: Record<string, unknown>
+  /** `null` ⇒ importable. Any string ⇒ excluded with this reason. */
+  error: string | null
+}
+
+export interface ParsedCsv {
+  headers: string[]
+  rows: Record<string, string>[]
+}
+
+/** Parse raw CSV text into trimmed headers + string-valued row records. */
+export function parseCsv(text: string): ParsedCsv {
+  const result = Papa.parse<Record<string, string>>(text, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: (header) => header.trim(),
+  })
+  const headers = result.meta.fields ?? []
+  const rows = (result.data ?? []).filter(
+    (row) => row && typeof row === "object"
+  )
+  return { headers, rows }
+}
+
+function cell(raw: Record<string, string>, column: string): string {
+  const value = raw[column]
+  return typeof value === "string" ? value.trim() : ""
+}
+
+/** Absolute positive minor units, or `null` for empty/zero/malformed. */
+function parseMagnitude(value: string, currency: CurrencyCode): bigint | null {
+  if (value.trim() === "") return null
+  const money = parseUserInput(value, currency)
+  if (money === null) return null
+  const magnitude =
+    (money as bigint) < 0n ? -(money as bigint) : (money as bigint)
+  return magnitude === 0n ? null : magnitude
+}
+
+function deriveAmount(
+  raw: Record<string, string>,
+  amount: AmountMapping,
+  currency: CurrencyCode
+): { type: ImportRowType; amountMinor: bigint | null; error: string | null } {
+  if (amount.kind === "signed") {
+    const value = cell(raw, amount.column)
+    if (value === "")
+      return { type: "expense", amountMinor: null, error: "Missing amount" }
+    const money = parseUserInput(value, currency)
+    if (money === null)
+      return {
+        type: "expense",
+        amountMinor: null,
+        error: `Unparseable amount "${value}"`,
+      }
+    const signed = money as bigint
+    if (signed === 0n)
+      return { type: "expense", amountMinor: null, error: "Zero amount" }
+    const isNegative = signed < 0n
+    const negativeType = amount.negativeMeans
+    const positiveType: ImportRowType =
+      negativeType === "expense" ? "income" : "expense"
+    return {
+      type: isNegative ? negativeType : positiveType,
+      amountMinor: isNegative ? -signed : signed,
+      error: null,
+    }
+  }
+
+  if (amount.kind === "split") {
+    const outflow = parseMagnitude(cell(raw, amount.outflowColumn), currency)
+    const inflow = parseMagnitude(cell(raw, amount.inflowColumn), currency)
+    if (outflow !== null)
+      return { type: "expense", amountMinor: outflow, error: null }
+    if (inflow !== null)
+      return { type: "income", amountMinor: inflow, error: null }
+    return {
+      type: "expense",
+      amountMinor: null,
+      error: "No outflow or inflow amount",
+    }
+  }
+
+  // typed
+  const magnitude = parseMagnitude(cell(raw, amount.amountColumn), currency)
+  if (magnitude === null) {
+    return {
+      type: "expense",
+      amountMinor: null,
+      error: "Missing or zero amount",
+    }
+  }
+  const typeValue = cell(raw, amount.typeColumn).toLowerCase()
+  const isExpense = amount.expenseValues.some(
+    (v) => v.toLowerCase() === typeValue
+  )
+  const isIncome = amount.incomeValues.some(
+    (v) => v.toLowerCase() === typeValue
+  )
+  if (isExpense) return { type: "expense", amountMinor: magnitude, error: null }
+  if (isIncome) return { type: "income", amountMinor: magnitude, error: null }
+  return {
+    type: "expense",
+    amountMinor: magnitude,
+    error: `Unknown transaction type "${typeValue}"`,
+  }
+}
+
+/** Map one raw CSV record into a `ParsedImportRow` under the given mapping. */
+export function mapCsvRow(
+  raw: Record<string, string>,
+  mapping: ColumnMapping,
+  currency: CurrencyCode
+): ParsedImportRow {
+  const date = parseImportDate(
+    cell(raw, mapping.dateColumn),
+    mapping.dateFormat
+  )
+  const description = cell(raw, mapping.descriptionColumn)
+  const {
+    type,
+    amountMinor,
+    error: amountError,
+  } = deriveAmount(raw, mapping.amount, currency)
+  const externalId = mapping.externalIdColumn
+    ? cell(raw, mapping.externalIdColumn) || null
+    : null
+
+  let error: string | null = null
+  if (date === null) error = "Unparseable date"
+  else if (description === "") error = "Missing description"
+  else if (amountError) error = amountError
+
+  return {
+    date,
+    type,
+    amountMinor,
+    description,
+    externalId,
+    rawPayload: raw,
+    error,
+  }
+}
+
+export function mapCsvRows(
+  rows: Record<string, string>[],
+  mapping: ColumnMapping,
+  currency: CurrencyCode
+): ParsedImportRow[] {
+  return rows.map((row) => mapCsvRow(row, mapping, currency))
+}
+
+// ---------------------------------------------------------------------------
+// QIF — separate parser, same seam (ADR-0040 §5).
+// ---------------------------------------------------------------------------
+
+/** Parse a QIF document (`!Type:Bank` style) into `ParsedImportRow`s. */
+export function parseQif(
+  text: string,
+  opts: { dateFormat: DateFormat; currency: CurrencyCode }
+): ParsedImportRow[] {
+  const rows: ParsedImportRow[] = []
+  let current: Record<string, string> = {}
+  let hasFields = false
+
+  const flush = () => {
+    if (!hasFields) return
+    const raw = { ...current }
+    const date = parseImportDate((current.D ?? "").trim(), opts.dateFormat)
+    const description = (current.P ?? current.M ?? "").trim()
+    const amountValue = (current.T ?? "").trim()
+    const money =
+      amountValue === "" ? null : parseUserInput(amountValue, opts.currency)
+    let type: ImportRowType = "expense"
+    let amountMinor: bigint | null = null
+    let amountError: string | null = null
+    if (money === null) {
+      amountError =
+        amountValue === ""
+          ? "Missing amount"
+          : `Unparseable amount "${amountValue}"`
+    } else if ((money as bigint) === 0n) {
+      amountError = "Zero amount"
+    } else {
+      const signed = money as bigint
+      type = signed < 0n ? "expense" : "income"
+      amountMinor = signed < 0n ? -signed : signed
+    }
+
+    let error: string | null = null
+    if (date === null) error = "Unparseable date"
+    else if (description === "") error = "Missing description"
+    else if (amountError) error = amountError
+
+    rows.push({
+      date,
+      type,
+      amountMinor,
+      description,
+      externalId: null,
+      rawPayload: raw,
+      error,
+    })
+    current = {}
+    hasFields = false
+  }
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (line === "") continue
+    if (line.startsWith("!")) continue // type/option directive
+    if (line === "^") {
+      flush()
+      continue
+    }
+    const tag = line[0]
+    current[tag] = line.slice(1)
+    hasFields = true
+  }
+  flush() // tolerate a missing trailing `^`
+
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+// Presets (ADR-0040 §4).
+// ---------------------------------------------------------------------------
+
+export interface ImportPreset {
+  id: "generic" | "mint" | "ynab"
+  label: string
+  /** `true` for QIF/columnar-agnostic — wizard skips column-mapping. */
+  suggestMapping(headers: string[]): ColumnMapping
+}
+
+function findHeader(headers: string[], patterns: RegExp[]): string {
+  for (const pattern of patterns) {
+    const hit = headers.find((header) => pattern.test(header))
+    if (hit) return hit
+  }
+  return ""
+}
+
+const genericPreset: ImportPreset = {
+  id: "generic",
+  label: "Generic CSV",
+  suggestMapping(headers) {
+    const dateColumn = findHeader(headers, [/^date$/i, /date/i, /tanggal/i])
+    const descriptionColumn = findHeader(headers, [
+      /description/i,
+      /payee/i,
+      /narrative/i,
+      /keterangan/i,
+      /memo/i,
+      /name/i,
+    ])
+    const outflow = findHeader(headers, [
+      /outflow/i,
+      /withdrawal/i,
+      /debit/i,
+      /debet/i,
+    ])
+    const inflow = findHeader(headers, [
+      /inflow/i,
+      /deposit/i,
+      /credit/i,
+      /kredit/i,
+    ])
+    const amount: AmountMapping =
+      outflow && inflow
+        ? { kind: "split", outflowColumn: outflow, inflowColumn: inflow }
+        : {
+            kind: "signed",
+            column: findHeader(headers, [/^amount$/i, /amount/i, /nominal/i]),
+            negativeMeans: "expense",
+          }
+    return { dateColumn, descriptionColumn, amount, dateFormat: "YYYY-MM-DD" }
+  },
+}
+
+const mintPreset: ImportPreset = {
+  id: "mint",
+  label: "Mint",
+  suggestMapping(headers) {
+    return {
+      dateColumn: findHeader(headers, [/^date$/i]) || "Date",
+      descriptionColumn:
+        findHeader(headers, [/^description$/i]) || "Description",
+      amount: {
+        kind: "typed",
+        amountColumn: findHeader(headers, [/^amount$/i]) || "Amount",
+        typeColumn:
+          findHeader(headers, [/transaction type/i]) || "Transaction Type",
+        expenseValues: ["debit"],
+        incomeValues: ["credit"],
+      },
+      dateFormat: "MM/DD/YYYY",
+    }
+  },
+}
+
+const ynabPreset: ImportPreset = {
+  id: "ynab",
+  label: "YNAB",
+  suggestMapping(headers) {
+    return {
+      dateColumn: findHeader(headers, [/^date$/i]) || "Date",
+      descriptionColumn: findHeader(headers, [/^payee$/i]) || "Payee",
+      amount: {
+        kind: "split",
+        outflowColumn: findHeader(headers, [/^outflow$/i]) || "Outflow",
+        inflowColumn: findHeader(headers, [/^inflow$/i]) || "Inflow",
+      },
+      dateFormat: "DD/MM/YYYY",
+    }
+  },
+}
+
+export const IMPORT_PRESETS: readonly ImportPreset[] = [
+  genericPreset,
+  mintPreset,
+  ynabPreset,
+]
+
+export function getPreset(id: ImportPreset["id"]): ImportPreset {
+  const preset = IMPORT_PRESETS.find((p) => p.id === id)
+  if (!preset) throw new Error(`Unknown import preset: ${id}`)
+  return preset
+}
+
+// ---------------------------------------------------------------------------
+// Staging hand-off.
+// ---------------------------------------------------------------------------
+
+export interface StagedRowDraft {
+  accountId: string
+  externalId: string | null
+  rawPayload: Record<string, unknown>
+  /** ISO calendar day (yyyy-mm-dd); coerced server-side via `z.coerce.date()`. */
+  date: string
+  /** Positive minor units as a string (serialization-safe `BigInt` source). */
+  amount: string
+  type: ImportRowType
+  description: string
+}
+
+/**
+ * Reduce parsed rows to the submittable subset, stamping the single chosen
+ * target account. Error rows are dropped here (the UI lists them separately);
+ * `stagedRowInputSchema` would reject them anyway.
+ */
+export function toStagedRows(
+  rows: ParsedImportRow[],
+  accountId: string
+): StagedRowDraft[] {
+  const staged: StagedRowDraft[] = []
+  for (const row of rows) {
+    if (row.error !== null || row.date === null || row.amountMinor === null)
+      continue
+    staged.push({
+      accountId,
+      externalId: row.externalId,
+      rawPayload: row.rawPayload,
+      date: row.date.toISOString().slice(0, 10),
+      amount: row.amountMinor.toString(),
+      type: row.type,
+      description: row.description,
+    })
+  }
+  return staged
+}
+
+/** SHA-256 hex of file bytes (batch content hash, ADR-0039 §5). Web Crypto. */
+export async function sha256Hex(input: ArrayBuffer | string): Promise<string> {
+  const data =
+    typeof input === "string"
+      ? new TextEncoder().encode(input)
+      : new Uint8Array(input)
+  const digest = await crypto.subtle.digest("SHA-256", data)
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/src/routes/_protected/accounts.tsx
+++ b/src/routes/_protected/accounts.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Select,
   SelectContent,
@@ -487,6 +488,9 @@ function AccountFormDialog({
   const [institutionName, setInstitutionName] = React.useState<string>(
     editing?.institutionName ?? ""
   )
+  const [isImportable, setIsImportable] = React.useState<boolean>(
+    editing?.isImportable ?? false
+  )
   const [error, setError] = React.useState<string | null>(null)
   const [submitting, setSubmitting] = React.useState(false)
 
@@ -516,6 +520,7 @@ function AccountFormDialog({
             name: name.trim(),
             accountSubtype: resolvedSubtype,
             institutionName: institutionName.trim() || null,
+            isImportable,
             idempotencyKey: createUuidV7(),
           },
         })
@@ -665,6 +670,22 @@ function AccountFormDialog({
               placeholder="e.g. Bank Central Asia"
             />
           </div>
+
+          {editing ? (
+            <div className="flex items-start gap-3 rounded-md border p-3">
+              <Checkbox
+                id="is-importable"
+                checked={isImportable}
+                onCheckedChange={(checked) => setIsImportable(checked === true)}
+              />
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="is-importable">Allow imports</Label>
+                <p className="text-xs text-muted-foreground">
+                  Let CSV/QIF imports promote transactions into this account.
+                </p>
+              </div>
+            </div>
+          ) : null}
 
           {error ? (
             <p className="text-sm text-destructive" role="alert">

--- a/src/routes/_protected/import.tsx
+++ b/src/routes/_protected/import.tsx
@@ -1,17 +1,18 @@
 import * as React from "react"
 import { createFileRoute, useRouter } from "@tanstack/react-router"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import Papa from "papaparse"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-
 import {
-  IconUpload,
-  IconPlus,
-  IconTrash,
-  IconFileSpreadsheet,
-  IconArrowRight,
-  IconCheck,
-} from "@tabler/icons-react"
+  Upload,
+  FileSpreadsheet,
+  ArrowLeft,
+  ArrowRight,
+  CheckCheck,
+  CircleAlert,
+  CopyCheck,
+  Sparkles,
+  Loader2,
+} from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
@@ -27,6 +28,17 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   Table,
   TableBody,
@@ -37,476 +49,985 @@ import {
 } from "@/components/ui/table"
 
 import {
-  getSmartRulesFn,
-  createSmartRuleFn,
-  deleteSmartRuleFn,
-} from "@/server/smart-rules"
+  DATE_FORMATS,
+  IMPORT_PRESETS,
+  getPreset,
+  mapCsvRows,
+  parseCsv,
+  parseQif,
+  sha256Hex,
+  toStagedRows,
+  type AmountMapping,
+  type ColumnMapping,
+  type DateFormat,
+  type ImportPreset,
+  type ParsedImportRow,
+} from "@/lib/csv-import"
 import {
-  getTransactionFormData,
-  bulkCreateTransactionsFn,
-} from "@/server/transactions"
-import { formatCurrency } from "@/lib/currency"
+  createImportBatchFn,
+  getImportBatchFn,
+  promoteImportBatchFn,
+  reviewImportRowsFn,
+} from "@/server/imports"
+import { getTransactionFormData } from "@/server/transactions"
+import { formatMoney } from "@/lib/money"
+import { type CurrencyCode } from "@/lib/data/currencies"
 import { createUuidV7 } from "@/lib/uuid-v7"
 
 export const Route = createFileRoute("/_protected/import")({
+  ssr: false,
+  staticData: { title: "Import Transactions" },
   component: ImportPage,
-  staticData: {
-    title: "Import & Rules Engine",
-  },
 })
 
-// === INTERFACES ===
-interface ParsedRow {
-  id: string
-  idempotencyKey: string
-  date: Date
-  description: string
-  amount: number
-  type: "expense" | "income"
-  accountId: string
-  categoryId?: string
-  merchantId?: string
-  // For preview info
-  assignedByRule?: boolean
-}
+type WizardStep = "upload" | "map" | "preview"
+type Verdict = "confirm" | "reject"
+type BatchData = Awaited<ReturnType<typeof getImportBatchFn>>
+type BatchRow = BatchData["rows"][number]
 
-type SmartRule = Awaited<ReturnType<typeof getSmartRulesFn>>[number]
-
-function applyRules(description: string, rulesList: readonly SmartRule[]) {
-  const lowerDesc = description.toLowerCase()
-
-  // Evaluasi keyword rule yang dipisah koma terhadap deskripsi transaksi.
-  for (const rule of rulesList) {
-    const keywords = rule.keyword
-      .split(",")
-      .map((keyword: string) => keyword.trim().toLowerCase())
-    for (const keyword of keywords) {
-      if (keyword && lowerDesc.includes(keyword)) {
-        return { categoryId: rule.categoryId, merchantId: rule.merchantId }
-      }
-    }
-  }
-  return { categoryId: null, merchantId: null }
-}
+const UNSET = "__unset__"
 
 function ImportPage() {
   const router = useRouter()
   const queryClient = useQueryClient()
 
-  // === DATA FETCHING ===
   const { data: formData } = useQuery({
     queryKey: ["transactionFormData"],
     queryFn: () => getTransactionFormData(),
   })
 
-  const { data: rules = [] } = useQuery({
-    queryKey: ["smartRules"],
-    queryFn: () => getSmartRulesFn(),
-  })
+  const importableAccounts = React.useMemo(
+    () => (formData?.accounts ?? []).filter((account) => account.isImportable),
+    [formData]
+  )
 
-  // === MUTATIONS ===
-  const createRuleMutation = useMutation({
-    mutationFn: (data: Parameters<typeof createSmartRuleFn>[0]["data"]) =>
-      createSmartRuleFn({ data }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["smartRules"] })
-      toast.success("Rule added successfully")
-      setNewRuleKeyword("")
-      setNewRuleCategory("")
-      setNewRuleMerchant("")
+  const [step, setStep] = React.useState<WizardStep>("upload")
+  const [presetId, setPresetId] = React.useState<ImportPreset["id"]>("generic")
+  const [fileName, setFileName] = React.useState("")
+  const [fileText, setFileText] = React.useState("")
+  const [fileKind, setFileKind] = React.useState<"csv" | "qif">("csv")
+  const [headers, setHeaders] = React.useState<string[]>([])
+  const [rawRows, setRawRows] = React.useState<Record<string, string>[]>([])
+  const [mapping, setMapping] = React.useState<ColumnMapping | null>(null)
+  const [qifDateFormat, setQifDateFormat] =
+    React.useState<DateFormat>("MM/DD/YYYY")
+  const [targetAccountId, setTargetAccountId] = React.useState("")
+  const [batchId, setBatchId] = React.useState<string | null>(null)
+  const [overrides, setOverrides] = React.useState<Record<string, Verdict>>({})
+
+  const targetAccount = importableAccounts.find(
+    (account) => account.id === targetAccountId
+  )
+  const currency = (targetAccount?.currency ?? "IDR") as CurrencyCode
+
+  // ----- File upload (event handler — not an effect) ----------------------
+  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file) return
+    const text = await file.text()
+    setFileName(file.name)
+    setFileText(text)
+    if (file.name.toLowerCase().endsWith(".qif")) {
+      setFileKind("qif")
+      setHeaders([])
+      setRawRows([])
+      setMapping(null)
+    } else {
+      const parsed = parseCsv(text)
+      setFileKind("csv")
+      setHeaders(parsed.headers)
+      setRawRows(parsed.rows)
+      setMapping(getPreset(presetId).suggestMapping(parsed.headers))
+    }
+    setStep("map")
+  }
+
+  const handlePreset = (id: ImportPreset["id"]) => {
+    setPresetId(id)
+    if (fileKind === "csv" && headers.length > 0) {
+      setMapping(getPreset(id).suggestMapping(headers))
+    }
+  }
+
+  const patchMapping = (patch: Partial<ColumnMapping>) =>
+    setMapping((current) => (current ? { ...current, ...patch } : current))
+
+  const changeAmountKind = (kind: AmountMapping["kind"]) => {
+    if (kind === "signed") {
+      patchMapping({
+        amount: { kind: "signed", column: "", negativeMeans: "expense" },
+      })
+    } else if (kind === "split") {
+      patchMapping({
+        amount: { kind: "split", outflowColumn: "", inflowColumn: "" },
+      })
+    } else {
+      patchMapping({
+        amount: {
+          kind: "typed",
+          amountColumn: "",
+          typeColumn: "",
+          expenseValues: ["debit"],
+          incomeValues: ["credit"],
+        },
+      })
+    }
+  }
+
+  // ----- Client-side preview (pure, memoized) -----------------------------
+  const parsedPreview = React.useMemo<ParsedImportRow[]>(() => {
+    if (!targetAccount) return []
+    if (fileKind === "qif") {
+      return parseQif(fileText, { dateFormat: qifDateFormat, currency })
+    }
+    if (!mapping) return []
+    return mapCsvRows(rawRows, mapping, currency)
+  }, [
+    targetAccount,
+    fileKind,
+    fileText,
+    qifDateFormat,
+    mapping,
+    rawRows,
+    currency,
+  ])
+
+  const readyCount = parsedPreview.filter((row) => row.error === null).length
+  const skippedCount = parsedPreview.length - readyCount
+
+  // ----- Staging ----------------------------------------------------------
+  const stageMutation = useMutation({
+    mutationFn: async () => {
+      if (!targetAccount) throw new Error("Select a target account first.")
+      const rows = toStagedRows(parsedPreview, targetAccount.id)
+      if (rows.length === 0) {
+        throw new Error("No importable rows — check the column mapping.")
+      }
+      const contentHash = await sha256Hex(fileText)
+      return createImportBatchFn({
+        data: {
+          sourceKind: "csv_upload",
+          accountId: targetAccount.id,
+          contentHash,
+          idempotencyKey: createUuidV7(),
+          rows,
+        },
+      })
     },
-  })
-
-  const deleteRuleMutation = useMutation({
-    mutationFn: (id: string) => deleteSmartRuleFn({ data: { id } }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["smartRules"] })
+    onSuccess: (summary) => {
+      setBatchId(summary.id)
+      setOverrides({})
+      setStep("preview")
+      if (summary.replayed) {
+        toast.info("This exact file was already imported — showing that batch.")
+      }
     },
+    onError: (error) =>
+      toast.error(error instanceof Error ? error.message : "Staging failed."),
   })
 
-  const bulkCreateMutation = useMutation({
-    mutationFn: (
-      data: Parameters<typeof bulkCreateTransactionsFn>[0]["data"]
-    ) => bulkCreateTransactionsFn({ data }),
-    onSuccess: async () => {
+  // ----- Preview (server batch with dedup verdicts) -----------------------
+  const batchQuery = useQuery({
+    queryKey: ["importBatch", batchId],
+    queryFn: () => getImportBatchFn({ data: { batchId: batchId as string } }),
+    enabled: batchId !== null,
+  })
+  const batch = batchQuery.data
+
+  const defaultVerdict = (row: BatchRow): Verdict =>
+    row.rowStatus === "duplicate" ? "reject" : "confirm"
+  const verdictOf = (row: BatchRow): Verdict =>
+    overrides[row.id] ?? defaultVerdict(row)
+  const toggleVerdict = (row: BatchRow) =>
+    setOverrides((current) => ({
+      ...current,
+      [row.id]: verdictOf(row) === "confirm" ? "reject" : "confirm",
+    }))
+
+  const promoteMutation = useMutation({
+    mutationFn: async () => {
+      if (!batch) throw new Error("No batch loaded.")
+      const reviewable = batch.rows.filter(
+        (row) => row.rowStatus !== "promoted"
+      )
+      const decisions = reviewable.map((row) => ({
+        rowId: row.id,
+        verdict: verdictOf(row),
+      }))
+      if (decisions.length > 0) {
+        await reviewImportRowsFn({
+          data: {
+            batchId: batch.batch.id,
+            idempotencyKey: createUuidV7(),
+            decisions,
+          },
+        })
+      }
+      return promoteImportBatchFn({
+        data: { batchId: batch.batch.id, idempotencyKey: createUuidV7() },
+      })
+    },
+    onSuccess: async (result) => {
       const [{ transactionCollection }] = await Promise.all([
         import("@/lib/collections"),
         queryClient.invalidateQueries({ queryKey: ["transactions_live"] }),
       ])
       await transactionCollection.utils.refetch()
-      toast.success("Transactions imported successfully!")
+      toast.success(
+        `Promoted ${result.promotedCount} transaction(s) to the ledger.`
+      )
       void router.navigate({ to: "/transactions" })
     },
-    onError: (err) => {
-      toast.error("Failed to import transactions.")
-      console.error(err)
-    },
+    onError: (error) =>
+      toast.error(error instanceof Error ? error.message : "Promotion failed."),
   })
 
-  // === RULES ENGINE STATE ===
-  const [newRuleKeyword, setNewRuleKeyword] = React.useState("")
-  const [newRuleCategory, setNewRuleCategory] = React.useState("")
-  const [newRuleMerchant, setNewRuleMerchant] = React.useState("")
-
-  // === CSV ENGINE STATE ===
-  const [parsedRows, setParsedRows] = React.useState<ParsedRow[]>([])
-  const [targetAccountId, setTargetAccountId] = React.useState("")
-  const [isParsing, setIsParsing] = React.useState(false)
-
-  // File Upload Handler
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    if (!targetAccountId) {
-      toast.error("Please select a Target Account first!")
-      return
-    }
-
-    setIsParsing(true)
-
-    Papa.parse(file, {
-      header: true,
-      skipEmptyLines: true,
-      complete: (results) => {
-        const rows: ParsedRow[] = []
-
-        results.data.forEach((row: any) => {
-          // This relies on generic standard columns.
-          // You may customize these mappings based on typical banking CSV exports.
-          const rawDate = row["Date"] || row["Tanggal"] || row.date
-          const rawDesc =
-            row["Description"] || row["Keterangan"] || row.description
-          const rawAmount = row["Amount"] || row["Nominal"] || row.amount
-          // Optional columns for pure debit/credit bank statements:
-          const rawCredit = row["Credit"] || row["Kredit"]
-          const rawDebit = row["Debit"] || row["Debet"]
-
-          if (!rawDate || !rawDesc) return
-
-          let finalAmount =
-            parseFloat(String(rawAmount).replace(/[^0-9.-]+/g, "")) || 0
-          let type: "income" | "expense" =
-            finalAmount < 0 ? "expense" : "income"
-
-          if (rawCredit) {
-            finalAmount =
-              parseFloat(String(rawCredit).replace(/[^0-9.-]+/g, "")) || 0
-            type = "income"
-          } else if (rawDebit) {
-            finalAmount =
-              parseFloat(String(rawDebit).replace(/[^0-9.-]+/g, "")) || 0
-            type = "expense"
-          }
-
-          if (finalAmount === 0) return
-
-          // Execute Smart Rules Engine
-          const matched = applyRules(rawDesc, rules)
-
-          rows.push({
-            id: createUuidV7(),
-            idempotencyKey: createUuidV7(),
-            date: new Date(rawDate),
-            description: String(rawDesc),
-            amount: Math.abs(finalAmount),
-            type,
-            accountId: targetAccountId,
-            categoryId: matched.categoryId ?? undefined,
-            merchantId: matched.merchantId ?? undefined,
-            assignedByRule: !!(matched.categoryId || matched.merchantId),
-          })
-        })
-
-        setParsedRows(rows)
-        setIsParsing(false)
-        e.target.value = "" // Reset
-        toast.success(
-          `Successfully parsed ${rows.length} transactions via Rules Engine.`
-        )
-      },
-      error: (error) => {
-        setIsParsing(false)
-        console.error(error)
-        toast.error("Failed to parse CSV file.")
-      },
-    })
-  }
-
-  const handleInjectToLedger = () => {
-    if (parsedRows.length === 0) return
-    bulkCreateMutation.mutate({
-      idempotencyKey: createUuidV7(),
-      transactions: parsedRows,
-    })
-  }
+  const confirmCount = batch
+    ? batch.rows.filter(
+        (row) => row.rowStatus !== "promoted" && verdictOf(row) === "confirm"
+      ).length
+    : 0
 
   return (
     <TooltipProvider>
       <SidebarProvider>
-        <AppSidebar />
+        <AppSidebar variant="inset" />
         <SidebarInset>
           <SiteHeader />
           <div className="flex flex-1 flex-col gap-6 p-4 md:p-6 lg:p-8">
-            <div className="flex flex-col gap-2">
+            <header className="flex flex-col gap-2">
               <h1 className="text-3xl font-bold tracking-tight">
-                Data Integration
+                Import Transactions
               </h1>
               <p className="text-muted-foreground">
-                Configure Machine-Readable IF-THEN Rules and process mass bank
-                CSV extracts.
+                Upload a CSV or QIF export, map the columns, review for
+                duplicates, then promote confirmed rows into your ledger.
               </p>
-            </div>
+              <WizardSteps step={step} />
+            </header>
 
-            <div className="grid gap-6 md:grid-cols-2">
-              {/* === LEFT PANEL: RULES ENGINE === */}
-              <Card className="flex flex-col">
-                <CardHeader>
-                  <div className="flex items-center gap-2">
-                    <IconFileSpreadsheet className="text-blue-600 dark:text-blue-400" />
-                    <div>
-                      <CardTitle>The Smart Rules Engine</CardTitle>
-                      <CardDescription>
-                        Keyword matching rules applied automatically upon CSV
-                        payload parsing.
-                      </CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="flex flex-1 flex-col gap-6">
-                  <div className="rounded-xl border bg-muted/20 p-4">
-                    <h3 className="mb-4 text-sm font-semibold tracking-wider text-muted-foreground uppercase">
-                      Create New Rule
-                    </h3>
-                    <div className="grid gap-4 sm:grid-cols-2">
-                      <div className="space-y-2 sm:col-span-2">
-                        <Label>IF Description Contains (comma separated)</Label>
-                        <Input
-                          placeholder="e.g. Starbucks, Fore, Spotify, Steam"
-                          value={newRuleKeyword}
-                          onChange={(e) => setNewRuleKeyword(e.target.value)}
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label>THEN Set Category</Label>
-                        <select
-                          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors"
-                          value={newRuleCategory}
-                          onChange={(e) => setNewRuleCategory(e.target.value)}
-                        >
-                          <option value="">No Auto-Category</option>
-                          {formData?.categories?.map((c: any) => (
-                            <option key={c.id} value={c.id}>
-                              {c.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label>THEN Set Merchant</Label>
-                        <select
-                          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors"
-                          value={newRuleMerchant}
-                          onChange={(e) => setNewRuleMerchant(e.target.value)}
-                        >
-                          <option value="">No Auto-Merchant</option>
-                          {formData?.merchants?.map((m: any) => (
-                            <option key={m.id} value={m.id}>
-                              {m.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    </div>
-                    <Button
-                      onClick={() =>
-                        createRuleMutation.mutate({
-                          keyword: newRuleKeyword,
-                          categoryId: newRuleCategory || undefined,
-                          merchantId: newRuleMerchant || undefined,
-                        })
-                      }
-                      disabled={!newRuleKeyword || createRuleMutation.isPending}
-                      className="mt-4 w-full"
-                    >
-                      <IconPlus size={16} className="mr-2" />
-                      Commit Rule to Engine
-                    </Button>
-                  </div>
+            {step === "upload" && (
+              <UploadStep
+                presetId={presetId}
+                onPreset={handlePreset}
+                onFile={handleFile}
+                fileName={fileName}
+              />
+            )}
 
-                  <div className="flex-1 space-y-3 overflow-y-auto pr-2">
-                    <h3 className="text-sm font-semibold tracking-wider text-muted-foreground uppercase">
-                      Active Directives ({rules.length})
-                    </h3>
-                    {rules.length === 0 && (
-                      <p className="text-sm text-muted-foreground italic">
-                        No rules configured yet.
-                      </p>
-                    )}
-                    {rules.map((rule: any) => (
-                      <div
-                        key={rule.id}
-                        className="group flex flex-col gap-2 rounded-lg border bg-card p-3 shadow-sm transition-colors hover:bg-muted/50"
-                      >
-                        <div className="flex items-center justify-between">
-                          <span className="font-mono text-sm font-semibold text-amber-600 dark:text-amber-400">
-                            IF "{rule.keyword}"
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => deleteRuleMutation.mutate(rule.id)}
-                            className="text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:text-red-600"
-                          >
-                            <IconTrash size={16} />
-                          </button>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                          <IconArrowRight size={14} />
-                          {rule.category ? (
-                            <span className="rounded-sm bg-blue-100 px-1.5 py-0.5 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-                              {rule.category.name}
-                            </span>
-                          ) : (
-                            <span className="italic">N/A</span>
-                          )}
-                          <span>+</span>
-                          {rule.merchant ? (
-                            <span className="rounded-sm bg-purple-100 px-1.5 py-0.5 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300">
-                              {rule.merchant.name}
-                            </span>
-                          ) : (
-                            <span className="italic">N/A</span>
-                          )}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
+            {step === "map" && (
+              <MapStep
+                fileName={fileName}
+                fileKind={fileKind}
+                headers={headers}
+                mapping={mapping}
+                onPatchMapping={patchMapping}
+                onChangeAmountKind={changeAmountKind}
+                qifDateFormat={qifDateFormat}
+                onQifDateFormat={setQifDateFormat}
+                accounts={importableAccounts}
+                targetAccountId={targetAccountId}
+                onTargetAccount={setTargetAccountId}
+                currency={currency}
+                preview={parsedPreview}
+                readyCount={readyCount}
+                skippedCount={skippedCount}
+                onBack={() => setStep("upload")}
+                onStage={() => stageMutation.mutate()}
+                staging={stageMutation.isPending}
+                canStage={!!targetAccount && readyCount > 0}
+              />
+            )}
 
-              {/* === RIGHT PANEL: DROPZONE & REVIEW === */}
-              <Card className="flex flex-col">
-                <CardHeader>
-                  <div className="flex items-center gap-2">
-                    <IconUpload className="text-emerald-600 dark:text-emerald-400" />
-                    <div>
-                      <CardTitle>CSV Ingestion Chamber</CardTitle>
-                      <CardDescription>
-                        Upload bank statements to parse and map records against
-                        active directives.
-                      </CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="flex flex-1 flex-col gap-6">
-                  <div className="space-y-4">
-                    <div className="space-y-2">
-                      <Label>1. Select Target Account Ledger</Label>
-                      <select
-                        className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors"
-                        value={targetAccountId}
-                        onChange={(e) => setTargetAccountId(e.target.value)}
-                      >
-                        <option value="" disabled>
-                          --- Select Account ---
-                        </option>
-                        {formData?.accounts?.map((acc: any) => (
-                          <option key={acc.id} value={acc.id}>
-                            {acc.name} ({acc.currency})
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label>2. Upload Bank CSV</Label>
-                      <Input
-                        type="file"
-                        accept=".csv"
-                        onChange={handleFileUpload}
-                        disabled={isParsing || !targetAccountId}
-                        className="cursor-pointer"
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Expected columns: Date, Description, Amount. (Format
-                        flexibly auto-detected).
-                      </p>
-                    </div>
-                  </div>
-
-                  {parsedRows.length > 0 && (
-                    <div className="flex flex-1 flex-col gap-4 overflow-hidden border-t pt-4">
-                      <div className="flex items-center justify-between">
-                        <h3 className="font-semibold text-emerald-600 dark:text-emerald-400">
-                          {parsedRows.length} Entries Ready
-                        </h3>
-                        <Button
-                          onClick={handleInjectToLedger}
-                          disabled={bulkCreateMutation.isPending}
-                          className="bg-emerald-600 text-white hover:bg-emerald-700"
-                        >
-                          {bulkCreateMutation.isPending
-                            ? "Executing..."
-                            : "Inject to Ledger"}
-                        </Button>
-                      </div>
-
-                      <div className="flex-1 overflow-auto rounded-md border">
-                        <Table>
-                          <TableHeader>
-                            <TableRow className="bg-muted/50">
-                              <TableHead className="w-24">Date</TableHead>
-                              <TableHead>Description</TableHead>
-                              <TableHead>Amount</TableHead>
-                              <TableHead>Category</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {parsedRows.slice(0, 50).map((row) => (
-                              <TableRow key={row.id}>
-                                <TableCell className="text-xs whitespace-nowrap">
-                                  {isNaN(row.date.getTime())
-                                    ? "Invalid"
-                                    : row.date.toLocaleDateString()}
-                                </TableCell>
-                                <TableCell className="max-w-[150px] truncate">
-                                  {row.description}
-                                </TableCell>
-                                <TableCell
-                                  className={`text-right font-medium whitespace-nowrap ${row.type === "expense" ? "text-red-500" : "text-emerald-500"}`}
-                                >
-                                  {row.type === "expense" ? "-" : "+"}
-                                  {formatCurrency(row.amount, "IDR")}
-                                </TableCell>
-                                <TableCell>
-                                  {row.assignedByRule ? (
-                                    <span className="inline-flex items-center gap-1 rounded bg-amber-100 px-1 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-900 dark:text-amber-300">
-                                      <IconCheck size={10} /> Auto-Mapped
-                                    </span>
-                                  ) : (
-                                    <span className="text-xs text-muted-foreground">
-                                      -
-                                    </span>
-                                  )}
-                                </TableCell>
-                              </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      </div>
-                      {parsedRows.length > 50 && (
-                        <p className="text-center text-xs text-muted-foreground italic">
-                          Showing first 50 rows of {parsedRows.length} total
-                          generated entries.
-                        </p>
-                      )}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
+            {step === "preview" && (
+              <PreviewStep
+                loading={batchQuery.isLoading}
+                batch={batch}
+                currency={currency}
+                verdictOf={verdictOf}
+                onToggle={toggleVerdict}
+                confirmCount={confirmCount}
+                onBack={() => setStep("map")}
+                onPromote={() => promoteMutation.mutate()}
+                promoting={promoteMutation.isPending}
+              />
+            )}
           </div>
         </SidebarInset>
       </SidebarProvider>
     </TooltipProvider>
+  )
+}
+
+// ===========================================================================
+// Step indicator
+// ===========================================================================
+
+function WizardSteps({ step }: { step: WizardStep }) {
+  const steps: { id: WizardStep; label: string }[] = [
+    { id: "upload", label: "1 · Upload" },
+    { id: "map", label: "2 · Map & account" },
+    { id: "preview", label: "3 · Review & promote" },
+  ]
+  const activeIndex = steps.findIndex((s) => s.id === step)
+  return (
+    <div className="flex flex-wrap items-center gap-2 pt-1 text-sm">
+      {steps.map((s, index) => (
+        <React.Fragment key={s.id}>
+          <span
+            className={
+              index <= activeIndex
+                ? "font-semibold text-foreground"
+                : "text-muted-foreground"
+            }
+          >
+            {s.label}
+          </span>
+          {index < steps.length - 1 && (
+            <ArrowRight size={14} className="text-muted-foreground" />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  )
+}
+
+// ===========================================================================
+// Step 1 — upload
+// ===========================================================================
+
+function UploadStep({
+  presetId,
+  onPreset,
+  onFile,
+  fileName,
+}: {
+  presetId: ImportPreset["id"]
+  onPreset: (id: ImportPreset["id"]) => void
+  onFile: (event: React.ChangeEvent<HTMLInputElement>) => void
+  fileName: string
+}) {
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <FileSpreadsheet className="text-emerald-600 dark:text-emerald-400" />
+          <div>
+            <CardTitle>Choose a format and upload</CardTitle>
+            <CardDescription>
+              Presets pre-fill the column mapping. CSV files are mapped in the
+              next step; QIF files are parsed automatically.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div className="space-y-2">
+          <Label>Format preset</Label>
+          <Select
+            value={presetId}
+            onValueChange={(value) => onPreset(value as ImportPreset["id"])}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {IMPORT_PRESETS.map((preset) => (
+                <SelectItem key={preset.id} value={preset.id}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            QIF files (.qif) skip column mapping regardless of the preset.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label>Statement file (.csv or .qif)</Label>
+          <div className="flex items-center gap-2">
+            <Upload size={16} className="text-muted-foreground" />
+            <Input
+              type="file"
+              accept=".csv,.qif"
+              onChange={onFile}
+              className="cursor-pointer"
+            />
+          </div>
+          {fileName && (
+            <p className="text-xs text-muted-foreground">
+              Selected: {fileName}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ===========================================================================
+// Step 2 — map columns + target account
+// ===========================================================================
+
+function HeaderSelect({
+  value,
+  onChange,
+  headers,
+  placeholder,
+}: {
+  value: string
+  onChange: (value: string) => void
+  headers: string[]
+  placeholder?: string
+}) {
+  return (
+    <Select
+      value={value || UNSET}
+      onValueChange={(next) => onChange(next === UNSET ? "" : next)}
+    >
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder ?? "Select column"} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={UNSET}>— none —</SelectItem>
+        {headers.map((header) => (
+          <SelectItem key={header} value={header}>
+            {header}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function MapStep({
+  fileName,
+  fileKind,
+  headers,
+  mapping,
+  onPatchMapping,
+  onChangeAmountKind,
+  qifDateFormat,
+  onQifDateFormat,
+  accounts,
+  targetAccountId,
+  onTargetAccount,
+  currency,
+  preview,
+  readyCount,
+  skippedCount,
+  onBack,
+  onStage,
+  staging,
+  canStage,
+}: {
+  fileName: string
+  fileKind: "csv" | "qif"
+  headers: string[]
+  mapping: ColumnMapping | null
+  onPatchMapping: (patch: Partial<ColumnMapping>) => void
+  onChangeAmountKind: (kind: AmountMapping["kind"]) => void
+  qifDateFormat: DateFormat
+  onQifDateFormat: (format: DateFormat) => void
+  accounts: { id: string; name: string; currency: string }[]
+  targetAccountId: string
+  onTargetAccount: (id: string) => void
+  currency: CurrencyCode
+  preview: ParsedImportRow[]
+  readyCount: number
+  skippedCount: number
+  onBack: () => void
+  onStage: () => void
+  staging: boolean
+  canStage: boolean
+}) {
+  const dateFormat = fileKind === "qif" ? qifDateFormat : mapping?.dateFormat
+  const setDateFormat = (format: DateFormat) =>
+    fileKind === "qif"
+      ? onQifDateFormat(format)
+      : onPatchMapping({ dateFormat: format })
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Map columns</CardTitle>
+          <CardDescription>{fileName}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-5">
+          <div className="space-y-2">
+            <Label>Target account</Label>
+            {accounts.length === 0 ? (
+              <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+                No importable accounts. Enable importing on an account first.
+              </p>
+            ) : (
+              <Select value={targetAccountId} onValueChange={onTargetAccount}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {accounts.map((account) => (
+                    <SelectItem key={account.id} value={account.id}>
+                      {account.name} ({account.currency})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Every row in this file imports into this one account. Amounts are
+              read in {currency}.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Date format</Label>
+            <Select
+              value={dateFormat}
+              onValueChange={(value) => setDateFormat(value as DateFormat)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DATE_FORMATS.map((format) => (
+                  <SelectItem key={format} value={format}>
+                    {format}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {fileKind === "csv" && mapping && (
+            <>
+              <Separator />
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Date column</Label>
+                  <HeaderSelect
+                    value={mapping.dateColumn}
+                    onChange={(value) => onPatchMapping({ dateColumn: value })}
+                    headers={headers}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Description column</Label>
+                  <HeaderSelect
+                    value={mapping.descriptionColumn}
+                    onChange={(value) =>
+                      onPatchMapping({ descriptionColumn: value })
+                    }
+                    headers={headers}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Amount mode</Label>
+                <Select
+                  value={mapping.amount.kind}
+                  onValueChange={(value) =>
+                    onChangeAmountKind(value as AmountMapping["kind"])
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="signed">
+                      Single signed amount column
+                    </SelectItem>
+                    <SelectItem value="split">
+                      Separate outflow / inflow columns
+                    </SelectItem>
+                    <SelectItem value="typed">Amount + type column</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <AmountModeEditor
+                amount={mapping.amount}
+                headers={headers}
+                onChange={(amount) => onPatchMapping({ amount })}
+              />
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="flex flex-col">
+        <CardHeader>
+          <CardTitle>Preview</CardTitle>
+          <CardDescription>
+            {readyCount} ready
+            {skippedCount > 0 ? ` · ${skippedCount} skipped` : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-1 flex-col gap-4">
+          <div className="flex-1 overflow-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-muted/50">
+                  <TableHead className="w-24">Date</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {preview.slice(0, 15).map((row, index) => (
+                  <TableRow
+                    key={index}
+                    className={row.error ? "bg-destructive/5" : undefined}
+                  >
+                    <TableCell className="text-xs whitespace-nowrap">
+                      {row.date ? row.date.toISOString().slice(0, 10) : "—"}
+                    </TableCell>
+                    <TableCell className="max-w-[180px] truncate">
+                      {row.error ? (
+                        <span className="text-xs text-destructive">
+                          {row.error}
+                        </span>
+                      ) : (
+                        row.description
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className={`text-right text-xs whitespace-nowrap ${
+                        row.type === "expense"
+                          ? "text-red-500"
+                          : "text-emerald-500"
+                      }`}
+                    >
+                      {row.amountMinor === null
+                        ? "—"
+                        : formatMoney(
+                            row.type === "expense"
+                              ? -row.amountMinor
+                              : row.amountMinor,
+                            currency
+                          )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {preview.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={3}
+                      className="py-8 text-center text-sm text-muted-foreground"
+                    >
+                      Select a target account to preview rows.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+          <div className="flex items-center justify-between">
+            <Button variant="ghost" onClick={onBack}>
+              <ArrowLeft size={16} className="mr-2" />
+              Back
+            </Button>
+            <Button onClick={onStage} disabled={!canStage || staging}>
+              {staging ? (
+                <Loader2 size={16} className="mr-2 animate-spin" />
+              ) : (
+                <ArrowRight size={16} className="mr-2" />
+              )}
+              Stage &amp; preview
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function AmountModeEditor({
+  amount,
+  headers,
+  onChange,
+}: {
+  amount: AmountMapping
+  headers: string[]
+  onChange: (amount: AmountMapping) => void
+}) {
+  if (amount.kind === "signed") {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Amount column</Label>
+          <HeaderSelect
+            value={amount.column}
+            onChange={(column) => onChange({ ...amount, column })}
+            headers={headers}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Negative means</Label>
+          <Select
+            value={amount.negativeMeans}
+            onValueChange={(value) =>
+              onChange({
+                ...amount,
+                negativeMeans: value as "expense" | "income",
+              })
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="expense">Expense (money out)</SelectItem>
+              <SelectItem value="income">Income (money in)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    )
+  }
+
+  if (amount.kind === "split") {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Outflow column (expense)</Label>
+          <HeaderSelect
+            value={amount.outflowColumn}
+            onChange={(outflowColumn) => onChange({ ...amount, outflowColumn })}
+            headers={headers}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Inflow column (income)</Label>
+          <HeaderSelect
+            value={amount.inflowColumn}
+            onChange={(inflowColumn) => onChange({ ...amount, inflowColumn })}
+            headers={headers}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <div className="space-y-2">
+        <Label>Amount column</Label>
+        <HeaderSelect
+          value={amount.amountColumn}
+          onChange={(amountColumn) => onChange({ ...amount, amountColumn })}
+          headers={headers}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Type column</Label>
+        <HeaderSelect
+          value={amount.typeColumn}
+          onChange={(typeColumn) => onChange({ ...amount, typeColumn })}
+          headers={headers}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Expense values</Label>
+        <Input
+          value={amount.expenseValues.join(", ")}
+          onChange={(event) =>
+            onChange({
+              ...amount,
+              expenseValues: splitValues(event.target.value),
+            })
+          }
+          placeholder="debit"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Income values</Label>
+        <Input
+          value={amount.incomeValues.join(", ")}
+          onChange={(event) =>
+            onChange({
+              ...amount,
+              incomeValues: splitValues(event.target.value),
+            })
+          }
+          placeholder="credit"
+        />
+      </div>
+    </div>
+  )
+}
+
+function splitValues(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+}
+
+// ===========================================================================
+// Step 3 — review & promote
+// ===========================================================================
+
+function PreviewStep({
+  loading,
+  batch,
+  currency,
+  verdictOf,
+  onToggle,
+  confirmCount,
+  onBack,
+  onPromote,
+  promoting,
+}: {
+  loading: boolean
+  batch: BatchData | undefined
+  currency: CurrencyCode
+  verdictOf: (row: BatchRow) => Verdict
+  onToggle: (row: BatchRow) => void
+  confirmCount: number
+  onBack: () => void
+  onPromote: () => void
+  promoting: boolean
+}) {
+  if (loading || !batch) {
+    return (
+      <Card>
+        <CardContent className="space-y-3 p-6">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-40 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle>Review &amp; promote</CardTitle>
+            <CardDescription>
+              Confirmed rows become ledger transactions. Duplicates are rejected
+              by default.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <Badge variant="secondary">{batch.batch.totalRows} rows</Badge>
+            {batch.batch.duplicateRows > 0 && (
+              <Badge variant="outline">
+                {batch.batch.duplicateRows} duplicate
+              </Badge>
+            )}
+            {batch.batch.promotedRows > 0 && (
+              <Badge>{batch.batch.promotedRows} promoted</Badge>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="overflow-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-muted/50">
+                <TableHead className="w-16">Import</TableHead>
+                <TableHead className="w-24">Date</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {batch.rows.map((row) => {
+                const promoted = row.rowStatus === "promoted"
+                const verdict = verdictOf(row)
+                return (
+                  <TableRow key={row.id}>
+                    <TableCell>
+                      <Checkbox
+                        checked={promoted ? true : verdict === "confirm"}
+                        disabled={promoted}
+                        onCheckedChange={() => onToggle(row)}
+                        aria-label="Import this row"
+                      />
+                    </TableCell>
+                    <TableCell className="text-xs whitespace-nowrap">
+                      {row.date
+                        ? new Date(row.date).toISOString().slice(0, 10)
+                        : "—"}
+                    </TableCell>
+                    <TableCell className="max-w-[220px] truncate">
+                      {row.description}
+                    </TableCell>
+                    <TableCell>
+                      <RowStatusBadges row={row} />
+                    </TableCell>
+                    <TableCell
+                      className={`text-right text-xs whitespace-nowrap ${
+                        row.type === "expense"
+                          ? "text-red-500"
+                          : "text-emerald-500"
+                      }`}
+                    >
+                      {row.amount === null
+                        ? "—"
+                        : formatMoney(
+                            BigInt(row.amount),
+                            (row.currency ?? currency) as CurrencyCode
+                          )}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" onClick={onBack} disabled={promoting}>
+            <ArrowLeft size={16} className="mr-2" />
+            Back
+          </Button>
+          <Button
+            onClick={onPromote}
+            disabled={promoting || confirmCount === 0}
+          >
+            {promoting ? (
+              <Loader2 size={16} className="mr-2 animate-spin" />
+            ) : (
+              <CheckCheck size={16} className="mr-2" />
+            )}
+            Promote {confirmCount} confirmed
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function RowStatusBadges({ row }: { row: BatchRow }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {row.rowStatus === "promoted" && <Badge>Promoted</Badge>}
+      {row.rowStatus === "duplicate" && (
+        <Badge variant="destructive" className="gap-1">
+          <CopyCheck size={11} /> Duplicate
+        </Badge>
+      )}
+      {row.possibleDuplicate && row.rowStatus !== "duplicate" && (
+        <Badge
+          variant="outline"
+          className="gap-1 border-amber-400 text-amber-600 dark:text-amber-400"
+        >
+          <CircleAlert size={11} /> Possible dup
+        </Badge>
+      )}
+      {row.suggestedCategoryId && (
+        <Badge variant="secondary" className="gap-1">
+          <Sparkles size={11} /> Auto
+        </Badge>
+      )}
+    </div>
   )
 }

--- a/src/routes/_protected/settings/rules.tsx
+++ b/src/routes/_protected/settings/rules.tsx
@@ -1,0 +1,239 @@
+import * as React from "react"
+import { createFileRoute } from "@tanstack/react-router"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { Plus, Trash2, ArrowRight, Wand2 } from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import {
+  getSmartRulesFn,
+  createSmartRuleFn,
+  deleteSmartRuleFn,
+} from "@/server/smart-rules"
+import { getTransactionFormData } from "@/server/transactions"
+
+const RULES_KEY = ["smartRules"] as const
+const NONE = "__none__"
+
+type SmartRule = Awaited<ReturnType<typeof getSmartRulesFn>>[number]
+
+export const Route = createFileRoute("/_protected/settings/rules")({
+  ssr: false,
+  staticData: { title: "Import rules" },
+  component: RulesPage,
+})
+
+function RulesPage() {
+  const queryClient = useQueryClient()
+
+  const { data: rules = [] } = useQuery({
+    queryKey: RULES_KEY,
+    queryFn: () => getSmartRulesFn(),
+  })
+  const { data: formData } = useQuery({
+    queryKey: ["transactionFormData"],
+    queryFn: () => getTransactionFormData(),
+  })
+
+  const [keyword, setKeyword] = React.useState("")
+  const [categoryId, setCategoryId] = React.useState(NONE)
+  const [merchantId, setMerchantId] = React.useState(NONE)
+
+  const createMutation = useMutation({
+    mutationFn: (data: Parameters<typeof createSmartRuleFn>[0]["data"]) =>
+      createSmartRuleFn({ data }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: RULES_KEY })
+      toast.success("Rule added.")
+      setKeyword("")
+      setCategoryId(NONE)
+      setMerchantId(NONE)
+    },
+    onError: (error) =>
+      toast.error(
+        error instanceof Error ? error.message : "Could not add rule."
+      ),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSmartRuleFn({ data: { id } }),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: RULES_KEY }),
+  })
+
+  const submit = () =>
+    createMutation.mutate({
+      keyword,
+      categoryId: categoryId === NONE ? undefined : categoryId,
+      merchantId: merchantId === NONE ? undefined : merchantId,
+    })
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider>
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-6 p-4 md:p-6 lg:p-8">
+            <header className="flex flex-col gap-2">
+              <h1 className="text-3xl font-bold tracking-tight">
+                Import rules
+              </h1>
+              <p className="text-muted-foreground">
+                Keyword rules auto-suggest a category and merchant for imported
+                transactions during review. They never promote a transaction on
+                their own.
+              </p>
+            </header>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <div className="flex items-center gap-2">
+                    <Wand2 className="text-blue-600 dark:text-blue-400" />
+                    <div>
+                      <CardTitle>Create rule</CardTitle>
+                      <CardDescription>
+                        If a description contains a keyword, suggest the chosen
+                        category and merchant.
+                      </CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <div className="space-y-2">
+                    <Label>
+                      If description contains (comma separated keywords)
+                    </Label>
+                    <Input
+                      placeholder="e.g. Starbucks, Fore, Spotify"
+                      value={keyword}
+                      onChange={(event) => setKeyword(event.target.value)}
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>Then set category</Label>
+                      <Select value={categoryId} onValueChange={setCategoryId}>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={NONE}>No category</SelectItem>
+                          {formData?.categories?.map((category) => (
+                            <SelectItem key={category.id} value={category.id}>
+                              {category.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Then set merchant</Label>
+                      <Select value={merchantId} onValueChange={setMerchantId}>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={NONE}>No merchant</SelectItem>
+                          {formData?.merchants?.map((merchant) => (
+                            <SelectItem key={merchant.id} value={merchant.id}>
+                              {merchant.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <Button
+                    onClick={submit}
+                    disabled={!keyword || createMutation.isPending}
+                  >
+                    <Plus size={16} className="mr-2" />
+                    Add rule
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Active rules ({rules.length})</CardTitle>
+                  <CardDescription>
+                    Evaluated in order; the first matching keyword wins.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-3">
+                  {rules.length === 0 && (
+                    <p className="text-sm text-muted-foreground italic">
+                      No rules configured yet.
+                    </p>
+                  )}
+                  {rules.map((rule: SmartRule) => (
+                    <div
+                      key={rule.id}
+                      className="group flex flex-col gap-2 rounded-lg border bg-card p-3 shadow-sm transition-colors hover:bg-muted/50"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-mono text-sm font-semibold text-amber-600 dark:text-amber-400">
+                          IF “{rule.keyword}”
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => deleteMutation.mutate(rule.id)}
+                          className="text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:text-destructive"
+                          aria-label="Delete rule"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <ArrowRight size={14} />
+                        {rule.category ? (
+                          <Badge variant="secondary">
+                            {rule.category.name}
+                          </Badge>
+                        ) : (
+                          <span className="italic">No category</span>
+                        )}
+                        <span>+</span>
+                        {rule.merchant ? (
+                          <Badge variant="secondary">
+                            {rule.merchant.name}
+                          </Badge>
+                        ) : (
+                          <span className="italic">No merchant</span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  )
+}

--- a/src/server/accounts.ts
+++ b/src/server/accounts.ts
@@ -103,6 +103,9 @@ export const updateAccountInputSchema = z.object({
   color: hexColorSchema.nullable().optional(),
   accountSubtype: subtypeSchema.optional(),
   institutionName: institutionNameSchema.nullable().optional(),
+  // Whether this account may receive provider/import feed data (taxonomy
+  // contract). Promotion of staged import rows requires this gate (ADR-0039 §6).
+  isImportable: z.boolean().optional(),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -373,6 +376,7 @@ export async function updateAccountForFamily({
     id: data.id,
     institutionName:
       data.institutionName === undefined ? undefined : data.institutionName,
+    isImportable: data.isImportable ?? null,
     name: data.name ?? null,
   })
   const auditCtx = await createAuditContext(
@@ -402,12 +406,16 @@ export async function updateAccountForFamily({
         accountSubtype?: string
         color?: string | null
         institutionName?: string | null
+        isImportable?: boolean
         name?: string
       } = {}
       if (data.name !== undefined) updateData.name = data.name
       if (data.color !== undefined) updateData.color = data.color
       if (data.institutionName !== undefined) {
         updateData.institutionName = data.institutionName
+      }
+      if (data.isImportable !== undefined) {
+        updateData.isImportable = data.isImportable
       }
       if (data.accountSubtype !== undefined) {
         // Re-normalize against the account's existing type so a subtype edit can

--- a/tests/e2e/import.e2e.ts
+++ b/tests/e2e/import.e2e.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-151 — the CSV import wizard drives the real browser → server-fn → staging
+// → promotion path that the integration suite (PER-82) exercises headlessly.
+// This proves the wizard actually stages a parsed CSV, previews it, and promotes
+// confirmed rows into the canonical ledger so they show up on /transactions.
+
+const IMPORT_CSV = [
+  "Date,Description,Amount",
+  "2026-01-15,E2E CSV Coffee,-15000",
+  "2026-01-16,E2E CSV Salary,2500000",
+  "",
+].join("\n")
+
+test.describe("CSV import wizard", () => {
+  test("enable imports on an account, then upload → preview → promote", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    // 1. Mark the starter account importable (the promotion gate, ADR-0039 §6).
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "Edit account" }).first().click()
+    await page.getByLabel("Allow imports").click()
+    await page.getByRole("button", { name: "Save changes" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // 2. Open the wizard and upload a generic CSV (preset defaults match it).
+    await page.goto("/import")
+    await waitForHydration(page)
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "statement.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(IMPORT_CSV),
+    })
+
+    // 3. Map step: choose the target account; the client preview should resolve.
+    await page
+      .getByRole("combobox")
+      .filter({ hasText: "Select account" })
+      .click()
+    await page.getByRole("option", { name: /Everyday Cash/ }).click()
+    await expect(page.getByText("2 ready", { exact: false })).toBeVisible()
+
+    await page.getByRole("button", { name: /Stage & preview/ }).click()
+
+    // 4. Preview step: both rows confirmed by default → promote.
+    await expect(page.getByText("Review & promote")).toBeVisible()
+    await page.getByRole("button", { name: /Promote 2 confirmed/ }).click()
+
+    // 5. Promotion lands the rows in the canonical ledger.
+    await expect(page).toHaveURL(/\/transactions(?:\?.*)?$/)
+    await waitForHydration(page)
+    await expect(page.getByText("E2E CSV Coffee")).toBeVisible()
+    await expect(page.getByText("E2E CSV Salary")).toBeVisible()
+  })
+})


### PR DESCRIPTION
## PER-151 — P4 CSV import wizard

Builds the self-serve CSV/QIF import wizard on top of the PER-82 / ADR-0039 staging contract. Replaces the old `/import` page that bypassed staging and wrote straight to the ledger.

**Flow:** upload → map columns (presets: generic / Mint / YNAB, or QIF) → pick one target account → server staging + deduplication preview → review (clean = confirm, exact-duplicate = reject) → promote confirmed rows into the canonical ledger.

The wizard only calls the existing four import server fns (`createImportBatchFn` → `getImportBatchFn` → `reviewImportRowsFn` → `promoteImportBatchFn`). **No server staging/promotion/ledger logic was changed** — all money invariants (dedup, idempotency, atomic balance, audit, RLS, FX projection) stay server-side per ADR-0039.

### What's here
- **ADR-0040** — CSV/QIF parser & wizard contract (three-mode amount model `signed`/`split`/`typed`, explicit date-format set, presets, QIF separate parser, review default verdicts). Builds on ADR-0039.
- **`src/lib/csv-import.ts`** — pure, DB-free parser/mapper + **22 unit tests**. Amounts parsed via the canonical currency-aware `parseUserInput` → absolute minor units; dates parsed under an explicit format (no silent month/day guessing); error rows surfaced, never silently dropped.
- **`/import`** rewritten as the staged wizard; **Smart Rules CRUD relocated to `/settings/rules`** (rules now surface as server-side preview suggestions).
- **`isImportable` toggle** added to the account update path + edit UI — the ADR-0039 promotion gate previously had no user-facing enable path, so the wizard's target-account list would always be empty.
- **`tests/e2e/import.e2e.ts`** — enable imports on an account → upload CSV → preview → promote → rows appear on `/transactions`.

### Decisions (grilled up-front)
- Smart Rules panel → relocated to `/settings/rules`.
- QIF → in-scope as a separate parser to the same `StagedRowInput` seam.
- One target account per file (per-row multi-account mapping reserved for PER-163).
- Three-mode amount model; explicit date format; clean=confirm / exact-dup=reject defaults.

### Verification
- `vp run check` ✅ (format, lint, types, no-use-effect, security)
- `vp test run` ✅ 334 tests
- `vp build` ✅ (no client-bundle prisma leak)
- E2E: spec written; the app server boots and serves, but Playwright Chromium can't launch locally (missing system libs `libnspr4`/`libnss3`). **Relying on CI for the e2e + real-Postgres integration run.**

Server-side promotion parity / idempotent replay / tenant isolation are covered by PER-82's real-Postgres integration suite, which this PR calls unchanged.

Refs PER-151. Blocked-by PER-82 + PER-143 (both merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)