### PR TITLE
feat(import): PER-171 — Sure migration guided importer UI + E2E (Phase 1b, ADR-0041)

### DIFF
--- a/src/lib/sure-migration.test.ts
+++ b/src/lib/sure-migration.test.ts
@@ -5,8 +5,13 @@ import {
   normalizeSureAccountType,
   orderCategoriesParentsFirst,
   parseSureBundle,
+  summarizeSureBundle,
   type SureCategory,
 } from "./sure-migration"
+import {
+  buildSureBundleV1Degraded,
+  buildSureBundleV2Complete,
+} from "../../tests/integration/support/sure-fixtures"
 
 // PER-170 / ADR-0041 — pure reader units: NDJSON parse + malformed rejection,
 // account-type normalization + fallback, the Sure sign inversion (incl. 0), and
@@ -208,5 +213,64 @@ describe("orderCategoriesParentsFirst", () => {
   test("is total and terminates on an accidental cycle", () => {
     const ordered = orderCategoriesParentsFirst([cat("a", "b"), cat("b", "a")])
     expect(ordered.map((c) => c.id).sort()).toEqual(["a", "b"])
+  })
+})
+
+// PER-171 — the guided importer's pre-confirm preview runs `summarizeSureBundle`
+// in the browser. These pins prove the client-side held classification mirrors
+// the server orchestrator's gates against the SAME synthetic fixtures the
+// integration suite promotes, so the previewed counts cannot drift from the
+// authoritative SureMigrationResult.
+describe("summarizeSureBundle (preview parity with the orchestrator)", () => {
+  test("v2 complete: created + held-by-reason match the fixture manifest", () => {
+    const manifest = buildSureBundleV2Complete()
+    const preview = summarizeSureBundle(parseSureBundle(manifest.ndjson))
+
+    expect(preview.accounts.total).toBe(manifest.expected.accountsCreated)
+    expect(preview.categories).toBe(manifest.expected.categoriesCreated)
+    expect(preview.merchants).toBe(manifest.expected.merchantsCreated)
+
+    expect(preview.transactions.total).toBe(manifest.expected.transactionsTotal)
+    // promotable mirrors the server's promotedThisRun on a fresh (non-replayed) run.
+    expect(preview.transactions.promotable).toBe(
+      manifest.expected.promotedThisRun
+    )
+    expect(preview.transactions.held).toBe(manifest.expected.held)
+    expect(preview.transactions.zeroAmountSkipped).toBe(
+      manifest.expected.zeroAmountSkipped
+    )
+    // staged = promotable + held (the orchestrator's staged-row count).
+    expect(preview.transactions.promotable + preview.transactions.held).toBe(
+      manifest.expected.staged
+    )
+
+    // One held row per distinct reason in the fixture (transfer, investment
+    // account, currency mismatch, split parent).
+    expect(preview.transactions.heldByReason).toEqual({
+      transfer: 1,
+      nonImportableAccount: 1,
+      currencyMismatch: 1,
+      split: 1,
+    })
+    // Two accounts are non-importable activity holders: the Investment account.
+    expect(preview.accounts.held).toBe(1)
+    expect(preview.accounts.importable).toBe(2)
+    expect(preview.transfers).toBe(1)
+    expect(preview.malformedLines).toBe(manifest.expected.malformedLines)
+    // Deferred entities (Holding, Rule) are surfaced, never silently dropped.
+    expect(preview.ignoredEntities).toEqual({ Holding: 1, Rule: 1 })
+  })
+
+  test("v1 degraded: malformed lines surfaced, single promotable income", () => {
+    const manifest = buildSureBundleV1Degraded()
+    const preview = summarizeSureBundle(parseSureBundle(manifest.ndjson))
+
+    expect(preview.accounts.total).toBe(manifest.expected.accountsCreated)
+    expect(preview.accounts.importable).toBe(1) // unknown type → cash-like fallback
+    expect(preview.transactions.promotable).toBe(
+      manifest.expected.promotedThisRun
+    )
+    expect(preview.transactions.held).toBe(0)
+    expect(preview.malformedLines).toBe(manifest.expected.malformedLines)
   })
 })

--- a/src/lib/sure-migration.test.ts
+++ b/src/lib/sure-migration.test.ts
@@ -5,9 +5,16 @@ import {
   normalizeSureAccountType,
   orderCategoriesParentsFirst,
   parseSureBundle,
+  sureHeldReason,
   summarizeSureBundle,
   type SureCategory,
+  type SurePreviewAccount,
+  type SureTransaction,
 } from "./sure-migration"
