### PR TITLE
feat(import): PER-170 — Sure full-family migration backend (Phase 1a, ADR-0041)

### DIFF
--- a/prisma/migrations/20260627120000_sure_migration_bindings/migration.sql
+++ b/prisma/migrations/20260627120000_sure_migration_bindings/migration.sql
@@ -1,0 +1,132 @@
+-- ============================================================================
+-- PER-170 / ADR-0041 — Sure full-family migration, Phase 1 schema deltas.
+--
+-- Additive + backward-compatible. Three pieces:
+--   1. Durable external-provider bindings on Category + Merchant (mirroring the
+--      Account binding) as PARTIAL UNIQUE indexes (Prisma cannot express the
+--      `WHERE externalProvider IS NOT NULL` predicate — hand-written here per the
+--      family_membership / idempotent_update_delete precedent).
+--   2. ImportBatch gains a provider-agnostic `provider` column and a 'migration'
+--      sourceKind, so a full-family import is a first-class batch.
+--   3. ImportBatchArtifact: tenant-private lossless bundle provenance, RLS-guarded
+--      with the ADR-0036 membership guard and a composite tenant FK.
+--
+-- familyId is part of every binding composite for tenant isolation (ADR-0010).
+-- New columns are nullable, so existing rows are untouched.
+-- ============================================================================
+
+-- 1. Category + Merchant provider-binding columns ----------------------------
+
+ALTER TABLE "Category"
+  ADD COLUMN "externalProvider" TEXT,
+  ADD COLUMN "externalId" TEXT;
+
+ALTER TABLE "Merchant"
+  ADD COLUMN "externalProvider" TEXT,
+  ADD COLUMN "externalId" TEXT;
+
+-- 2. Partial UNIQUE bindings (WHERE externalProvider IS NOT NULL) -------------
+--    Why partial: Postgres treats NULLs as DISTINCT by default, so manual rows
+--    (externalProvider = NULL) are already unique under any composite index. The
+--    predicate keeps the index SMALL (provider-bound rows only) and makes the
+--    binding uniqueness an EXPLICIT, import-only invariant (ADR-0041 §7).
+
+-- Account: HARDEN the existing plain lookup index into the partial unique
+-- binding. The partial unique still serves equality lookups on provider-bound
+-- rows, so dropping the redundant plain index loses no access path.
+DROP INDEX IF EXISTS "Account_familyId_externalProvider_externalAccountId_idx";
+CREATE UNIQUE INDEX "account_provider_binding"
+  ON "Account" ("familyId", "externalProvider", "externalAccountId")
+  WHERE "externalProvider" IS NOT NULL;
+
+CREATE UNIQUE INDEX "category_provider_binding"
+  ON "Category" ("familyId", "externalProvider", "externalId")
+  WHERE "externalProvider" IS NOT NULL;
+
+CREATE UNIQUE INDEX "merchant_provider_binding"
+  ON "Merchant" ("familyId", "externalProvider", "externalId")
+  WHERE "externalProvider" IS NOT NULL;
+
+-- 3. ImportBatch: provider column + 'migration' sourceKind -------------------
+
+ALTER TABLE "ImportBatch" ADD COLUMN "provider" TEXT;
+
+ALTER TABLE "ImportBatch" DROP CONSTRAINT IF EXISTS import_batch_source_kind_domain;
+ALTER TABLE "ImportBatch"
+  ADD CONSTRAINT import_batch_source_kind_domain
+  CHECK ("sourceKind" IN ('csv_upload', 'provider', 'migration'));
+
+-- A migration batch must name its provider (provider-agnostic, no hardcoded
+-- per-provider sourceKind — ADR-0041 §8).
+ALTER TABLE "ImportBatch"
+  ADD CONSTRAINT import_batch_migration_provider
+  CHECK ("sourceKind" <> 'migration' OR "provider" IS NOT NULL);
+
+-- 4. ImportBatchArtifact -----------------------------------------------------
+
+CREATE TABLE "ImportBatchArtifact" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "importBatchId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "storageKind" TEXT NOT NULL DEFAULT 'inline_bytea',
+    "contentHash" TEXT NOT NULL,
+    "byteSize" INTEGER NOT NULL,
+    "bytes" BYTEA,
+    "storageRef" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ImportBatchArtifact_pkey" PRIMARY KEY ("id")
+);
+
+-- One artifact per (batch, raw-bundle hash): re-running the migration on the
+-- same bundle reuses the existing batch (ADR-0039 §5) and never re-inserts the
+-- artifact (ADR-0041 §7 one-shot).
+CREATE UNIQUE INDEX "import_artifact_batch_content"
+  ON "ImportBatchArtifact" ("importBatchId", "contentHash");
+CREATE INDEX "ImportBatchArtifact_familyId_idx"
+  ON "ImportBatchArtifact" ("familyId");
+
+ALTER TABLE "ImportBatchArtifact" ADD CONSTRAINT "ImportBatchArtifact_familyId_fkey"
+  FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- Composite tenant FK: an artifact can never point at another family's batch
+-- even with a forged batchId (ADR-0010 pattern, like RawImportedTransaction).
+ALTER TABLE "ImportBatchArtifact" ADD CONSTRAINT "import_artifact_batch_family_fkey"
+  FOREIGN KEY ("importBatchId", "familyId") REFERENCES "ImportBatch"("id", "familyId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Domain CHECKs (house convention: String + CHECK).
+ALTER TABLE "ImportBatchArtifact"
+  ADD CONSTRAINT import_artifact_storage_kind_domain
+  CHECK ("storageKind" IN ('inline_bytea', 'object_store'));
+-- Storage-form invariant: inline bytes XOR external reference, matched to kind.
+ALTER TABLE "ImportBatchArtifact"
+  ADD CONSTRAINT import_artifact_storage_shape
+  CHECK (
+    ("storageKind" = 'inline_bytea' AND "bytes" IS NOT NULL AND "storageRef" IS NULL)
+    OR ("storageKind" = 'object_store' AND "storageRef" IS NOT NULL AND "bytes" IS NULL)
+  );
+ALTER TABLE "ImportBatchArtifact"
+  ADD CONSTRAINT import_artifact_byte_size_positive
+  CHECK ("byteSize" > 0);
+
+-- RLS: tenant isolation + ADR-0036 membership guard. Raw bundles are
+-- family-private financial PII and must never cross-read.
+ALTER TABLE "ImportBatchArtifact" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY import_artifact_tenant_isolation ON "ImportBatchArtifact"
+  FOR ALL
+  USING (
+    "familyId" = current_setting('app.family_id', true)::text
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  )
+  WITH CHECK (
+    "familyId" = current_setting('app.family_id', true)::text
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  );
+ALTER TABLE "ImportBatchArtifact" FORCE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Family {
   budgets      Budget[]
   importBatches ImportBatch[]
   rawImportedTransactions RawImportedTransaction[]
+  importBatchArtifacts ImportBatchArtifact[]
 }
 
 // ADR-0036: first-class family membership + role authorization.
@@ -202,6 +203,13 @@ model Merchant {
   color   String?
   logoUrl String?
 
+  // Durable external-provider binding (ADR-0041 §3, mirrors Account). NULL for
+  // manually-created merchants. A PARTIAL UNIQUE (familyId, externalProvider,
+  // externalId) WHERE externalProvider IS NOT NULL is created in raw SQL
+  // (migration `sure_migration_bindings`) — Prisma cannot express the predicate.
+  externalProvider String?
+  externalId       String?
+
   familyId     String
   family       Family        @relation(fields: [familyId], references: [id])
   transactions Transaction[]
@@ -225,6 +233,14 @@ model Category {
   isSystem Boolean @default(false)
   familyId String?
   family   Family? @relation(fields: [familyId], references: [id])
+
+  // Durable external-provider binding (ADR-0041 §3, mirrors Account). NULL for
+  // manually-created and system categories. A PARTIAL UNIQUE (familyId,
+  // externalProvider, externalId) WHERE externalProvider IS NOT NULL is created
+  // in raw SQL (migration `sure_migration_bindings`). Sure categories are always
+  // TENANT-owned (familyId set, isSystem=false); system rows are out of scope.
+  externalProvider String?
+  externalId       String?
 
   parentId     String?
   parent       Category?     @relation("SubCategories", fields: [parentId], references: [id])
@@ -680,8 +696,12 @@ model ImportBatch {
   // Acting member (User.id). Plain id, not an FK, like Transaction.userId.
   createdById String
 
-  // 'csv_upload' | 'provider' (DB CHECK). 'provider' reserved for PER-118.
+  // 'csv_upload' | 'provider' | 'migration' (DB CHECK). 'provider' reserved for
+  // PER-118; 'migration' is a full-family bring-your-own-data import (ADR-0041).
   sourceKind  String
+  // Provider-agnostic origin label for sourceKind='migration' (e.g. 'sure'), so
+  // future migrations don't hardcode a per-provider sourceKind (ADR-0041 §8).
+  provider    String?
   // OPTIONAL batch-level default/hint only. The AUTHORITATIVE target account is
   // per-row on RawImportedTransaction, because one file can span many accounts.
   accountId   String?
@@ -707,7 +727,8 @@ model ImportBatch {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  rawRows RawImportedTransaction[]
+  rawRows   RawImportedTransaction[]
+  artifacts ImportBatchArtifact[]
 
   // Per-file batch dedup target (ADR-0039 §5).
   @@unique([familyId, sourceKind, contentHash], name: "import_batch_content_dedup", map: "import_batch_content_dedup")
@@ -768,4 +789,48 @@ model RawImportedTransaction {
   @@index([importBatchId, rowStatus])
   @@index([familyId, fingerprint])
   @@index([accountId])
+}
+
+// ADR-0041 §8 — lossless raw-bundle provenance for a full-family migration.
+//
+// One row per uploaded bundle (`all.ndjson`). The raw bytes are retained as
+// tenant-private provenance AND as the durable source for the deferred Phase
+// 2/3 entities (Balance/Transfer/Trade/Holding/Valuation/Recurring/Rule), so a
+// re-run never re-uploads. The bundle holds real financial PII; encryption-at-
+// rest is the deployment's DB/disk-level encryption (NOT app-level column
+// crypto), gated by RLS app_is_active_member — consistent with the same PII
+// already living plaintext in canonical Transaction/Account rows.
+//
+// `storageKind` is a forward-compat discriminator: today only 'inline_bytea'
+// (gzip(all.ndjson) in `bytes`); a future object-store form adds 'object_store'
+// + `storageRef` WITHOUT a breaking schema change. `contentHash` + `byteSize`
+// provide one-shot idempotency (§7) and integrity. Composite tenant FK
+// (importBatchId, familyId) + FORCE RLS in raw SQL (migration
+// `sure_migration_bindings`).
+model ImportBatchArtifact {
+  id            String @id @default(cuid())
+  familyId      String
+  family        Family @relation(fields: [familyId], references: [id], onDelete: Cascade)
+
+  importBatchId String
+  importBatch   ImportBatch @relation(fields: [importBatchId, familyId], references: [id, familyId], onDelete: Cascade, onUpdate: Cascade, map: "import_artifact_batch_family_fkey")
+
+  filename    String
+  // 'inline_bytea' today; 'object_store' reserved (DB CHECK).
+  storageKind String @default("inline_bytea")
+  // sha256 of the RAW (pre-compression) bundle bytes — the one-shot dedup anchor.
+  contentHash String
+  // Size of the raw (pre-compression) bundle in bytes. Enforced under a guard.
+  byteSize    Int
+  // gzip(all.ndjson) bytes for storageKind='inline_bytea'. NULL when an external
+  // store holds them (storageKind='object_store', reserved).
+  bytes       Bytes?
+  // External-store key/URL for storageKind='object_store' (reserved-nullable).
+  storageRef  String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([importBatchId, contentHash], name: "import_artifact_batch_content", map: "import_artifact_batch_content")
+  @@index([familyId])
 }

--- a/src/lib/sure-migration.test.ts
+++ b/src/lib/sure-migration.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "vite-plus/test"
+import type { CurrencyCode } from "./data/currencies"
+import {
+  classifySureAmount,
+  normalizeSureAccountType,
+  orderCategoriesParentsFirst,
+  parseSureBundle,
+  type SureCategory,
+} from "./sure-migration"
+
+// PER-170 / ADR-0041 — pure reader units: NDJSON parse + malformed rejection,
+// account-type normalization + fallback, the Sure sign inversion (incl. 0), and
+// the parent-first category ordering for the two-pass remap.
+
+const line = (entity: string, data: unknown) => JSON.stringify({ entity, data })
+
+describe("parseSureBundle", () => {
+  test("routes known entities into typed arrays and skips blank lines", () => {
+    const content = [
+      line("Account", {
+        id: "a1",
+        name: "Checking",
+        accountable_type: "Depository",
+        classification: "asset",
+        subtype: "checking",
+        currency: "IDR",
+        balance: "1000.0",
+      }),
+      "",
+      line("Category", {
+        id: "c1",
+        name: "Food",
+        classification: "expense",
+        lucide_icon: "utensils",
+      }),
+      line("Merchant", { id: "m1", name: "Warung", logo_url: null }),
+      line("Transaction", {
+        id: "t1",
+        account_id: "a1",
+        date: "2026-06-15",
+        amount: "17000.0",
+        currency: "IDR",
+        name: "Lumpia beef",
+        kind: "standard",
+      }),
+      "   ",
+    ].join("\n")
+
+    const bundle = parseSureBundle(content)
+    expect(bundle.accounts).toHaveLength(1)
+    expect(bundle.categories).toHaveLength(1)
+    expect(bundle.merchants).toHaveLength(1)
+    expect(bundle.transactions).toHaveLength(1)
+    expect(bundle.malformedLines).toHaveLength(0)
+    expect(bundle.accounts[0]?.id).toBe("a1")
+  })
+
+  test("rejects malformed lines without aborting the rest of the parse", () => {
+    const content = [
+      "{ not json",
+      JSON.stringify({ entity: "Account" }), // missing data envelope
+      line("Account", { id: "a1" }), // fails schema (missing required fields)
+      line("Merchant", { id: "m1", name: "Ok" }), // valid — survives
+    ].join("\n")
+
+    const bundle = parseSureBundle(content)
+    expect(bundle.merchants).toHaveLength(1)
+    expect(
+      bundle.malformedLines.map((m) => m.line).sort((a, b) => a - b)
+    ).toEqual([1, 2, 3])
+    expect(bundle.malformedLines[0]?.reason).toMatch(/invalid JSON/i)
+  })
+
+  test("counts deferred/unknown entities as ignored, not malformed", () => {
+    const content = [
+      line("Trade", { id: "tr1" }),
+      line("Holding", { id: "h1" }),
+      line("Trade", { id: "tr2" }),
+      line("Rule", { id: "r1" }),
+    ].join("\n")
+
+    const bundle = parseSureBundle(content)
+    expect(bundle.malformedLines).toHaveLength(0)
+    expect(bundle.ignoredEntities).toEqual({ Trade: 2, Holding: 1, Rule: 1 })
+  })
+
+  test("parses Transfer entities (typed source for deferred Phase 1.5)", () => {
+    const content = line("Transfer", {
+      id: "x1",
+      inflow_transaction_id: "in1",
+      outflow_transaction_id: "out1",
+      status: "confirmed",
+    })
+    const bundle = parseSureBundle(content)
+    expect(bundle.transfers).toHaveLength(1)
+    expect(bundle.transfers[0]?.outflow_transaction_id).toBe("out1")
+  })
+})
+
+describe("normalizeSureAccountType", () => {
+  test("maps each Sure accountable_type to the ADR-0041 §2 taxonomy", () => {
+    const depository = normalizeSureAccountType("Depository", "savings")
+    expect(depository).toMatchObject({
+      accountClass: "ASSET",
+      accountType: "DEPOSITORY",
+      accountSubtype: "savings",
+      balanceSource: "transaction_flow",
+      isImportable: true,
+    })
+
+    const credit = normalizeSureAccountType("CreditCard", null)
+    expect(credit).toMatchObject({
+      accountClass: "LIABILITY",
+      accountType: "CREDIT",
+      accountSubtype: "credit_card",
+      isImportable: true,
+    })
+
+    const loan = normalizeSureAccountType("Loan", undefined)
+    expect(loan.accountType).toBe("LOAN")
+    expect(loan.accountClass).toBe("LIABILITY")
+  })
+
+  test("holds Investment (transaction_flow but not importable in Phase 1)", () => {
+    const investment = normalizeSureAccountType("Investment", "mutual_fund")
+    expect(investment).toMatchObject({
+      accountType: "INVESTMENT",
+      accountSubtype: "mutual_fund",
+      balanceSource: "transaction_flow",
+      isImportable: false,
+    })
+    // Unknown investment subtype falls back to brokerage.
+    expect(normalizeSureAccountType("Investment", null).accountSubtype).toBe(
+      "brokerage"
+    )
+  })
+
+  test("maps PreciousMetal/OtherAsset to valuation-driven TRACKED_ASSET (held)", () => {
+    const gold = normalizeSureAccountType("PreciousMetal", null)
+    expect(gold).toMatchObject({
+      accountType: "TRACKED_ASSET",
+      accountSubtype: "gold",
+      balanceSource: "valuation",
+      isImportable: false,
+    })
+    expect(normalizeSureAccountType("OtherAsset", null).accountSubtype).toBe(
+      "generic_asset"
+    )
+  })
+
+  test("unknown accountable_type falls back to a cash-like depository shell", () => {
+    const fallback = normalizeSureAccountType("Spaceship", "warp")
+    expect(fallback).toMatchObject({
+      accountType: "DEPOSITORY",
+      accountSubtype: "checking",
+      balanceSource: "transaction_flow",
+      isImportable: true,
+    })
+  })
+})
+
+describe("classifySureAmount (the Sure sign inversion)", () => {
+  const IDR = "IDR" as CurrencyCode
+
+  test("Sure positive amount → Permoney expense", () => {
+    // IDR is modeled with 2 minor digits (sen): 17000.0 → 1_700_000 minor units.
+    const result = classifySureAmount("17000.0", IDR)
+    expect(result.type).toBe("expense")
+    expect(result.absMinorUnits).toBe(1_700_000n)
+    expect(result.isZeroAmount).toBe(false)
+  })
+
+  test("Sure negative amount → Permoney income (abs magnitude)", () => {
+    const result = classifySureAmount("-5000.0", IDR)
+    expect(result.type).toBe("income")
+    expect(result.absMinorUnits).toBe(500_000n)
+  })
+
+  test("Sure zero amount → expense, flagged for review", () => {
+    const result = classifySureAmount("0", IDR)
+    expect(result.type).toBe("expense")
+    expect(result.absMinorUnits).toBe(0n)
+    expect(result.isZeroAmount).toBe(true)
+  })
+})
+
+describe("orderCategoriesParentsFirst", () => {
+  const cat = (id: string, parent_id: string | null = null): SureCategory => ({
+    id,
+    name: id,
+    classification: "expense",
+    parent_id,
+  })
+
+  test("emits every parent before its children", () => {
+    const input = [cat("child", "parent"), cat("parent"), cat("grand", "child")]
+    const ordered = orderCategoriesParentsFirst(input).map((c) => c.id)
+    expect(ordered.indexOf("parent")).toBeLessThan(ordered.indexOf("child"))
+    expect(ordered.indexOf("child")).toBeLessThan(ordered.indexOf("grand"))
+    expect(ordered).toHaveLength(3)
+  })
+
+  test("treats a missing parent (degraded export) as a root", () => {
+    const ordered = orderCategoriesParentsFirst([cat("orphan", "ghost")])
+    expect(ordered.map((c) => c.id)).toEqual(["orphan"])
+  })
+
+  test("is total and terminates on an accidental cycle", () => {
+    const ordered = orderCategoriesParentsFirst([cat("a", "b"), cat("b", "a")])
+    expect(ordered.map((c) => c.id).sort()).toEqual(["a", "b"])
+  })
+})

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -1,0 +1,420 @@
+// ============================================================================
+// PER-170 / ADR-0041 — Sure full-family migration, pure reader utilities.
+//
+// Deterministic, side-effect-free building blocks of the Sure migration: the
+// `all.ndjson` line parser (with malformed-line rejection), the Sure v2 entity
+// Zod schemas, the Sure→Permoney account-type normalizer, the sign→type+abs
+// classifier (the Sure sign inversion), and the parent-first category ordering.
+//
+// Server orchestration (account/category/merchant creation, id-maps, staging,
+// promotion) lives in `src/server/sure-migration.ts` and calls into these. This
+// module is the Sure specialization parallel to `src/lib/import-staging.ts`; it
+// imports nothing from Prisma/Node so it stays client-safe and unit-testable.
+//
+// CONTRACT — the reader targets Sure export v2 (`Family::DataExporter`,
+// `EXPORT_VERSION = 2`). `all.ndjson` is one JSON object per line under a stable
+// envelope `{ "entity": <Name>, "data": { ...snake_case attributes } }`. v2-only
+// entities (Balance/Transfer/Trade/Holding/RecurringTransaction/Rule) are
+// OPTIONAL — a degraded/pre-v2 bundle simply omits them and the reader degrades
+// gracefully (ADR-0041 §1/§5/§6). The synthetic fixture builder emits this exact
+// shape; when a real bundle reveals a quirk we iterate the builder, never commit
+// real data (ADR-0041 §11).
+// ============================================================================
+
+import { z } from "zod"
+import type { CurrencyCode } from "./data/currencies"
+import {
+  type AccountTaxonomy,
+  type AccountType,
+  normalizeAccountTaxonomy,
+} from "./accounts"
+import { toMinorUnits } from "./money"
+
+export const SURE_EXPORT_VERSION = 2
+export const SURE_PROVIDER = "sure"
+
+// ---------------------------------------------------------------------------
+// Entity envelope + Zod schemas (Sure v2 attribute names — snake_case Rails)
+// ---------------------------------------------------------------------------
+
+// Phase-1 entities the reader maps. Deferred v2 entities (Transfer, Trade,
+// Holding, RecurringTransaction, Rule, Tag, Valuation, Budget, BudgetCategory)
+// are retained in the raw bundle and counted as `ignoredEntities`, not parsed
+// into typed rows — except `Transfer`, which we DO parse so the gating tests and
+// the deferred Phase-1.5 transfer pairing have a typed source (ADR-0041 §10).
+export const SURE_ENTITY = {
+  account: "Account",
+  balance: "Balance",
+  category: "Category",
+  merchant: "Merchant",
+  transaction: "Transaction",
+  transfer: "Transfer",
+} as const
+
+// Sure stores money as a decimal STRING ("17000.0"); accept a number too and
+// canonicalize to the clean decimal string `toMinorUnits` expects.
+const sureDecimalSchema = z
+  .union([z.string(), z.number()])
+  .transform((value) =>
+    typeof value === "number" ? String(value) : value.trim()
+  )
+  .refine((value) => /^-?\d+(\.\d+)?$/.test(value), "malformed decimal amount")
+
+// Sure `accountable_type` discriminator (STI class name). Unknown values are
+// tolerated by `normalizeSureAccountType` (conservative fallback), so the schema
+// keeps it a free string rather than an enum.
+export const sureAccountSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  accountable_type: z.string().min(1),
+  classification: z.enum(["asset", "liability"]).nullable().optional(),
+  subtype: z.string().nullable().optional(),
+  currency: z.string().min(3).max(3),
+  // Sure's reported balances — retained as provenance ONLY (never written as a
+  // reconciled number, ADR-0041 §5). `start_balance` for the opening comes from
+  // the Balance snapshot, not here.
+  balance: sureDecimalSchema.nullable().optional(),
+  cash_balance: sureDecimalSchema.nullable().optional(),
+})
+export type SureAccount = z.infer<typeof sureAccountSchema>
+
+export const sureBalanceSchema = z.object({
+  account_id: z.string().min(1),
+  date: z.string().min(1),
+  start_balance: sureDecimalSchema.nullable().optional(),
+  end_balance: sureDecimalSchema.nullable().optional(),
+})
+export type SureBalance = z.infer<typeof sureBalanceSchema>
+
+export const sureCategorySchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  classification: z.enum(["expense", "income"]),
+  color: z.string().nullable().optional(),
+  lucide_icon: z.string().nullable().optional(),
+  parent_id: z.string().nullable().optional(),
+})
+export type SureCategory = z.infer<typeof sureCategorySchema>
+
+export const sureMerchantSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  color: z.string().nullable().optional(),
+  logo_url: z.string().nullable().optional(),
+})
+export type SureMerchant = z.infer<typeof sureMerchantSchema>
+
+// Sure transaction `kind`. `standard` is the only promotable kind in Phase 1;
+// the transfer kinds are HELD (ADR-0041 §6). Free string for forward-compat.
+export const sureTransactionSchema = z.object({
+  id: z.string().min(1),
+  account_id: z.string().min(1),
+  category_id: z.string().nullable().optional(),
+  merchant_id: z.string().nullable().optional(),
+  date: z.string().min(1),
+  // Sign convention: Sure stores outflow/expense POSITIVE, inflow/income
+  // NEGATIVE (inverted vs Permoney). See `classifySureAmount`.
+  amount: sureDecimalSchema,
+  currency: z.string().min(3).max(3),
+  name: z.string().nullable().optional(),
+  kind: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  excluded: z.boolean().nullable().optional(),
+  tag_ids: z.array(z.string()).nullable().optional(),
+  // v2 embedded splits — OUT OF SCOPE Phase 1 (held). Presence flags a split
+  // parent; contents are retained in rawPayload, not parsed into Permoney rows.
+  split_lines: z.array(z.unknown()).nullable().optional(),
+})
+export type SureTransaction = z.infer<typeof sureTransactionSchema>
+
+export const sureTransferSchema = z.object({
+  id: z.string().min(1),
+  inflow_transaction_id: z.string().min(1),
+  outflow_transaction_id: z.string().min(1),
+  status: z.string().nullable().optional(),
+})
+export type SureTransfer = z.infer<typeof sureTransferSchema>
+
+// ---------------------------------------------------------------------------
+// NDJSON parse (per-line, malformed-line rejection — ADR-0041 §1)
+// ---------------------------------------------------------------------------
+
+export interface SureMalformedLine {
+  line: number // 1-based source line number
+  reason: string
+}
+
+export interface ParsedSureBundle {
+  accounts: SureAccount[]
+  balances: SureBalance[]
+  categories: SureCategory[]
+  merchants: SureMerchant[]
+  transactions: SureTransaction[]
+  transfers: SureTransfer[]
+  /** Lines rejected as malformed (bad JSON, bad envelope, or failed schema). */
+  malformedLines: SureMalformedLine[]
+  /** Deferred/unknown entity name → count (retained in the raw bundle only). */
+  ignoredEntities: Record<string, number>
+}
+
+const ndjsonEnvelopeSchema = z.object({
+  entity: z.string().min(1),
+  data: z.record(z.string(), z.unknown()),
+})
+
+interface EntitySink<T> {
+  schema: z.ZodType<T>
+  push: (value: T) => void
+}
+
+/**
+ * Parse a Sure `all.ndjson` bundle one line at a time. Blank lines are skipped.
+ * A line is rejected as malformed (collected, not thrown) when it is not valid
+ * JSON, does not match the `{ entity, data }` envelope, or fails its entity
+ * schema. Known but deferred entities are counted in `ignoredEntities` and
+ * retained only in the raw bundle. The parse never throws on row-level problems
+ * so one corrupt line can never abort a multi-thousand-row migration; the
+ * orchestrator decides how to surface `malformedLines`.
+ */
+export function parseSureBundle(content: string): ParsedSureBundle {
+  const bundle: ParsedSureBundle = {
+    accounts: [],
+    balances: [],
+    categories: [],
+    merchants: [],
+    transactions: [],
+    transfers: [],
+    malformedLines: [],
+    ignoredEntities: {},
+  }
+
+  const sinks: Record<string, EntitySink<unknown>> = {
+    [SURE_ENTITY.account]: {
+      schema: sureAccountSchema,
+      push: (v) => bundle.accounts.push(v as SureAccount),
+    },
+    [SURE_ENTITY.balance]: {
+      schema: sureBalanceSchema,
+      push: (v) => bundle.balances.push(v as SureBalance),
+    },
+    [SURE_ENTITY.category]: {
+      schema: sureCategorySchema,
+      push: (v) => bundle.categories.push(v as SureCategory),
+    },
+    [SURE_ENTITY.merchant]: {
+      schema: sureMerchantSchema,
+      push: (v) => bundle.merchants.push(v as SureMerchant),
+    },
+    [SURE_ENTITY.transaction]: {
+      schema: sureTransactionSchema,
+      push: (v) => bundle.transactions.push(v as SureTransaction),
+    },
+    [SURE_ENTITY.transfer]: {
+      schema: sureTransferSchema,
+      push: (v) => bundle.transfers.push(v as SureTransfer),
+    },
+  }
+
+  const lines = content.split("\n")
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineNumber = index + 1
+    const raw = lines[index]?.trim() ?? ""
+    if (raw === "") continue
+
+    let json: unknown
+    try {
+      json = JSON.parse(raw)
+    } catch {
+      bundle.malformedLines.push({ line: lineNumber, reason: "invalid JSON" })
+      continue
+    }
+
+    const envelope = ndjsonEnvelopeSchema.safeParse(json)
+    if (!envelope.success) {
+      bundle.malformedLines.push({
+        line: lineNumber,
+        reason: "missing { entity, data } envelope",
+      })
+      continue
+    }
+
+    const { entity, data } = envelope.data
+    const sink = sinks[entity]
+    if (!sink) {
+      bundle.ignoredEntities[entity] = (bundle.ignoredEntities[entity] ?? 0) + 1
+      continue
+    }
+
+    const parsed = sink.schema.safeParse(data)
+    if (!parsed.success) {
+      bundle.malformedLines.push({
+        line: lineNumber,
+        reason: `invalid ${entity}: ${parsed.error.issues[0]?.message ?? "schema error"}`,
+      })
+      continue
+    }
+    sink.push(parsed.data)
+  }
+
+  return bundle
+}
+
+// ---------------------------------------------------------------------------
+// Account type normalization (Sure accountable_type → Permoney taxonomy §2)
+// ---------------------------------------------------------------------------
+
+export interface NormalizedSureAccount extends AccountTaxonomy {
+  /** Phase-1 promotion gate: only importable accounts have rows promoted. */
+  isImportable: boolean
+}
+
+interface SureAccountTypeRule {
+  accountType: AccountType
+  isImportable: boolean
+  /** Sure `subtype` → Permoney subtype overrides; else `defaultSubtype`. */
+  subtypeMap?: Record<string, string>
+  defaultSubtype: string
+}
+
+// ADR-0041 §2. `accountClass` + `balanceSource` are derived downstream by
+// `normalizeAccountTaxonomy` (pure function of `accountType`) so they can NEVER
+// drift from Sure-copied values. Investment is transaction_flow in the taxonomy
+// but HELD in Phase 1 (its meaningful postings are Trades/Holdings, PER-150);
+// PreciousMetal/OtherAsset are valuation-driven TRACKED_ASSET (PER-146).
+const SURE_ACCOUNT_TYPE_RULES: Record<string, SureAccountTypeRule> = {
+  Depository: {
+    accountType: "DEPOSITORY",
+    isImportable: true,
+    subtypeMap: {
+      savings: "savings",
+      checking: "checking",
+      cooperative: "cooperative",
+    },
+    defaultSubtype: "checking",
+  },
+  CreditCard: {
+    accountType: "CREDIT",
+    isImportable: true,
+    defaultSubtype: "credit_card",
+  },
+  Loan: {
+    accountType: "LOAN",
+    isImportable: true,
+    defaultSubtype: "personal_loan",
+  },
+  Investment: {
+    accountType: "INVESTMENT",
+    isImportable: false,
+    subtypeMap: {
+      mutual_fund: "mutual_fund",
+      cooperative_share: "cooperative_share",
+    },
+    defaultSubtype: "brokerage",
+  },
+  PreciousMetal: {
+    accountType: "TRACKED_ASSET",
+    isImportable: false,
+    defaultSubtype: "gold",
+  },
+  OtherAsset: {
+    accountType: "TRACKED_ASSET",
+    isImportable: false,
+    defaultSubtype: "generic_asset",
+  },
+}
+
+// Conservative fallback for an unknown `accountable_type`: a cash-like
+// depository/checking shell (ADR-0041 §2). Cash-like and importable so its plain
+// flow rows still promote; the account shell always exists so refs resolve.
+const SURE_ACCOUNT_FALLBACK: SureAccountTypeRule = {
+  accountType: "DEPOSITORY",
+  isImportable: true,
+  defaultSubtype: "checking",
+}
+
+/**
+ * Normalize a Sure `accountable_type` (+ `subtype`) into Permoney taxonomy plus
+ * the Phase-1 `isImportable` gate. `accountClass`/`balanceSource` come from
+ * `normalizeAccountTaxonomy`, so this can never produce an inconsistent taxonomy.
+ */
+export function normalizeSureAccountType(
+  accountableType: string,
+  subtype?: string | null
+): NormalizedSureAccount {
+  const rule = SURE_ACCOUNT_TYPE_RULES[accountableType] ?? SURE_ACCOUNT_FALLBACK
+  const key = subtype?.trim().toLowerCase()
+  const mappedSubtype = (key && rule.subtypeMap?.[key]) || rule.defaultSubtype
+  const taxonomy = normalizeAccountTaxonomy({
+    accountType: rule.accountType,
+    accountSubtype: mappedSubtype,
+  })
+  return { ...taxonomy, isImportable: rule.isImportable }
+}
+
+// ---------------------------------------------------------------------------
+// Sign → type + abs amount (the Sure inversion — ADR-0041 §4.C)
+// ---------------------------------------------------------------------------
+
+export interface ClassifiedSureAmount {
+  /** Permoney row type; PER-82 re-signs at promote (expense→neg, income→pos). */
+  type: "income" | "expense"
+  /** Absolute minor units, ready for the PER-82 `StagedRowInput.amount` seam. */
+  absMinorUnits: bigint
+  /** Sure amount was exactly 0 → classified as expense and flagged for review. */
+  isZeroAmount: boolean
+}
+
+/**
+ * Convert a Sure entry amount (outflow/expense POSITIVE, inflow/income NEGATIVE)
+ * into a Permoney `(type, abs)` pair in the target account's currency. This is a
+ * pure CLASSIFICATION, not a sign hack — PER-82 re-derives the signed ledger
+ * amount from `type` + abs at promote. `0` is classified as `expense` and
+ * flagged (`isZeroAmount`) so the orchestrator can surface it for review.
+ */
+export function classifySureAmount(
+  amount: string,
+  currency: CurrencyCode
+): ClassifiedSureAmount {
+  const minor = toMinorUnits(amount, currency) as bigint
+  const isZeroAmount = minor === 0n
+  // Sure: outflow > 0 → expense; inflow < 0 → income; 0 → expense (flagged).
+  const type = minor >= 0n ? "expense" : "income"
+  const absMinorUnits = minor < 0n ? -minor : minor
+  return { type, absMinorUnits, isZeroAmount }
+}
+
+// ---------------------------------------------------------------------------
+// Category parent-first ordering (two-pass remap support — ADR-0041 §3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Order Sure categories so every parent precedes its children, letting the
+ * orchestrator build the id-map in one forward pass (a child's `parent_id`
+ * always resolves). Roots — categories with no `parent_id`, or whose parent is
+ * absent from the bundle (degraded export) — come first. Any cycle (Sure should
+ * never emit one) is broken deterministically by emitting the remaining nodes in
+ * stable input order, so the function is total and never loops.
+ */
+export function orderCategoriesParentsFirst(
+  categories: readonly SureCategory[]
+): SureCategory[] {
+  const byId = new Map(categories.map((category) => [category.id, category]))
+  const ordered: SureCategory[] = []
+  const placed = new Set<string>()
+
+  const place = (category: SureCategory, guard: Set<string>): void => {
+    if (placed.has(category.id)) return
+    const parentId = category.parent_id ?? null
+    const parent = parentId ? byId.get(parentId) : undefined
+    if (parent && !placed.has(parent.id) && !guard.has(category.id)) {
+      guard.add(category.id)
+      place(parent, guard)
+    }
+    if (placed.has(category.id)) return
+    ordered.push(category)
+    placed.add(category.id)
+  }
+
+  for (const category of categories) place(category, new Set())
+  return ordered
+}

