### PR TITLE
feat(settings): PER-113 (Phase 1) — settings hub + navigation cohesion

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { Link } from "@tanstack/react-router"
 import {
   IconChartBar,
   IconCoin,
@@ -12,7 +13,7 @@ import {
   IconFileSpreadsheet,
 } from "@tabler/icons-react"
 
-import { NavMain } from "@/components/nav-main"
+import { NavMain, type NavItem } from "@/components/nav-main"
 import { NavSecondary } from "@/components/nav-secondary"
 import { NavUser } from "@/components/nav-user"
 import {
@@ -26,7 +27,11 @@ import {
 } from "@/components/ui/sidebar"
 
 // Kita ubah data navigasinya khusus untuk Permoney
-const data = {
+const data: {
+  user: { name: string; email: string; avatar: string }
+  navMain: NavItem[]
+  navSecondary: NavItem[]
+} = {
   user: {
     name: "Hendri Permana",
     email: "hendripermana13@gmail.com",
@@ -66,13 +71,13 @@ const data = {
   ],
   navSecondary: [
     {
-      title: "Family Space",
-      url: "#",
+      title: "Members",
+      url: "/settings/members",
       icon: IconUsers,
     },
     {
       title: "Settings",
-      url: "#",
+      url: "/settings",
       icon: IconSettings,
     },
   ],
@@ -88,14 +93,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               asChild
               className="data-[slot=sidebar-menu-button]:p-1.5!"
             >
-              <a href="/dashboard">
+              <Link to="/dashboard">
                 <div className="flex aspect-square size-6 items-center justify-center rounded-lg bg-yellow-500 text-black">
                   <span className="text-lg font-bold">🍯</span>
                 </div>
                 <span className="text-base font-bold tracking-tight">
                   Permoney
                 </span>
-              </a>
+              </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { Link, type LinkProps } from "@tanstack/react-router"
+import type { Icon } from "@tabler/icons-react"
+
 import {
   SidebarGroup,
   SidebarGroupLabel,
@@ -8,15 +11,13 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
 
-export function NavMain({
-  items,
-}: {
-  items: {
-    title: string
-    url: string
-    icon: any
-  }[]
-}) {
+export interface NavItem {
+  title: string
+  url: LinkProps["to"]
+  icon: Icon
+}
+
+export function NavMain({ items }: { items: NavItem[] }) {
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Menu Utama</SidebarGroupLabel>
@@ -24,11 +25,12 @@ export function NavMain({
         {items.map((item) => (
           <SidebarMenuItem key={item.title}>
             <SidebarMenuButton asChild tooltip={item.title}>
-              <a href={item.url}>
-                {/* Ini adalah kunci perbaikannya: Ikon dipanggil sebagai komponen JSX */}
+              {/* TanStack <Link> keeps navigation client-side: no full reload,
+                  so ssr:false + TanStack DB routes never re-boot on each click. */}
+              <Link to={item.url} activeProps={{ "data-active": "true" }}>
                 {item.icon && <item.icon className="size-5" />}
                 <span className="font-medium">{item.title}</span>
-              </a>
+              </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
         ))}

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import * as React from "react"
+import { Link } from "@tanstack/react-router"
+
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -8,16 +10,13 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import type { NavItem } from "@/components/nav-main"
 
 export function NavSecondary({
   items,
   ...props
 }: React.ComponentPropsWithoutRef<typeof SidebarGroup> & {
-  items: {
-    title: string
-    url: string
-    icon: any
-  }[]
+  items: NavItem[]
 }) {
   return (
     <SidebarGroup {...props}>
@@ -26,10 +25,10 @@ export function NavSecondary({
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
               <SidebarMenuButton asChild size="sm">
-                <a href={item.url}>
+                <Link to={item.url} activeProps={{ "data-active": "true" }}>
                   {item.icon && <item.icon className="size-4" />}
                   <span>{item.title}</span>
-                </a>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   type ErrorComponentProps,
 } from "@tanstack/react-router"
 import { QueryClientProvider } from "@tanstack/react-query"
+import { ThemeProvider } from "next-themes"
 import { getQueryClient } from "@/lib/query-client"
 import { Button } from "@/components/ui/button"
 import { useMountEffect } from "@/hooks/use-mount-effect"
@@ -116,12 +117,22 @@ function RootComponent() {
     <RootDocument>
       {/* 3. BUNGKUS APLIKASIMU DENGAN PROVIDER */}
       <QueryClientProvider client={queryClient}>
-        <Outlet />
-        {/* Render lazy devtools hanya di dev environment */}
-        <React.Suspense fallback={null}>
-          {/* <TanStackRouterDevtools position="bottom-right" /> */}
-          <ReactQueryDevtools />
-        </React.Suspense>
+        {/* next-themes drives the `.dark` class on <html>; the user's persisted
+            choice (User.theme) is restored client-side via the profile pane.
+            <html> already carries suppressHydrationWarning for this. */}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <Outlet />
+          {/* Render lazy devtools hanya di dev environment */}
+          <React.Suspense fallback={null}>
+            {/* <TanStackRouterDevtools position="bottom-right" /> */}
+            <ReactQueryDevtools />
+          </React.Suspense>
+        </ThemeProvider>
       </QueryClientProvider>
     </RootDocument>
   )

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { QueryClientProvider } from "@tanstack/react-query"
 import { ThemeProvider } from "next-themes"
 import { getQueryClient } from "@/lib/query-client"
 import { Button } from "@/components/ui/button"
+import { Toaster } from "@/components/ui/sonner"
 import { useMountEffect } from "@/hooks/use-mount-effect"
 
 import appCss from "../styles.css?url"
@@ -127,6 +128,10 @@ function RootComponent() {
           disableTransitionOnChange
         >
           <Outlet />
+          {/* Single global toast outlet. Without this mounted, every
+              toast.success/error across the app (import, smart rules, settings)
+              is a silent no-op. */}
+          <Toaster richColors closeButton />
           {/* Render lazy devtools hanya di dev environment */}
           <React.Suspense fallback={null}>
             {/* <TanStackRouterDevtools position="bottom-right" /> */}

--- a/src/routes/_protected/settings/family.tsx
+++ b/src/routes/_protected/settings/family.tsx
@@ -1,0 +1,216 @@
+import * as React from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { Globe2, ArrowRight } from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  getSettingsOverviewFn,
+  updateFamilyPreferencesFn,
+} from "@/server/settings"
+import { SETTINGS_OVERVIEW_KEY } from "./index"
+
+export const Route = createFileRoute("/_protected/settings/family")({
+  ssr: false,
+  staticData: { title: "Family preferences" },
+  component: FamilyPreferencesPage,
+})
+
+// A curated shortlist for the dropdown. The server accepts any valid IANA zone,
+// and the caller's current zone is always merged in below so a value chosen
+// elsewhere never disappears from the list.
+const COMMON_TIMEZONES = [
+  "Asia/Jakarta",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Australia/Sydney",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "America/New_York",
+  "America/Chicago",
+  "America/Los_Angeles",
+  "UTC",
+] as const
+
+function FamilyPreferencesPage() {
+  const queryClient = useQueryClient()
+  const { data: overview, isLoading } = useQuery({
+    queryKey: SETTINGS_OVERVIEW_KEY,
+    queryFn: async () => await getSettingsOverviewFn(),
+  })
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider
+        style={
+          {
+            "--sidebar-width": "calc(var(--spacing) * 72)",
+          } as React.CSSProperties
+        }
+      >
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+            <div className="flex items-center gap-3">
+              <Globe2 className="size-6 text-yellow-500" aria-hidden />
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Family preferences
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Workspace-wide settings that apply to every member.
+                </p>
+              </div>
+            </div>
+
+            <BaseCurrencyCard currency={overview?.family.currency ?? "—"} />
+            <TimezoneCard
+              key={overview?.family.timezone}
+              timezone={overview?.family.timezone}
+              isLoading={isLoading}
+              onSaved={() =>
+                queryClient.invalidateQueries({
+                  queryKey: SETTINGS_OVERVIEW_KEY,
+                })
+              }
+            />
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  )
+}
+
+function BaseCurrencyCard({ currency }: { currency: string }) {
+  // ADR-0035: the base reporting currency is fixed at onboarding — it anchors
+  // every historical report and the materialized base projection, so it is
+  // intentionally read-only here. Rate management lives under Currencies & FX.
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Base reporting currency</CardTitle>
+        <CardDescription>
+          Every report is normalized to this currency. It was set when your
+          workspace was created and is fixed for the life of the ledger.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="rounded-md border bg-muted px-3 py-1.5 font-mono text-lg font-semibold">
+            {currency}
+          </span>
+          <span className="text-sm text-muted-foreground">
+            Set at onboarding · locked
+          </span>
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/currencies">
+            Manage exchange rates
+            <ArrowRight className="size-4" aria-hidden />
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}
+
+function TimezoneCard({
+  timezone,
+  isLoading,
+  onSaved,
+}: {
+  timezone: string | undefined
+  isLoading: boolean
+  onSaved: () => void
+}) {
+  // Initialized once from the server value (the `key` on this component resets
+  // state whenever the persisted timezone changes), so no effect-based sync.
+  const [selected, setSelected] = React.useState(timezone ?? "")
+
+  const options = React.useMemo(() => {
+    const set = new Set<string>(COMMON_TIMEZONES)
+    if (timezone) set.add(timezone)
+    if (selected) set.add(selected)
+    return Array.from(set).sort()
+  }, [timezone, selected])
+
+  const mutation = useMutation({
+    mutationFn: async () =>
+      await updateFamilyPreferencesFn({ data: { timezone: selected } }),
+    onSuccess: () => {
+      toast.success("Timezone updated.")
+      onSaved()
+    },
+    onError: (error) => toast.error((error as Error).message),
+  })
+
+  const dirty = selected !== "" && selected !== timezone
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Regional timezone</CardTitle>
+        <CardDescription>
+          Used to align reporting periods and day boundaries for the whole
+          workspace.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid max-w-sm gap-1.5">
+          <Label htmlFor="timezone">Timezone</Label>
+          <Select
+            value={selected}
+            onValueChange={setSelected}
+            disabled={isLoading || mutation.isPending}
+          >
+            <SelectTrigger id="timezone">
+              <SelectValue placeholder="Select a timezone" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((zone) => (
+                <SelectItem key={zone} value={zone}>
+                  {zone}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={!dirty || mutation.isPending}
+        >
+          {mutation.isPending ? "Saving…" : "Save timezone"}
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/routes/_protected/settings/family.tsx
+++ b/src/routes/_protected/settings/family.tsx
@@ -158,7 +158,7 @@ function TimezoneCard({
     const set = new Set<string>(COMMON_TIMEZONES)
     if (timezone) set.add(timezone)
     if (selected) set.add(selected)
-    return Array.from(set).sort()
+    return Array.from(set).sort((a, b) => a.localeCompare(b))
   }, [timezone, selected])
 
   const mutation = useMutation({

--- a/src/routes/_protected/settings/index.tsx
+++ b/src/routes/_protected/settings/index.tsx
@@ -1,0 +1,185 @@
+import * as React from "react"
+import { createFileRoute, Link, type LinkProps } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import {
+  Settings as SettingsIcon,
+  Globe2,
+  UserCircle2,
+  Users,
+  Wand2,
+  Coins,
+  FileSpreadsheet,
+  ChevronRight,
+  type LucideIcon,
+} from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { getSettingsOverviewFn } from "@/server/settings"
+
+export const SETTINGS_OVERVIEW_KEY = ["settings-overview"] as const
+
+export const Route = createFileRoute("/_protected/settings/")({
+  ssr: false,
+  staticData: { title: "Settings" },
+  component: SettingsHubPage,
+})
+
+interface SettingsLink {
+  title: string
+  description: string
+  to: LinkProps["to"]
+  icon: LucideIcon
+  badge?: string
+}
+
+const FAMILY_LINKS: SettingsLink[] = [
+  {
+    title: "Family preferences",
+    description: "Base reporting currency and regional timezone.",
+    to: "/settings/family",
+    icon: Globe2,
+  },
+  {
+    title: "Members",
+    description: "Invite family members and manage their roles.",
+    to: "/settings/members",
+    icon: Users,
+  },
+  {
+    title: "Smart rules",
+    description: "Keyword rules that auto-categorize imported transactions.",
+    to: "/settings/rules",
+    icon: Wand2,
+  },
+]
+
+const PERSONAL_LINKS: SettingsLink[] = [
+  {
+    title: "Profile & appearance",
+    description: "Your display name and light / dark / system theme.",
+    to: "/settings/profile",
+    icon: UserCircle2,
+  },
+]
+
+const RELATED_LINKS: SettingsLink[] = [
+  {
+    title: "Currencies & FX",
+    description: "Manage exchange-rate snapshots used for base reporting.",
+    to: "/currencies",
+    icon: Coins,
+  },
+  {
+    title: "Smart Import",
+    description: "Import CSV / QIF statements and review staged rows.",
+    to: "/import",
+    icon: FileSpreadsheet,
+  },
+]
+
+function SettingsHubPage() {
+  const { data: overview } = useQuery({
+    queryKey: SETTINGS_OVERVIEW_KEY,
+    queryFn: async () => await getSettingsOverviewFn(),
+  })
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider
+        style={
+          {
+            "--sidebar-width": "calc(var(--spacing) * 72)",
+          } as React.CSSProperties
+        }
+      >
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+            <div className="flex items-center gap-3">
+              <SettingsIcon className="size-6 text-yellow-500" aria-hidden />
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Settings
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Workspace preferences, your profile, and the tools that keep
+                  your ledger tidy.
+                  {overview ? (
+                    <>
+                      {" "}
+                      Reporting in{" "}
+                      <span className="font-medium text-foreground">
+                        {overview.family.currency}
+                      </span>{" "}
+                      · {overview.family.timezone}.
+                    </>
+                  ) : null}
+                </p>
+              </div>
+            </div>
+
+            <SettingsSection title="Family workspace" links={FAMILY_LINKS} />
+            <SettingsSection title="Your account" links={PERSONAL_LINKS} />
+            <SettingsSection title="Related tools" links={RELATED_LINKS} />
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  )
+}
+
+function SettingsSection({
+  title,
+  links,
+}: {
+  title: string
+  links: SettingsLink[]
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-sm font-medium text-muted-foreground">{title}</h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {links.map((link) => (
+          <SettingsCard key={link.title} link={link} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function SettingsCard({ link }: { link: SettingsLink }) {
+  const Icon = link.icon
+  return (
+    <Link to={link.to} className="group">
+      <Card
+        className={cn(
+          "h-full transition-transform",
+          "hover:scale-[1.02] hover:border-primary/40"
+        )}
+      >
+        <CardHeader>
+          <div className="flex items-start justify-between gap-2">
+            <Icon className="size-5 text-yellow-500" aria-hidden />
+            <ChevronRight
+              className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </div>
+          <CardTitle className="text-base">{link.title}</CardTitle>
+          <CardDescription>{link.description}</CardDescription>
+        </CardHeader>
+      </Card>
+    </Link>
+  )
+}

--- a/src/routes/_protected/settings/profile.tsx
+++ b/src/routes/_protected/settings/profile.tsx
@@ -1,0 +1,203 @@
+import * as React from "react"
+import { createFileRoute } from "@tanstack/react-router"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useTheme } from "next-themes"
+import { toast } from "sonner"
+import { UserCircle2, Sun, Moon, Monitor } from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+import {
+  getSettingsOverviewFn,
+  updateProfileFn,
+  type Theme,
+} from "@/server/settings"
+import { SETTINGS_OVERVIEW_KEY } from "./index"
+
+export const Route = createFileRoute("/_protected/settings/profile")({
+  ssr: false,
+  staticData: { title: "Profile" },
+  component: ProfilePage,
+})
+
+function ProfilePage() {
+  const queryClient = useQueryClient()
+  const { data: overview, isLoading } = useQuery({
+    queryKey: SETTINGS_OVERVIEW_KEY,
+    queryFn: async () => await getSettingsOverviewFn(),
+  })
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider
+        style={
+          {
+            "--sidebar-width": "calc(var(--spacing) * 72)",
+          } as React.CSSProperties
+        }
+      >
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+            <div className="flex items-center gap-3">
+              <UserCircle2 className="size-6 text-yellow-500" aria-hidden />
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Profile &amp; appearance
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Your display name and how Permoney looks on this device.
+                </p>
+              </div>
+            </div>
+
+            <ProfileCard
+              key={`${overview?.profile.name}:${overview?.profile.theme}`}
+              name={overview?.profile.name}
+              email={overview?.profile.email ?? "—"}
+              persistedTheme={overview?.profile.theme}
+              isLoading={isLoading}
+              onSaved={() =>
+                queryClient.invalidateQueries({
+                  queryKey: SETTINGS_OVERVIEW_KEY,
+                })
+              }
+            />
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  )
+}
+
+const THEME_OPTIONS: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+]
+
+function ProfileCard({
+  name,
+  email,
+  persistedTheme,
+  isLoading,
+  onSaved,
+}: {
+  name: string | undefined
+  email: string
+  persistedTheme: Theme | undefined
+  isLoading: boolean
+  onSaved: () => void
+}) {
+  const { setTheme } = useTheme()
+  // Seeded once from the server (the `key` on this component resets it whenever
+  // the persisted values change). next-themes owns the live DOM class; this
+  // local state is the not-yet-saved selection persisted to User.theme.
+  const [displayName, setDisplayName] = React.useState(name ?? "")
+  const [theme, setLocalTheme] = React.useState<Theme>(
+    persistedTheme ?? "system"
+  )
+
+  const mutation = useMutation({
+    mutationFn: async () =>
+      await updateProfileFn({ data: { name: displayName.trim(), theme } }),
+    onSuccess: () => {
+      toast.success("Profile updated.")
+      onSaved()
+    },
+    onError: (error) => toast.error((error as Error).message),
+  })
+
+  const dirty =
+    displayName.trim() !== "" &&
+    (displayName.trim() !== (name ?? "") || theme !== persistedTheme)
+
+  // Apply the theme to the DOM immediately for instant preview; the durable
+  // write to User.theme happens on Save.
+  const chooseTheme = (next: Theme) => {
+    setLocalTheme(next)
+    setTheme(next)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Your profile</CardTitle>
+        <CardDescription>
+          Visible to other members of your family workspace.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <div className="grid max-w-sm gap-1.5">
+          <Label htmlFor="display-name">Display name</Label>
+          <Input
+            id="display-name"
+            value={displayName}
+            maxLength={120}
+            disabled={isLoading || mutation.isPending}
+            onChange={(event) => setDisplayName(event.target.value)}
+          />
+        </div>
+        <div className="grid max-w-sm gap-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            value={email}
+            readOnly
+            aria-readonly
+            tabIndex={-1}
+            className="text-muted-foreground"
+          />
+          <p className="text-xs text-muted-foreground">
+            Email changes require verification (coming soon).
+          </p>
+        </div>
+        <div className="grid gap-1.5">
+          <Label>Theme</Label>
+          <div className="flex flex-wrap gap-2">
+            {THEME_OPTIONS.map((option) => {
+              const Icon = option.icon
+              const active = theme === option.value
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={active ? "default" : "outline"}
+                  size="sm"
+                  className={cn(active && "ring-2 ring-primary/40")}
+                  onClick={() => chooseTheme(option.value)}
+                >
+                  <Icon className="size-4" aria-hidden />
+                  {option.label}
+                </Button>
+              )
+            })}
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={!dirty || mutation.isPending}
+        >
+          {mutation.isPending ? "Saving…" : "Save changes"}
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,0 +1,225 @@
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { auditLog, createAuditContext } from "./middleware/audit"
+import {
+  familyMiddleware,
+  requireCapability,
+  scopedTenantTransaction,
+} from "./middleware/with-family"
+
+// =============================================================================
+// PER-113 — Settings hub: family preferences + profile/theme (Phase 1).
+//
+// These are settings-grade mutations, not balance-affecting ledger writes, but
+// they obey the same durable invariants the project mandates for every
+// mutation: an interactive tenant transaction (app.family_id + app.user_id GUCs
+// drive RLS, including the AuditLog insert policy), tenant-scoped writes, and an
+// append-only `AuditLog` row in the SAME transaction. They are naturally
+// idempotent (last-write-wins on a scalar field), so they do not need the
+// `IdempotencyRecord` replay machinery the ledger mutations use.
+//
+// Base reporting currency is deliberately NOT editable here: ADR-0035 fixes
+// `Family.currency` for the life of the ledger (it anchors every historical
+// report and the materialized base projection). The family pane shows it
+// read-only and links to /currencies; never add a base-currency mutation to the
+// settings surface.
+// =============================================================================
+
+// `Intl.DateTimeFormat` throws a RangeError for an unknown IANA zone, so this is
+// the most runtime-portable validation (no hard-coded zone list to rot).
+function isValidTimeZone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: value })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const THEME_VALUES = ["light", "dark", "system"] as const
+export type Theme = (typeof THEME_VALUES)[number]
+
+const updateFamilyPreferencesInputSchema = z.object({
+  timezone: z
+    .string()
+    .trim()
+    .min(1, "Timezone is required")
+    .refine(isValidTimeZone, "Unknown IANA timezone"),
+})
+export type UpdateFamilyPreferencesInput = z.infer<
+  typeof updateFamilyPreferencesInputSchema
+>
+
+const updateProfileInputSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(120),
+  theme: z.enum(THEME_VALUES),
+})
+export type UpdateProfileInput = z.infer<typeof updateProfileInputSchema>
+
+export interface FamilyPreferences {
+  currency: string
+  timezone: string
+}
+export interface ProfilePreferences {
+  name: string
+  email: string
+  theme: Theme
+}
+export interface SettingsOverview {
+  family: FamilyPreferences
+  profile: ProfilePreferences
+}
+
+// ---------------------------------------------------------------------------
+// Domain helpers (test-injectable tenant runner, exactly like family-members).
+// ---------------------------------------------------------------------------
+
+export async function readSettingsOverviewForFamily({
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  familyId: string
+  userId: string
+  runInTenantTransaction?: typeof scopedTenantTransaction
+}): Promise<SettingsOverview> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const family = await tx.family.findUniqueOrThrow({
+      where: { id: familyId },
+      select: { currency: true, timezone: true },
+    })
+    const user = await tx.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { name: true, email: true, theme: true },
+    })
+    return {
+      family: { currency: family.currency, timezone: family.timezone },
+      profile: {
+        name: user.name,
+        email: user.email,
+        theme: normalizeTheme(user.theme),
+      },
+    }
+  })
+}
+
+export async function updateFamilyPreferencesForFamily({
+  data: rawData,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: UpdateFamilyPreferencesInput
+  familyId: string
+  userId: string
+  runInTenantTransaction?: typeof scopedTenantTransaction
+}): Promise<FamilyPreferences> {
+  const data = updateFamilyPreferencesInputSchema.parse(rawData)
+  const auditCtx = await createAuditContext({ user: { id: userId, familyId } })
+
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const before = await tx.family.findUniqueOrThrow({
+      where: { id: familyId },
+      select: { currency: true, timezone: true },
+    })
+    const after = await tx.family.update({
+      where: { id: familyId },
+      data: { timezone: data.timezone },
+      select: { currency: true, timezone: true },
+    })
+    await auditLog(tx, auditCtx, {
+      action: "update",
+      entityType: "Family",
+      entityId: familyId,
+      before: { timezone: before.timezone },
+      after: { timezone: after.timezone },
+    })
+    return { currency: after.currency, timezone: after.timezone }
+  })
+}
+
+export async function updateProfileForUser({
+  data: rawData,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: UpdateProfileInput
+  familyId: string
+  userId: string
+  runInTenantTransaction?: typeof scopedTenantTransaction
+}): Promise<ProfilePreferences> {
+  const data = updateProfileInputSchema.parse(rawData)
+  const auditCtx = await createAuditContext({ user: { id: userId, familyId } })
+
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const before = await tx.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { name: true, email: true, theme: true },
+    })
+    const after = await tx.user.update({
+      where: { id: userId },
+      data: { name: data.name, theme: data.theme },
+      select: { name: true, email: true, theme: true },
+    })
+    await auditLog(tx, auditCtx, {
+      action: "update",
+      entityType: "User",
+      entityId: userId,
+      before: { name: before.name, theme: normalizeTheme(before.theme) },
+      after: { name: after.name, theme: normalizeTheme(after.theme) },
+    })
+    return {
+      name: after.name,
+      email: after.email,
+      theme: normalizeTheme(after.theme),
+    }
+  })
+}
+
+// Persisted theme is a free-form String column; coerce any legacy/unknown value
+// back to the safe "system" default so the client never receives a junk theme.
+function normalizeTheme(value: string): Theme {
+  return (THEME_VALUES as readonly string[]).includes(value)
+    ? (value as Theme)
+    : "system"
+}
+
+// ---------------------------------------------------------------------------
+// Server functions.
+// ---------------------------------------------------------------------------
+
+export const getSettingsOverviewFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .handler(async ({ context }) => {
+    return await readSettingsOverviewForFamily({
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+export const updateFamilyPreferencesFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("settings:write")])
+  .inputValidator((data: UpdateFamilyPreferencesInput) =>
+    updateFamilyPreferencesInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await updateFamilyPreferencesForFamily({
+      data,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+export const updateProfileFn = createServerFn({ method: "POST" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: UpdateProfileInput) =>
+    updateProfileInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await updateProfileForUser({
+      data,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })

--- a/tests/e2e/settings.e2e.ts
+++ b/tests/e2e/settings.e2e.ts
@@ -44,8 +44,11 @@ test.describe("settings hub & nav cohesion", () => {
       .first()
       .click()
     await expect(page).toHaveURL(/\/settings\/members$/)
+    // "Family members" is both the site-header title and the page's own h1
+    // (header first in DOM order), so target the page heading with .last() to
+    // avoid a strict-mode double match.
     await expect(
-      page.getByRole("heading", { name: "Family members" })
+      page.getByRole("heading", { name: "Family members" }).last()
     ).toBeVisible()
 
     await page.goto("/settings")

--- a/tests/e2e/settings.e2e.ts
+++ b/tests/e2e/settings.e2e.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-113 — Settings hub + navigation cohesion. Drives the real browser path:
+//   * the sidebar "Settings" link is a TanStack <Link>, so clicking it performs
+//     an in-app (no full reload) navigation — proven by a window sentinel that
+//     survives the click;
+//   * the previously-orphaned Members and Smart Rules panes are reachable from
+//     the hub;
+//   * theme + family-timezone preferences round-trip through the server fns.
+
+test.describe("settings hub & nav cohesion", () => {
+  test("reaches /settings from the sidebar without a full reload", async ({
+    page,
+  }) => {
+    await onboard(page)
+    await page.goto("/dashboard")
+    await waitForHydration(page)
+
+    // Sentinel on the live window. A full page reload would wipe it; an SPA
+    // navigation keeps it. This is the architectural assertion of this ticket.
+    await page.evaluate(() => {
+      ;(window as unknown as { __permoneySpa?: boolean }).__permoneySpa = true
+    })
+
+    await page.getByRole("link", { name: "Settings" }).click()
+    await expect(page).toHaveURL(/\/settings$/)
+
+    const survived = await page.evaluate(
+      () => (window as unknown as { __permoneySpa?: boolean }).__permoneySpa
+    )
+    expect(survived).toBe(true)
+  })
+
+  test("opens the Members and Smart Rules panes from the hub", async ({
+    page,
+  }) => {
+    await onboard(page)
+    await page.goto("/settings")
+    await waitForHydration(page)
+
+    await page
+      .getByRole("link", { name: /Members/ })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/settings\/members$/)
+    await expect(
+      page.getByRole("heading", { name: "Family members" })
+    ).toBeVisible()
+
+    await page.goto("/settings")
+    await waitForHydration(page)
+    await page
+      .getByRole("link", { name: /Smart rules/ })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/settings\/rules$/)
+  })
+
+  test("changes the theme to dark and persists it", async ({ page }) => {
+    await onboard(page)
+    await page.goto("/settings/profile")
+    await waitForHydration(page)
+
+    await page.getByRole("button", { name: "Dark" }).click()
+    await expect(page.locator("html")).toHaveClass(/dark/)
+
+    await page.getByRole("button", { name: "Save changes" }).click()
+    await expect(page.getByText("Profile updated.")).toBeVisible()
+  })
+
+  test("changes the family timezone", async ({ page }) => {
+    await onboard(page)
+    await page.goto("/settings/family")
+    await waitForHydration(page)
+
+    await page.getByRole("combobox", { name: "Timezone" }).click()
+    await page.getByRole("option", { name: "UTC" }).click()
+    await page.getByRole("button", { name: "Save timezone" }).click()
+    await expect(page.getByText("Timezone updated.")).toBeVisible()
+  })
+})

--- a/tests/integration/settings.integration.ts
+++ b/tests/integration/settings.integration.ts
@@ -1,0 +1,196 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import {
+  readSettingsOverviewForFamily,
+  updateFamilyPreferencesForFamily,
+  updateProfileForUser,
+} from "@/server/settings"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+// PER-113 — Real-Postgres proof of the settings mutations: family preference
+// (timezone) and profile/theme writes go through a tenant transaction, persist,
+// write an audit row in the same tx, and stay tenant-isolated.
+
+describe("settings mutations (PER-113)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // Inject the harness tenant runner so the domain fns run with both GUCs set to
+  // the acting member — exactly what familyMiddleware would do in production.
+  const runner = (actorId: string) => {
+    return <T>(
+      familyId: string,
+      userId: string,
+      fn: Parameters<typeof harness.withMember>[2]
+    ) => {
+      expect(userId).toBe(actorId)
+      return harness.withMember(familyId, userId, fn) as Promise<T>
+    }
+  }
+
+  test("updates family timezone, persists it, and writes an audit row", async () => {
+    const family = await factories.createFamily()
+    const user = await factories.createUser({ familyId: family.id })
+    await factories.createFamilyMember({
+      familyId: family.id,
+      userId: user.id,
+      role: "owner",
+    })
+
+    const result = await updateFamilyPreferencesForFamily({
+      data: { timezone: "America/New_York" },
+      familyId: family.id,
+      userId: user.id,
+      runInTenantTransaction: runner(user.id),
+    })
+    expect(result.timezone).toBe("America/New_York")
+
+    const persisted = await harness.prisma.family.findUniqueOrThrow({
+      where: { id: family.id },
+      select: { timezone: true },
+    })
+    expect(persisted.timezone).toBe("America/New_York")
+
+    // AuditLog SELECT is membership-gated by RLS, so it must be read inside a
+    // tenant transaction (GUCs set), never via the bare GUC-less client.
+    const audit = await harness.withFamily(family.id, (tx) =>
+      tx.auditLog.findFirst({
+        where: {
+          familyId: family.id,
+          entityType: "Family",
+          entityId: family.id,
+        },
+        orderBy: { createdAt: "desc" },
+      })
+    )
+    expect(audit).not.toBeNull()
+    expect(audit?.action).toBe("update")
+    expect(audit?.afterJson).toMatchObject({ timezone: "America/New_York" })
+  })
+
+  test("rejects an unknown IANA timezone", async () => {
+    const family = await factories.createFamily()
+    const user = await factories.createUser({ familyId: family.id })
+    await factories.createFamilyMember({
+      familyId: family.id,
+      userId: user.id,
+      role: "owner",
+    })
+
+    await expect(
+      updateFamilyPreferencesForFamily({
+        data: { timezone: "Mars/Phobos" },
+        familyId: family.id,
+        userId: user.id,
+        runInTenantTransaction: runner(user.id),
+      })
+    ).rejects.toThrow()
+  })
+
+  test("updates profile name + theme and audits the change", async () => {
+    const family = await factories.createFamily()
+    const user = await factories.createUser({ familyId: family.id })
+    await factories.createFamilyMember({
+      familyId: family.id,
+      userId: user.id,
+      role: "member",
+    })
+
+    const result = await updateProfileForUser({
+      data: { name: "Renamed Person", theme: "dark" },
+      familyId: family.id,
+      userId: user.id,
+      runInTenantTransaction: runner(user.id),
+    })
+    expect(result.name).toBe("Renamed Person")
+    expect(result.theme).toBe("dark")
+
+    const persisted = await harness.prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+      select: { name: true, theme: true },
+    })
+    expect(persisted).toMatchObject({ name: "Renamed Person", theme: "dark" })
+
+    const overview = await readSettingsOverviewForFamily({
+      familyId: family.id,
+      userId: user.id,
+      runInTenantTransaction: runner(user.id),
+    })
+    expect(overview.profile.name).toBe("Renamed Person")
+    expect(overview.profile.theme).toBe("dark")
+    expect(overview.family.timezone).toBe(family.timezone)
+
+    // This user is a plain member (no owner), so read as the explicit member —
+    // withFamily would resolve a non-existent owner and fail the membership GUC.
+    const audit = await harness.withMember(family.id, user.id, (tx) =>
+      tx.auditLog.findFirst({
+        where: { familyId: family.id, entityType: "User", entityId: user.id },
+        orderBy: { createdAt: "desc" },
+      })
+    )
+    expect(audit?.afterJson).toMatchObject({
+      name: "Renamed Person",
+      theme: "dark",
+    })
+  })
+
+  test("a member of family B cannot update family A's preferences (RLS)", async () => {
+    const familyA = await factories.createFamily()
+    const ownerA = await factories.createUser({ familyId: familyA.id })
+    await factories.createFamilyMember({
+      familyId: familyA.id,
+      userId: ownerA.id,
+      role: "owner",
+    })
+
+    const familyB = await factories.createFamily()
+    const ownerB = await factories.createUser({ familyId: familyB.id })
+    await factories.createFamilyMember({
+      familyId: familyB.id,
+      userId: ownerB.id,
+      role: "owner",
+    })
+
+    // ownerB acting with family A's id: the RLS membership guard runs the write
+    // under app.user_id=ownerB / app.family_id=familyA, where ownerB is not a
+    // member — the Family update affects zero rows, so findUniqueOrThrow on the
+    // pre-image (or the update) fails and nothing in family A changes.
+    await expect(
+      updateFamilyPreferencesForFamily({
+        data: { timezone: "Europe/London" },
+        familyId: familyA.id,
+        userId: ownerB.id,
+        runInTenantTransaction: runner(ownerB.id),
+      })
+    ).rejects.toThrow()
+
+    const persisted = await harness.prisma.family.findUniqueOrThrow({
+      where: { id: familyA.id },
+      select: { timezone: true },
+    })
+    expect(persisted.timezone).toBe(familyA.timezone)
+  })
+})


### PR DESCRIPTION
## PER-113 (Phase 1) — Settings hub + navigation cohesion

Builds the missing **connective tissue** flagged in the head-eng review: each prior vertical slice shipped a page, but navigation/IA never tied them together. This phase delivers a `/settings` hub, wires the orphaned panes, and fixes the app-shell navigation. Foundation/reporting/import remain unchanged.

Linear: [PER-113](https://linear.app/permana/issue/PER-113) · Phase 1 only.

### Routes & UI
- **`/settings` hub** — launcher with navigation cards grouped into *Family workspace*, *Your account*, and *Related tools*; links every pane including the previously-orphaned **Members** ([PER-144](https://linear.app/permana/issue/PER-144)) and **Smart Rules** ([PER-151](https://linear.app/permana/issue/PER-151)), plus **Currencies & FX** and **Smart Import**.
- **`/settings/family`** — timezone editable; **base reporting currency is read-only** with a link to `/currencies`.
- **`/settings/profile`** — display name + theme (light/dark/system) via `next-themes`, persisted durably to `User.theme`.

### Navigation (architectural fix, not cosmetic)
- Converted `nav-main`, `nav-secondary`, and the `app-sidebar` logo from raw `<a href>` to TanStack **`<Link>`** → in-app navigation no longer does a full reload, so `ssr:false` + TanStack DB routes (transactions, etc.) stop re-booting on every click.
- Removed the dead `url:"#"` links; **Family Space → /settings/members**, **Settings → /settings**.
- Mounted `next-themes` `ThemeProvider` in `__root` for the `.dark` class (the `<html>` already carried `suppressHydrationWarning`).

### Server — `src/server/settings.ts`
Settings-grade mutations that honor the same durable invariants as ledger writes:
- `getSettingsOverviewFn` / `updateFamilyPreferencesFn` / `updateProfileFn`.
- Interactive **tenant transaction** (`app.family_id` + `app.user_id` GUCs), tenant validation, and an **append-only `AuditLog` row in the same transaction**.
- `updateFamilyPreferencesFn` gates on the `settings:write` capability; timezone validated against IANA via `Intl`.

> **Isolation note:** `Family` (tenant root) and `User` (auth identity) have no RLS policy. The membership-gated `audit_log_tenant_insert` policy is what isolates them — a non-member's settings write fails the audit insert and **rolls back the whole transaction**. The mandated "audit in the same tx" rule is doing real isolation work here. There's an integration test proving it.

### Decisions locked (with the user)
| Decision | Choice | Why |
|---|---|---|
| Base currency editability | **Read-only + link** | ADR-0035 (Accepted, newer than the ticket) fixes `Family.currency` for the life of the ledger; ADRs outrank ticket criteria. |
| Family fields in Phase 1 | **Timezone only** | `dateFormat`/`locale` have no schema columns; deferred to avoid an out-of-scope migration. |
| Hub structure | **Launcher index** | Keeps `members`/`rules`/`currencies` as standalone full-shell routes — no rewrite, per ticket. |

### Tests
- **Real-Postgres integration** (`tests/integration/settings.integration.ts`) — timezone persist + audit, profile name/theme persist + audit, unknown-timezone rejection, cross-tenant isolation. ✅ 4/4 locally.
- **Playwright e2e** (`tests/e2e/settings.e2e.ts`) — reach `/settings` from the sidebar with **no full reload** (window sentinel survives the click), open Members + Smart Rules panes, toggle dark theme, change timezone. *(Runs in CI — Chromium can't launch in this local env.)*

### Local gates
`vp check` ✅ · `vp test run` ✅ (334) · settings integration ✅ (4) · `vp build` ✅. Waiting on full CI (integration + e2e).

### Deferred to follow-up (Phase 2+)
Categories, merchants, security/sessions, data export, danger zone, and date-format/locale family prefs (need new schema columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)