+// Anchor the client-side preview classifier to the REAL server gate, not a
+// hand-written copy: import the server's `isPromotable` and assert identical
+// verdicts. Behavior-neutral export (PER-171); the integration suite stays green.
+import { isPromotable } from "@/server/sure-migration"
 import {
   buildSureBundleV1Degraded,
   buildSureBundleV2Complete,
@@ -217,60 +224,135 @@ describe("orderCategoriesParentsFirst", () => {
 })
 
 // PER-171 — the guided importer's pre-confirm preview runs `summarizeSureBundle`
-// in the browser. These pins prove the client-side held classification mirrors
-// the server orchestrator's gates against the SAME synthetic fixtures the
-// integration suite promotes, so the previewed counts cannot drift from the
-// authoritative SureMigrationResult.
-describe("summarizeSureBundle (preview parity with the orchestrator)", () => {
-  test("v2 complete: created + held-by-reason match the fixture manifest", () => {
+// in the browser. To be an honest drift guard (not "copy vs copy"), the held
+// classification is asserted against the REAL server verdict `isPromotable`,
+// across a branch matrix AND every transaction in the synthetic fixtures.
+describe("sureHeldReason parity with the server's isPromotable", () => {
+  // One account per Sure accountable_type branch (importable vs held), built
+  // through the same normalizer the orchestrator persists from, so the account
+  // gate (isImportable + balanceSource) is faithful.
+  const accountSpecs: Array<[string, string | null]> = [
+    ["Depository", "checking"],
+    ["CreditCard", null],
+    ["Loan", null],
+    ["Investment", "mutual_fund"],
+    ["PreciousMetal", null],
+    ["OtherAsset", null],
+    ["Spaceship", "warp"], // unknown → conservative depository fallback
+  ]
+  const accounts: Array<SurePreviewAccount & { id: string }> = accountSpecs.map(
+    ([type, subtype], index) => ({
+      id: `acc-${index}`,
+      currency: "IDR",
+      ...normalizeSureAccountType(type, subtype),
+    })
+  )
+
+  // One transaction per gate branch: standard, currency mismatch, transfer
+  // kinds, defaulted/blank kind, and split parent.
+  const txnVariants: Array<Partial<SureTransaction>> = [
+    { kind: "standard", currency: "IDR" },
+    { kind: "standard", currency: "EUR" }, // currency mismatch
+    { kind: "funds_movement", currency: "IDR" },
+    { kind: "cc_payment", currency: "IDR" },
+    { kind: undefined, currency: "IDR" }, // defaults to standard
+    { kind: "   ", currency: "IDR" }, // blank → standard
+    { kind: "standard", currency: "IDR", split_lines: [{}] }, // split parent
+  ]
+
+  test("identical verdict for every account × transaction branch", () => {
+    for (const account of accounts) {
+      for (const variant of txnVariants) {
+        const txn: SureTransaction = {
+          id: "t",
+          account_id: account.id,
+          date: "2026-01-01",
+          amount: "1000.0",
+          currency: variant.currency ?? "IDR",
+          ...variant,
+        }
+        const clientPromotable = sureHeldReason(txn, account) === null
+        const serverPromotable = isPromotable(txn, account)
+        expect(clientPromotable).toBe(serverPromotable)
+      }
+    }
+  })
+
+  test("identical verdict for every transaction in the synthetic bundles", () => {
+    for (const build of [
+      buildSureBundleV2Complete,
+      buildSureBundleV1Degraded,
+    ]) {
+      const bundle = parseSureBundle(build().ndjson)
+      const accountById = new Map(
+        bundle.accounts.map((a) => [
+          a.id,
+          {
+            id: a.id,
+            currency: a.currency,
+            ...normalizeSureAccountType(a.accountable_type, a.subtype),
+          } satisfies SurePreviewAccount & { id: string },
+        ])
+      )
+      for (const txn of bundle.transactions) {
+        const account = accountById.get(txn.account_id)
+        if (!account) continue
+        expect(sureHeldReason(txn, account) === null).toBe(
+          isPromotable(txn, account)
+        )
+      }
+    }
+  })
+})
+
+// The preview must fully reconcile to the SureMigrationResult: every bucket the
+// server distinguishes (held, zero-amount, invalid-date, unmapped) plus malformed
+// lines and ignored entities is surfaced, and the buckets sum back to the total —
+// so a user never sees an unexplained gap.
+describe("summarizeSureBundle reconciliation", () => {
+  test("v2 complete: buckets sum to total and surface all provenance", () => {
     const manifest = buildSureBundleV2Complete()
     const preview = summarizeSureBundle(parseSureBundle(manifest.ndjson))
+    const t = preview.transactions
 
-    expect(preview.accounts.total).toBe(manifest.expected.accountsCreated)
-    expect(preview.categories).toBe(manifest.expected.categoriesCreated)
-    expect(preview.merchants).toBe(manifest.expected.merchantsCreated)
+    // total = importing + held + zero + invalid-date + unmapped (the exact
+    // partition the orchestrator applies before staging).
+    expect(
+      t.promotable +
+        t.held +
+        t.zeroAmountSkipped +
+        t.invalidDateSkipped +
+        t.unmappable
+    ).toBe(t.total)
+    // held is itemized per reason and the parts sum to the held total.
+    expect(
+      t.heldByReason.transfer +
+        t.heldByReason.nonImportableAccount +
+        t.heldByReason.currencyMismatch +
+        t.heldByReason.split
+    ).toBe(t.held)
 
-    expect(preview.transactions.total).toBe(manifest.expected.transactionsTotal)
-    // promotable mirrors the server's promotedThisRun on a fresh (non-replayed) run.
-    expect(preview.transactions.promotable).toBe(
-      manifest.expected.promotedThisRun
-    )
-    expect(preview.transactions.held).toBe(manifest.expected.held)
-    expect(preview.transactions.zeroAmountSkipped).toBe(
-      manifest.expected.zeroAmountSkipped
-    )
-    // staged = promotable + held (the orchestrator's staged-row count).
-    expect(preview.transactions.promotable + preview.transactions.held).toBe(
-      manifest.expected.staged
-    )
-
-    // One held row per distinct reason in the fixture (transfer, investment
-    // account, currency mismatch, split parent).
-    expect(preview.transactions.heldByReason).toEqual({
-      transfer: 1,
-      nonImportableAccount: 1,
-      currencyMismatch: 1,
-      split: 1,
-    })
-    // Two accounts are non-importable activity holders: the Investment account.
-    expect(preview.accounts.held).toBe(1)
-    expect(preview.accounts.importable).toBe(2)
-    expect(preview.transfers).toBe(1)
+    expect(t.promotable).toBe(manifest.expected.promotedThisRun)
+    expect(t.held).toBe(manifest.expected.held)
+    expect(t.zeroAmountSkipped).toBe(manifest.expected.zeroAmountSkipped)
     expect(preview.malformedLines).toBe(manifest.expected.malformedLines)
-    // Deferred entities (Holding, Rule) are surfaced, never silently dropped.
+    // Deferred entities are surfaced, never silently dropped.
     expect(preview.ignoredEntities).toEqual({ Holding: 1, Rule: 1 })
   })
 
-  test("v1 degraded: malformed lines surfaced, single promotable income", () => {
+  test("v1 degraded: malformed lines surfaced; buckets still reconcile", () => {
     const manifest = buildSureBundleV1Degraded()
     const preview = summarizeSureBundle(parseSureBundle(manifest.ndjson))
+    const t = preview.transactions
 
-    expect(preview.accounts.total).toBe(manifest.expected.accountsCreated)
-    expect(preview.accounts.importable).toBe(1) // unknown type → cash-like fallback
-    expect(preview.transactions.promotable).toBe(
-      manifest.expected.promotedThisRun
-    )
-    expect(preview.transactions.held).toBe(0)
+    expect(
+      t.promotable +
+        t.held +
+        t.zeroAmountSkipped +
+        t.invalidDateSkipped +
+        t.unmappable
+    ).toBe(t.total)
+    expect(t.promotable).toBe(manifest.expected.promotedThisRun)
     expect(preview.malformedLines).toBe(manifest.expected.malformedLines)
   })
 })

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -402,7 +402,7 @@ export type SureHeldReason =
   | "currencyMismatch"
   | "split"
 
-interface SurePreviewAccount extends NormalizedSureAccount {
+export interface SurePreviewAccount extends NormalizedSureAccount {
   currency: string
 }
 
@@ -416,7 +416,7 @@ function isImportableSureAccount(account: NormalizedSureAccount): boolean {
  * Precedence matches the server's `isPromotable`: non-standard kind, then a
  * non-importable account, then a currency mismatch, then a split parent.
  */
-function sureHeldReason(
+export function sureHeldReason(
   txn: SureTransaction,
   account: SurePreviewAccount
 ): SureHeldReason | null {

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -384,6 +384,157 @@ export function classifySureAmount(
 }
 
 // ---------------------------------------------------------------------------
+// Pre-confirm preview summary (PER-171 — client-side mirror of the gates)
+// ---------------------------------------------------------------------------
+
+// The guided importer's preview is computed in the browser by running THIS same
+// reader on the uploaded bundle, because the migration server fn commits in one
+// shot (no server dry-run). To keep the preview honest, the held classification
+// below mirrors the orchestrator's `isPromotable` gate (src/server/sure-migration.ts)
+// branch-for-branch and with the SAME precedence, so the previewed counts agree
+// with the authoritative SureMigrationResult after promotion. The parity is
+// pinned by a unit test against the synthetic v2 fixture manifest.
+
+/** A held transaction's single primary reason (assigned with isPromotable's precedence). */
+export type SureHeldReason =
+  | "transfer"
+  | "nonImportableAccount"
+  | "currencyMismatch"
+  | "split"
+
+interface SurePreviewAccount extends NormalizedSureAccount {
+  currency: string
+}
+
+/** An account's Phase-1 promotion eligibility (mirror of isPromotable's account gate). */
+function isImportableSureAccount(account: NormalizedSureAccount): boolean {
+  return account.isImportable && account.balanceSource === "transaction_flow"
+}
+
+/**
+ * Why a staged Sure transaction is held in Phase 1, or `null` if it will promote.
+ * Precedence matches the server's `isPromotable`: non-standard kind, then a
+ * non-importable account, then a currency mismatch, then a split parent.
+ */
+function sureHeldReason(
+  txn: SureTransaction,
+  account: SurePreviewAccount
+): SureHeldReason | null {
+  const kind = (txn.kind ?? "standard").trim() || "standard"
+  if (kind !== "standard") return "transfer"
+  if (!isImportableSureAccount(account)) return "nonImportableAccount"
+  if (txn.currency !== account.currency) return "currencyMismatch"
+  if (txn.split_lines && txn.split_lines.length > 0) return "split"
+  return null
+}
+
+export interface SureBundlePreview {
+  accounts: { total: number; importable: number; held: number }
+  categories: number
+  merchants: number
+  transactions: {
+    total: number
+    /** Standard rows on importable, currency-matching accounts — become ledger txns. */
+    promotable: number
+    /** Staged but held this phase (sum of `heldByReason`). */
+    held: number
+    heldByReason: Record<SureHeldReason, number>
+    /** Zero-amount rows — retained in the artifact, not stageable (ADR-0041 §4.C). */
+    zeroAmountSkipped: number
+    /** Unparseable dates — retained in the artifact, not staged. */
+    invalidDateSkipped: number
+    /** Rows whose account is absent from the bundle (degraded export). */
+    unmappable: number
+  }
+  /** Typed Transfer rows (deferred Phase-2 pairing source). */
+  transfers: number
+  malformedLines: number
+  ignoredEntities: Record<string, number>
+}
+
+/**
+ * Summarize a parsed Sure bundle into the honest "what will be created vs held"
+ * counts the guided importer previews before the user confirms. This is a pure
+ * mirror of the orchestrator's staging gates; the post-promote screen replaces
+ * these estimates with the authoritative server result.
+ */
+export function summarizeSureBundle(
+  bundle: ParsedSureBundle
+): SureBundlePreview {
+  const accountById = new Map<string, SurePreviewAccount>()
+  let importableAccounts = 0
+  for (const account of bundle.accounts) {
+    const normalized: SurePreviewAccount = {
+      ...normalizeSureAccountType(account.accountable_type, account.subtype),
+      currency: account.currency,
+    }
+    accountById.set(account.id, normalized)
+    if (isImportableSureAccount(normalized)) importableAccounts += 1
+  }
+
+  const heldByReason: Record<SureHeldReason, number> = {
+    transfer: 0,
+    nonImportableAccount: 0,
+    currencyMismatch: 0,
+    split: 0,
+  }
+  let promotable = 0
+  let held = 0
+  let zeroAmountSkipped = 0
+  let invalidDateSkipped = 0
+  let unmappable = 0
+
+  for (const txn of bundle.transactions) {
+    const account = accountById.get(txn.account_id)
+    if (!account) {
+      unmappable += 1
+      continue
+    }
+    if (Number.isNaN(new Date(txn.date).getTime())) {
+      invalidDateSkipped += 1
+      continue
+    }
+    const { isZeroAmount } = classifySureAmount(
+      txn.amount,
+      account.currency as CurrencyCode
+    )
+    if (isZeroAmount) {
+      zeroAmountSkipped += 1
+      continue
+    }
+    const reason = sureHeldReason(txn, account)
+    if (reason === null) {
+      promotable += 1
+      continue
+    }
+    heldByReason[reason] += 1
+    held += 1
+  }
+
+  return {
+    accounts: {
+      total: bundle.accounts.length,
+      importable: importableAccounts,
+      held: bundle.accounts.length - importableAccounts,
+    },
+    categories: bundle.categories.length,
+    merchants: bundle.merchants.length,
+    transactions: {
+      total: bundle.transactions.length,
+      promotable,
+      held,
+      heldByReason,
+      zeroAmountSkipped,
+      invalidDateSkipped,
+      unmappable,
+    },
+    transfers: bundle.transfers.length,
+    malformedLines: bundle.malformedLines.length,
+    ignoredEntities: bundle.ignoredEntities,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Category parent-first ordering (two-pass remap support — ADR-0041 §3)
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_protected/-sure-import-ui.test.tsx
+++ b/src/routes/_protected/-sure-import-ui.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vite-plus/test"
+import { cleanup, render, screen } from "@testing-library/react"
+
+import { DoneStage } from "./-sure-import-ui"
+import type { SureMigrationResult } from "@/server/sure-migration"
+
+// PER-171 — the Done screen must read as success in the real-world degraded case
+// where a bundle stages accounts/categories/merchants but promotes ZERO
+// transactions (every row is a held transfer leg). It must NOT look empty/failed.
+
+afterEach(cleanup)
+
+function makeResult(
+  overrides: Omit<Partial<SureMigrationResult>, "transactions"> & {
+    transactions?: Partial<SureMigrationResult["transactions"]>
+  } = {}
+): SureMigrationResult {
+  const { transactions: txnOverrides, ...rest } = overrides
+  return {
+    batchId: "batch-1",
+    replayed: false,
+    contentHash: "hash",
+    byteSize: 1000,
+    accounts: { created: 3, reused: 0 },
+    categories: { created: 4, reused: 0 },
+    merchants: { created: 2, reused: 0 },
+    transactions: {
+      total: 6,
+      staged: 6,
+      promotedThisRun: 0,
+      held: 6,
+      zeroAmountSkipped: 0,
+      invalidDateSkipped: 0,
+      ...txnOverrides,
+    },
+    malformedLines: 0,
+    ignoredEntities: {},
+    ...rest,
+  }
+}
+
+const noop = () => {}
+
+describe("DoneStage", () => {
+  it("zero promoted (fresh) reads as success, not failure", () => {
+    render(
+      <DoneStage
+        result={makeResult()}
+        onViewTransactions={noop}
+        onImportAnother={noop}
+      />
+    )
+
+    // Reassuring framing, not the happy-path "Migration complete".
+    expect(screen.getByText("Accounts & details imported")).toBeTruthy()
+    expect(screen.getByText(/none were lost/i)).toBeTruthy()
+    expect(screen.queryByText("Migration complete")).toBeNull()
+    // No lonely "0 transactions added to your ledger" hero.
+    expect(screen.queryByText(/added to your ledger/i)).toBeNull()
+
+    // Entities that DID land are still shown, and the held bucket reconciles.
+    expect(screen.getByText("Accounts")).toBeTruthy()
+    expect(screen.getByText(/6 held for transfers/i)).toBeTruthy()
+    expect(screen.getByText("View transactions")).toBeTruthy()
+  })
+
+  it("promoted rows read as a completed migration with the count", () => {
+    render(
+      <DoneStage
+        result={makeResult({
+          transactions: { promotedThisRun: 9, held: 5, total: 14, staged: 14 },
+        })}
+        onViewTransactions={noop}
+        onImportAnother={noop}
+      />
+    )
+
+    expect(screen.getByText("Migration complete")).toBeTruthy()
+    expect(screen.getByText(/added to your ledger/i)).toBeTruthy()
+    expect(screen.getByText("9")).toBeTruthy() // the promoted-count hero
+    expect(screen.getByText(/5 held for transfers/i)).toBeTruthy()
+  })
+
+  it("a replayed run reads as already-imported, not an error", () => {
+    render(
+      <DoneStage
+        result={makeResult({
+          replayed: true,
+          transactions: { promotedThisRun: 0, held: 4 },
+        })}
+        onViewTransactions={noop}
+        onImportAnother={noop}
+      />
+    )
+
+    expect(screen.getByText("Already imported")).toBeTruthy()
+    expect(screen.getByText(/nothing was duplicated/i)).toBeTruthy()
+    expect(screen.queryByText("Accounts & details imported")).toBeNull()
+  })
+})

--- a/src/routes/_protected/-sure-import-ui.tsx
+++ b/src/routes/_protected/-sure-import-ui.tsx
@@ -1,0 +1,696 @@
+import * as React from "react"
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowRightLeft,
+  CalendarX2,
+  CircleCheckBig,
+  CircleSlash,
+  Coins,
+  FileJson,
+  FileWarning,
+  Layers,
+  Link2Off,
+  Loader2,
+  PackageOpen,
+  PiggyBank,
+  ScrollText,
+  ShieldCheck,
+  Store,
+  Tags,
+  Wallet,
+} from "lucide-react"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+import type { SureBundlePreview, SureHeldReason } from "@/lib/sure-migration"
+// Type-only import — erased at build, so this presentational module stays free
+// of the server fn's runtime graph and remains unit-testable in jsdom.
+import type { SureMigrationResult } from "@/server/sure-migration"
+
+// PER-171 — presentational layer for the guided Sure importer. Kept separate
+// from the route (`import_.sure.tsx`) so the orchestration (file read, server
+// fn, collection refetch, navigation) lives in the route while these pure,
+// prop-driven views — especially the honest reconciliation and the graceful
+// zero-promoted result — are unit-tested directly.
+
+export type Stage = "upload" | "review" | "done"
+
+const HELD_REASONS: Record<
+  SureHeldReason,
+  { label: string; detail: string; icon: typeof ArrowRightLeft }
+> = {
+  transfer: {
+    label: "Transfers",
+    detail:
+      "Paired moves between your own accounts — imported in a later step.",
+    icon: ArrowRightLeft,
+  },
+  split: {
+    label: "Split transactions",
+    detail: "One payment divided across several categories.",
+    icon: Layers,
+  },
+  nonImportableAccount: {
+    label: "Investment & tracked-asset activity",
+    detail: "These balances are tracked by valuation, not by each transaction.",
+    icon: PiggyBank,
+  },
+  currencyMismatch: {
+    label: "Currency mismatches",
+    detail: "The transaction's currency differs from its account.",
+    icon: Coins,
+  },
+}
+
+// ===========================================================================
+// Header + stage rail
+// ===========================================================================
+
+export function SureImportHeader({ stage }: { stage: Stage }) {
+  return (
+    <header className="flex max-w-3xl flex-col gap-3">
+      <div className="flex items-center gap-2 text-sm font-semibold tracking-wide text-emerald-600 uppercase dark:text-emerald-400">
+        <ShieldCheck size={16} />
+        Sure migration
+      </div>
+      <h1 className="text-4xl font-extrabold tracking-tight text-balance">
+        Bring your whole Sure history across
+      </h1>
+      <p className="text-lg text-muted-foreground">
+        Upload your Sure export and we'll account for every line — what crosses
+        into your ledger now, and what we hold for a later step. Nothing is
+        dropped.
+      </p>
+      <StageRail stage={stage} />
+    </header>
+  )
+}
+
+function StageRail({ stage }: { stage: Stage }) {
+  const steps: { id: Stage; label: string }[] = [
+    { id: "upload", label: "Upload" },
+    { id: "review", label: "Review" },
+    { id: "done", label: "Done" },
+  ]
+  const activeIndex = steps.findIndex((s) => s.id === stage)
+  return (
+    <ol className="flex flex-wrap items-center gap-2 pt-1 text-sm">
+      {steps.map((step, index) => (
+        <React.Fragment key={step.id}>
+          <li
+            className={cn(
+              "flex items-center gap-2 rounded-full px-3 py-1 font-semibold transition-colors",
+              index < activeIndex && "text-emerald-600 dark:text-emerald-400",
+              index === activeIndex &&
+                "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+              index > activeIndex && "text-muted-foreground"
+            )}
+          >
+            <span
+              className={cn(
+                "flex size-5 items-center justify-center rounded-full text-xs",
+                index <= activeIndex
+                  ? "bg-emerald-600 text-white"
+                  : "bg-muted text-muted-foreground"
+              )}
+            >
+              {index + 1}
+            </span>
+            {step.label}
+          </li>
+          {index < steps.length - 1 && (
+            <ArrowRight size={14} className="text-muted-foreground" />
+          )}
+        </React.Fragment>
+      ))}
+    </ol>
+  )
+}
+
+// ===========================================================================
+// Stage 1 — upload
+// ===========================================================================
+
+export function UploadStage({
+  onFile,
+  csvImportHref,
+}: {
+  onFile: (event: React.ChangeEvent<HTMLInputElement>) => void
+  csvImportHref: React.ReactNode
+}) {
+  return (
+    <Card className="max-w-2xl overflow-hidden">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+            <FileJson size={22} />
+          </span>
+          <div>
+            <CardTitle className="text-xl">Upload your Sure export</CardTitle>
+            <CardDescription>
+              Choose the <code className="font-mono">all.ndjson</code> file from
+              your Sure data export.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <label
+          htmlFor="sure-bundle"
+          className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/50 py-10 text-center transition-colors hover:border-emerald-400 hover:bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30 dark:hover:border-emerald-700"
+        >
+          <ScrollText className="text-emerald-600 dark:text-emerald-400" />
+          <span className="font-semibold">Choose your all.ndjson file</span>
+          <span className="text-xs text-muted-foreground">
+            We read it in your browser first — nothing imports until you
+            confirm.
+          </span>
+          <input
+            id="sure-bundle"
+            type="file"
+            accept=".ndjson,.jsonl,.json,.txt"
+            onChange={onFile}
+            className="sr-only"
+          />
+        </label>
+        <p className="text-xs text-muted-foreground">
+          Looking to import a bank statement instead? {csvImportHref}
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ===========================================================================
+// Stage 2 — review (client preview; the honest, fully-reconciled manifest)
+// ===========================================================================
+
+export function ReviewStage({
+  fileName,
+  preview,
+  onBack,
+  onConfirm,
+  running,
+}: {
+  fileName: string
+  preview: SureBundlePreview
+  onBack: () => void
+  onConfirm: () => void
+  running: boolean
+}) {
+  const t = preview.transactions
+  const ignoredTotal = sumValues(preview.ignoredEntities)
+  const heldReasons = (Object.keys(HELD_REASONS) as SureHeldReason[]).filter(
+    (reason) => t.heldByReason[reason] > 0
+  )
+  const hasHeld =
+    t.held > 0 ||
+    t.zeroAmountSkipped > 0 ||
+    t.invalidDateSkipped > 0 ||
+    t.unmappable > 0
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Reviewing <span className="font-semibold">{fileName}</span>
+      </p>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Crossing now */}
+        <Card className="border-emerald-200 dark:border-emerald-900">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <CircleCheckBig
+                size={18}
+                className="text-emerald-600 dark:text-emerald-400"
+              />
+              <CardTitle className="text-lg">
+                Crossing into your ledger
+              </CardTitle>
+            </div>
+            <CardDescription>
+              Created or matched on import, then promoted to your ledger.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-1">
+            <ManifestRow
+              icon={Wallet}
+              label="Accounts"
+              value={preview.accounts.total}
+              hint={
+                preview.accounts.held > 0
+                  ? `${preview.accounts.importable} import activity`
+                  : undefined
+              }
+            />
+            <ManifestRow
+              icon={Tags}
+              label="Categories"
+              value={preview.categories}
+            />
+            <ManifestRow
+              icon={Store}
+              label="Merchants"
+              value={preview.merchants}
+            />
+            <Separator className="my-2" />
+            <ManifestRow
+              icon={CircleCheckBig}
+              label="Transactions to your ledger"
+              value={t.promotable}
+              emphasis
+            />
+          </CardContent>
+        </Card>
+
+        {/* Held for a later step */}
+        <Card
+          className={cn(
+            hasHeld
+              ? "border-amber-200 dark:border-amber-900/60"
+              : "border-border"
+          )}
+        >
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <CircleSlash
+                size={18}
+                className={cn(
+                  hasHeld
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-muted-foreground"
+                )}
+              />
+              <CardTitle className="text-lg">Held for a later step</CardTitle>
+            </div>
+            <CardDescription>
+              {hasHeld
+                ? "Kept safely in the import, not yet on your ledger."
+                : "Nothing held — every transaction in this bundle will import."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            {heldReasons.map((reason) => (
+              <HeldRow
+                key={reason}
+                icon={HELD_REASONS[reason].icon}
+                label={HELD_REASONS[reason].label}
+                detail={HELD_REASONS[reason].detail}
+                count={t.heldByReason[reason]}
+              />
+            ))}
+            {t.zeroAmountSkipped > 0 && (
+              <HeldRow
+                icon={CircleSlash}
+                label="Zero-amount entries"
+                detail="Entries with no value to post."
+                count={t.zeroAmountSkipped}
+              />
+            )}
+            {t.invalidDateSkipped > 0 && (
+              <HeldRow
+                icon={CalendarX2}
+                label="Unreadable dates"
+                detail="Rows whose date couldn't be parsed."
+                count={t.invalidDateSkipped}
+              />
+            )}
+            {t.unmappable > 0 && (
+              <HeldRow
+                icon={Link2Off}
+                label="Unmatched accounts"
+                detail="Rows whose account is missing from the export."
+                count={t.unmappable}
+              />
+            )}
+            {!hasHeld && (
+              <p className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">
+                Clean bundle — all {t.total} transactions are ready to import.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Full reconciliation — every transaction in the file is accounted for. */}
+      <ReconciliationStrip
+        total={t.total}
+        importing={t.promotable}
+        held={t.held}
+        zeroAmount={t.zeroAmountSkipped}
+        invalidDate={t.invalidDateSkipped}
+        unmapped={t.unmappable}
+        malformedLines={preview.malformedLines}
+        ignoredTotal={ignoredTotal}
+      />
+
+      {t.held > 0 && <ReconciliationNote />}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button variant="ghost" onClick={onBack} disabled={running}>
+          <ArrowLeft size={16} className="mr-2" />
+          Choose a different file
+        </Button>
+        <Button
+          size="lg"
+          onClick={onConfirm}
+          disabled={running || t.promotable === 0}
+          className="rounded-full"
+        >
+          {running ? (
+            <Loader2 size={16} className="mr-2 animate-spin" />
+          ) : (
+            <ArrowRight size={16} className="mr-2" />
+          )}
+          {running
+            ? "Importing…"
+            : `Import ${t.promotable} transaction${t.promotable === 1 ? "" : "s"}`}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ===========================================================================
+// Stage 3 — done (authoritative server result; graceful at 0 promoted)
+// ===========================================================================
+
+export function DoneStage({
+  result,
+  onViewTransactions,
+  onImportAnother,
+}: {
+  result: SureMigrationResult
+  onViewTransactions: () => void
+  onImportAnother: () => void
+}) {
+  const t = result.transactions
+  const ignoredTotal = sumValues(result.ignoredEntities)
+  const nothingPromoted = t.promotedThisRun === 0
+
+  let title: string
+  let description: string
+  if (result.replayed) {
+    title = "Already imported"
+    description =
+      "This exact export was imported before — nothing was duplicated."
+  } else if (nothingPromoted) {
+    // The real-world degraded/transfer-heavy case: accounts and reference data
+    // land, but every transaction is held. This is success, not failure.
+    title = "Accounts & details imported"
+    description =
+      "Your accounts, categories and merchants are in. The transactions are held for the transfer step — none were lost."
+  } else {
+    title = "Migration complete"
+    description = "Your Sure history is now part of your Permoney ledger."
+  }
+
+  return (
+    <div className="flex max-w-3xl flex-col gap-6">
+      <Card className="overflow-hidden">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <span className="flex size-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+              {nothingPromoted && !result.replayed ? (
+                <PackageOpen size={22} />
+              ) : (
+                <CircleCheckBig size={22} />
+              )}
+            </span>
+            <div>
+              <CardTitle className="text-xl">{title}</CardTitle>
+              <CardDescription>{description}</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-6">
+          {t.promotedThisRun > 0 && (
+            <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
+              <span className="text-5xl font-extrabold tracking-tight tabular-nums">
+                {t.promotedThisRun}
+              </span>
+              <span className="pb-1 text-lg text-muted-foreground">
+                transaction{t.promotedThisRun === 1 ? "" : "s"} added to your
+                ledger
+              </span>
+            </div>
+          )}
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <ResultStat
+              icon={Wallet}
+              label="Accounts"
+              created={result.accounts.created}
+              reused={result.accounts.reused}
+            />
+            <ResultStat
+              icon={Tags}
+              label="Categories"
+              created={result.categories.created}
+              reused={result.categories.reused}
+            />
+            <ResultStat
+              icon={Store}
+              label="Merchants"
+              created={result.merchants.created}
+              reused={result.merchants.reused}
+            />
+          </div>
+
+          {/* Full reconciliation of the transaction buckets the server returns. */}
+          {(t.held > 0 ||
+            t.zeroAmountSkipped > 0 ||
+            t.invalidDateSkipped > 0 ||
+            result.malformedLines > 0 ||
+            ignoredTotal > 0) && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold">
+                Held & retained ({t.total} transaction
+                {t.total === 1 ? "" : "s"} in the export)
+              </span>
+              <div className="flex flex-wrap gap-2 text-sm">
+                {t.held > 0 && (
+                  <Badge
+                    variant="outline"
+                    className="border-amber-400 text-amber-700 dark:text-amber-300"
+                  >
+                    {t.held} held for transfers
+                  </Badge>
+                )}
+                {t.zeroAmountSkipped > 0 && (
+                  <Badge variant="outline">
+                    {t.zeroAmountSkipped} zero-amount
+                  </Badge>
+                )}
+                {t.invalidDateSkipped > 0 && (
+                  <Badge variant="outline">
+                    {t.invalidDateSkipped} unreadable date
+                  </Badge>
+                )}
+                {result.malformedLines > 0 && (
+                  <Badge variant="outline" className="gap-1">
+                    <FileWarning size={11} />
+                    {result.malformedLines} unreadable line
+                  </Badge>
+                )}
+                {ignoredTotal > 0 && (
+                  <Badge variant="outline">{ignoredTotal} deferred</Badge>
+                )}
+              </div>
+            </div>
+          )}
+
+          {t.held > 0 && <ReconciliationNote />}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button variant="ghost" onClick={onImportAnother}>
+          <ArrowLeft size={16} className="mr-2" />
+          Import another export
+        </Button>
+        <Button size="lg" onClick={onViewTransactions} className="rounded-full">
+          View transactions
+          <ArrowRight size={16} className="ml-2" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ===========================================================================
+// Shared presentational pieces
+// ===========================================================================
+
+function sumValues(record: Record<string, number>): number {
+  return Object.values(record).reduce((sum, n) => sum + n, 0)
+}
+
+function ManifestRow({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  emphasis,
+}: {
+  icon: typeof Wallet
+  label: string
+  value: number
+  hint?: string
+  emphasis?: boolean
+}) {
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <Icon
+        size={18}
+        className={cn(
+          emphasis
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-muted-foreground"
+        )}
+      />
+      <span className={cn("flex-1", emphasis && "font-semibold")}>{label}</span>
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+      <span
+        className={cn(
+          "tabular-nums",
+          emphasis ? "text-xl font-bold" : "font-semibold"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function HeldRow({
+  icon: Icon,
+  label,
+  detail,
+  count,
+}: {
+  icon: typeof ArrowRightLeft
+  label: string
+  detail: string
+  count: number
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-amber-100 bg-amber-50/60 p-3 dark:border-amber-900/40 dark:bg-amber-950/20">
+      <Icon
+        size={18}
+        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+      />
+      <div className="flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-semibold">{label}</span>
+          <span className="font-bold tabular-nums">{count}</span>
+        </div>
+        <p className="text-xs text-muted-foreground">{detail}</p>
+      </div>
+    </div>
+  )
+}
+
+function ReconciliationStrip({
+  total,
+  importing,
+  held,
+  zeroAmount,
+  invalidDate,
+  unmapped,
+  malformedLines,
+  ignoredTotal,
+}: {
+  total: number
+  importing: number
+  held: number
+  zeroAmount: number
+  invalidDate: number
+  unmapped: number
+  malformedLines: number
+  ignoredTotal: number
+}) {
+  const parts = [
+    { label: "importing now", value: importing },
+    { label: "held", value: held },
+    { label: "zero-amount", value: zeroAmount },
+    { label: "unreadable dates", value: invalidDate },
+    { label: "unmatched account", value: unmapped },
+  ].filter((part) => part.value > 0)
+
+  return (
+    <div className="rounded-2xl border bg-muted/30 p-4 text-sm">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="font-semibold">
+          {total} transaction{total === 1 ? "" : "s"} in this file
+        </span>
+        <span className="text-muted-foreground">
+          = {parts.map((p) => `${p.value} ${p.label}`).join(" + ") || "0"}
+        </span>
+      </div>
+      {(malformedLines > 0 || ignoredTotal > 0) && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          {malformedLines > 0 &&
+            `${malformedLines} line(s) couldn't be read and were skipped. `}
+          {ignoredTotal > 0 &&
+            `${ignoredTotal} entr(ies) for features not yet supported are kept in the import for later.`}
+        </p>
+      )}
+      <p className="mt-1 text-xs text-muted-foreground">
+        Every line is accounted for — nothing is silently dropped.
+      </p>
+    </div>
+  )
+}
+
+function ResultStat({
+  icon: Icon,
+  label,
+  created,
+  reused,
+}: {
+  icon: typeof Wallet
+  label: string
+  created: number
+  reused: number
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded-2xl border p-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icon size={16} />
+        {label}
+      </div>
+      <div className="text-2xl font-bold tabular-nums">{created}</div>
+      <div className="text-xs text-muted-foreground">
+        new{reused > 0 ? ` · ${reused} reused` : ""}
+      </div>
+    </div>
+  )
+}
+
+function ReconciliationNote() {
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm dark:border-amber-900/60 dark:bg-amber-950/30">
+      <ArrowRightLeft
+        size={18}
+        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+      />
+      <p className="text-amber-900 dark:text-amber-100">
+        <span className="font-semibold">A few balances won't match yet.</span>{" "}
+        Transfers and split transactions aren't migrated in this step, so any
+        account that used them will finish reconciling once transfers are
+        imported in a later step. Your full export is kept safely until then.
+      </p>
+    </div>
+  )
+}

--- a/src/routes/_protected/import.tsx
+++ b/src/routes/_protected/import.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { createFileRoute, useRouter } from "@tanstack/react-router"
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
@@ -12,6 +12,7 @@ import {
   CopyCheck,
   Sparkles,
   Loader2,
+  FileJson,
 } from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
@@ -306,6 +307,28 @@ function ImportPage() {
               </p>
               <WizardSteps step={step} />
             </header>
+
+            {step === "upload" && (
+              <Link
+                to="/import/sure"
+                className="group flex max-w-2xl items-center gap-4 rounded-2xl border border-emerald-200 bg-emerald-50/60 p-4 transition-colors hover:border-emerald-400 hover:bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30 dark:hover:border-emerald-700"
+              >
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+                  <FileJson size={20} />
+                </span>
+                <div className="flex-1">
+                  <p className="font-semibold">Coming from Sure?</p>
+                  <p className="text-sm text-muted-foreground">
+                    Migrate your whole history — accounts, categories, merchants
+                    and transactions — in one guided step.
+                  </p>
+                </div>
+                <ArrowRight
+                  size={18}
+                  className="shrink-0 text-emerald-600 transition-transform group-hover:translate-x-0.5 dark:text-emerald-400"
+                />
+              </Link>
+            )}
 
             {step === "upload" && (
               <UploadStep

--- a/src/routes/_protected/import_.sure.tsx
+++ b/src/routes/_protected/import_.sure.tsx
@@ -2,48 +2,21 @@ import * as React from "react"
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
 import { useMutation } from "@tanstack/react-query"
 import { toast } from "sonner"
-import {
-  ArrowLeft,
-  ArrowRight,
-  ArrowRightLeft,
-  CalendarX2,
-  CircleCheckBig,
-  CircleSlash,
-  Coins,
-  FileJson,
-  Layers,
-  Loader2,
-  PiggyBank,
-  ScrollText,
-  ShieldCheck,
-  Store,
-  Tags,
-  Wallet,
-} from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
-import { cn } from "@/lib/utils"
-import {
-  parseSureBundle,
-  summarizeSureBundle,
-  type SureBundlePreview,
-  type SureHeldReason,
-} from "@/lib/sure-migration"
+import { parseSureBundle, summarizeSureBundle } from "@/lib/sure-migration"
 import { runSureMigrationFn } from "@/server/sure-migration"
 import { transactionCollection } from "@/lib/collections"
+import {
+  DoneStage,
+  ReviewStage,
+  type Stage,
+  SureImportHeader,
+  UploadStage,
+} from "./-sure-import-ui"
 
 // PER-171 / ADR-0041 §11 — the guided Sure migration importer. Distinct from the
 // PER-151 CSV column-mapping wizard: this is a whole-bundle, multi-entity
@@ -51,9 +24,8 @@ import { transactionCollection } from "@/lib/collections"
 // atomic call, so the pre-confirm preview is computed in the browser by running
 // the SAME reader (`parseSureBundle` + `summarizeSureBundle`) the server uses.
 // Phase-1 balances are intentionally PARTIAL (transfers/splits/non-importable
-// accounts are held), so the UI's job is honest surfacing: every line is either
-// crossing into the ledger now or visibly held for a later crossing — nothing is
-// silently dropped, and the reconciliation gap is stated plainly.
+// accounts are held); this route owns the read → preview → confirm → result flow
+// while `-sure-import-ui` owns the honest, fully-reconciled presentation.
 
 export const Route = createFileRoute("/_protected/import_/sure")({
   ssr: false,
@@ -68,38 +40,10 @@ export const Route = createFileRoute("/_protected/import_/sure")({
 })
 
 type SureMigrationResult = Awaited<ReturnType<typeof runSureMigrationFn>>
-type Stage = "upload" | "review" | "done"
 
 // Mirror of the server's bundle ceiling; pre-checked here for a friendly message
 // rather than a thrown server error on a 64 MiB+ upload.
 const MAX_BUNDLE_BYTES = 64 * 1024 * 1024
-
-const HELD_REASONS: Record<
-  SureHeldReason,
-  { label: string; detail: string; icon: typeof ArrowRightLeft }
-> = {
-  transfer: {
-    label: "Transfers",
-    detail:
-      "Paired moves between your own accounts — imported in a later step.",
-    icon: ArrowRightLeft,
-  },
-  split: {
-    label: "Split transactions",
-    detail: "One payment divided across several categories.",
-    icon: Layers,
-  },
-  nonImportableAccount: {
-    label: "Investment & tracked-asset activity",
-    detail: "These balances are tracked by valuation, not by each transaction.",
-    icon: PiggyBank,
-  },
-  currencyMismatch: {
-    label: "Currency mismatches",
-    detail: "The transaction's currency differs from its account.",
-    icon: Coins,
-  },
-}
 
 function SureImportPage() {
   const router = useRouter()
@@ -107,10 +51,14 @@ function SureImportPage() {
   const [stage, setStage] = React.useState<Stage>("upload")
   const [fileName, setFileName] = React.useState("")
   const [bundleText, setBundleText] = React.useState("")
-  const [preview, setPreview] = React.useState<SureBundlePreview | null>(null)
+  const [preview, setPreview] = React.useState<ReturnType<
+    typeof summarizeSureBundle
+  > | null>(null)
   const [result, setResult] = React.useState<SureMigrationResult | null>(null)
 
   // File read + parse is an event handler, not an effect (no-use-effect rule).
+  // The bundle string lives only in component state and flows solely to the
+  // server fn — never localStorage, a persisted collection, or a log (PII).
   const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     event.target.value = ""
@@ -164,23 +112,21 @@ function SureImportPage() {
         <SidebarInset>
           <SiteHeader />
           <div className="flex flex-1 flex-col gap-8 p-4 md:p-6 lg:p-8">
-            <header className="flex max-w-3xl flex-col gap-3">
-              <div className="flex items-center gap-2 text-sm font-semibold tracking-wide text-emerald-600 uppercase dark:text-emerald-400">
-                <ShieldCheck size={16} />
-                Sure migration
-              </div>
-              <h1 className="text-4xl font-extrabold tracking-tight text-balance">
-                Bring your whole Sure history across
-              </h1>
-              <p className="text-lg text-muted-foreground">
-                Upload your Sure export and we'll account for every line — what
-                crosses into your ledger now, and what we hold for a later step.
-                Nothing is dropped.
-              </p>
-              <StageRail stage={stage} />
-            </header>
+            <SureImportHeader stage={stage} />
 
-            {stage === "upload" && <UploadStage onFile={handleFile} />}
+            {stage === "upload" && (
+              <UploadStage
+                onFile={handleFile}
+                csvImportHref={
+                  <Link
+                    to="/import"
+                    className="font-semibold text-emerald-600 underline-offset-4 hover:underline dark:text-emerald-400"
+                  >
+                    Use the CSV / QIF wizard
+                  </Link>
+                }
+              />
+            )}
 
             {stage === "review" && preview && (
               <ReviewStage
@@ -205,506 +151,5 @@ function SureImportPage() {
         </SidebarInset>
       </SidebarProvider>
     </TooltipProvider>
-  )
-}
-
-// ===========================================================================
-// Stage rail
-// ===========================================================================
-
-function StageRail({ stage }: { stage: Stage }) {
-  const steps: { id: Stage; label: string }[] = [
-    { id: "upload", label: "Upload" },
-    { id: "review", label: "Review" },
-    { id: "done", label: "Done" },
-  ]
-  const activeIndex = steps.findIndex((s) => s.id === stage)
-  return (
-    <ol className="flex flex-wrap items-center gap-2 pt-1 text-sm">
-      {steps.map((step, index) => (
-        <React.Fragment key={step.id}>
-          <li
-            className={cn(
-              "flex items-center gap-2 rounded-full px-3 py-1 font-semibold transition-colors",
-              index < activeIndex && "text-emerald-600 dark:text-emerald-400",
-              index === activeIndex &&
-                "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
-              index > activeIndex && "text-muted-foreground"
-            )}
-          >
-            <span
-              className={cn(
-                "flex size-5 items-center justify-center rounded-full text-xs",
-                index <= activeIndex
-                  ? "bg-emerald-600 text-white"
-                  : "bg-muted text-muted-foreground"
-              )}
-            >
-              {index + 1}
-            </span>
-            {step.label}
-          </li>
-          {index < steps.length - 1 && (
-            <ArrowRight size={14} className="text-muted-foreground" />
-          )}
-        </React.Fragment>
-      ))}
-    </ol>
-  )
-}
-
-// ===========================================================================
-// Stage 1 — upload
-// ===========================================================================
-
-function UploadStage({
-  onFile,
-}: {
-  onFile: (event: React.ChangeEvent<HTMLInputElement>) => void
-}) {
-  return (
-    <Card className="max-w-2xl overflow-hidden">
-      <CardHeader>
-        <div className="flex items-center gap-3">
-          <span className="flex size-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-            <FileJson size={22} />
-          </span>
-          <div>
-            <CardTitle className="text-xl">Upload your Sure export</CardTitle>
-            <CardDescription>
-              Choose the <code className="font-mono">all.ndjson</code> file from
-              your Sure data export.
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-5">
-        <label
-          htmlFor="sure-bundle"
-          className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/50 py-10 text-center transition-colors hover:border-emerald-400 hover:bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30 dark:hover:border-emerald-700"
-        >
-          <ScrollText className="text-emerald-600 dark:text-emerald-400" />
-          <span className="font-semibold">Choose your all.ndjson file</span>
-          <span className="text-xs text-muted-foreground">
-            We read it in your browser first — nothing imports until you
-            confirm.
-          </span>
-          <input
-            id="sure-bundle"
-            type="file"
-            accept=".ndjson,.jsonl,.json,.txt"
-            onChange={onFile}
-            className="sr-only"
-          />
-        </label>
-        <p className="text-xs text-muted-foreground">
-          Looking to import a bank statement instead?{" "}
-          <Link
-            to="/import"
-            className="font-semibold text-emerald-600 underline-offset-4 hover:underline dark:text-emerald-400"
-          >
-            Use the CSV / QIF wizard
-          </Link>
-          .
-        </p>
-      </CardContent>
-    </Card>
-  )
-}
-
-// ===========================================================================
-// Stage 2 — review (client preview, the honest manifest)
-// ===========================================================================
-
-function ReviewStage({
-  fileName,
-  preview,
-  onBack,
-  onConfirm,
-  running,
-}: {
-  fileName: string
-  preview: SureBundlePreview
-  onBack: () => void
-  onConfirm: () => void
-  running: boolean
-}) {
-  const t = preview.transactions
-  const ignoredTotal = Object.values(preview.ignoredEntities).reduce(
-    (sum, n) => sum + n,
-    0
-  )
-  const heldReasons = (Object.keys(HELD_REASONS) as SureHeldReason[]).filter(
-    (reason) => t.heldByReason[reason] > 0
-  )
-  const hasHeld =
-    t.held > 0 ||
-    t.zeroAmountSkipped > 0 ||
-    t.invalidDateSkipped > 0 ||
-    preview.accounts.held > 0
-
-  return (
-    <div className="flex flex-col gap-6">
-      <p className="text-sm text-muted-foreground">
-        Reviewing <span className="font-semibold">{fileName}</span>
-      </p>
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        {/* Crossing now */}
-        <Card className="border-emerald-200 dark:border-emerald-900">
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <CircleCheckBig
-                size={18}
-                className="text-emerald-600 dark:text-emerald-400"
-              />
-              <CardTitle className="text-lg">
-                Crossing into your ledger
-              </CardTitle>
-            </div>
-            <CardDescription>
-              Created or matched on import, then promoted to your ledger.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-1">
-            <ManifestRow
-              icon={Wallet}
-              label="Accounts"
-              value={preview.accounts.total}
-              hint={
-                preview.accounts.held > 0
-                  ? `${preview.accounts.importable} import activity`
-                  : undefined
-              }
-            />
-            <ManifestRow
-              icon={Tags}
-              label="Categories"
-              value={preview.categories}
-            />
-            <ManifestRow
-              icon={Store}
-              label="Merchants"
-              value={preview.merchants}
-            />
-            <Separator className="my-2" />
-            <ManifestRow
-              icon={CircleCheckBig}
-              label="Transactions to your ledger"
-              value={t.promotable}
-              emphasis
-            />
-          </CardContent>
-        </Card>
-
-        {/* Held for a later crossing */}
-        <Card
-          className={cn(
-            hasHeld
-              ? "border-amber-200 dark:border-amber-900/60"
-              : "border-border"
-          )}
-        >
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <CircleSlash
-                size={18}
-                className={cn(
-                  hasHeld
-                    ? "text-amber-600 dark:text-amber-400"
-                    : "text-muted-foreground"
-                )}
-              />
-              <CardTitle className="text-lg">Held for a later step</CardTitle>
-            </div>
-            <CardDescription>
-              {hasHeld
-                ? "Kept safely in the import, not yet on your ledger."
-                : "Nothing held — every transaction in this bundle will import."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-3">
-            {heldReasons.map((reason) => (
-              <HeldRow
-                key={reason}
-                icon={HELD_REASONS[reason].icon}
-                label={HELD_REASONS[reason].label}
-                detail={HELD_REASONS[reason].detail}
-                count={t.heldByReason[reason]}
-              />
-            ))}
-            {t.zeroAmountSkipped > 0 && (
-              <HeldRow
-                icon={CircleSlash}
-                label="Zero-amount entries"
-                detail="Entries with no value to post."
-                count={t.zeroAmountSkipped}
-              />
-            )}
-            {t.invalidDateSkipped > 0 && (
-              <HeldRow
-                icon={CalendarX2}
-                label="Unreadable dates"
-                detail="Rows whose date couldn't be parsed."
-                count={t.invalidDateSkipped}
-              />
-            )}
-            {!hasHeld && (
-              <p className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">
-                Clean bundle — all {t.total} transactions are ready to import.
-              </p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      {t.held > 0 && <ReconciliationNote />}
-
-      {(preview.malformedLines > 0 || ignoredTotal > 0) && (
-        <p className="text-xs text-muted-foreground">
-          {preview.malformedLines > 0 &&
-            `${preview.malformedLines} line(s) couldn't be read and were skipped. `}
-          {ignoredTotal > 0 &&
-            `${ignoredTotal} entr(ies) for features not yet supported were kept in the import for later.`}
-        </p>
-      )}
-
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <Button variant="ghost" onClick={onBack} disabled={running}>
-          <ArrowLeft size={16} className="mr-2" />
-          Choose a different file
-        </Button>
-        <Button
-          size="lg"
-          onClick={onConfirm}
-          disabled={running || t.promotable === 0}
-          className="rounded-full"
-        >
-          {running ? (
-            <Loader2 size={16} className="mr-2 animate-spin" />
-          ) : (
-            <ArrowRight size={16} className="mr-2" />
-          )}
-          Import {t.promotable} transaction{t.promotable === 1 ? "" : "s"}
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// ===========================================================================
-// Stage 3 — done (authoritative server result)
-// ===========================================================================
-
-function DoneStage({
-  result,
-  onViewTransactions,
-  onImportAnother,
-}: {
-  result: SureMigrationResult
-  onViewTransactions: () => void
-  onImportAnother: () => void
-}) {
-  const t = result.transactions
-  return (
-    <div className="flex max-w-3xl flex-col gap-6">
-      <Card className="overflow-hidden">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <span className="flex size-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-              <CircleCheckBig size={22} />
-            </span>
-            <div>
-              <CardTitle className="text-xl">
-                {result.replayed ? "Already imported" : "Migration complete"}
-              </CardTitle>
-              <CardDescription>
-                {result.replayed
-                  ? "This exact export was imported before — nothing was duplicated."
-                  : "Your Sure history is now part of your Permoney ledger."}
-              </CardDescription>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
-            <span className="text-5xl font-extrabold tracking-tight tabular-nums">
-              {t.promotedThisRun}
-            </span>
-            <span className="pb-1 text-lg text-muted-foreground">
-              transaction{t.promotedThisRun === 1 ? "" : "s"} added to your
-              ledger
-            </span>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-3">
-            <ResultStat
-              icon={Wallet}
-              label="Accounts"
-              created={result.accounts.created}
-              reused={result.accounts.reused}
-            />
-            <ResultStat
-              icon={Tags}
-              label="Categories"
-              created={result.categories.created}
-              reused={result.categories.reused}
-            />
-            <ResultStat
-              icon={Store}
-              label="Merchants"
-              created={result.merchants.created}
-              reused={result.merchants.reused}
-            />
-          </div>
-
-          {t.held > 0 && (
-            <div className="flex flex-wrap items-center gap-2 text-sm">
-              <span className="font-semibold">Held for a later step:</span>
-              <Badge
-                variant="outline"
-                className="border-amber-400 text-amber-700 dark:text-amber-300"
-              >
-                {t.held} transaction{t.held === 1 ? "" : "s"}
-              </Badge>
-              {t.zeroAmountSkipped > 0 && (
-                <Badge variant="outline">
-                  {t.zeroAmountSkipped} zero-amount
-                </Badge>
-              )}
-              {t.invalidDateSkipped > 0 && (
-                <Badge variant="outline">
-                  {t.invalidDateSkipped} unreadable date
-                </Badge>
-              )}
-            </div>
-          )}
-
-          {t.held > 0 && <ReconciliationNote />}
-        </CardContent>
-      </Card>
-
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <Button variant="ghost" onClick={onImportAnother}>
-          <ArrowLeft size={16} className="mr-2" />
-          Import another export
-        </Button>
-        <Button size="lg" onClick={onViewTransactions} className="rounded-full">
-          View transactions
-          <ArrowRight size={16} className="ml-2" />
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// ===========================================================================
-// Shared presentational pieces
-// ===========================================================================
-
-function ManifestRow({
-  icon: Icon,
-  label,
-  value,
-  hint,
-  emphasis,
-}: {
-  icon: typeof Wallet
-  label: string
-  value: number
-  hint?: string
-  emphasis?: boolean
-}) {
-  return (
-    <div className="flex items-center gap-3 py-1.5">
-      <Icon
-        size={18}
-        className={cn(
-          emphasis
-            ? "text-emerald-600 dark:text-emerald-400"
-            : "text-muted-foreground"
-        )}
-      />
-      <span className={cn("flex-1", emphasis && "font-semibold")}>{label}</span>
-      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
-      <span
-        className={cn(
-          "tabular-nums",
-          emphasis ? "text-xl font-bold" : "font-semibold"
-        )}
-      >
-        {value}
-      </span>
-    </div>
-  )
-}
-
-function HeldRow({
-  icon: Icon,
-  label,
-  detail,
-  count,
-}: {
-  icon: typeof ArrowRightLeft
-  label: string
-  detail: string
-  count: number
-}) {
-  return (
-    <div className="flex items-start gap-3 rounded-xl border border-amber-100 bg-amber-50/60 p-3 dark:border-amber-900/40 dark:bg-amber-950/20">
-      <Icon
-        size={18}
-        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
-      />
-      <div className="flex-1">
-        <div className="flex items-center justify-between gap-2">
-          <span className="font-semibold">{label}</span>
-          <span className="font-bold tabular-nums">{count}</span>
-        </div>
-        <p className="text-xs text-muted-foreground">{detail}</p>
-      </div>
-    </div>
-  )
-}
-
-function ResultStat({
-  icon: Icon,
-  label,
-  created,
-  reused,
-}: {
-  icon: typeof Wallet
-  label: string
-  created: number
-  reused: number
-}) {
-  return (
-    <div className="flex flex-col gap-1 rounded-2xl border p-4">
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Icon size={16} />
-        {label}
-      </div>
-      <div className="text-2xl font-bold tabular-nums">{created}</div>
-      <div className="text-xs text-muted-foreground">
-        new{reused > 0 ? ` · ${reused} reused` : ""}
-      </div>
-    </div>
-  )
-}
-
-function ReconciliationNote() {
-  return (
-    <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm dark:border-amber-900/60 dark:bg-amber-950/30">
-      <ArrowRightLeft
-        size={18}
-        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
-      />
-      <p className="text-amber-900 dark:text-amber-100">
-        <span className="font-semibold">A few balances won't match yet.</span>{" "}
-        Transfers and split transactions aren't migrated in this step, so any
-        account that used them will finish reconciling once transfers are
-        imported in a later step. Your full export is kept safely until then.
-      </p>
-    </div>
   )
 }

--- a/src/routes/_protected/import_.sure.tsx
+++ b/src/routes/_protected/import_.sure.tsx
@@ -1,0 +1,710 @@
+import * as React from "react"
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
+import { useMutation } from "@tanstack/react-query"
+import { toast } from "sonner"
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowRightLeft,
+  CalendarX2,
+  CircleCheckBig,
+  CircleSlash,
+  Coins,
+  FileJson,
+  Layers,
+  Loader2,
+  PiggyBank,
+  ScrollText,
+  ShieldCheck,
+  Store,
+  Tags,
+  Wallet,
+} from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+import {
+  parseSureBundle,
+  summarizeSureBundle,
+  type SureBundlePreview,
+  type SureHeldReason,
+} from "@/lib/sure-migration"
+import { runSureMigrationFn } from "@/server/sure-migration"
+import { transactionCollection } from "@/lib/collections"
+
+// PER-171 / ADR-0041 §11 — the guided Sure migration importer. Distinct from the
+// PER-151 CSV column-mapping wizard: this is a whole-bundle, multi-entity
+// orchestration. The migration server fn (`runSureMigrationFn`) commits in ONE
+// atomic call, so the pre-confirm preview is computed in the browser by running
+// the SAME reader (`parseSureBundle` + `summarizeSureBundle`) the server uses.
+// Phase-1 balances are intentionally PARTIAL (transfers/splits/non-importable
+// accounts are held), so the UI's job is honest surfacing: every line is either
+// crossing into the ledger now or visibly held for a later crossing — nothing is
+// silently dropped, and the reconciliation gap is stated plainly.
+
+export const Route = createFileRoute("/_protected/import_/sure")({
+  ssr: false,
+  staticData: { title: "Migrate from Sure" },
+  loader: async () => {
+    // Collections are client-only; preload so /transactions is warm after promote
+    // and useLiveQuery elsewhere never starts syncing during a render commit.
+    await transactionCollection.preload()
+    return null
+  },
+  component: SureImportPage,
+})
+
+type SureMigrationResult = Awaited<ReturnType<typeof runSureMigrationFn>>
+type Stage = "upload" | "review" | "done"
+
+// Mirror of the server's bundle ceiling; pre-checked here for a friendly message
+// rather than a thrown server error on a 64 MiB+ upload.
+const MAX_BUNDLE_BYTES = 64 * 1024 * 1024
+
+const HELD_REASONS: Record<
+  SureHeldReason,
+  { label: string; detail: string; icon: typeof ArrowRightLeft }
+> = {
+  transfer: {
+    label: "Transfers",
+    detail:
+      "Paired moves between your own accounts — imported in a later step.",
+    icon: ArrowRightLeft,
+  },
+  split: {
+    label: "Split transactions",
+    detail: "One payment divided across several categories.",
+    icon: Layers,
+  },
+  nonImportableAccount: {
+    label: "Investment & tracked-asset activity",
+    detail: "These balances are tracked by valuation, not by each transaction.",
+    icon: PiggyBank,
+  },
+  currencyMismatch: {
+    label: "Currency mismatches",
+    detail: "The transaction's currency differs from its account.",
+    icon: Coins,
+  },
+}
+
+function SureImportPage() {
+  const router = useRouter()
+
+  const [stage, setStage] = React.useState<Stage>("upload")
+  const [fileName, setFileName] = React.useState("")
+  const [bundleText, setBundleText] = React.useState("")
+  const [preview, setPreview] = React.useState<SureBundlePreview | null>(null)
+  const [result, setResult] = React.useState<SureMigrationResult | null>(null)
+
+  // File read + parse is an event handler, not an effect (no-use-effect rule).
+  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file) return
+    if (file.size > MAX_BUNDLE_BYTES) {
+      toast.error("That bundle is over the 64 MiB limit.")
+      return
+    }
+    const text = await file.text()
+    const summary = summarizeSureBundle(parseSureBundle(text))
+    setFileName(file.name)
+    setBundleText(text)
+    setPreview(summary)
+    setResult(null)
+    setStage("review")
+  }
+
+  const runMutation = useMutation({
+    mutationFn: () =>
+      runSureMigrationFn({ data: { filename: fileName, bundle: bundleText } }),
+    onSuccess: async (migration) => {
+      setResult(migration)
+      setStage("done")
+      // Sync the local ledger with the server source of truth so /transactions
+      // reflects the promoted rows the instant the user navigates there.
+      await transactionCollection.utils.refetch()
+      if (migration.replayed) {
+        toast.info("Already imported — nothing was duplicated.")
+      } else {
+        toast.success(
+          `Imported ${migration.transactions.promotedThisRun} transaction(s).`
+        )
+      }
+    },
+    onError: (error) =>
+      toast.error(error instanceof Error ? error.message : "Migration failed."),
+  })
+
+  const restart = () => {
+    setStage("upload")
+    setFileName("")
+    setBundleText("")
+    setPreview(null)
+    setResult(null)
+  }
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider>
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-8 p-4 md:p-6 lg:p-8">
+            <header className="flex max-w-3xl flex-col gap-3">
+              <div className="flex items-center gap-2 text-sm font-semibold tracking-wide text-emerald-600 uppercase dark:text-emerald-400">
+                <ShieldCheck size={16} />
+                Sure migration
+              </div>
+              <h1 className="text-4xl font-extrabold tracking-tight text-balance">
+                Bring your whole Sure history across
+              </h1>
+              <p className="text-lg text-muted-foreground">
+                Upload your Sure export and we'll account for every line — what
+                crosses into your ledger now, and what we hold for a later step.
+                Nothing is dropped.
+              </p>
+              <StageRail stage={stage} />
+            </header>
+
+            {stage === "upload" && <UploadStage onFile={handleFile} />}
+
+            {stage === "review" && preview && (
+              <ReviewStage
+                fileName={fileName}
+                preview={preview}
+                onBack={restart}
+                onConfirm={() => runMutation.mutate()}
+                running={runMutation.isPending}
+              />
+            )}
+
+            {stage === "done" && result && (
+              <DoneStage
+                result={result}
+                onViewTransactions={() =>
+                  void router.navigate({ to: "/transactions" })
+                }
+                onImportAnother={restart}
+              />
+            )}
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  )
+}
+
+// ===========================================================================
+// Stage rail
+// ===========================================================================
+
+function StageRail({ stage }: { stage: Stage }) {
+  const steps: { id: Stage; label: string }[] = [
+    { id: "upload", label: "Upload" },
+    { id: "review", label: "Review" },
+    { id: "done", label: "Done" },
+  ]
+  const activeIndex = steps.findIndex((s) => s.id === stage)
+  return (
+    <ol className="flex flex-wrap items-center gap-2 pt-1 text-sm">
+      {steps.map((step, index) => (
+        <React.Fragment key={step.id}>
+          <li
+            className={cn(
+              "flex items-center gap-2 rounded-full px-3 py-1 font-semibold transition-colors",
+              index < activeIndex && "text-emerald-600 dark:text-emerald-400",
+              index === activeIndex &&
+                "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+              index > activeIndex && "text-muted-foreground"
+            )}
+          >
+            <span
+              className={cn(
+                "flex size-5 items-center justify-center rounded-full text-xs",
+                index <= activeIndex
+                  ? "bg-emerald-600 text-white"
+                  : "bg-muted text-muted-foreground"
+              )}
+            >
+              {index + 1}
+            </span>
+            {step.label}
+          </li>
+          {index < steps.length - 1 && (
+            <ArrowRight size={14} className="text-muted-foreground" />
+          )}
+        </React.Fragment>
+      ))}
+    </ol>
+  )
+}
+
+// ===========================================================================
+// Stage 1 — upload
+// ===========================================================================
+
+function UploadStage({
+  onFile,
+}: {
+  onFile: (event: React.ChangeEvent<HTMLInputElement>) => void
+}) {
+  return (
+    <Card className="max-w-2xl overflow-hidden">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+            <FileJson size={22} />
+          </span>
+          <div>
+            <CardTitle className="text-xl">Upload your Sure export</CardTitle>
+            <CardDescription>
+              Choose the <code className="font-mono">all.ndjson</code> file from
+              your Sure data export.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <label
+          htmlFor="sure-bundle"
+          className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/50 py-10 text-center transition-colors hover:border-emerald-400 hover:bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30 dark:hover:border-emerald-700"
+        >
+          <ScrollText className="text-emerald-600 dark:text-emerald-400" />
+          <span className="font-semibold">Choose your all.ndjson file</span>
+          <span className="text-xs text-muted-foreground">
+            We read it in your browser first — nothing imports until you
+            confirm.
+          </span>
+          <input
+            id="sure-bundle"
+            type="file"
+            accept=".ndjson,.jsonl,.json,.txt"
+            onChange={onFile}
+            className="sr-only"
+          />
+        </label>
+        <p className="text-xs text-muted-foreground">
+          Looking to import a bank statement instead?{" "}
+          <Link
+            to="/import"
+            className="font-semibold text-emerald-600 underline-offset-4 hover:underline dark:text-emerald-400"
+          >
+            Use the CSV / QIF wizard
+          </Link>
+          .
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ===========================================================================
+// Stage 2 — review (client preview, the honest manifest)
+// ===========================================================================
+
+function ReviewStage({
+  fileName,
+  preview,
+  onBack,
+  onConfirm,
+  running,
+}: {
+  fileName: string
+  preview: SureBundlePreview
+  onBack: () => void
+  onConfirm: () => void
+  running: boolean
+}) {
+  const t = preview.transactions
+  const ignoredTotal = Object.values(preview.ignoredEntities).reduce(
+    (sum, n) => sum + n,
+    0
+  )
+  const heldReasons = (Object.keys(HELD_REASONS) as SureHeldReason[]).filter(
+    (reason) => t.heldByReason[reason] > 0
+  )
+  const hasHeld =
+    t.held > 0 ||
+    t.zeroAmountSkipped > 0 ||
+    t.invalidDateSkipped > 0 ||
+    preview.accounts.held > 0
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Reviewing <span className="font-semibold">{fileName}</span>
+      </p>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Crossing now */}
+        <Card className="border-emerald-200 dark:border-emerald-900">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <CircleCheckBig
+                size={18}
+                className="text-emerald-600 dark:text-emerald-400"
+              />
+              <CardTitle className="text-lg">
+                Crossing into your ledger
+              </CardTitle>
+            </div>
+            <CardDescription>
+              Created or matched on import, then promoted to your ledger.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-1">
+            <ManifestRow
+              icon={Wallet}
+              label="Accounts"
+              value={preview.accounts.total}
+              hint={
+                preview.accounts.held > 0
+                  ? `${preview.accounts.importable} import activity`
+                  : undefined
+              }
+            />
+            <ManifestRow
+              icon={Tags}
+              label="Categories"
+              value={preview.categories}
+            />
+            <ManifestRow
+              icon={Store}
+              label="Merchants"
+              value={preview.merchants}
+            />
+            <Separator className="my-2" />
+            <ManifestRow
+              icon={CircleCheckBig}
+              label="Transactions to your ledger"
+              value={t.promotable}
+              emphasis
+            />
+          </CardContent>
+        </Card>
+
+        {/* Held for a later crossing */}
+        <Card
+          className={cn(
+            hasHeld
+              ? "border-amber-200 dark:border-amber-900/60"
+              : "border-border"
+          )}
+        >
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <CircleSlash
+                size={18}
+                className={cn(
+                  hasHeld
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-muted-foreground"
+                )}
+              />
+              <CardTitle className="text-lg">Held for a later step</CardTitle>
+            </div>
+            <CardDescription>
+              {hasHeld
+                ? "Kept safely in the import, not yet on your ledger."
+                : "Nothing held — every transaction in this bundle will import."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            {heldReasons.map((reason) => (
+              <HeldRow
+                key={reason}
+                icon={HELD_REASONS[reason].icon}
+                label={HELD_REASONS[reason].label}
+                detail={HELD_REASONS[reason].detail}
+                count={t.heldByReason[reason]}
+              />
+            ))}
+            {t.zeroAmountSkipped > 0 && (
+              <HeldRow
+                icon={CircleSlash}
+                label="Zero-amount entries"
+                detail="Entries with no value to post."
+                count={t.zeroAmountSkipped}
+              />
+            )}
+            {t.invalidDateSkipped > 0 && (
+              <HeldRow
+                icon={CalendarX2}
+                label="Unreadable dates"
+                detail="Rows whose date couldn't be parsed."
+                count={t.invalidDateSkipped}
+              />
+            )}
+            {!hasHeld && (
+              <p className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">
+                Clean bundle — all {t.total} transactions are ready to import.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {t.held > 0 && <ReconciliationNote />}
+
+      {(preview.malformedLines > 0 || ignoredTotal > 0) && (
+        <p className="text-xs text-muted-foreground">
+          {preview.malformedLines > 0 &&
+            `${preview.malformedLines} line(s) couldn't be read and were skipped. `}
+          {ignoredTotal > 0 &&
+            `${ignoredTotal} entr(ies) for features not yet supported were kept in the import for later.`}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button variant="ghost" onClick={onBack} disabled={running}>
+          <ArrowLeft size={16} className="mr-2" />
+          Choose a different file
+        </Button>
+        <Button
+          size="lg"
+          onClick={onConfirm}
+          disabled={running || t.promotable === 0}
+          className="rounded-full"
+        >
+          {running ? (
+            <Loader2 size={16} className="mr-2 animate-spin" />
+          ) : (
+            <ArrowRight size={16} className="mr-2" />
+          )}
+          Import {t.promotable} transaction{t.promotable === 1 ? "" : "s"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ===========================================================================
+// Stage 3 — done (authoritative server result)
+// ===========================================================================
+
+function DoneStage({
+  result,
+  onViewTransactions,
+  onImportAnother,
+}: {
+  result: SureMigrationResult
+  onViewTransactions: () => void
+  onImportAnother: () => void
+}) {
+  const t = result.transactions
+  return (
+    <div className="flex max-w-3xl flex-col gap-6">
+      <Card className="overflow-hidden">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <span className="flex size-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+              <CircleCheckBig size={22} />
+            </span>
+            <div>
+              <CardTitle className="text-xl">
+                {result.replayed ? "Already imported" : "Migration complete"}
+              </CardTitle>
+              <CardDescription>
+                {result.replayed
+                  ? "This exact export was imported before — nothing was duplicated."
+                  : "Your Sure history is now part of your Permoney ledger."}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
+            <span className="text-5xl font-extrabold tracking-tight tabular-nums">
+              {t.promotedThisRun}
+            </span>
+            <span className="pb-1 text-lg text-muted-foreground">
+              transaction{t.promotedThisRun === 1 ? "" : "s"} added to your
+              ledger
+            </span>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <ResultStat
+              icon={Wallet}
+              label="Accounts"
+              created={result.accounts.created}
+              reused={result.accounts.reused}
+            />
+            <ResultStat
+              icon={Tags}
+              label="Categories"
+              created={result.categories.created}
+              reused={result.categories.reused}
+            />
+            <ResultStat
+              icon={Store}
+              label="Merchants"
+              created={result.merchants.created}
+              reused={result.merchants.reused}
+            />
+          </div>
+
+          {t.held > 0 && (
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="font-semibold">Held for a later step:</span>
+              <Badge
+                variant="outline"
+                className="border-amber-400 text-amber-700 dark:text-amber-300"
+              >
+                {t.held} transaction{t.held === 1 ? "" : "s"}
+              </Badge>
+              {t.zeroAmountSkipped > 0 && (
+                <Badge variant="outline">
+                  {t.zeroAmountSkipped} zero-amount
+                </Badge>
+              )}
+              {t.invalidDateSkipped > 0 && (
+                <Badge variant="outline">
+                  {t.invalidDateSkipped} unreadable date
+                </Badge>
+              )}
+            </div>
+          )}
+
+          {t.held > 0 && <ReconciliationNote />}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button variant="ghost" onClick={onImportAnother}>
+          <ArrowLeft size={16} className="mr-2" />
+          Import another export
+        </Button>
+        <Button size="lg" onClick={onViewTransactions} className="rounded-full">
+          View transactions
+          <ArrowRight size={16} className="ml-2" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ===========================================================================
+// Shared presentational pieces
+// ===========================================================================
+
+function ManifestRow({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  emphasis,
+}: {
+  icon: typeof Wallet
+  label: string
+  value: number
+  hint?: string
+  emphasis?: boolean
+}) {
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <Icon
+        size={18}
+        className={cn(
+          emphasis
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-muted-foreground"
+        )}
+      />
+      <span className={cn("flex-1", emphasis && "font-semibold")}>{label}</span>
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+      <span
+        className={cn(
+          "tabular-nums",
+          emphasis ? "text-xl font-bold" : "font-semibold"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function HeldRow({
+  icon: Icon,
+  label,
+  detail,
+  count,
+}: {
+  icon: typeof ArrowRightLeft
+  label: string
+  detail: string
+  count: number
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-amber-100 bg-amber-50/60 p-3 dark:border-amber-900/40 dark:bg-amber-950/20">
+      <Icon
+        size={18}
+        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+      />
+      <div className="flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-semibold">{label}</span>
+          <span className="font-bold tabular-nums">{count}</span>
+        </div>
+        <p className="text-xs text-muted-foreground">{detail}</p>
+      </div>
+    </div>
+  )
+}
+
+function ResultStat({
+  icon: Icon,
+  label,
+  created,
+  reused,
+}: {
+  icon: typeof Wallet
+  label: string
+  created: number
+  reused: number
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded-2xl border p-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icon size={16} />
+        {label}
+      </div>
+      <div className="text-2xl font-bold tabular-nums">{created}</div>
+      <div className="text-xs text-muted-foreground">
+        new{reused > 0 ? ` · ${reused} reused` : ""}
+      </div>
+    </div>
+  )
+}
+
+function ReconciliationNote() {
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm dark:border-amber-900/60 dark:bg-amber-950/30">
+      <ArrowRightLeft
+        size={18}
+        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+      />
+      <p className="text-amber-900 dark:text-amber-100">
+        <span className="font-semibold">A few balances won't match yet.</span>{" "}
+        Transfers and split transactions aren't migrated in this step, so any
+        account that used them will finish reconciling once transfers are
+        imported in a later step. Your full export is kept safely until then.
+      </p>
+    </div>
+  )
+}

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -179,7 +179,10 @@ function openingBalanceMinor(
 // Promotion gating (ADR-0041 §6)
 // ---------------------------------------------------------------------------
 
-function isPromotable(
+// Phase-1 promotion gate. Exported so the client-side preview classifier in
+// `src/lib/sure-migration.ts` can be parity-tested against the REAL server
+// verdict (not a hand-written copy). Behavior-neutral export — see PER-171.
+export function isPromotable(
   txn: SureTransaction,
   account: PermoneyAccountInfo
 ): boolean {

--- a/tests/e2e/sure-migration.e2e.ts
+++ b/tests/e2e/sure-migration.e2e.ts
@@ -38,6 +38,8 @@ test.describe("Sure guided migration", () => {
     await expect(page.getByText("Held for a later step")).toBeVisible()
     await expect(page.getByText("Transfers", { exact: true })).toBeVisible()
     await expect(page.getByText(/A few balances won't match yet/)).toBeVisible()
+    // Every bucket reconciles back to the file total — no unexplained gap.
+    await expect(page.getByText(/transactions in this file/)).toBeVisible()
 
     // 4. Confirm: only the 2 promotable standard rows import.
     await page.getByRole("button", { name: /Import 2 transactions/ }).click()

--- a/tests/e2e/sure-migration.e2e.ts
+++ b/tests/e2e/sure-migration.e2e.ts
@@ -17,14 +17,16 @@ test.describe("Sure guided migration", () => {
   }) => {
     await onboard(page)
 
-    // 1. Reach the guided importer from the CSV import page's entry banner.
+    // 1. The CSV import page links to the guided Sure importer (entry point).
     await page.goto("/import")
     await waitForHydration(page)
     await page.getByRole("link", { name: /Coming from Sure/ }).click()
     await expect(page).toHaveURL(/\/import\/sure$/)
-    await waitForHydration(page)
 
-    // 2. Upload the synthetic all.ndjson; the client-side preview resolves.
+    // 2. Upload the synthetic all.ndjson on a fresh load so the file-input change
+    // handler is wired before Playwright sets files programmatically.
+    await page.goto("/import/sure")
+    await waitForHydration(page)
     await page.locator('input[type="file"]').setInputFiles({
       name: "all.ndjson",
       mimeType: "application/x-ndjson",
@@ -34,7 +36,7 @@ test.describe("Sure guided migration", () => {
     // 3. Preview honestly splits crossing-now from held, with the gap note.
     await expect(page.getByText("Crossing into your ledger")).toBeVisible()
     await expect(page.getByText("Held for a later step")).toBeVisible()
-    await expect(page.getByText("Transfers")).toBeVisible()
+    await expect(page.getByText("Transfers", { exact: true })).toBeVisible()
     await expect(page.getByText(/A few balances won't match yet/)).toBeVisible()
 
     // 4. Confirm: only the 2 promotable standard rows import.

--- a/tests/e2e/sure-migration.e2e.ts
+++ b/tests/e2e/sure-migration.e2e.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+import { buildSureBundleV2Complete } from "../integration/support/sure-fixtures"
+
+// PER-171 / ADR-0041 §11 — the guided Sure importer drives the real browser →
+// runSureMigrationFn → staging → promotion path against the SAME synthetic v2
+// bundle the integration suite (PER-170) promotes headlessly. It proves the
+// preview surfaces created vs held HONESTLY, the confirm promotes the standard
+// rows into the canonical ledger, and re-running the identical bundle is
+// idempotent (replayed, zero duplicates) rather than an error.
+
+const bundle = buildSureBundleV2Complete()
+
+test.describe("Sure guided migration", () => {
+  test("upload → honest preview → promote → idempotent re-run", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    // 1. Reach the guided importer from the CSV import page's entry banner.
+    await page.goto("/import")
+    await waitForHydration(page)
+    await page.getByRole("link", { name: /Coming from Sure/ }).click()
+    await expect(page).toHaveURL(/\/import\/sure$/)
+    await waitForHydration(page)
+
+    // 2. Upload the synthetic all.ndjson; the client-side preview resolves.
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "all.ndjson",
+      mimeType: "application/x-ndjson",
+      buffer: Buffer.from(bundle.ndjson),
+    })
+
+    // 3. Preview honestly splits crossing-now from held, with the gap note.
+    await expect(page.getByText("Crossing into your ledger")).toBeVisible()
+    await expect(page.getByText("Held for a later step")).toBeVisible()
+    await expect(page.getByText("Transfers")).toBeVisible()
+    await expect(page.getByText(/A few balances won't match yet/)).toBeVisible()
+
+    // 4. Confirm: only the 2 promotable standard rows import.
+    await page.getByRole("button", { name: /Import 2 transactions/ }).click()
+
+    // 5. Done screen reports the authoritative result and a manual navigate.
+    await expect(page.getByText("Migration complete")).toBeVisible()
+    await page.getByRole("button", { name: /View transactions/ }).click()
+
+    await expect(page).toHaveURL(/\/transactions(?:\?.*)?$/)
+    await waitForHydration(page)
+    await expect(page.getByText("Lumpia beef")).toBeVisible()
+    await expect(page.getByText("June salary")).toBeVisible()
+
+    // 6. Re-run the identical bundle — idempotent, nothing duplicated.
+    await page.goto("/import/sure")
+    await waitForHydration(page)
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "all.ndjson",
+      mimeType: "application/x-ndjson",
+      buffer: Buffer.from(bundle.ndjson),
+    })
+    await page.getByRole("button", { name: /Import 2 transactions/ }).click()
+    await expect(page.getByText("Already imported")).toBeVisible()
+
+    // The ledger still holds exactly one of each promoted row (no duplicate).
+    await page.goto("/transactions")
+    await waitForHydration(page)
+    await expect(page.getByText("Lumpia beef")).toHaveCount(1)
+  })
+})


### PR DESCRIPTION
## PER-171 — Phase 1b: Sure migration guided importer UI + E2E

Builds the **guided** whole-bundle Sure importer (distinct from the PER-151 CSV column-mapping wizard) on top of the merged Phase-1a backend (`runSureMigrationFn`, PR #131 — **unchanged here**). Closes the UI half of [PER-171](https://linear.app/permana/issue/PER-171).

### The pivotal constraint
`runSureMigrationFn` is a **single atomic call** — it parses, stages, and promotes in one shot and returns the authoritative `SureMigrationResult`. There is no server dry-run. So the pre-confirm preview is computed **in the browser by running the same reader the server uses** (`parseSureBundle`), guaranteeing zero logic drift.

### What's here
- **`src/lib/sure-migration.ts` → `summarizeSureBundle`** — a pure, client-safe preview that mirrors the orchestrator's `isPromotable` gate branch-for-branch, with the **same held precedence** (transfer → non-importable account → currency mismatch → split). Parity is pinned by unit tests against the synthetic v2/v1 fixture manifests, so the previewed counts can't drift from the authoritative result.
- **`src/routes/_protected/import_.sure.tsx`** (`/import/sure`) — `upload → review → done`.
  - **Review** is an honest manifest: *Crossing into your ledger* vs *Held for a later step*, itemized by reason, plus a plain **reconciliation-gap note** so a partial Phase-1 balance never reads as data loss.
  - **Done** shows the authoritative `SureMigrationResult` (created/reused per entity, promoted/held/skipped), reads `replayed:true` as *"already imported — nothing duplicated"*, refetches `transactionCollection`, and navigates on an explicit button (not a flashing toast).
- **`src/routes/_protected/import.tsx`** — entry banner linking to the guided importer.
- **`tests/e2e/sure-migration.e2e.ts`** — upload synthetic v2 bundle → assert honest preview → promote → 2 rows on `/transactions` → idempotent re-run (replayed, no duplicates), reusing the integration fixture manifest.

### Honest surfacing (ADR §5)
Transfers, splits, and Investment/TrackedAsset accounts are **held** this phase; balances finish reconciling once transfers are migrated. The UI surfaces held/skipped breakdowns from the result counts and states the gap plainly — not just happy-path "created" numbers.

### Conformance
`ssr:false` + loader `preload()`; no inline styles, no direct `useEffect`, no `any`; types via `Awaited<ReturnType<typeof runSureMigrationFn>>`; shadcn primitives + `cn()` + lucide, Wise theme (DESIGN.md).

### Verification
- ✅ `vp check` — clean (190 files, 0 lint/type/format issues)
- ✅ `vp test run` — 350 passed (incl. new `summarizeSureBundle` parity tests)
- ✅ `vp build` — clean; no server-code leak into the client graph
- ⏳ **E2E**: green expected in CI. Playwright Chromium can't launch in this local WSL env (missing system libs), so the new `sure-migration.e2e.ts` is verifiable only in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)