--- a/src/server/imports.ts
+++ b/src/server/imports.ts
@@ -83,7 +83,13 @@ const stagedRowInputSchema = z.object({
 export type StagedRowInput = z.input<typeof stagedRowInputSchema>
 
 const createImportBatchInputSchema = z.object({
-  sourceKind: z.enum(["csv_upload", "provider"]).default("csv_upload"),
+  sourceKind: z
+    .enum(["csv_upload", "provider", "migration"])
+    .default("csv_upload"),
+  // Provider-agnostic origin label for sourceKind="migration" (e.g. "sure").
+  // The DB CHECK requires it to be present for migration batches (ADR-0041 §8).
+  // Passthrough only — the staging/dedup/promotion logic is unchanged.
+  provider: z.string().min(1).nullable().optional(),
   accountId: z.string().min(1).nullable().optional(),
   contentHash: z.string().min(1),
   idempotencyKey: uuidV7Schema.optional(),
@@ -282,6 +288,7 @@ export async function createImportBatchForFamily({
         familyId,
         createdById: user.id,
         sourceKind: data.sourceKind,
+        provider: data.provider ?? null,
         accountId: data.accountId ?? null,
         contentHash: data.contentHash,
         idempotencyKey: data.idempotencyKey ?? null,

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -1,0 +1,641 @@
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import type { CurrencyCode } from "../lib/data/currencies"
+import {
+  classifySureAmount,
+  normalizeSureAccountType,
+  orderCategoriesParentsFirst,
+  parseSureBundle,
+  SURE_PROVIDER,
+  type SureBalance,
+  type SureTransaction,
+} from "../lib/sure-migration"
+import { toMinorUnits } from "../lib/money"
+import { createUuidV7 } from "../lib/uuid-v7"
+import {
+  createImportBatchForFamily,
+  promoteImportBatchForFamily,
+  reviewImportRowsForFamily,
+  type StagedRowInput,
+} from "./imports"
+import {
+  type AuditLogEntry,
+  auditLogs,
+  createAuditContext,
+} from "./middleware/audit"
+import {
+  requireCapability,
+  scopedTenantTransaction,
+  type TenantTransactionClient,
+} from "./middleware/with-family"
+import type { RunInTenantTransaction } from "./mutation-kit"
+import { createdAuditEntries } from "./transactions"
+
+// ============================================================================
+// PER-170 / ADR-0041 — Sure full-family migration (Phase 1), orchestration.
+//
+// One DEEP MODULE behind a single server fn. It reads `all.ndjson`, creates
+// accounts / categories / merchants under durable `externalProvider="sure"`
+// bindings, builds Sure-id → Permoney-id maps, then feeds transactions through
+// the UNCHANGED PER-82 staging pipeline (stage → dedup → confirm → promote). It
+// is NOT a new ledger writer — promotion reuses the one canonical create core.
+//
+// Re-running the whole migration is idempotent at every layer (ADR-0041 §7):
+//   * accounts/categories/merchants — reused via the partial-unique binding,
+//   * the batch — reused via `ImportBatch.contentHash = sha256(all.ndjson)`,
+//   * each transaction row — its `promotionIdempotencyKey` is minted ONCE at
+//     stage time and persisted, so re-promotion is a no-op at the
+//     `Transaction (familyId, idempotencyKey)` backstop.
+//
+// The raw bundle is retained losslessly in `ImportBatchArtifact` (gzip BYTEA,
+// `storageKind='inline_bytea'`) as tenant-private provenance and the durable
+// source for the deferred Phase 2/3 entities (§8). Encryption-at-rest is the
+// deployment's DB/disk-level encryption gated by RLS — NOT app-level column
+// crypto — consistent with the same PII already living in Transaction/Account.
+// ============================================================================
+
+// Reject absurdly large bundles before parsing — protects the DB row, backups,
+// and the import worker (aligned with the PER-164 large-import concern). The
+// real validation bundle is ~1–2 MB (3002 transactions); 64 MiB is generous.
+const MAX_BUNDLE_BYTES = 64 * 1024 * 1024
+
+const sureMigrationInputSchema = z.object({
+  filename: z.string().min(1).max(255),
+  // Raw `all.ndjson` content. Phase 1a accepts it as a UTF-8 string over the
+  // server-fn POST; a future slice may switch to multipart upload.
+  bundle: z.string().min(1),
+})
+
+export type SureMigrationInput = z.input<typeof sureMigrationInputSchema>
+
+export interface SureMigrationResult {
+  batchId: string
+  replayed: boolean
+  contentHash: string
+  byteSize: number
+  accounts: { created: number; reused: number }
+  categories: { created: number; reused: number }
+  merchants: { created: number; reused: number }
+  transactions: {
+    total: number
+    staged: number
+    promotedThisRun: number
+    held: number
+    zeroAmountSkipped: number
+    invalidDateSkipped: number
+  }
+  malformedLines: number
+  ignoredEntities: Record<string, number>
+}
+
+interface PermoneyAccountInfo {
+  id: string
+  currency: string
+  isImportable: boolean
+  balanceSource: string
+}
+
+// ---------------------------------------------------------------------------
+// Isomorphic byte helpers (Web Crypto + CompressionStream — no Node imports, so
+// the module never pulls a Node-only dep into a client graph; ADR-0041 §1 keeps
+// this a plain `.ts`, like `imports.ts`).
+// ---------------------------------------------------------------------------
+
+async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("")
+}
+
+async function gzipBytes(
+  input: Uint8Array<ArrayBuffer>
+): Promise<Uint8Array<ArrayBuffer>> {
+  const stream = new CompressionStream("gzip")
+  const writer = stream.writable.getWriter()
+  await writer.write(input)
+  await writer.close()
+  const reader = stream.readable.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      chunks.push(value)
+      total += value.length
+    }
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Account opening balance (ADR-0041 §5 — transfer-independent, additive)
+// ---------------------------------------------------------------------------
+
+/**
+ * Opening balance for a newly-created account, applied ONCE at creation (re-run
+ * reuses the account and never re-applies). Restricted to ASSET cash-like
+ * accounts where the snapshot sign is unambiguous (`account_normal_balance_sign`
+ * requires ASSET balance ≥ 0): the earliest `Balance.start_balance`, else 0.
+ *
+ * NEVER plugs `Sure.balance − Σ(txns)` (§5 forbidden — double-counts deferred
+ * transfers). LIABILITY opening from Sure snapshots is deferred (fallback 0 +
+ * documented gap): Sure's liability balance SIGN convention is not pinned by the
+ * ADR, and a wrong guess would corrupt the ledger. Non-cash shells stay neutral.
+ */
+function openingBalanceMinor(
+  account: { accountClass: string; balanceSource: string; currency: string },
+  sureAccountId: string,
+  balances: readonly SureBalance[]
+): bigint {
+  if (
+    account.accountClass !== "ASSET" ||
+    account.balanceSource !== "transaction_flow"
+  ) {
+    return 0n
+  }
+  const snapshots = balances
+    .filter((b) => b.account_id === sureAccountId && b.start_balance != null)
+    .sort((a, z2) => a.date.localeCompare(z2.date))
+  const earliest = snapshots[0]
+  if (!earliest?.start_balance) return 0n
+  const minor = toMinorUnits(
+    earliest.start_balance,
+    account.currency as CurrencyCode
+  ) as bigint
+  // A negative opening on an ASSET would violate the balance-sign CHECK; treat
+  // it as an unreconcilable gap (fallback 0), never a plug.
+  return minor >= 0n ? minor : 0n
+}
+
+// ---------------------------------------------------------------------------
+// Promotion gating (ADR-0041 §6)
+// ---------------------------------------------------------------------------
+
+function isPromotable(
+  txn: SureTransaction,
+  account: PermoneyAccountInfo
+): boolean {
+  const kind = (txn.kind ?? "standard").trim() || "standard"
+  if (kind !== "standard") return false
+  if (!account.isImportable || account.balanceSource !== "transaction_flow") {
+    return false
+  }
+  if (txn.currency !== account.currency) return false
+  if (txn.split_lines && txn.split_lines.length > 0) return false
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration (testable entry — mirrors createImportBatchForFamily shape)
+// ---------------------------------------------------------------------------
+
+export async function runSureMigrationForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: unknown
+  familyId: string
+  user: { id: string; familyId?: string | null }
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SureMigrationResult> {
+  const data = sureMigrationInputSchema.parse(rawData)
+
+  const rawBytes = new TextEncoder().encode(data.bundle)
+  if (rawBytes.length > MAX_BUNDLE_BYTES) {
+    throw new Error(
+      `Sure bundle is ${rawBytes.length} bytes, exceeding the ${MAX_BUNDLE_BYTES}-byte limit`
+    )
+  }
+  const contentHash = await sha256Hex(rawBytes)
+  const auditCtx = await createAuditContext({ user })
+
+  const bundle = parseSureBundle(data.bundle)
+
+  // --- 1. Accounts -> id-map (+ account info for mapping) -------------------
+  const accountMap = new Map<string, string>() // sureId -> permoneyId
+  const accountInfo = new Map<string, PermoneyAccountInfo>() // permoneyId -> info
+  let accountsCreated = 0
+  let accountsReused = 0
+
+  await runInTenantTransaction(familyId, user.id, async (tx) => {
+    const auditEntries: AuditLogEntry[] = []
+    for (const sureAccount of bundle.accounts) {
+      const reused = await reuseAccount(tx, familyId, sureAccount.id)
+      if (reused) {
+        accountMap.set(sureAccount.id, reused.id)
+        accountInfo.set(reused.id, reused)
+        accountsReused += 1
+        continue
+      }
+      const taxonomy = normalizeSureAccountType(
+        sureAccount.accountable_type,
+        sureAccount.subtype
+      )
+      const balance = openingBalanceMinor(
+        { ...taxonomy, currency: sureAccount.currency },
+        sureAccount.id,
+        bundle.balances
+      )
+      const created = await tx.account.create({
+        data: {
+          familyId,
+          name: sureAccount.name,
+          accountClass: taxonomy.accountClass,
+          accountType: taxonomy.accountType,
+          accountSubtype: taxonomy.accountSubtype,
+          balanceSource: taxonomy.balanceSource,
+          balance,
+          currency: sureAccount.currency,
+          isImportable: taxonomy.isImportable,
+          externalProvider: SURE_PROVIDER,
+          externalAccountId: sureAccount.id,
+          status: "active",
+        },
+      })
+      accountMap.set(sureAccount.id, created.id)
+      accountInfo.set(created.id, {
+        id: created.id,
+        currency: created.currency,
+        isImportable: created.isImportable,
+        balanceSource: created.balanceSource,
+      })
+      accountsCreated += 1
+      auditEntries.push(...createdAuditEntries("Account", [created]))
+    }
+    await auditLogs(tx, auditCtx, withFamily(auditEntries, familyId))
+  })
+
+  // --- 2. Categories -> id-map (two-pass: parents before children) ----------
+  const categoryMap = new Map<string, string>()
+  let categoriesCreated = 0
+  let categoriesReused = 0
+
+  await runInTenantTransaction(familyId, user.id, async (tx) => {
+    const auditEntries: AuditLogEntry[] = []
+    for (const sureCategory of orderCategoriesParentsFirst(bundle.categories)) {
+      const reused = await reuseBoundId(
+        tx,
+        "category",
+        familyId,
+        sureCategory.id
+      )
+      if (reused) {
+        categoryMap.set(sureCategory.id, reused)
+        categoriesReused += 1
+        continue
+      }
+      const parentId = sureCategory.parent_id
+        ? (categoryMap.get(sureCategory.parent_id) ?? null)
+        : null
+      const created = await tx.category.create({
+        data: {
+          familyId,
+          name: sureCategory.name,
+          type: sureCategory.classification,
+          color: sureCategory.color ?? "#6172F3",
+          icon: sureCategory.lucide_icon ?? "shapes",
+          parentId,
+          isSystem: false,
+          externalProvider: SURE_PROVIDER,
+          externalId: sureCategory.id,
+        },
+      })
+      categoryMap.set(sureCategory.id, created.id)
+      categoriesCreated += 1
+      auditEntries.push(...createdAuditEntries("Category", [created]))
+    }
+    await auditLogs(tx, auditCtx, withFamily(auditEntries, familyId))
+  })
+
+  // --- 3. Merchants -> id-map ----------------------------------------------
+  const merchantMap = new Map<string, string>()
+  let merchantsCreated = 0
+  let merchantsReused = 0
+
+  await runInTenantTransaction(familyId, user.id, async (tx) => {
+    const auditEntries: AuditLogEntry[] = []
+    for (const sureMerchant of bundle.merchants) {
+      const reused = await reuseBoundId(
+        tx,
+        "merchant",
+        familyId,
+        sureMerchant.id
+      )
+      if (reused) {
+        merchantMap.set(sureMerchant.id, reused)
+        merchantsReused += 1
+        continue
+      }
+      const created = await tx.merchant.create({
+        data: {
+          familyId,
+          name: sureMerchant.name,
+          color: sureMerchant.color ?? null,
+          logoUrl: sureMerchant.logo_url ?? null,
+          externalProvider: SURE_PROVIDER,
+          externalId: sureMerchant.id,
+        },
+      })
+      merchantMap.set(sureMerchant.id, created.id)
+      merchantsCreated += 1
+      auditEntries.push(...createdAuditEntries("Merchant", [created]))
+    }
+    await auditLogs(tx, auditCtx, withFamily(auditEntries, familyId))
+  })
+
+  // --- 4. Transactions -> StagedRowInput[] (per-row id remap + classify) ----
+  const rows: StagedRowInput[] = []
+  const promotableBySureId = new Map<string, boolean>()
+  let zeroAmountSkipped = 0
+  let invalidDateSkipped = 0
+
+  for (const txn of bundle.transactions) {
+    const permoneyAccountId = accountMap.get(txn.account_id)
+    if (!permoneyAccountId) continue // unmappable — shell missing (shouldn't happen)
+    const account = accountInfo.get(permoneyAccountId)
+    if (!account) continue
+
+    const date = new Date(txn.date)
+    if (Number.isNaN(date.getTime())) {
+      invalidDateSkipped += 1
+      continue
+    }
+
+    const { type, absMinorUnits, isZeroAmount } = classifySureAmount(
+      txn.amount,
+      account.currency as CurrencyCode
+    )
+    // PER-82's staged amount is strictly positive minor units; a 0-amount Sure
+    // entry can't be represented. It is retained in the artifact (lossless) and
+    // counted here rather than staged (ADR-0041 §4.C "flagged for review").
+    if (isZeroAmount) {
+      zeroAmountSkipped += 1
+      continue
+    }
+
+    const promotable = isPromotable(txn, account)
+    promotableBySureId.set(txn.id, promotable)
+    rows.push({
+      accountId: permoneyAccountId,
+      externalId: txn.id,
+      rawPayload: { sureEntity: "Transaction", ...txn },
+      date,
+      amount: absMinorUnits.toString(),
+      type,
+      description: (txn.name ?? "").trim() || "Imported transaction",
+      suggestedCategoryId: txn.category_id
+        ? (categoryMap.get(txn.category_id) ?? null)
+        : null,
+      suggestedMerchantId: txn.merchant_id
+        ? (merchantMap.get(txn.merchant_id) ?? null)
+        : null,
+    })
+  }
+
+  // --- 5. Stage through PER-82 (reuses the batch on re-run via contentHash) --
+  let batchId: string
+  let replayed: boolean
+  if (rows.length > 0) {
+    const batch = await createImportBatchForFamily({
+      data: {
+        sourceKind: "migration",
+        provider: SURE_PROVIDER,
+        contentHash,
+        rows,
+      },
+      familyId,
+      user,
+      runInTenantTransaction,
+    })
+    batchId = batch.id
+    replayed = batch.replayed
+  } else {
+    // Degraded bundle with zero stageable rows still gets a batch + artifact so
+    // the raw provenance and the deferred-entity source are retained.
+    batchId = await ensureEmptyMigrationBatch(
+      runInTenantTransaction,
+      familyId,
+      user,
+      contentHash,
+      auditCtx
+    )
+    replayed = false
+  }
+
+  // --- 6. Retain the raw bundle (gzip BYTEA artifact, one-shot per content) --
+  const gzip = await gzipBytes(rawBytes)
+  await runInTenantTransaction(familyId, user.id, async (tx) => {
+    const existing = await tx.importBatchArtifact.findFirst({
+      where: { importBatchId: batchId, contentHash },
+      select: { id: true },
+    })
+    if (existing) return
+    const created = await tx.importBatchArtifact.create({
+      data: {
+        familyId,
+        importBatchId: batchId,
+        filename: data.filename,
+        storageKind: "inline_bytea",
+        contentHash,
+        byteSize: rawBytes.length,
+        bytes: Buffer.from(gzip),
+      },
+    })
+    await auditLogs(
+      tx,
+      auditCtx,
+      withFamily(
+        createdAuditEntries("ImportBatchArtifact", [created]),
+        familyId
+      )
+    )
+  })
+
+  // --- 7. Confirm gated rows that are still normalized, then promote --------
+  let promotedThisRun = 0
+  if (rows.length > 0) {
+    const confirmRowIds = await runInTenantTransaction(
+      familyId,
+      user.id,
+      async (tx) => {
+        const staged = await tx.rawImportedTransaction.findMany({
+          where: { familyId, importBatchId: batchId, rowStatus: "normalized" },
+          select: { id: true, externalId: true },
+        })
+        return staged
+          .filter(
+            (r) =>
+              r.externalId != null &&
+              promotableBySureId.get(r.externalId) === true
+          )
+          .map((r) => r.id)
+      }
+    )
+
+    if (confirmRowIds.length > 0) {
+      await reviewImportRowsForFamily({
+        data: {
+          batchId,
+          idempotencyKey: createUuidV7(),
+          decisions: confirmRowIds.map((rowId) => ({
+            rowId,
+            verdict: "confirm" as const,
+          })),
+        },
+        familyId,
+        user,
+        runInTenantTransaction,
+      })
+    }
+
+    const promotion = await promoteImportBatchForFamily({
+      data: { batchId, idempotencyKey: createUuidV7() },
+      familyId,
+      user,
+      runInTenantTransaction,
+    })
+    promotedThisRun = promotion.promotedCount
+  }
+
+  const promotableCount = Array.from(promotableBySureId.values()).filter(
+    Boolean
+  ).length
+
+  return {
+    batchId,
+    replayed,
+    contentHash,
+    byteSize: rawBytes.length,
+    accounts: { created: accountsCreated, reused: accountsReused },
+    categories: { created: categoriesCreated, reused: categoriesReused },
+    merchants: { created: merchantsCreated, reused: merchantsReused },
+    transactions: {
+      total: bundle.transactions.length,
+      staged: rows.length,
+      promotedThisRun,
+      held: rows.length - promotableCount,
+      zeroAmountSkipped,
+      invalidDateSkipped,
+    },
+    malformedLines: bundle.malformedLines.length,
+    ignoredEntities: bundle.ignoredEntities,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Binding reuse helpers (find-by-partial-unique-binding; never recreate — §7)
+// ---------------------------------------------------------------------------
+
+async function reuseAccount(
+  tx: TenantTransactionClient,
+  familyId: string,
+  sureAccountId: string
+): Promise<PermoneyAccountInfo | null> {
+  const existing = await tx.account.findFirst({
+    where: {
+      familyId,
+      externalProvider: SURE_PROVIDER,
+      externalAccountId: sureAccountId,
+    },
+    select: {
+      id: true,
+      currency: true,
+      isImportable: true,
+      balanceSource: true,
+    },
+  })
+  return existing
+}
+
+async function reuseBoundId(
+  tx: TenantTransactionClient,
+  entity: "category" | "merchant",
+  familyId: string,
+  sureId: string
+): Promise<string | null> {
+  const where = {
+    familyId,
+    externalProvider: SURE_PROVIDER,
+    externalId: sureId,
+  }
+  const existing =
+    entity === "category"
+      ? await tx.category.findFirst({ where, select: { id: true } })
+      : await tx.merchant.findFirst({ where, select: { id: true } })
+  return existing?.id ?? null
+}
+
+// Tag audit entries with the familyId explicitly (defense-in-depth; auditLogs
+// otherwise falls back to ctx.session.user.familyId).
+function withFamily(
+  entries: AuditLogEntry[],
+  familyId: string
+): AuditLogEntry[] {
+  return entries.map((entry) => ({ ...entry, familyId }))
+}
+
+// A migration with zero stageable rows still needs a batch to anchor the
+// retained artifact. Reuses the existing batch on re-run (contentHash dedup).
+async function ensureEmptyMigrationBatch(
+  runInTenantTransaction: RunInTenantTransaction,
+  familyId: string,
+  user: { id: string; familyId?: string | null },
+  contentHash: string,
+  auditCtx: Awaited<ReturnType<typeof createAuditContext>>
+): Promise<string> {
+  return runInTenantTransaction(familyId, user.id, async (tx) => {
+    const existing = await tx.importBatch.findUnique({
+      where: {
+        import_batch_content_dedup: {
+          familyId,
+          sourceKind: "migration",
+          contentHash,
+        },
+      },
+      select: { id: true },
+    })
+    if (existing) return existing.id
+    const batch = await tx.importBatch.create({
+      data: {
+        familyId,
+        createdById: user.id,
+        sourceKind: "migration",
+        provider: SURE_PROVIDER,
+        contentHash,
+        status: "ready_for_review",
+        totalRows: 0,
+      },
+    })
+    await auditLogs(
+      tx,
+      auditCtx,
+      withFamily(createdAuditEntries("ImportBatch", [batch]), familyId)
+    )
+    return batch.id
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Server-fn surface (capability-gated — ADR-0036 ledger:write, no new cap)
+// ---------------------------------------------------------------------------
+
+export const runSureMigrationFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: unknown) => sureMigrationInputSchema.parse(data))
+  .handler(async ({ data, context }) =>
+    runSureMigrationForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  )

--- a/tests/integration/support/sure-fixtures.ts
+++ b/tests/integration/support/sure-fixtures.ts
@@ -1,0 +1,320 @@
+// ============================================================================
+// PER-170 / ADR-0041 — Synthetic Sure v2 bundle builder (test-only).
+//
+// Deterministic, schema-faithful `all.ndjson` generators for the Sure full-family
+// migration tests. We NEVER commit a real Sure export (ADR-0041 §11); these
+// fixtures emit the exact `{ entity, data }` envelope the production reader
+// (`src/lib/sure-migration.ts`) consumes, so a parser/orchestrator change that
+// breaks real bundles also breaks these.
+//
+// Two scenarios:
+//   * `buildSureBundleV2Complete` — a full v2 export: depository (with Balance
+//     snapshot opening), investment (held, not importable), a USD account (for
+//     the currency-mismatch hold), parent/child categories, merchants, and the
+//     full transaction taxonomy (promotable expense + income, zero-amount,
+//     non-standard kind, split parent, currency mismatch, held investment), plus
+//     a Transfer row for typed-source coverage.
+//   * `buildSureBundleV1Degraded` — a pre-v2 / degraded export: NO Balance or
+//     Transfer entities (opening falls back to 0), an unknown `accountable_type`
+//     (conservative depository fallback), an orphan category (missing parent),
+//     a promotable INCOME row (so an opening-0 ASSET stays sign-valid), and a
+//     couple of malformed lines the parser must reject without aborting.
+//
+// Each builder returns the NDJSON string AND a manifest of the ids + expected
+// orchestration counts, so a test asserts against intent rather than re-deriving
+// the arithmetic.
+// ============================================================================
+
+const envelope = (entity: string, data: Record<string, unknown>): string =>
+  JSON.stringify({ entity, data })
+
+export interface SureBundleManifest {
+  ndjson: string
+  ids: Record<string, string>
+  expected: {
+    accountsCreated: number
+    categoriesCreated: number
+    merchantsCreated: number
+    transactionsTotal: number
+    staged: number
+    promotedThisRun: number
+    held: number
+    zeroAmountSkipped: number
+    malformedLines: number
+  }
+  /** Opening balance (minor units) the depository account should be created with. */
+  openingBalanceMinor: bigint
+}
+
+// ---------------------------------------------------------------------------
+// v2 complete
+// ---------------------------------------------------------------------------
+
+export function buildSureBundleV2Complete(): SureBundleManifest {
+  const ids = {
+    checking: "sure-acc-checking",
+    invest: "sure-acc-invest",
+    usd: "sure-acc-usd",
+    catFood: "sure-cat-food",
+    catDining: "sure-cat-dining",
+    catSalary: "sure-cat-salary",
+    merWarung: "sure-mer-warung",
+    merEmployer: "sure-mer-employer",
+    txnExpense: "sure-txn-expense",
+    txnIncome: "sure-txn-income",
+    txnZero: "sure-txn-zero",
+    txnHeldInvest: "sure-txn-held-invest",
+    txnHeldKind: "sure-txn-held-kind",
+    txnHeldSplit: "sure-txn-held-split",
+    txnHeldCurrency: "sure-txn-held-currency",
+    transfer: "sure-transfer-1",
+  }
+
+  const lines = [
+    // --- Accounts ---------------------------------------------------------
+    envelope("Account", {
+      id: ids.checking,
+      name: "BCA Checking",
+      accountable_type: "Depository",
+      classification: "asset",
+      subtype: "checking",
+      currency: "IDR",
+      balance: "100000.0",
+    }),
+    envelope("Account", {
+      id: ids.invest,
+      name: "Bibit Reksadana",
+      accountable_type: "Investment",
+      classification: "asset",
+      subtype: "mutual_fund",
+      currency: "IDR",
+      balance: "5000000.0",
+    }),
+    envelope("Account", {
+      id: ids.usd,
+      name: "Wise USD",
+      accountable_type: "Depository",
+      classification: "asset",
+      subtype: "checking",
+      currency: "USD",
+      balance: "0.0",
+    }),
+    // --- Balance snapshot (opening for the checking account) --------------
+    envelope("Balance", {
+      account_id: ids.checking,
+      date: "2026-01-01",
+      start_balance: "100000.0",
+      end_balance: "100000.0",
+    }),
+    // An earlier-id but later-date snapshot to prove "earliest date wins".
+    envelope("Balance", {
+      account_id: ids.checking,
+      date: "2026-03-01",
+      start_balance: "250000.0",
+      end_balance: "250000.0",
+    }),
+    // --- Categories (parent before/after child to exercise the reorder) ---
+    envelope("Category", {
+      id: ids.catDining,
+      name: "Dining",
+      classification: "expense",
+      parent_id: ids.catFood,
+      lucide_icon: "utensils",
+    }),
+    envelope("Category", {
+      id: ids.catFood,
+      name: "Food",
+      classification: "expense",
+      lucide_icon: "apple",
+    }),
+    envelope("Category", {
+      id: ids.catSalary,
+      name: "Salary",
+      classification: "income",
+      lucide_icon: "banknote",
+    }),
+    // --- Merchants --------------------------------------------------------
+    envelope("Merchant", {
+      id: ids.merWarung,
+      name: "Warung Tegal",
+      logo_url: null,
+    }),
+    envelope("Merchant", {
+      id: ids.merEmployer,
+      name: "PT Permana",
+      logo_url: null,
+    }),
+    // --- Transactions -----------------------------------------------------
+    // Promotable expense (Sure POSITIVE → Permoney expense, ledger negative).
+    envelope("Transaction", {
+      id: ids.txnExpense,
+      account_id: ids.checking,
+      category_id: ids.catDining,
+      merchant_id: ids.merWarung,
+      date: "2026-06-15",
+      amount: "17000.0",
+      currency: "IDR",
+      name: "Lumpia beef",
+      kind: "standard",
+    }),
+    // Promotable income (Sure NEGATIVE → Permoney income, ledger positive).
+    envelope("Transaction", {
+      id: ids.txnIncome,
+      account_id: ids.checking,
+      category_id: ids.catSalary,
+      merchant_id: ids.merEmployer,
+      date: "2026-06-25",
+      amount: "-5000.0",
+      currency: "IDR",
+      name: "June salary",
+      kind: "standard",
+    }),
+    // Zero-amount → classified expense, flagged, skipped from staging.
+    envelope("Transaction", {
+      id: ids.txnZero,
+      account_id: ids.checking,
+      date: "2026-06-16",
+      amount: "0",
+      currency: "IDR",
+      name: "Zero adjustment",
+      kind: "standard",
+    }),
+    // Held: account not importable (Investment).
+    envelope("Transaction", {
+      id: ids.txnHeldInvest,
+      account_id: ids.invest,
+      date: "2026-06-17",
+      amount: "1000000.0",
+      currency: "IDR",
+      name: "Reksadana buy",
+      kind: "standard",
+    }),
+    // Held: non-standard kind (transfer leg).
+    envelope("Transaction", {
+      id: ids.txnHeldKind,
+      account_id: ids.checking,
+      date: "2026-06-18",
+      amount: "20000.0",
+      currency: "IDR",
+      name: "Move to savings",
+      kind: "funds_movement",
+    }),
+    // Held: split parent (split_lines present).
+    envelope("Transaction", {
+      id: ids.txnHeldSplit,
+      account_id: ids.checking,
+      date: "2026-06-19",
+      amount: "30000.0",
+      currency: "IDR",
+      name: "Groceries split",
+      kind: "standard",
+      split_lines: [
+        { category_id: ids.catFood, amount: "20000.0" },
+        { category_id: ids.catDining, amount: "10000.0" },
+      ],
+    }),
+    // Held: currency mismatch (txn IDR on a USD account).
+    envelope("Transaction", {
+      id: ids.txnHeldCurrency,
+      account_id: ids.usd,
+      date: "2026-06-20",
+      amount: "40000.0",
+      currency: "IDR",
+      name: "Mismatched currency",
+      kind: "standard",
+    }),
+    // --- Transfer (typed source for deferred Phase 1.5) -------------------
+    envelope("Transfer", {
+      id: ids.transfer,
+      inflow_transaction_id: ids.txnIncome,
+      outflow_transaction_id: ids.txnHeldKind,
+      status: "confirmed",
+    }),
+    // Deferred/unknown entities — counted as ignored, retained in the artifact.
+    envelope("Holding", { id: "sure-holding-1", account_id: ids.invest }),
+    envelope("Rule", { id: "sure-rule-1" }),
+  ]
+
+  return {
+    ndjson: lines.join("\n"),
+    ids,
+    expected: {
+      accountsCreated: 3,
+      categoriesCreated: 3,
+      merchantsCreated: 2,
+      transactionsTotal: 7,
+      staged: 6, // all 7 minus the zero-amount row
+      promotedThisRun: 2, // expense + income on the importable IDR depository
+      held: 4, // invest + non-standard kind + split + currency mismatch
+      zeroAmountSkipped: 1,
+      malformedLines: 0,
+    },
+    // 100000.0 IDR → 10_000_000 minor (earliest snapshot, not the 250000 one).
+    openingBalanceMinor: 10_000_000n,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// v1 degraded
+// ---------------------------------------------------------------------------
+
+export function buildSureBundleV1Degraded(): SureBundleManifest {
+  const ids = {
+    wallet: "sure-acc-wallet",
+    catOrphan: "sure-cat-orphan",
+    txnIncome: "sure-txn-degraded-income",
+  }
+
+  const lines = [
+    // Unknown accountable_type → conservative depository/checking fallback.
+    envelope("Account", {
+      id: ids.wallet,
+      name: "Mystery Wallet",
+      accountable_type: "Spaceship",
+      classification: "asset",
+      subtype: "warp",
+      currency: "IDR",
+      balance: "0.0",
+    }),
+    // Orphan category: parent_id points at a category absent from the bundle.
+    envelope("Category", {
+      id: ids.catOrphan,
+      name: "Uncategorized",
+      classification: "income",
+      parent_id: "sure-cat-ghost",
+    }),
+    // Malformed line 1: not JSON.
+    "{ this is not valid json",
+    // Malformed line 2: valid JSON, missing the data envelope.
+    JSON.stringify({ entity: "Account" }),
+    // Promotable INCOME (Sure NEGATIVE) so an opening-0 ASSET stays sign-valid
+    // after promotion (ledger positive).
+    envelope("Transaction", {
+      id: ids.txnIncome,
+      account_id: ids.wallet,
+      category_id: ids.catOrphan,
+      date: "2026-05-10",
+      amount: "-12345.0",
+      currency: "IDR",
+      name: "Cash gift",
+      kind: "standard",
+    }),
+  ]
+
+  return {
+    ndjson: lines.join("\n"),
+    ids,
+    expected: {
+      accountsCreated: 1,
+      categoriesCreated: 1,
+      merchantsCreated: 0,
+      transactionsTotal: 1,
+      staged: 1,
+      promotedThisRun: 1,
+      held: 0,
+      zeroAmountSkipped: 0,
+      malformedLines: 2,
+    },
+    openingBalanceMinor: 0n, // no Balance entity → no plug, opening 0
+  }
+}

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -1,0 +1,323 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import { IDENTITY_RATE } from "@/lib/fx"
+import { SURE_PROVIDER } from "@/lib/sure-migration"
+import { runSureMigrationForFamily } from "@/server/sure-migration"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+import {
+  buildSureBundleV1Degraded,
+  buildSureBundleV2Complete,
+} from "./support/sure-fixtures"
+
+// PER-170 / ADR-0041 — Real-Postgres proof of the Sure full-family migration:
+// provider-bound account/category/merchant creation, snapshot opening (no plug),
+// the Sure sign inversion at promotion, §6 gating (held rows stay staged), the
+// PER-82 promotion parity it reuses (signed amount, atomic balance, base FX
+// projection, audit), one-shot idempotent re-run, lossless artifact retention,
+// and tenant isolation under RLS.
+
+describe("Sure full-family migration vertical slice (PER-170)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // Inject the harness tenant runner so domain fns run with both GUCs set to the
+  // acting member — exactly what familyMiddleware does in production.
+  const runner =
+    () =>
+    <T>(
+      familyId: string,
+      userId: string,
+      fn: Parameters<typeof harness.withMember>[2]
+    ) =>
+      harness.withMember(familyId, userId, fn) as Promise<T>
+
+  interface Tenant {
+    familyId: string
+    userId: string
+  }
+
+  const setupTenant = async (currency = "IDR"): Promise<Tenant> => {
+    const family = await factories.createFamily({ currency })
+    const user = await factories.createUser({ familyId: family.id })
+    await factories.createFamilyMember({
+      familyId: family.id,
+      userId: user.id,
+      role: "owner",
+    })
+    return { familyId: family.id, userId: user.id }
+  }
+
+  const migrate = (tenant: Tenant, filename: string, bundle: string) =>
+    runSureMigrationForFamily({
+      data: { filename, bundle },
+      familyId: tenant.familyId,
+      user: { id: tenant.userId, familyId: tenant.familyId },
+      runInTenantTransaction: runner(),
+    })
+
+  const accountByBinding = (tenant: Tenant, externalAccountId: string) =>
+    harness.withMember(tenant.familyId, tenant.userId, (tx) =>
+      tx.account.findFirst({
+        where: {
+          familyId: tenant.familyId,
+          externalProvider: SURE_PROVIDER,
+          externalAccountId,
+        },
+      })
+    )
+
+  // ---- full v2 bundle ------------------------------------------------------
+
+  test("migrates a v2 bundle: bound entities, snapshot opening, only gated rows promoted", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV2Complete()
+
+    const result = await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    expect(result.replayed).toBe(false)
+    expect(result.accounts).toEqual({ created: 3, reused: 0 })
+    expect(result.categories).toEqual({ created: 3, reused: 0 })
+    expect(result.merchants).toEqual({ created: 2, reused: 0 })
+    expect(result.transactions.total).toBe(fixture.expected.transactionsTotal)
+    expect(result.transactions.staged).toBe(fixture.expected.staged)
+    expect(result.transactions.promotedThisRun).toBe(
+      fixture.expected.promotedThisRun
+    )
+    expect(result.transactions.held).toBe(fixture.expected.held)
+    expect(result.transactions.zeroAmountSkipped).toBe(1)
+    expect(result.malformedLines).toBe(0)
+    expect(result.ignoredEntities).toMatchObject({ Holding: 1, Rule: 1 })
+
+    // Provider-bound depository, opening from the EARLIEST snapshot, then the
+    // expense (−1_700_000) + income (+500_000) deltas applied atomically.
+    const checking = await accountByBinding(tenant, fixture.ids.checking)
+    expect(checking?.accountType).toBe("DEPOSITORY")
+    expect(checking?.isImportable).toBe(true)
+    expect(checking?.balance).toBe(
+      fixture.openingBalanceMinor - 1_700_000n + 500_000n
+    )
+
+    // Investment shell exists but is held (not importable).
+    const invest = await accountByBinding(tenant, fixture.ids.invest)
+    expect(invest?.accountType).toBe("INVESTMENT")
+    expect(invest?.isImportable).toBe(false)
+
+    // Held rows are staged-not-promoted: still normalized, never a Transaction.
+    const { staged, promotedRows, txnCount } = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      async (tx) => ({
+        staged: await tx.rawImportedTransaction.count({
+          where: { familyId: tenant.familyId, rowStatus: "normalized" },
+        }),
+        promotedRows: await tx.rawImportedTransaction.count({
+          where: { familyId: tenant.familyId, rowStatus: "promoted" },
+        }),
+        txnCount: await tx.transaction.count({
+          where: { familyId: tenant.familyId },
+        }),
+      })
+    )
+    expect(staged).toBe(fixture.expected.held) // 4 held remain normalized
+    expect(promotedRows).toBe(2)
+    expect(txnCount).toBe(2)
+
+    // Lossless artifact retained (gzip BYTEA, hash + size provenance).
+    const artifact = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.importBatchArtifact.findFirst({
+          where: { familyId: tenant.familyId, importBatchId: result.batchId },
+        })
+    )
+    expect(artifact?.storageKind).toBe("inline_bytea")
+    expect(artifact?.contentHash).toBe(result.contentHash)
+    expect(artifact?.byteSize).toBe(result.byteSize)
+    expect(artifact?.bytes?.length).toBeGreaterThan(0)
+  })
+
+  test("promotion parity: sign inversion, atomic balance, base FX projection, audit, mapped refs", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV2Complete()
+    await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    const checking = await accountByBinding(tenant, fixture.ids.checking)
+    const txns = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.transaction.findMany({
+          where: { familyId: tenant.familyId, accountId: checking!.id },
+          orderBy: { date: "asc" },
+        })
+    )
+    expect(txns).toHaveLength(2)
+
+    const [expense, income] = txns
+    // Sure POSITIVE 17000.0 → Permoney expense, ledger NEGATIVE minor units.
+    expect(expense?.type).toBe("expense")
+    expect(expense?.amount).toBe(-1_700_000n)
+    // Sure NEGATIVE −5000.0 → Permoney income, ledger POSITIVE.
+    expect(income?.type).toBe("income")
+    expect(income?.amount).toBe(500_000n)
+
+    // PER-159: base-currency FX projection MUST be set (IDR family, IDR account).
+    expect(expense?.baseAmount).toBe(-1_700_000n)
+    expect(expense?.baseCurrency).toBe("IDR")
+    expect(expense?.fxRateScaled).toBe(IDENTITY_RATE)
+    expect(expense?.idempotencyKey).toBeTruthy()
+
+    // Tenant-validated suggested refs carried through to the canonical row.
+    const dining = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.category.findFirst({
+          where: {
+            familyId: tenant.familyId,
+            externalProvider: SURE_PROVIDER,
+            externalId: fixture.ids.catDining,
+          },
+        })
+    )
+    expect(expense?.categoryId).toBe(dining?.id)
+
+    // Audit rows written in the promotion transaction.
+    const auditCount = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.auditLog.count({
+          where: { entityType: "Transaction", entityId: expense!.id },
+        })
+    )
+    expect(auditCount).toBeGreaterThanOrEqual(1)
+  })
+
+  // ---- one-shot idempotency ------------------------------------------------
+
+  test("re-running the same bundle is idempotent: reuses everything, no double-book", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV2Complete()
+
+    const first = await migrate(tenant, "all.ndjson", fixture.ndjson)
+    const checkingAfterFirst = await accountByBinding(
+      tenant,
+      fixture.ids.checking
+    )
+
+    const second = await migrate(tenant, "all.ndjson", fixture.ndjson)
+    expect(second.batchId).toBe(first.batchId)
+    expect(second.replayed).toBe(true)
+    expect(second.accounts).toEqual({ created: 0, reused: 3 })
+    expect(second.categories).toEqual({ created: 0, reused: 3 })
+    expect(second.merchants).toEqual({ created: 0, reused: 2 })
+    expect(second.transactions.promotedThisRun).toBe(0) // already promoted
+
+    const { accountCount, txnCount, artifactCount, checking } =
+      await harness.withMember(tenant.familyId, tenant.userId, async (tx) => ({
+        accountCount: await tx.account.count({
+          where: { familyId: tenant.familyId },
+        }),
+        txnCount: await tx.transaction.count({
+          where: { familyId: tenant.familyId },
+        }),
+        artifactCount: await tx.importBatchArtifact.count({
+          where: { familyId: tenant.familyId },
+        }),
+        checking: await tx.account.findUniqueOrThrow({
+          where: { id: checkingAfterFirst!.id },
+        }),
+      }))
+    expect(accountCount).toBe(3) // no new shells
+    expect(txnCount).toBe(2) // no double-book
+    expect(artifactCount).toBe(1) // one-shot artifact
+    expect(checking.balance).toBe(checkingAfterFirst!.balance) // balance stable
+  })
+
+  // ---- degraded v1 bundle --------------------------------------------------
+
+  test("degraded bundle: unknown-type fallback, orphan category, no-snapshot opening 0, rejects malformed", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV1Degraded()
+
+    const result = await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    expect(result.malformedLines).toBe(2)
+    expect(result.accounts).toEqual({ created: 1, reused: 0 })
+    expect(result.categories).toEqual({ created: 1, reused: 0 })
+    expect(result.transactions.promotedThisRun).toBe(1)
+
+    const wallet = await accountByBinding(tenant, fixture.ids.wallet)
+    // Unknown accountable_type → conservative cash-like depository, importable.
+    expect(wallet?.accountType).toBe("DEPOSITORY")
+    expect(wallet?.isImportable).toBe(true)
+    // No Balance entity → opening 0 (no plug); income promotion → +1_234_500.
+    expect(wallet?.balance).toBe(1_234_500n)
+
+    // Orphan category (missing parent) created as a root.
+    const orphan = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.category.findFirst({
+          where: {
+            familyId: tenant.familyId,
+            externalProvider: SURE_PROVIDER,
+            externalId: fixture.ids.catOrphan,
+          },
+        })
+    )
+    expect(orphan?.parentId).toBeNull()
+  })
+
+  // ---- tenant isolation ----------------------------------------------------
+
+  test("family B cannot read family A's migrated accounts or raw artifact", async () => {
+    const a = await setupTenant()
+    const b = await setupTenant()
+    const fixture = buildSureBundleV2Complete()
+    const result = await migrate(a, "all.ndjson", fixture.ndjson)
+
+    // B, scoped to its own GUCs, sees none of A's provider-bound rows or the
+    // family-private artifact (RLS membership guard + composite tenant FK).
+    const leaked = await harness.withMember(
+      b.familyId,
+      b.userId,
+      async (tx) => ({
+        accounts: await tx.account.count({
+          where: { externalProvider: SURE_PROVIDER },
+        }),
+        artifacts: await tx.importBatchArtifact.count({
+          where: { importBatchId: result.batchId },
+        }),
+      })
+    )
+    expect(leaked.accounts).toBe(0)
+    expect(leaked.artifacts).toBe(0)
+  })
+})


### PR DESCRIPTION
## PER-170 — Sure full-family migration backend (Phase 1a)

Implements the backend of ADR-0041 Phase 1 (Accepted). **No UI** — that is PER-171. The slice is end-to-end testable through a capability-gated server fn plus real-Postgres integration tests.

### What ships
- **Schema (additive, backward-compatible):** `externalProvider`/`externalId` provider bindings on Category + Merchant (mirroring Account), as hand-written **partial UNIQUE** indexes `WHERE externalProvider IS NOT NULL` keyed on `(familyId, externalProvider, externalId)` (Prisma can't express the predicate; familyId in the composite per ADR-0010). `ImportBatch` gains a provider-agnostic `provider` column + a `'migration'` sourceKind. New **`ImportBatchArtifact`** table for tenant-private lossless bundle provenance.
- **Pure reader** (`src/lib/sure-migration.ts`): NDJSON per-line parse with malformed-line rejection, Sure v2 Zod schemas, `accountable_type` → Permoney taxonomy normalizer (conservative depository fallback), the Sure **sign inversion** (outflow POSITIVE → expense, inflow NEGATIVE → income, 0 → flagged), parent-first category ordering. 14 unit tests.
- **Orchestration** (`src/server/sure-migration.ts`): one deep module behind a single server fn. Creates provider-bound accounts/categories/merchants → id-maps → feeds transactions through the **unchanged PER-82 staging pipeline** (stage → dedup → confirm → promote). Not a new ledger writer. §5 opening from earliest Balance snapshot else 0 (never plugs); §6 gating (only standard-kind, importable, transaction_flow, currency-matched, non-split rows promote); §7 one-shot idempotency at every layer.

### Storage form & encryption decision (recorded per ADR-0041 §8/§11)
- **Inline gzip BYTEA** (`storageKind='inline_bytea'`): the raw `all.ndjson` is gzipped and stored in `ImportBatchArtifact.bytes`, with `contentHash` (sha256) + `byteSize` for provenance and a 64 MiB pre-parse size guard. A discriminator column (`storageKind` + `storageRef`) leaves a clean seam to swap to `object_store` later without a schema break; a shape CHECK enforces inline-bytes XOR external-ref.
- **Encryption-at-rest** relies on **DB/disk-level encryption + RLS family scoping** (membership guard `app_is_active_member` + `FORCE ROW LEVEL SECURITY` + composite tenant FK) — **not** app-level column crypto. This is consistent with the same financial PII already living unencrypted-at-column in `Transaction`/`Account`; adding column crypto only here would be inconsistent security theatre and break queryability without raising the real bar.

### Tests
Synthetic, schema-faithful fixtures (v2-complete + v1-degraded; **no real bundle committed**) + real-Postgres integration coverage: promotion parity (sign inversion, atomic balance delta, base-currency FX projection per PER-159, audit rows, tenant-validated refs), idempotent re-run (no double-book / no new shells / one-shot artifact), opening snapshot vs no-plug fallback, §6 held rows staged-not-promoted, and tenant isolation under RLS.

### Gates
`vp check` ✅ · `vp test run` — 348 unit + 252 integration ✅ · `vp build` ✅ (build green confirms the server module did not leak into the client bundle).

Refs PER-170 (ADR-0041 Phase 1). Follow-up: PER-171 (migration UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
