### PR TITLE
feat(import): PER-175 — Sure migration transfers (dual-leg pairing + liability kinds, ADR-0042)

### DIFF
--- a/docs/adr/0041-sure-full-family-migration.md
+++ b/docs/adr/0041-sure-full-family-migration.md
@@ -10,6 +10,7 @@
 | **Superseded by** | —                                                                                |
 | **Builds on**     | ADR-0039 (import staging spine, PER-82), ADR-0008 §5, `docs/account-taxonomy.md` |
 | **Amends**        | ADR-0039 §1/§10 (adds `migration` source kind + bundle artifact retention)       |
+| **Amended by**    | ADR-0042 (2026-06-28, PER-175): §5 posting predicate + §10 Phase 1.5             |
 | **Reserves for**  | Phase 2 transfers/trades (PER-150/PER-146), Phase 3 rules (smart-rule engine)    |
 
 ## Context
@@ -220,6 +221,17 @@ classifies. `sureMinor == 0` is treated as `expense` and flagged for review.
 (PER-159 lesson).
 
 ### 5. Opening balance for cash-like accounts (transfer-independent, additive)
+
+> **Amended by ADR-0042 (2026-06-28, PER-175).** This section was written under
+> the assumption that transfers stay deferred. PER-175 promotes transfers, which
+> **generalizes the "posting" predicate**: a row posts if it is a standard
+> promotable row **or a transfer leg in a promotable pair** (the same pure
+> analysis the promotion step uses — `gateSet === promoteSet`). The "nothing
+> posts → latest valuation" branch below therefore applies **only** to accounts
+> with genuinely no posting; a transfer-touched account falls into the "posting
+> exists" branch (so its opening precedes the first transfer and the transfer flow
+> is not double-counted). See ADR-0042 § _Consequences_ for the full reasoning and
+> the pre-launch one-shot assumption (and its limit).
 
 PER-82 promotion applies signed deltas onto the account's **current** balance, so
 the opening balance matters. It is set **once at account creation**, only for
@@ -433,20 +445,21 @@ the artifact is recommended, consistent with the fixture-privacy decision (§11)
 
 ### 10. Phasing (what is deferred, and why it is safe)
 
-| Phase   | Scope                                                | Blocked by              |
-| ------- | ---------------------------------------------------- | ----------------------- |
-| **1**   | accounts + categories + **merchants** + transactions | PER-82 (done)           |
-| **1.5** | transfers (pair legs → `Transfer` mutation)          | transfer-import design  |
-| **2**   | trades / holdings / `TRACKED_ASSET` valuations       | PER-150, PER-146        |
-| **3**   | rules → `SmartRule`                                  | smart-rule apply engine |
+| Phase   | Scope                                                                      | Blocked by              |
+| ------- | -------------------------------------------------------------------------- | ----------------------- |
+| **1**   | accounts + categories + **merchants** + transactions                       | PER-82 (done)           |
+| **1.5** | transfers (pair legs → `Transfer` mutation) — **DONE, ADR-0042 / PER-175** | —                       |
+| **2**   | trades / holdings / `TRACKED_ASSET` valuations                             | PER-150, PER-146        |
+| **3**   | rules → `SmartRule`                                                        | smart-rule apply engine |
 
 Deferral is safe because every deferred input is **retained** (§8) and every
 held row is **staged not dropped** (§6). **Phase 1.5 (transfers)** pairs legs
 **deterministically** from `Transfer.{inflow,outflow}_transaction_id` when the
 entity is present (the common v2 case); a bundle **without** `Transfer` rows (like
-the validation fixture) needs a **separate heuristic-pairing ADR** — Phase 1.5
-must not silently heuristically pair, since `funds_movement` legs across accounts
-can collide on amount+date.
+the validation fixture) needs a **separate heuristic-pairing ADR** — **now
+ADR-0042 (PER-175)**, which pairs clean legs strictly, resolves balanced clusters
+only by unique bidirectional name hints, and HOLDS everything ambiguous rather
+than silently pairing `funds_movement` legs that collide on amount+date.
 
 ### 11. UI shape & fixtures
 

--- a/docs/adr/0042-sure-transfer-pairing.md
+++ b/docs/adr/0042-sure-transfer-pairing.md
@@ -39,6 +39,34 @@ promotes them as proper **dual-leg Permoney transfers**.
   counterpart account name EXACTLY** (normalized); 8 are substring-only (mis-bind
   risk); 17 have no usable hint. Directional prefixes are **English only**
   (435 `"Transfer to"` + 435 `"Transfer from"`; zero Indonesian `ke/dari`).
+- **Sure tags transfers ASYMMETRICALLY** (discovered head-eng on the first
+  adversarial harness run): only the **cash-side** leg carries the specialized
+  kind (`cc_payment` / `loan_payment`); the **liability-side** leg (on the
+  `CreditCard`/`Loan` account) is tagged the generic `funds_movement`. All 28
+  liability-side legs in the bundle are `funds_movement`. So a real card/loan
+  payment is `[special, funds_movement]`, **never** `[special, special]`. The gate
+  must be asymmetric-aware or it wrongly holds every cc/loan payment (§2).
+
+### Real distribution (verified against `all.ndjson` — the honest Phase-1 ceiling)
+
+The TIE_OUT holds (928 legs all accounted for), and after the asymmetric-kind fix
+the distribution is:
+
+| Outcome                                                                                                                            | Legs        |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **paired** (promoted as dual-leg transfers)                                                                                        | ~648 (~70%) |
+| `non_importable` — Investment / PreciousMetal / OtherAsset legs **held by §6** (Phase 1 does not import these accounts; by design) | 210         |
+| `ambiguous_cluster` — held conservatively (no unique name match)                                                                   | 60          |
+| `kind_divergence` — loan-sourced `funds_movement` → `liability_draw`, no leg tagged it → held                                      | ~4          |
+| `unpaired_orphan`                                                                                                                  | 6           |
+
+The original "≥83%" was a **projection that did not account for the §6
+importability gate**: ~23% of transfer legs touch Investment/TrackedAsset
+accounts and are **correctly held** (their economically-meaningful postings are
+Trades/Holdings, deferred to PER-150/146). So the honest Phase-1 auto-pair ceiling
+is **~70%**, with the remainder **held legitimately** (dominated by §6), not
+fabricated. This is honest surfacing, not a failure — the DoD bar is corrected
+accordingly below.
 
 ## Decision
 
@@ -79,12 +107,18 @@ Before calling the canonical core, each candidate pair passes, in order:
    Investment/TrackedAsset legs hold, consistent with ADR-0041 §6,
 3. **currency match** between the two legs (else `currency_mismatch` — FX transfer
    pairing is deferred),
-4. **`kind` cross-check (strict equality)**: Permoney **derives** the transfer
-   kind from the two account types (`deriveTransferKindForAccounts`) and requires
-   it to equal both legs' Sure `kind`. Any divergence — **including a
-   legal-but-unexpected `liability_draw`** (a loan-sourced `funds_movement`) — is
-   HELD `kind_divergence`, never silently promoted with a guessed kind. This also
-   catches a flipped pair for free (wrong direction derives the wrong kind).
+4. **`kind` cross-check (asymmetric-aware)**: Permoney **derives** the transfer
+   kind from the two account types (`deriveTransferKindForAccounts`) and validates
+   it against the two legs' Sure `kind`. Because Sure tags transfers
+   **asymmetrically** (only the cash-side leg carries the specialized kind; the
+   liability-side leg is the generic `funds_movement` — see Context), the rule is:
+   **every leg kind must be the derived kind OR `funds_movement`, AND at least one
+   leg must carry the derived kind.** This promotes `cc_payment`/`loan_payment`
+   (the common case), while still holding a genuine divergence — a loan-sourced
+   `funds_movement` (derived `liability_draw`, no leg tagged it → `kind_divergence`,
+   never invents a borrowing event) and a Sure `cc_payment` whose accounts don't
+   justify it. A bilateral-exact rule was the original bug: it held all 21 cc/loan
+   payment pairs because Sure never tags both legs.
 
 The Postgres balance-sign CHECK (e.g. a `cc_payment` overshooting a liability past
 zero) is the runtime backstop: a throw from the core is caught per-pair and held
@@ -191,11 +225,16 @@ opening-balance reconciliation safeguard becomes mandatory.**
 - **Pure edge matrix** (`src/lib/sure-migration.test.ts`): Tier 0/1/2, no-fuzz
   negatives (off-by-day, amount mismatch), cross-currency/self/orphan held,
   cluster bidirectional resolve, ambiguous (no-hint and duplicate-name) held,
-  gate precedence (importable → currency → kind, incl. `liability_draw`
-  divergence), determinism (shuffled input → identical pairing), exhaustiveness.
+  gate precedence (importable → currency → kind), the **asymmetric kind combos**
+  (`[cc_payment, funds_movement]` and `[loan_payment, funds_movement]` promote;
+  loan-sourced `funds_movement` → `liability_draw` held; a Sure `cc_payment` the
+  accounts don't justify → held), determinism, exhaustiveness.
 - **Mode A (deterministic, `Transfer` entity)**: dual-leg promote, atomic both-
-  account balance, `Transfer` link, base/FX set, `cc_payment` moves the CREDIT
-  liability toward zero; `currency_mismatch` / `not_staged` / orphan held.
+  account balance, `Transfer` link, base/FX set; **`cc_payment` AND `loan_payment`
+  pairs tagged ASYMMETRICALLY** (liability-side `funds_movement`, exactly like the
+  real export) promote and move each liability toward zero — so a bilateral-exact
+  regression can never pass CI again; `currency_mismatch` / `not_staged` / orphan
+  held.
 - **Mode B (degraded heuristic)**: clean + cluster promote; every held bucket
   populated and reconciling; balances; held rows stay normalized.
 - **Dedicated regression**: transfers must NOT double-count the opening balance.

--- a/docs/adr/0042-sure-transfer-pairing.md
+++ b/docs/adr/0042-sure-transfer-pairing.md
@@ -1,0 +1,233 @@
+# ADR-0042 — Sure migration transfers (dual-leg pairing + liability kinds)
+
+|                   |                                                                                        |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| **Status**        | Accepted                                                                               |
+| **Date**          | 2026-06-28                                                                             |
+| **Accepted**      | 2026-06-28                                                                             |
+| **Deciders**      | Hendri Permana                                                                         |
+| **Supersedes**    | —                                                                                      |
+| **Superseded by** | —                                                                                      |
+| **Builds on**     | ADR-0041 (Sure full-family migration Phase 1), ADR-0039 (import staging spine, PER-82) |
+| **Amends**        | ADR-0041 §5 (opening-balance posting predicate) + §10 (Phase 1.5 phasing row)          |
+| **Reserves for**  | FX/cross-currency transfer pairing; Phase 2 trades/holdings; Phase 3 rules             |
+
+## Context
+
+ADR-0041 Phase 1 **holds every transfer-kind transaction** — the single largest
+migration-accuracy gap. This ADR is the **separate heuristic-pairing decision**
+that ADR-0041 §10 explicitly forward-referenced ("a bundle without `Transfer`
+rows needs a separate heuristic-pairing ADR"). It pairs the held legs and
+promotes them as proper **dual-leg Permoney transfers**.
+
+### Real-export investigation (head-eng verified 2026-06-28 vs `fixture/sure-sample/all.ndjson`)
+
+- **928 transfer-kind legs**: 902 `funds_movement`, 14 `loan_payment`, 12
+  `cc_payment`. Permoney's transfer `kind` domain already covers these +
+  `liability_draw`.
+- The degraded export carries **no `Transfer` entity and no `transfer_id`**;
+  `entry_id` is unique per leg (NOT a shared pairing key). So in/out pairing is
+  **lost** in this export. A full Sure v2 export _should_ carry
+  `Transfer { inflow_transaction_id, outflow_transaction_id }` — deterministic.
+- Heuristic pairing by `(date, |amount|, opposite sign, different account)`:
+  **772/928 legs (~83%) pair cleanly** (385 clean pairs + 1 near); **37 ambiguous
+  clusters** (152 legs, same date+amount, balanced in/out) resolvable via the
+  `name` directional hint (`"Transfer to <X>"` ↔ `"Transfer from <X>"`); **4
+  orphan singles** (likely income/expense mis-tagged, or counterpart outside the
+  export).
+- Cluster name-hint analysis (152 cluster legs): **127/152 (84%) match a
+  counterpart account name EXACTLY** (normalized); 8 are substring-only (mis-bind
+  risk); 17 have no usable hint. Directional prefixes are **English only**
+  (435 `"Transfer to"` + 435 `"Transfer from"`; zero Indonesian `ke/dari`).
+
+## Decision
+
+**A pure, deterministic pairer (`src/lib/sure-migration.ts`) groups the held
+transfer legs into `(outflow, inflow)` candidate pairs; the orchestrator
+(`src/server/sure-migration.ts`) promotes each promotable pair through the
+UNCHANGED canonical transfer core `createTransactionForFamily({type:"transfer"})`
+— no new ledger writer. Pairing is precise-first, heuristic-fallback, and
+HOLDS on ambiguity; it NEVER fabricates a counterparty.**
+
+### 1. Pairing precedence (precise-first, hold-on-ambiguity)
+
+- **Tier 0 — deterministic.** When the bundle carries `Transfer` rows, pair the
+  two legs via `Transfer.{outflow,inflow}_transaction_id`. Authoritative; the
+  direction comes from the entity, not the sign. (The common v2 case.)
+- **Tier 1 — clean heuristic.** Group remaining legs by the **exact** key
+  `(date.slice(0,10), |amount| minor units, currency)`. A group with exactly one
+  outflow (Sure amount `> 0` = source/`accountId`) + one inflow (`< 0` =
+  dest/`toAccountId`) on **different** accounts is a clean pair. **No fuzzing** —
+  no ±1-day or approximate-amount matching, because a fabricated transfer is
+  ledger poison and strict clean pairs alone already reach ~83%.
+- **Tier 2 — cluster resolution.** A `>1`-per-side group is resolved **only** by
+  a **unique perfect matching** of **bidirectional, exact-normalized** directional
+  name hints: an outflow `"Transfer to <X>"` and an inflow `"Transfer from <Y>"`
+  must each name the other's account (trim + lowercase + collapse-whitespace, no
+  substring). If any leg has ≥2 valid counterparts or the matching is not unique,
+  the **whole cluster is HELD** (`ambiguous_cluster`).
+- **Held, never fabricated.** Self-transfers, cross-currency-via-amount, orphans
+  (one-sided groups), and unresolved clusters are HELD with a typed reason.
+
+### 2. Promotion gate (per candidate pair, first failure wins)
+
+Before calling the canonical core, each candidate pair passes, in order:
+
+1. **both legs staged** with a recoverable stable key (else `not_staged`),
+2. **both accounts `isImportable && balanceSource == transaction_flow`** (else
+   `non_importable`) — so `CREDIT`/`LOAN` promote (cc/loan payments), while
+   Investment/TrackedAsset legs hold, consistent with ADR-0041 §6,
+3. **currency match** between the two legs (else `currency_mismatch` — FX transfer
+   pairing is deferred),
+4. **`kind` cross-check (strict equality)**: Permoney **derives** the transfer
+   kind from the two account types (`deriveTransferKindForAccounts`) and requires
+   it to equal both legs' Sure `kind`. Any divergence — **including a
+   legal-but-unexpected `liability_draw`** (a loan-sourced `funds_movement`) — is
+   HELD `kind_divergence`, never silently promoted with a guessed kind. This also
+   catches a flipped pair for free (wrong direction derives the wrong kind).
+
+The Postgres balance-sign CHECK (e.g. a `cc_payment` overshooting a liability past
+zero) is the runtime backstop: a throw from the core is caught per-pair and held
+`db_rejected` — one poisoned pair never blocks the rest.
+
+The canonical core derives `kind`, applies both balance deltas atomically, writes
+the `Transfer` link row, materializes base/FX projection, and audits — the
+migration adds none of this (CLAUDE.md "no new ledger writer", "bulk paths match
+single paths"). `cc_payment`/`loan_payment` move a liability balance toward zero
+per `docs/liability-semantics.md`.
+
+### 3. Idempotency (self-healing stable key — "2B")
+
+Each pair is keyed by the **outflow leg's persisted `promotionIdempotencyKey`**
+(minted once at PER-170 stage time). The core's `replayIdempotentTransaction`
+runs **before any balance delta**, so a re-run returns the existing legs, creates
+no second leg and moves no balance. The leg-create runs in the core's **own**
+transaction; the two staged rows are then marked `promoted` in a **second**
+transaction, recovering the leg ids via the stable key → outflow leg →
+`Transfer` → inflow leg (identical on fresh create and replay). A crash between
+the two transactions leaves a brief **provenance lag** (legs correct, rows still
+`normalized`) that **self-heals** on the next re-run **without duplication** — the
+stable key makes re-promotion a no-op. This deliberately keeps the canonical
+writer **unchanged** (its own P2002 recovery intact), which a transaction-reuse
+injection would have disarmed. On re-run, **persisted linkage is authoritative**:
+only not-yet-promoted legs are paired, so Tier-2 nondeterminism can never
+contradict an existing `Transfer`.
+
+### 4. Observability (leg-based, DB-anchored — ADR-0041 §5 provenance pattern)
+
+`SureMigrationResult.transfers` reports leg-based counts: `legsSeen`,
+`legsStaged`, `pairsPromotedThisRun`, `legsPromotedTotal` (read back from
+`rowStatus` — cumulative, stable across re-runs), `pairedByTier`, and
+`heldLegsByReason` (every held leg carries exactly **one** DB-anchored reason —
+the first failing gate / structural outcome — persisted in
+`RawImportedTransaction.errorReason`, including the runtime `db_rejected`). Two
+reconcile invariants are asserted in the real-Postgres tests:
+
+- **internal:** `legsStaged === legsPromotedTotal + Σ heldLegsByReason`,
+- **spanning:** every bundle transaction is counted in exactly one place —
+  `total === standard{promoted+held} + transfers{legsPromotedTotal + Σheld} +
+zero + invalidDate + unmapped`. Transfer legs live **only** in the `transfers`
+  block (excluded from `transactions.held`).
+
+## Consequences
+
+### Opening-balance posting predicate is generalized (amends ADR-0041 §5)
+
+Promoting transfers **invalidates** PER-174's assumption that transfers stay
+deferred. PER-174 set a held-transfer-only account's opening to the **latest
+valuation** ("nothing posts → opening = current value, nothing added on top",
+verified at **14/35** ASSET-flow accounts on a real export). Once PER-175 posts
+those transfers, that opening (which already embeds the transfer movements) +
+the transfer flow **double-counts** — silent ledger corruption.
+
+The fix (mandatory, not scope creep): the **pure pairing analysis runs up-front,
+before account creation**, and the opening-balance posting predicate is
+generalized so a row "posts" if it is a standard promotable row **or a transfer
+leg in a promotable pair** (`willPost = standard-promotable ∪ promotable-transfer`,
+the **same** analysis the promotion step uses — `gateSet === promoteSet`, with
+unmappable-account legs excluded so the two never disagree). A transfer-touched
+account then falls into the **"posting exists"** branch (opening = earliest
+valuation strictly before the first posting, else gap), and the "latest
+valuation" branch applies **only** to accounts with genuinely no posting.
+
+### Cross-version assumption (pre-launch, one-shot) and its limit
+
+PER-174 and PER-175 **ship together**: once PER-175 merges there is no
+"PER-174-only" build in anyone's hands, so a **fresh** one-shot migration is
+always correct and a same-bundle re-run is idempotent (transfers skip-if-promoted,
+opening already correct). The **only** broken case is running the pre-PER-175
+importer, setting latest-valuation openings, **then** running PER-175 on the same
+reused accounts (opening is "set once, never re-applied"). Because Permoney is
+**pre-launch** (no live ledger; the migration is tested on the author's own data),
+we rely on the one-shot nature and a **deployment note** rather than a
+reconciliation pass: _if you already ran the importer on a pre-PER-175 build,
+re-import into a FRESH family before the first PER-175 run._ **This assumption is
+valid only because Permoney is pre-launch and one-shot. If Permoney is live with a
+real ledger when a future migration phase changes which rows post, an
+opening-balance reconciliation safeguard becomes mandatory.**
+
+### Other consequences
+
+- `cc_payment`/`loan_payment` legs now post to liability accounts; the canonical
+  core's derived kind + the strict cross-check keep liability semantics honest.
+- Held legs remain staged provenance and the input for any future manual review
+  / FX-transfer phase; nothing is dropped or fabricated.
+
+## Acceptance criteria
+
+- [x] Tier 0 deterministic pairing when the `Transfer` entity is present.
+- [x] Degraded heuristic: clean pairs + cluster resolution promote as dual-leg
+      transfers (atomic balance on both accounts, `Transfer` link, audit,
+      base/FX); ambiguous/orphan/gated legs are HELD (never fabricated).
+- [x] Idempotent re-run (no second `Transfer`, no second balance); self-healing
+      stable-key window; tenant isolation/RLS.
+- [x] Opening-balance double-count fix (transfer-aware posting predicate).
+- [x] Observability: leg-based counts + per-reason held buckets; internal +
+      spanning reconcile invariants asserted in real Postgres.
+- [x] `vp run check && vp test run && vp build` clean; real-PG integration green.
+
+## Testing (real Postgres — mandatory)
+
+- **Pure edge matrix** (`src/lib/sure-migration.test.ts`): Tier 0/1/2, no-fuzz
+  negatives (off-by-day, amount mismatch), cross-currency/self/orphan held,
+  cluster bidirectional resolve, ambiguous (no-hint and duplicate-name) held,
+  gate precedence (importable → currency → kind, incl. `liability_draw`
+  divergence), determinism (shuffled input → identical pairing), exhaustiveness.
+- **Mode A (deterministic, `Transfer` entity)**: dual-leg promote, atomic both-
+  account balance, `Transfer` link, base/FX set, `cc_payment` moves the CREDIT
+  liability toward zero; `currency_mismatch` / `not_staged` / orphan held.
+- **Mode B (degraded heuristic)**: clean + cluster promote; every held bucket
+  populated and reconciling; balances; held rows stay normalized.
+- **Dedicated regression**: transfers must NOT double-count the opening balance.
+- **Self-heal 2B**: a created leg with reverted (unmarked) rows re-promotes via
+  the stable key with no double leg/balance.
+- **Idempotent re-run** and **tenant isolation** for transfers.
+
+## Alternatives considered
+
+1. **Fuzzy pairing (±1 day / approximate amount).** Rejected — manufactures false
+   transfers; strict clean pairs already reach ~83%, cluster resolution is upside.
+2. **Substring/partial name match in clusters.** Rejected — 8 substring-only legs
+   risk a permanent mis-bind ("BCA Tabungan" vs "BCA Kartu Kredit"); HELD is safe
+   and reversible, a mis-bind is not.
+3. **Allow `liability_draw` through when account shapes justify it.** Rejected —
+   only 1 real pair; auto-asserting a borrowing event Sure itself never recorded
+   is not worth it. Strict `kind` equality holds it for human confirmation.
+4. **Transaction-reuse injection to make leg-create + row-mark atomic.** Rejected
+   — it disarms the canonical core's P2002 recovery (a second `runInTenantTransaction`
+   on an aborted reused tx); the stable-key self-healing window is non-doubling
+   and keeps the canonical writer pristine.
+5. **A second, batched dual-leg promote writer.** Rejected — duplicates dual-leg /
+   derived-kind / liability / Transfer-link / balance / audit logic that must stay
+   in sync (CLAUDE.md "no new ledger writer", "bulk paths match single paths").
+6. **An opening-balance reconciliation pass for the cross-version edge.** Rejected
+   for now — over-engineering pre-launch; documented assumption + limit instead.
+
+## References
+
+- PER-175 (this ADR's ticket), PER-163 (full-family migration)
+- ADR-0041 (Phase 1 — §5 opening balance, §6 gating, §10 phasing — amended here)
+- ADR-0039 / PER-82 (import staging spine), ADR-0035 (FX base projection)
+- ADR-0006 (idempotency + audit), ADR-0010/0011 (tenant FK / app validation)
+- `docs/liability-semantics.md` (cc/loan payment, liability kinds)
+- Sure source: `app/models/family/data_exporter.rb`, `app/models/transfer.rb`

--- a/src/lib/sure-migration.test.ts
+++ b/src/lib/sure-migration.test.ts
@@ -13,6 +13,14 @@ import {
   type SureTransaction,
   type SureValuation,
 } from "./sure-migration"
+import {
+  classifyTransferPairGate,
+  normalizeSureAccountName,
+  pairSureTransfers,
+  parseSureTransferHint,
+  type SureTransfer,
+  type SureTransferAccountMeta,
+} from "./sure-migration"
 // Anchor the client-side preview classifier to the REAL server gate, not a
 // hand-written copy: import the server's `isPromotable` and assert identical
 // verdicts. Behavior-neutral export (PER-171); the integration suite stays green.
@@ -341,7 +349,11 @@ describe("summarizeSureBundle reconciliation", () => {
     ).toBe(t.held)
 
     expect(t.promotable).toBe(manifest.expected.promotedThisRun)
-    expect(t.held).toBe(manifest.expected.held)
+    // The PER-171 preview lumps every transfer-kind leg into `held` (reason
+    // `transfer`) — it runs BEFORE pairing. The server's `transactions.held`
+    // (manifest.expected.held) is STANDARD-only (ADR-0042 moves transfer legs to
+    // the `transfers` block), so preview.held = standard-held + transfer legs.
+    expect(t.held).toBe(manifest.expected.held + t.heldByReason.transfer)
     expect(t.zeroAmountSkipped).toBe(manifest.expected.zeroAmountSkipped)
     expect(preview.malformedLines).toBe(manifest.expected.malformedLines)
     // Real unmapped entities are surfaced, never silently dropped.
@@ -665,5 +677,364 @@ describe("willPostThisRun parity with the promote set", () => {
     expect(post(manifest.ids.txnHeldInvest)).toBe(false) // non-importable
     expect(post(manifest.ids.txnHeldKind)).toBe(false) // non-standard kind
     expect(post(manifest.ids.txnHeldCurrency)).toBe(false) // currency mismatch
+  })
+})
+
+// ===========================================================================
+// ADR-0042 — transfer pairing edge matrix (pure, no DB). The whole decision
+// tree: Tier 0/1/2, the no-fuzz negatives, structural holds, gate precedence,
+// determinism, and exhaustiveness.
+// ===========================================================================
+
+const leg = (
+  id: string,
+  accountId: string,
+  amount: string,
+  kind: string,
+  name: string | null = null,
+  date = "2026-05-01",
+  currency = "IDR"
+): SureTransaction => ({
+  id,
+  account_id: accountId,
+  amount,
+  currency,
+  kind,
+  name,
+  date,
+})
+
+const meta = (
+  id: string,
+  name: string,
+  accountType: SureTransferAccountMeta["accountType"] = "DEPOSITORY",
+  opts: Partial<SureTransferAccountMeta> = {}
+): SureTransferAccountMeta => ({
+  sureAccountId: id,
+  name,
+  currency: opts.currency ?? "IDR",
+  accountType,
+  isImportable: opts.isImportable ?? true,
+  balanceSource: opts.balanceSource ?? "transaction_flow",
+})
+
+const metaMap = (
+  ...entries: SureTransferAccountMeta[]
+): Map<string, SureTransferAccountMeta> =>
+  new Map(entries.map((m) => [m.sureAccountId, m]))
+
+describe("parseSureTransferHint", () => {
+  test("parses English directional prefixes, normalizing the target", () => {
+    expect(parseSureTransferHint("Transfer to BCA Savings")).toEqual({
+      direction: "to",
+      target: "bca savings",
+    })
+    expect(parseSureTransferHint("Transfer from   Main  ")).toEqual({
+      direction: "from",
+      target: "main",
+    })
+  })
+
+  test("accepts the cheap Indonesian future-proofing", () => {
+    expect(parseSureTransferHint("transfer ke Gopay")?.direction).toBe("to")
+    expect(parseSureTransferHint("Transfer dari Ovo")?.direction).toBe("from")
+  })
+
+  test("returns null for non-directional names (no fabrication)", () => {
+    expect(parseSureTransferHint("Cash withdrawal")).toBeNull()
+    expect(parseSureTransferHint("")).toBeNull()
+    expect(parseSureTransferHint(null)).toBeNull()
+  })
+})
+
+describe("normalizeSureAccountName", () => {
+  test("trim + lowercase + collapse whitespace", () => {
+    expect(normalizeSureAccountName("  BCA   Savings ")).toBe("bca savings")
+  })
+})
+
+describe("pairSureTransfers — Tier 0 deterministic", () => {
+  test("a Transfer entity pairs its two legs authoritatively", () => {
+    const legs = [
+      leg("o", "a", "40000.0", "funds_movement", "Transfer to B"),
+      leg("i", "b", "-40000.0", "funds_movement", "Transfer from A"),
+    ]
+    const transfers: SureTransfer[] = [
+      { id: "x", outflow_transaction_id: "o", inflow_transaction_id: "i" },
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("a", "A"), meta("b", "B")),
+      transfers,
+    })
+    expect(result.pairs).toHaveLength(1)
+    expect(result.pairs[0]?.tier).toBe("deterministic")
+    expect(result.pairs[0]?.outflow.id).toBe("o")
+    expect(result.pairs[0]?.inflow.id).toBe("i")
+    expect(result.held).toHaveLength(0)
+  })
+
+  test("a Transfer referencing a never-staged leg holds the present one not_staged", () => {
+    const legs = [leg("i", "b", "-40000.0", "funds_movement")]
+    const transfers: SureTransfer[] = [
+      {
+        id: "x",
+        outflow_transaction_id: "missing",
+        inflow_transaction_id: "i",
+      },
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("b", "B")),
+      transfers,
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held).toEqual([{ txn: legs[0], reason: "not_staged" }])
+  })
+
+  test("cross-currency Transfer entity → currency_mismatch HELD (FX deferred)", () => {
+    const legs = [
+      leg("o", "a", "10000.0", "funds_movement"),
+      leg("i", "u", "-1.0", "funds_movement", null, "2026-05-01", "USD"),
+    ]
+    const transfers: SureTransfer[] = [
+      { id: "x", outflow_transaction_id: "o", inflow_transaction_id: "i" },
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(
+        meta("a", "A"),
+        meta("u", "U", "DEPOSITORY", { currency: "USD" })
+      ),
+      transfers,
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held.map((h) => h.reason)).toEqual([
+      "currency_mismatch",
+      "currency_mismatch",
+    ])
+  })
+})
+
+describe("pairSureTransfers — Tier 1 clean & the no-fuzz negatives", () => {
+  test("exactly one out + one in, same day/amount, different account → clean pair", () => {
+    const legs = [
+      leg("o", "a", "40000.0", "funds_movement"),
+      leg("i", "b", "-40000.0", "funds_movement"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("a", "A"), meta("b", "B")),
+    })
+    expect(result.pairs).toHaveLength(1)
+    expect(result.pairs[0]?.tier).toBe("clean")
+  })
+
+  test("off-by-one-day does NOT pair (no fuzzing) → both orphan", () => {
+    const legs = [
+      leg("o", "a", "40000.0", "funds_movement", null, "2026-05-01"),
+      leg("i", "b", "-40000.0", "funds_movement", null, "2026-05-02"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("a", "A"), meta("b", "B")),
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held.map((h) => h.reason)).toEqual([
+      "unpaired_orphan",
+      "unpaired_orphan",
+    ])
+  })
+
+  test("amount mismatch does NOT pair → both orphan", () => {
+    const legs = [
+      leg("o", "a", "40000.0", "funds_movement"),
+      leg("i", "b", "-41000.0", "funds_movement"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("a", "A"), meta("b", "B")),
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held).toHaveLength(2)
+  })
+
+  test("self-transfer (same account out & in) is never a pair → held", () => {
+    const legs = [
+      leg("o", "a", "40000.0", "funds_movement"),
+      leg("i", "a", "-40000.0", "funds_movement"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("a", "A")),
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held.map((h) => h.reason)).toEqual([
+      "unpaired_orphan",
+      "unpaired_orphan",
+    ])
+  })
+
+  test("a lone outflow → unpaired_orphan", () => {
+    const legs = [leg("o", "a", "40000.0", "funds_movement")]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(meta("a", "A")),
+    })
+    expect(result.held).toEqual([{ txn: legs[0], reason: "unpaired_orphan" }])
+  })
+})
+
+describe("pairSureTransfers — Tier 2 cluster resolution", () => {
+  test("bidirectional exact name hints resolve a balanced cluster uniquely", () => {
+    const legs = [
+      leg("o1", "wallet", "12000.0", "funds_movement", "Transfer to Gopay"),
+      leg("i1", "gopay", "-12000.0", "funds_movement", "Transfer from Wallet"),
+      leg("o2", "dana", "12000.0", "funds_movement", "Transfer to Ovo"),
+      leg("i2", "ovo", "-12000.0", "funds_movement", "Transfer from Dana"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(
+        meta("wallet", "Wallet"),
+        meta("gopay", "Gopay"),
+        meta("dana", "Dana"),
+        meta("ovo", "Ovo")
+      ),
+    })
+    expect(result.pairs).toHaveLength(2)
+    expect(result.pairs.every((p) => p.tier === "resolved_cluster")).toBe(true)
+    expect(result.held).toHaveLength(0)
+    // The matching is by NAME, not arbitrary: wallet→gopay, dana→ovo.
+    const byOut = new Map(result.pairs.map((p) => [p.outflow.id, p.inflow.id]))
+    expect(byOut.get("o1")).toBe("i1")
+    expect(byOut.get("o2")).toBe("i2")
+  })
+
+  test("no directional hints → whole cluster HELD ambiguous", () => {
+    const legs = [
+      leg("o1", "wallet", "8000.0", "funds_movement", "Cash move"),
+      leg("i1", "gopay", "-8000.0", "funds_movement", "Cash move"),
+      leg("o2", "dana", "8000.0", "funds_movement", "Cash move"),
+      leg("i2", "ovo", "-8000.0", "funds_movement", "Cash move"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(
+        meta("wallet", "Wallet"),
+        meta("gopay", "Gopay"),
+        meta("dana", "Dana"),
+        meta("ovo", "Ovo")
+      ),
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held).toHaveLength(4)
+    expect(result.held.every((h) => h.reason === "ambiguous_cluster")).toBe(
+      true
+    )
+  })
+
+  test("≥2 valid counterparts (duplicate names BOTH sides) → whole cluster HELD", () => {
+    // Two sources both named "Joint" and two dests both named "Pool": each
+    // "Transfer to Pool / from Joint" leg validly matches BOTH counterparts →
+    // no unique perfect matching → the whole cluster is held, never guessed.
+    const legs = [
+      leg("o1", "a", "5000.0", "funds_movement", "Transfer to Pool"),
+      leg("o2", "b", "5000.0", "funds_movement", "Transfer to Pool"),
+      leg("i1", "c", "-5000.0", "funds_movement", "Transfer from Joint"),
+      leg("i2", "d", "-5000.0", "funds_movement", "Transfer from Joint"),
+    ]
+    const result = pairSureTransfers({
+      legs,
+      metaById: metaMap(
+        meta("a", "Joint"),
+        meta("b", "Joint"),
+        meta("c", "Pool"),
+        meta("d", "Pool")
+      ),
+    })
+    expect(result.pairs).toHaveLength(0)
+    expect(result.held.every((h) => h.reason === "ambiguous_cluster")).toBe(
+      true
+    )
+  })
+})
+
+describe("classifyTransferPairGate — precedence importable → currency → kind", () => {
+  const o = leg("o", "a", "25000.0", "funds_movement")
+  const i = leg("i", "b", "-25000.0", "funds_movement")
+
+  test("non-importable source holds before any other check", () => {
+    expect(
+      classifyTransferPairGate(
+        meta("a", "A", "INVESTMENT", { isImportable: false }),
+        meta("b", "B"),
+        o,
+        i
+      )
+    ).toBe("non_importable")
+  })
+
+  test("loan-source funds_movement → kind_divergence (derived liability_draw)", () => {
+    expect(
+      classifyTransferPairGate(meta("a", "A", "LOAN"), meta("b", "B"), o, i)
+    ).toBe("kind_divergence")
+  })
+
+  test("derived cc_payment matching Sure cc_payment passes", () => {
+    expect(
+      classifyTransferPairGate(
+        meta("a", "A", "DEPOSITORY"),
+        meta("b", "B", "CREDIT"),
+        leg("o", "a", "25000.0", "cc_payment"),
+        leg("i", "b", "-25000.0", "cc_payment")
+      )
+    ).toBeNull()
+  })
+
+  test("plain depository↔depository funds_movement passes", () => {
+    expect(
+      classifyTransferPairGate(meta("a", "A"), meta("b", "B"), o, i)
+    ).toBeNull()
+  })
+})
+
+describe("pairSureTransfers — determinism & exhaustiveness", () => {
+  const legs = [
+    leg("o", "a", "40000.0", "funds_movement"),
+    leg("i", "b", "-40000.0", "funds_movement"),
+    leg("orph", "a", "9000.0", "funds_movement"),
+    leg("kdO", "loan", "25000.0", "funds_movement", null, "2026-05-05"),
+    leg("kdI", "c", "-25000.0", "funds_movement", null, "2026-05-05"),
+  ]
+  const metas = metaMap(
+    meta("a", "A"),
+    meta("b", "B"),
+    meta("c", "C"),
+    meta("loan", "Loan", "LOAN")
+  )
+
+  test("shuffled input yields identical pairing", () => {
+    const forward = pairSureTransfers({ legs, metaById: metas })
+    const reversed = pairSureTransfers({
+      legs: [...legs].reverse(),
+      metaById: metas,
+    })
+    const key = (r: ReturnType<typeof pairSureTransfers>) => ({
+      pairs: r.pairs
+        .map((p) => `${p.outflow.id}->${p.inflow.id}:${p.tier}`)
+        .sort(),
+      held: r.held.map((h) => `${h.txn.id}:${h.reason}`).sort(),
+    })
+    expect(key(reversed)).toEqual(key(forward))
+  })
+
+  test("every input leg lands in exactly one of pairs or held", () => {
+    const result = pairSureTransfers({ legs, metaById: metas })
+    const inPairs = result.pairs.flatMap((p) => [p.outflow.id, p.inflow.id])
+    const inHeld = result.held.map((h) => h.txn.id)
+    const all = [...inPairs, ...inHeld].sort()
+    expect(all).toEqual(legs.map((l) => l.id).sort())
+    expect(new Set(all).size).toBe(legs.length) // disjoint
   })
 })

--- a/src/lib/sure-migration.test.ts
+++ b/src/lib/sure-migration.test.ts
@@ -981,7 +981,30 @@ describe("classifyTransferPairGate — precedence importable → currency → ki
     ).toBe("kind_divergence")
   })
 
-  test("derived cc_payment matching Sure cc_payment passes", () => {
+  test("ASYMMETRIC cc_payment ([cc_payment, funds_movement]) promotes", () => {
+    // Real Sure tagging: cash-side `cc_payment`, CreditCard-side `funds_movement`.
+    expect(
+      classifyTransferPairGate(
+        meta("a", "A", "DEPOSITORY"),
+        meta("b", "B", "CREDIT"),
+        leg("o", "a", "25000.0", "cc_payment"),
+        leg("i", "b", "-25000.0", "funds_movement")
+      )
+    ).toBeNull()
+  })
+
+  test("ASYMMETRIC loan_payment ([loan_payment, funds_movement]) promotes", () => {
+    expect(
+      classifyTransferPairGate(
+        meta("a", "A", "DEPOSITORY"),
+        meta("b", "B", "LOAN"),
+        leg("o", "a", "25000.0", "loan_payment"),
+        leg("i", "b", "-25000.0", "funds_movement")
+      )
+    ).toBeNull()
+  })
+
+  test("symmetric [cc_payment, cc_payment] still passes (forward-compatible)", () => {
     expect(
       classifyTransferPairGate(
         meta("a", "A", "DEPOSITORY"),
@@ -990,6 +1013,19 @@ describe("classifyTransferPairGate — precedence importable → currency → ki
         leg("i", "b", "-25000.0", "cc_payment")
       )
     ).toBeNull()
+  })
+
+  test("anomaly: Sure cc_payment but accounts derive funds_movement → HELD", () => {
+    // `cc_payment` is neither the derived kind (funds_movement) nor the generic
+    // funds_movement → held, never promoted with a guessed kind.
+    expect(
+      classifyTransferPairGate(
+        meta("a", "A", "DEPOSITORY"),
+        meta("b", "B", "DEPOSITORY"),
+        leg("o", "a", "25000.0", "cc_payment"),
+        leg("i", "b", "-25000.0", "funds_movement")
+      )
+    ).toBe("kind_divergence")
   })
 
   test("plain depository↔depository funds_movement passes", () => {

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -31,6 +31,7 @@ import {
   type AccountType,
   normalizeAccountTaxonomy,
 } from "./accounts"
+import { deriveTransferKindForAccounts } from "./liability-semantics"
 import { toMinorUnits } from "./money"
 
 export const SURE_EXPORT_VERSION = 2
@@ -632,4 +633,403 @@ export function orderCategoriesParentsFirst(
 
   for (const category of categories) place(category, new Set())
   return ordered
+}
+
+// ---------------------------------------------------------------------------
+// Transfer pairing (ADR-0042 — Phase 2: dual-leg pairing + liability kinds)
+//
+// Pure, deterministic pairing of Sure transfer-kind legs into (outflow, inflow)
+// candidate pairs the orchestrator promotes through the canonical transfer core
+// (`createTransactionForFamily({type:"transfer"})`) — NEVER a new ledger writer.
+// Precedence is precise-first, heuristic-fallback, hold-on-ambiguity:
+//
+//   Tier 0 — DETERMINISTIC: a Sure `Transfer { outflow_transaction_id,
+//            inflow_transaction_id }` pairs its two legs AUTHORITATIVELY (the
+//            common v2 case). Direction is taken from the entity, not the sign.
+//   Tier 1 — CLEAN heuristic: legs grouped by (day, |amount| minor, currency);
+//            exactly one outflow (Sure amount > 0 = source) + one inflow (< 0 =
+//            dest) on DIFFERENT accounts → a clean pair. No fuzzing, ever.
+//   Tier 2 — CLUSTER resolution: a >1-per-side group is resolved ONLY by
+//            bidirectional, exact-normalized directional name hints
+//            ("Transfer to <X>" on the outflow ↔ "Transfer from <Y>" on the
+//            inflow, each naming the other's account). A unique perfect matching
+//            promotes; anything ambiguous/partial → the WHOLE cluster is HELD.
+//
+// Everything unresolved is HELD with a typed reason — NEVER a fabricated
+// counterparty (HOLD > guess; a fabricated transfer is ledger poison). Each
+// candidate pair then passes a gate (importable → currency → kind, first failure
+// wins); a failing gate HOLDS both legs. Permoney DERIVES the transfer `kind`
+// from the two account types (`deriveTransferKindForAccounts`); Sure's own leg
+// `kind` is a strict cross-check (divergence — including a legal-but-unexpected
+// `liability_draw` — is HELD, never silently promoted with a guessed kind).
+//
+// `currency_mismatch` and `not_staged` are STRUCTURALLY Tier-0 outcomes: a
+// degraded bundle (no `Transfer` entity) can't produce them heuristically —
+// cross-currency legs differ in amount so they fall to `unpaired_orphan`, and
+// every heuristic input leg is already staged. They arise only when an
+// authoritative `Transfer` entity links a cross-currency pair (FX transfer,
+// deferred) or references a leg that was never staged.
+// ---------------------------------------------------------------------------
+
+/** Which tier produced a promotable pair (provenance for the result + tests). */
+export type SureTransferTier = "deterministic" | "clean" | "resolved_cluster"
+
+/**
+ * Why a transfer leg is held (disjoint + exhaustive, one per leg). The pure
+ * pairer assigns every reason EXCEPT `db_rejected`, which is a runtime outcome
+ * (the canonical core threw, e.g. a liability balance-sign CHECK) the
+ * orchestrator records.
+ */
+export type SureTransferHeldReason =
+  | "not_staged"
+  | "non_importable"
+  | "currency_mismatch"
+  | "kind_divergence"
+  | "db_rejected"
+  | "unpaired_orphan"
+  | "ambiguous_cluster"
+
+/** Reasons the pure pairer can assign (everything but the runtime `db_rejected`). */
+export type SureTransferPureHeldReason = Exclude<
+  SureTransferHeldReason,
+  "db_rejected"
+>
+
+/** Gate failures for a formed candidate pair (precedence: importable→currency→kind). */
+export type SureTransferGateReason =
+  | "non_importable"
+  | "currency_mismatch"
+  | "kind_divergence"
+
+/**
+ * Per-account metadata the pairer needs — all derivable from the bundle +
+ * taxonomy (no DB): the Permoney `accountType` (for kind derivation), the Sure
+ * account `name` (for directional-hint matching), `currency`, and the Phase-1
+ * importability gate inputs.
+ */
+export interface SureTransferAccountMeta {
+  sureAccountId: string
+  name: string
+  currency: string
+  accountType: AccountType
+  isImportable: boolean
+  balanceSource: string
+}
+
+export interface SureTransferCandidatePair {
+  tier: SureTransferTier
+  /** Sure amount > 0 — the source leg (→ Permoney `accountId`). */
+  outflow: SureTransaction
+  /** Sure amount < 0 — the destination leg (→ Permoney `toAccountId`). */
+  inflow: SureTransaction
+}
+
+export interface SureTransferHeldLeg {
+  txn: SureTransaction
+  reason: SureTransferPureHeldReason
+}
+
+export interface SureTransferPairingResult {
+  /** Gate-passed, promotable pairs (the orchestrator drives the canonical core). */
+  pairs: SureTransferCandidatePair[]
+  /** Held legs with their typed reason (staged but never promoted — provenance). */
+  held: SureTransferHeldLeg[]
+}
+
+/** A parsed directional transfer hint (`"Transfer to <X>"` / `"… from <Y>"`). */
+export interface SureTransferHint {
+  direction: "to" | "from"
+  /** The counterpart account name, normalized (trim + lowercase + collapse ws). */
+  target: string
+}
+
+// English directional prefixes only — verified against the real export (435 "to"
+// + 435 "from", zero Indonesian "ke/dari"). `ke|dari` are accepted as cheap,
+// harmless future-proofing but the real data is 100% English. Adding any other
+// pattern would be fabrication, not parsing.
+const SURE_TRANSFER_HINT_RE = /^transfer\s+(to|from|ke|dari)\s+(.+)$/i
+
+/** Normalize an account name for exact-match comparison (no partial/substring). */
+export function normalizeSureAccountName(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ")
+}
+
+/**
+ * Parse a Sure transaction `name` into a directional transfer hint, or `null`
+ * when it carries none. `to`/`ke` mean an outflow toward the target account;
+ * `from`/`dari` mean an inflow sourced from it. The target is normalized for
+ * the exact bidirectional match (`normalizeSureAccountName`).
+ */
+export function parseSureTransferHint(
+  name: string | null | undefined
+): SureTransferHint | null {
+  if (!name) return null
+  const match = SURE_TRANSFER_HINT_RE.exec(name.trim())
+  if (!match) return null
+  const direction =
+    match[1].toLowerCase() === "from" || match[1].toLowerCase() === "dari"
+      ? "from"
+      : "to"
+  return { direction, target: normalizeSureAccountName(match[2]) }
+}
+
+function isImportableFlowAccount(meta: SureTransferAccountMeta): boolean {
+  return meta.isImportable && meta.balanceSource === "transaction_flow"
+}
+
+/**
+ * Gate a formed candidate pair (precedence: importable → currency → kind), or
+ * `null` when it is promotable. Pure: every input comes from the bundle/taxonomy.
+ * The `kind` cross-check derives Permoney's transfer kind from the two account
+ * types and requires STRICT equality to BOTH legs' Sure `kind` — any divergence
+ * (including a legal-but-unexpected `liability_draw`) holds the pair.
+ */
+export function classifyTransferPairGate(
+  outflowMeta: SureTransferAccountMeta,
+  inflowMeta: SureTransferAccountMeta,
+  outflowTxn: SureTransaction,
+  inflowTxn: SureTransaction
+): SureTransferGateReason | null {
+  if (
+    !isImportableFlowAccount(outflowMeta) ||
+    !isImportableFlowAccount(inflowMeta)
+  ) {
+    return "non_importable"
+  }
+  if (
+    outflowTxn.currency !== inflowTxn.currency ||
+    outflowMeta.currency !== inflowMeta.currency
+  ) {
+    return "currency_mismatch"
+  }
+  const derived = deriveTransferKindForAccounts({
+    fromAccountType: outflowMeta.accountType,
+    toAccountType: inflowMeta.accountType,
+  })
+  const outflowKind = (outflowTxn.kind ?? "").trim()
+  const inflowKind = (inflowTxn.kind ?? "").trim()
+  if (outflowKind !== derived || inflowKind !== derived)
+    return "kind_divergence"
+  return null
+}
+
+/**
+ * Pair Sure transfer-kind legs deterministically. `legs` MUST be pre-filtered by
+ * the orchestrator to exactly the legs that will be staged (mappable account,
+ * valid date, non-zero amount) so the pure pairer and the DB-gated promotion
+ * agree on which legs post (the `gateSet === promoteSet` invariant that protects
+ * the PER-174 opening-balance pre-scan). `transfers` enables Tier-0 deterministic
+ * pairing when the bundle carries the `Transfer` entity.
+ */
+export function pairSureTransfers(input: {
+  legs: readonly SureTransaction[]
+  metaById: ReadonlyMap<string, SureTransferAccountMeta>
+  transfers?: readonly SureTransfer[]
+}): SureTransferPairingResult {
+  const { metaById } = input
+  // Stable order → identical pairing on every run (idempotency precondition).
+  const legs = [...input.legs].sort((a, b) => a.id.localeCompare(b.id))
+  const legById = new Map(legs.map((leg) => [leg.id, leg]))
+
+  const pairs: SureTransferCandidatePair[] = []
+  const held: SureTransferHeldLeg[] = []
+  const consumed = new Set<string>()
+
+  const hold = (
+    txn: SureTransaction,
+    reason: SureTransferPureHeldReason
+  ): void => {
+    if (consumed.has(txn.id)) return
+    held.push({ txn, reason })
+    consumed.add(txn.id)
+  }
+
+  const signedMinor = (txn: SureTransaction, currency: string): bigint =>
+    toMinorUnits(txn.amount, currency as CurrencyCode) as bigint
+
+  // A formed candidate pair → gate → promote or hold-both. Direction is fixed by
+  // the caller (outflow = source, inflow = dest); the gate never reorders it.
+  const gateAndCommit = (
+    outflow: SureTransaction,
+    inflow: SureTransaction,
+    tier: SureTransferTier
+  ): void => {
+    const outflowMeta = metaById.get(outflow.account_id)
+    const inflowMeta = metaById.get(inflow.account_id)
+    if (!outflowMeta || !inflowMeta) {
+      // Defensive — caller pre-filters mappable legs, so this is a Tier-0 entity
+      // pointing at a leg dropped before staging.
+      hold(outflow, "not_staged")
+      hold(inflow, "not_staged")
+      return
+    }
+    const gate = classifyTransferPairGate(
+      outflowMeta,
+      inflowMeta,
+      outflow,
+      inflow
+    )
+    if (gate) {
+      hold(outflow, gate)
+      hold(inflow, gate)
+      return
+    }
+    pairs.push({ tier, outflow, inflow })
+    consumed.add(outflow.id)
+    consumed.add(inflow.id)
+  }
+
+  // --- Tier 0: authoritative `Transfer` entity ------------------------------
+  for (const transfer of input.transfers ?? []) {
+    if (
+      consumed.has(transfer.outflow_transaction_id) ||
+      consumed.has(transfer.inflow_transaction_id)
+    ) {
+      continue
+    }
+    const outflow = legById.get(transfer.outflow_transaction_id)
+    const inflow = legById.get(transfer.inflow_transaction_id)
+    if (!outflow || !inflow) {
+      // The entity references a leg that was never staged (unmappable / zero /
+      // invalid-date). Hold the present leg; never invent the missing one.
+      if (outflow) hold(outflow, "not_staged")
+      if (inflow) hold(inflow, "not_staged")
+      continue
+    }
+    gateAndCommit(outflow, inflow, "deterministic")
+  }
+
+  // --- Tier 1 + 2: heuristic over the remaining legs ------------------------
+  const remaining = legs.filter((leg) => !consumed.has(leg.id))
+  const groups = new Map<string, SureTransaction[]>()
+  for (const leg of remaining) {
+    const meta = metaById.get(leg.account_id)
+    if (!meta) {
+      hold(leg, "not_staged")
+      continue
+    }
+    const minor = signedMinor(leg, meta.currency)
+    if (minor === 0n) {
+      // Caller filters zero-amount legs; guard so a stray never groups.
+      hold(leg, "unpaired_orphan")
+      continue
+    }
+    const absMinor = minor < 0n ? -minor : minor
+    const key = `${leg.date.slice(0, 10)}|${absMinor}|${leg.currency}`
+    const bucket = groups.get(key)
+    if (bucket) bucket.push(leg)
+    else groups.set(key, [leg])
+  }
+
+  for (const key of [...groups.keys()].sort((a, b) => a.localeCompare(b))) {
+    const groupLegs = groups.get(key) ?? []
+    const outflows = groupLegs
+      .filter(
+        (leg) => signedMinor(leg, metaById.get(leg.account_id)!.currency) > 0n
+      )
+      .sort((a, b) => a.id.localeCompare(b.id))
+    const inflows = groupLegs
+      .filter(
+        (leg) => signedMinor(leg, metaById.get(leg.account_id)!.currency) < 0n
+      )
+      .sort((a, b) => a.id.localeCompare(b.id))
+
+    // One-sided group → every leg is an orphan (no counterpart exists).
+    if (outflows.length === 0 || inflows.length === 0) {
+      for (const leg of groupLegs) hold(leg, "unpaired_orphan")
+      continue
+    }
+
+    // Tier 1: exactly one of each on different accounts → clean pair.
+    if (outflows.length === 1 && inflows.length === 1) {
+      const [outflow] = outflows
+      const [inflow] = inflows
+      if (!outflow || !inflow) continue
+      if (outflow.account_id === inflow.account_id) {
+        // Self-transfer (same account out & in) is never a real pair.
+        hold(outflow, "unpaired_orphan")
+        hold(inflow, "unpaired_orphan")
+        continue
+      }
+      gateAndCommit(outflow, inflow, "clean")
+      continue
+    }
+
+    // Tier 2: cluster resolved only by a UNIQUE bidirectional name matching.
+    resolveCluster(outflows, inflows, metaById, gateAndCommit, hold)
+  }
+
+  return { pairs, held }
+}
+
+/**
+ * Resolve a balanced/unbalanced cluster (>1 per side, same day+|amount|) using
+ * bidirectional, exact-normalized directional name hints. A pair `(O, I)` is a
+ * valid match iff O says `"Transfer to <I.account.name>"` AND I says
+ * `"Transfer from <O.account.name>"` (both exact-normalized). The cluster
+ * resolves ONLY when these valid matches form a unique perfect matching across
+ * every leg; otherwise the WHOLE cluster is held `ambiguous_cluster` — never an
+ * arbitrary pick.
+ */
+function resolveCluster(
+  outflows: readonly SureTransaction[],
+  inflows: readonly SureTransaction[],
+  metaById: ReadonlyMap<string, SureTransferAccountMeta>,
+  gateAndCommit: (
+    outflow: SureTransaction,
+    inflow: SureTransaction,
+    tier: SureTransferTier
+  ) => void,
+  hold: (txn: SureTransaction, reason: SureTransferPureHeldReason) => void
+): void {
+  const holdWholeCluster = (): void => {
+    for (const leg of [...outflows, ...inflows]) hold(leg, "ambiguous_cluster")
+  }
+
+  const isValidMatch = (
+    outflow: SureTransaction,
+    inflow: SureTransaction
+  ): boolean => {
+    if (outflow.account_id === inflow.account_id) return false
+    const outflowMeta = metaById.get(outflow.account_id)
+    const inflowMeta = metaById.get(inflow.account_id)
+    if (!outflowMeta || !inflowMeta) return false
+    const outflowHint = parseSureTransferHint(outflow.name)
+    const inflowHint = parseSureTransferHint(inflow.name)
+    return (
+      outflowHint?.direction === "to" &&
+      inflowHint?.direction === "from" &&
+      outflowHint.target === normalizeSureAccountName(inflowMeta.name) &&
+      inflowHint.target === normalizeSureAccountName(outflowMeta.name)
+    )
+  }
+
+  // Unequal sides can never be a perfect matching → hold whole cluster.
+  if (outflows.length !== inflows.length) {
+    holdWholeCluster()
+    return
+  }
+
+  // Each outflow must have exactly one valid inflow, and each inflow must be
+  // claimed by exactly one outflow — anything else is ambiguous.
+  const chosen = new Map<string, SureTransaction>()
+  const inflowClaims = new Map<string, number>()
+  for (const outflow of outflows) {
+    const matches = inflows.filter((inflow) => isValidMatch(outflow, inflow))
+    if (matches.length !== 1 || !matches[0]) {
+      holdWholeCluster()
+      return
+    }
+    chosen.set(outflow.id, matches[0])
+    inflowClaims.set(matches[0].id, (inflowClaims.get(matches[0].id) ?? 0) + 1)
+  }
+  if ([...inflowClaims.values()].some((count) => count !== 1)) {
+    holdWholeCluster()
+    return
+  }
+
+  for (const outflow of outflows) {
+    const inflow = chosen.get(outflow.id)
+    if (inflow) gateAndCommit(outflow, inflow, "resolved_cluster")
+  }
 }

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -780,9 +780,19 @@ function isImportableFlowAccount(meta: SureTransferAccountMeta): boolean {
 /**
  * Gate a formed candidate pair (precedence: importable → currency → kind), or
  * `null` when it is promotable. Pure: every input comes from the bundle/taxonomy.
+ *
  * The `kind` cross-check derives Permoney's transfer kind from the two account
- * types and requires STRICT equality to BOTH legs' Sure `kind` — any divergence
- * (including a legal-but-unexpected `liability_draw`) holds the pair.
+ * types and validates it against the two legs' Sure `kind`. Sure tags transfers
+ * **ASYMMETRICALLY** (verified head-eng vs the real `all.ndjson`): only the
+ * cash-side leg carries the specialized kind (`cc_payment` / `loan_payment`); the
+ * liability-side leg is tagged the generic `funds_movement`. So a real card/loan
+ * payment is `[special, funds_movement]`, never `[special, special]`. The rule is
+ * therefore asymmetric-aware: **every leg kind must be the derived kind OR the
+ * generic `funds_movement`, AND at least one leg must carry the derived kind.**
+ * This promotes `cc_payment`/`loan_payment` (ADR-0042 §2 / the Q5 lock) while still
+ * holding a genuine divergence: a loan-SOURCED `funds_movement` (derived
+ * `liability_draw`, no leg tagged it → HELD) and a Sure `cc_payment` whose accounts
+ * don't justify it (`cc_payment` is neither derived nor `funds_movement` → HELD).
  */
 export function classifyTransferPairGate(
   outflowMeta: SureTransferAccountMeta,
@@ -808,8 +818,17 @@ export function classifyTransferPairGate(
   })
   const outflowKind = (outflowTxn.kind ?? "").trim()
   const inflowKind = (inflowTxn.kind ?? "").trim()
-  if (outflowKind !== derived || inflowKind !== derived)
+  // Asymmetric-aware: each leg is the derived kind or the generic funds_movement…
+  const allowsLeg = (kind: string): boolean =>
+    kind === derived || kind === "funds_movement"
+  if (!allowsLeg(outflowKind) || !allowsLeg(inflowKind)) {
     return "kind_divergence"
+  }
+  // …and at least one leg actually carries the derived kind (so a pair Sure never
+  // tagged with the specialized kind — e.g. a loan-sourced liability_draw — holds).
+  if (outflowKind !== derived && inflowKind !== derived) {
+    return "kind_divergence"
+  }
   return null
 }
 

--- a/src/routes/_protected/-sure-import-ui.test.tsx
+++ b/src/routes/_protected/-sure-import-ui.test.tsx
@@ -39,6 +39,22 @@ function makeResult(
     valuationsParsed: 0,
     malformedLines: 0,
     ignoredEntities: {},
+    transfers: {
+      legsSeen: 0,
+      legsStaged: 0,
+      pairsPromotedThisRun: 0,
+      legsPromotedTotal: 0,
+      pairedByTier: { deterministic: 0, clean: 0, resolvedCluster: 0 },
+      heldLegsByReason: {
+        not_staged: 0,
+        non_importable: 0,
+        currency_mismatch: 0,
+        kind_divergence: 0,
+        db_rejected: 0,
+        unpaired_orphan: 0,
+        ambiguous_cluster: 0,
+      },
+    },
     ...rest,
   }
 }

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -6,9 +6,14 @@ import {
   classifySureAmount,
   normalizeSureAccountType,
   orderCategoriesParentsFirst,
+  pairSureTransfers,
   parseSureBundle,
   SURE_PROVIDER,
   type SureTransaction,
+  type SureTransferAccountMeta,
+  type SureTransferHeldReason,
+  type SureTransferPairingResult,
+  type SureTransferTier,
   type SureValuation,
 } from "../lib/sure-migration"
 import { toMinorUnits } from "../lib/money"
@@ -30,7 +35,7 @@ import {
   type TenantTransactionClient,
 } from "./middleware/with-family"
 import type { RunInTenantTransaction } from "./mutation-kit"
-import { createdAuditEntries } from "./transactions"
+import { createTransactionForFamily, createdAuditEntries } from "./transactions"
 
 // ============================================================================
 // PER-170 / ADR-0041 — Sure full-family migration (Phase 1), orchestration.
@@ -101,6 +106,25 @@ export interface SureMigrationResult {
   valuationsParsed: number
   malformedLines: number
   ignoredEntities: Record<string, number>
+  // Transfer dual-leg pairing & promotion (ADR-0042). Leg-based so the reconcile
+  // invariant `legsStaged === legsPromotedTotal + Σ heldLegsByReason` is exact for
+  // any grouping. `legsPromotedTotal` is read from `rowStatus` AFTER the pass
+  // (cumulative — stable across idempotent re-runs); `pairsPromotedThisRun` and
+  // `pairedByTier` reflect only this run's work (0 on a clean re-run). Each held
+  // leg carries exactly one DB-anchored reason (the first failing gate / structural
+  // outcome), surfaced per-reason so the importer UI explains the WHY honestly.
+  transfers: {
+    legsSeen: number
+    legsStaged: number
+    pairsPromotedThisRun: number
+    legsPromotedTotal: number
+    pairedByTier: {
+      deterministic: number
+      clean: number
+      resolvedCluster: number
+    }
+    heldLegsByReason: Record<SureTransferHeldReason, number>
+  }
 }
 
 interface PermoneyAccountInfo {
@@ -284,9 +308,20 @@ export function willPostThisRun(
  * Per Sure-account `YYYY-MM-DD` of the earliest transaction that will post a
  * balance delta this run. Account info is derived purely from the Sure taxonomy
  * (no DB) so the pre-scan can run before any account row exists.
+ *
+ * ADR-0042 amends ADR-0041 §5: a row "posts" if it is a standard promotable row
+ * ({@link willPostThisRun}) OR a transfer leg in a PROMOTABLE pair
+ * (`promotableTransferLegIds`, computed by the SAME pure pairing the promotion
+ * step uses — `gateSet === promoteSet`). Without this, a held-transfer-only
+ * account would keep PER-174's "nothing posts → latest valuation" opening (≈ its
+ * current value, already embedding the transfers); promoting the transfers on top
+ * would DOUBLE-COUNT. Including them flips the account to "posting exists" →
+ * opening = earliest valuation strictly before the first posting (or gap), and the
+ * transfer flows post on top correctly.
  */
 function earliestPromotedDateBySureAccount(
-  bundle: ReturnType<typeof parseSureBundle>
+  bundle: ReturnType<typeof parseSureBundle>,
+  promotableTransferLegIds: ReadonlySet<string>
 ): Map<string, string> {
   const sureAccountById = new Map(bundle.accounts.map((a) => [a.id, a]))
   const earliest = new Map<string, string>()
@@ -303,12 +338,72 @@ function earliestPromotedDateBySureAccount(
       isImportable: taxonomy.isImportable,
       balanceSource: taxonomy.balanceSource,
     }
-    if (!willPostThisRun(txn, info)) continue
+    const posts =
+      willPostThisRun(txn, info) || promotableTransferLegIds.has(txn.id)
+    if (!posts) continue
+    // A transfer leg posts a balance delta even though its date may be invalid
+    // for the standard predicate; guard so the bucket key stays a valid day.
+    if (Number.isNaN(new Date(txn.date).getTime())) continue
     const day = txn.date.slice(0, 10)
     const prev = earliest.get(txn.account_id)
     if (prev === undefined || day < prev) earliest.set(txn.account_id, day)
   }
   return earliest
+}
+
+// ---------------------------------------------------------------------------
+// Transfer pairing inputs (pure, taxonomy-derived — ADR-0042)
+// ---------------------------------------------------------------------------
+
+/** Any non-`standard` Sure kind is a transfer leg in Phase 1 (held until paired). */
+function isSureTransferLeg(txn: SureTransaction): boolean {
+  const kind = (txn.kind ?? "standard").trim() || "standard"
+  return kind !== "standard"
+}
+
+/** Per-Sure-account metadata for the pure pairer (no DB; mirrors the staging taxonomy). */
+function buildSureTransferMeta(
+  bundle: ReturnType<typeof parseSureBundle>
+): Map<string, SureTransferAccountMeta> {
+  const meta = new Map<string, SureTransferAccountMeta>()
+  for (const account of bundle.accounts) {
+    const taxonomy = normalizeSureAccountType(
+      account.accountable_type,
+      account.subtype
+    )
+    meta.set(account.id, {
+      sureAccountId: account.id,
+      name: account.name,
+      currency: account.currency,
+      accountType: taxonomy.accountType,
+      isImportable: taxonomy.isImportable,
+      balanceSource: taxonomy.balanceSource,
+    })
+  }
+  return meta
+}
+
+/**
+ * The transfer legs that WILL be staged — mappable account, valid date, non-zero
+ * amount: exactly the gates the standard staging path applies. Feeding the pure
+ * pairer this same set keeps `gateSet === promoteSet` (the unmappable-leg lockstep
+ * that protects the opening pre-scan, ADR-0042 / ADR-0041 §5).
+ */
+function stageableSureTransferLegs(
+  bundle: ReturnType<typeof parseSureBundle>,
+  metaById: ReadonlyMap<string, SureTransferAccountMeta>
+): SureTransaction[] {
+  return bundle.transactions.filter((txn) => {
+    if (!isSureTransferLeg(txn)) return false
+    const meta = metaById.get(txn.account_id)
+    if (!meta) return false
+    if (Number.isNaN(new Date(txn.date).getTime())) return false
+    const minor = toMinorUnits(
+      txn.amount,
+      meta.currency as CurrencyCode
+    ) as bigint
+    return minor !== 0n
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -364,7 +459,29 @@ export async function runSureMigrationForFamily({
   // anchor the degraded date-heuristic compares against — derived from the SAME
   // posting predicate the promotion path uses (no drift).
   const bundleHasKind = bundleHasValuationKind(bundle.valuations)
-  const earliestPromotedDate = earliestPromotedDateBySureAccount(bundle)
+
+  // Transfer pairing is computed PURELY and UP-FRONT (ADR-0042): the promotable
+  // pairs feed BOTH the opening-balance pre-scan (a transfer-touched account now
+  // "posts", so its opening must precede the first transfer — ADR-0041 §5 as
+  // amended by ADR-0042) AND the later promotion step. ONE analysis means the
+  // opening pre-scan can never disagree with what actually promotes.
+  const transferMeta = buildSureTransferMeta(bundle)
+  const transferLegs = stageableSureTransferLegs(bundle, transferMeta)
+  const transferLegsSeen = bundle.transactions.filter(isSureTransferLeg).length
+  const transferPairing = pairSureTransfers({
+    legs: transferLegs,
+    metaById: transferMeta,
+    transfers: bundle.transfers,
+  })
+  const promotableTransferLegIds = new Set<string>()
+  for (const pair of transferPairing.pairs) {
+    promotableTransferLegIds.add(pair.outflow.id)
+    promotableTransferLegIds.add(pair.inflow.id)
+  }
+  const earliestPromotedDate = earliestPromotedDateBySureAccount(
+    bundle,
+    promotableTransferLegIds
+  )
 
   // --- 1. Accounts -> id-map (+ account info for mapping) -------------------
   const accountMap = new Map<string, string>() // sureId -> permoneyId
@@ -679,6 +796,23 @@ export async function runSureMigrationForFamily({
     Boolean
   ).length
 
+  // --- 8. Pair & promote transfers as dual-leg Permoney transfers (ADR-0042) -
+  // Reuses the SAME pure pairing computed up-front; promotes each pair through the
+  // canonical `createTransactionForFamily` core (no new ledger writer), holding
+  // anything ambiguous/orphan/gated with a DB-anchored typed reason.
+  const transfers = await pairAndPromoteSureTransfers({
+    pairing: transferPairing,
+    transferLegs,
+    legsSeen: transferLegsSeen,
+    batchId,
+    familyId,
+    user,
+    accountMap,
+    transferMeta,
+    runInTenantTransaction,
+    auditCtx,
+  })
+
   return {
     batchId,
     replayed,
@@ -689,12 +823,17 @@ export async function runSureMigrationForFamily({
     merchants: { created: merchantsCreated, reused: merchantsReused },
     transactions: {
       total: bundle.transactions.length,
+      // `staged` is all staged rows (standard + transfer legs); it decomposes as
+      // `promotedThisRun` (standard) + `held` (standard) + `transfers.legsStaged`.
       staged: rows.length,
       promotedThisRun,
-      held: rows.length - promotableCount,
+      // STANDARD held only — transfer legs are owned by the `transfers` block, so
+      // every leg is counted in exactly one place (the spanning reconcile, Q7).
+      held: rows.length - promotableCount - transferLegs.length,
       zeroAmountSkipped,
       invalidDateSkipped,
     },
+    transfers,
     openingBalances: {
       fromOpeningAnchor: openingFromAnchor,
       fromDateHeuristic: openingFromDateHeuristic,
@@ -797,6 +936,369 @@ async function ensureEmptyMigrationBatch(
       withFamily(createdAuditEntries("ImportBatch", [batch]), familyId)
     )
     return batch.id
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Transfer pairing & promotion (ADR-0042 — dual-leg via the canonical core)
+// ---------------------------------------------------------------------------
+
+const EMPTY_HELD_BY_REASON = (): Record<SureTransferHeldReason, number> => ({
+  not_staged: 0,
+  non_importable: 0,
+  currency_mismatch: 0,
+  kind_divergence: 0,
+  db_rejected: 0,
+  unpaired_orphan: 0,
+  ambiguous_cluster: 0,
+})
+
+const TIER_TO_RESULT_KEY: Record<
+  SureTransferTier,
+  keyof SureMigrationResult["transfers"]["pairedByTier"]
+> = {
+  deterministic: "deterministic",
+  clean: "clean",
+  resolved_cluster: "resolvedCluster",
+}
+
+interface StagedTransferRow {
+  id: string
+  externalId: string | null
+  rowStatus: string
+  promotionIdempotencyKey: string
+}
+
+/**
+ * Pair & promote Sure transfer legs as dual-leg Permoney transfers (ADR-0042).
+ *
+ * Each promotable pair is created through the UNCHANGED canonical core
+ * `createTransactionForFamily({type:"transfer"})` (no new ledger writer), keyed by
+ * the OUTFLOW leg's persisted `promotionIdempotencyKey` (the stable idempotency
+ * anchor minted once at PER-170 stage time). The core's own `replayIdempotentTransaction`
+ * runs BEFORE any balance delta, so a re-run returns the existing legs, creates no
+ * second leg and moves no balance (self-healing 2B — the leg-create runs in the
+ * core's OWN tx, then both staged rows are marked promoted in a second tx by
+ * recovering the leg ids via the stable key → outflow leg → `Transfer` →
+ * inflow leg, which works identically on fresh create and replay).
+ *
+ * Held legs (structural or gated) keep `rowStatus="normalized"` and persist their
+ * typed reason in `errorReason`; a runtime rejection from the core (e.g. a
+ * liability balance-sign CHECK) is caught per-pair and held as `db_rejected` — one
+ * poisoned pair never blocks the rest. All counts are read back from `rowStatus` at
+ * the end (DB-anchored), so the reconcile invariant holds across idempotent re-runs.
+ */
+async function pairAndPromoteSureTransfers({
+  pairing,
+  transferLegs,
+  legsSeen,
+  batchId,
+  familyId,
+  user,
+  accountMap,
+  transferMeta,
+  runInTenantTransaction,
+  auditCtx,
+}: {
+  pairing: SureTransferPairingResult
+  transferLegs: readonly SureTransaction[]
+  legsSeen: number
+  batchId: string
+  familyId: string
+  user: { id: string; familyId?: string | null }
+  accountMap: ReadonlyMap<string, string>
+  transferMeta: ReadonlyMap<string, SureTransferAccountMeta>
+  runInTenantTransaction: RunInTenantTransaction
+  auditCtx: Awaited<ReturnType<typeof createAuditContext>>
+}): Promise<SureMigrationResult["transfers"]> {
+  const pairedByTier = { deterministic: 0, clean: 0, resolvedCluster: 0 }
+  const legsStaged = transferLegs.length
+
+  if (legsStaged === 0 && pairing.pairs.length === 0) {
+    return {
+      legsSeen,
+      legsStaged: 0,
+      pairsPromotedThisRun: 0,
+      legsPromotedTotal: 0,
+      pairedByTier,
+      heldLegsByReason: EMPTY_HELD_BY_REASON(),
+    }
+  }
+
+  const allLegIds = transferLegs.map((leg) => leg.id)
+
+  // Recover the staged held rows (stable key + status + rowId) by Sure id.
+  const stagedRows: StagedTransferRow[] = await runInTenantTransaction(
+    familyId,
+    user.id,
+    async (tx) =>
+      tx.rawImportedTransaction.findMany({
+        where: {
+          familyId,
+          importBatchId: batchId,
+          externalId: { in: allLegIds },
+        },
+        select: {
+          id: true,
+          externalId: true,
+          rowStatus: true,
+          promotionIdempotencyKey: true,
+        },
+      })
+  )
+  const rowByExternalId = new Map(
+    stagedRows.map((row) => [row.externalId, row])
+  )
+
+  let pairsPromotedThisRun = 0
+
+  // --- Promote each promotable pair -----------------------------------------
+  for (const pair of pairing.pairs) {
+    const outRow = rowByExternalId.get(pair.outflow.id)
+    const inRow = rowByExternalId.get(pair.inflow.id)
+    // A pair promotes only when BOTH legs recovered a staged row + stable key.
+    if (!outRow || !inRow) {
+      if (outRow)
+        await persistSureHeldReason(
+          runInTenantTransaction,
+          familyId,
+          user,
+          auditCtx,
+          outRow,
+          "not_staged"
+        )
+      if (inRow)
+        await persistSureHeldReason(
+          runInTenantTransaction,
+          familyId,
+          user,
+          auditCtx,
+          inRow,
+          "not_staged"
+        )
+      continue
+    }
+    // Re-run: a promoted pair is authoritative & done — skip (Q3 linkage authority;
+    // 2B marks both rows in one tx so they are never split across statuses).
+    if (outRow.rowStatus === "promoted" || inRow.rowStatus === "promoted") {
+      continue
+    }
+
+    const outMeta = transferMeta.get(pair.outflow.account_id)
+    const outAccountId = accountMap.get(pair.outflow.account_id)
+    const inAccountId = accountMap.get(pair.inflow.account_id)
+    if (!outMeta || !outAccountId || !inAccountId) {
+      await persistSureHeldReason(
+        runInTenantTransaction,
+        familyId,
+        user,
+        auditCtx,
+        outRow,
+        "not_staged"
+      )
+      await persistSureHeldReason(
+        runInTenantTransaction,
+        familyId,
+        user,
+        auditCtx,
+        inRow,
+        "not_staged"
+      )
+      continue
+    }
+
+    const minor = toMinorUnits(
+      pair.outflow.amount,
+      outMeta.currency as CurrencyCode
+    ) as bigint
+    const absMinor = minor < 0n ? -minor : minor
+    const stableKey = outRow.promotionIdempotencyKey
+
+    try {
+      // Leg-create + Transfer + dual balance + audit — the canonical core's OWN
+      // tx (2B keeps the canonical writer & its P2002 recovery pristine).
+      await createTransactionForFamily({
+        data: {
+          type: "transfer",
+          accountId: outAccountId,
+          toAccountId: inAccountId,
+          amount: absMinor.toString(),
+          description: (pair.outflow.name ?? "").trim() || "Imported transfer",
+          date: new Date(pair.outflow.date),
+          idempotencyKey: stableKey,
+          status: "CLEARED",
+        },
+        familyId,
+        user,
+        runInTenantTransaction,
+      })
+
+      // Second tx: recover both leg ids via the stable key (fresh OR replay) and
+      // mark both staged rows promoted — minimal window, self-healing on re-run.
+      await runInTenantTransaction(familyId, user.id, async (tx) => {
+        const outflowLeg = await tx.transaction.findFirst({
+          where: { familyId, idempotencyKey: stableKey },
+          select: { id: true },
+        })
+        if (!outflowLeg) {
+          throw new Error("Promoted transfer outflow leg not found")
+        }
+        const transfer = await tx.transfer.findFirst({
+          where: { outflowTransactionId: outflowLeg.id },
+          select: { inflowTransactionId: true },
+        })
+        if (!transfer) throw new Error("Transfer link row not found")
+
+        const entries: AuditLogEntry[] = []
+        await markSureTransferRowPromoted(tx, outRow.id, outflowLeg.id, entries)
+        await markSureTransferRowPromoted(
+          tx,
+          inRow.id,
+          transfer.inflowTransactionId,
+          entries
+        )
+        await auditLogs(tx, auditCtx, withFamily(entries, familyId))
+      })
+
+      pairsPromotedThisRun += 1
+      pairedByTier[TIER_TO_RESULT_KEY[pair.tier]] += 1
+    } catch {
+      // Runtime rejection (e.g. liability balance-sign CHECK overshoot) → HOLD the
+      // pair as db_rejected, keep both rows normalized; the next re-run retries it.
+      await persistSureHeldReason(
+        runInTenantTransaction,
+        familyId,
+        user,
+        auditCtx,
+        outRow,
+        "db_rejected"
+      )
+      await persistSureHeldReason(
+        runInTenantTransaction,
+        familyId,
+        user,
+        auditCtx,
+        inRow,
+        "db_rejected"
+      )
+    }
+  }
+
+  // --- Persist the pure pairer's held reasons (skip anything already promoted) -
+  for (const heldLeg of pairing.held) {
+    const row = rowByExternalId.get(heldLeg.txn.id)
+    if (!row || row.rowStatus === "promoted") continue
+    await persistSureHeldReason(
+      runInTenantTransaction,
+      familyId,
+      user,
+      auditCtx,
+      row,
+      heldLeg.reason
+    )
+  }
+
+  // --- Count from rowStatus (DB-anchored → reconciles on re-run, Q7 #2) ------
+  const finalRows = await runInTenantTransaction(
+    familyId,
+    user.id,
+    async (tx) =>
+      tx.rawImportedTransaction.findMany({
+        where: {
+          familyId,
+          importBatchId: batchId,
+          externalId: { in: allLegIds },
+        },
+        select: { rowStatus: true, errorReason: true },
+      })
+  )
+  const heldLegsByReason = EMPTY_HELD_BY_REASON()
+  let legsPromotedTotal = 0
+  for (const row of finalRows) {
+    if (row.rowStatus === "promoted") {
+      legsPromotedTotal += 1
+      continue
+    }
+    const reason = (row.errorReason ?? "") as SureTransferHeldReason
+    if (reason in heldLegsByReason) heldLegsByReason[reason] += 1
+    else heldLegsByReason.unpaired_orphan += 1
+  }
+
+  return {
+    legsSeen,
+    legsStaged,
+    pairsPromotedThisRun,
+    legsPromotedTotal,
+    pairedByTier,
+    heldLegsByReason,
+  }
+}
+
+/** Mark a held transfer row promoted (links the created leg; clears any held reason). */
+async function markSureTransferRowPromoted(
+  tx: TenantTransactionClient,
+  rowId: string,
+  legId: string,
+  entries: AuditLogEntry[]
+): Promise<void> {
+  await tx.rawImportedTransaction.update({
+    where: { id: rowId },
+    data: {
+      rowStatus: "promoted",
+      promotedTransactionId: legId,
+      errorReason: null,
+    },
+  })
+  entries.push({
+    action: "update",
+    entityType: "RawImportedTransaction",
+    entityId: rowId,
+    before: { rowStatus: "normalized", promotedTransactionId: null },
+    after: { rowStatus: "promoted", promotedTransactionId: legId },
+  })
+}
+
+/**
+ * Persist a transfer leg's typed hold reason in `errorReason` on its still-held
+ * (`normalized`) row — DB-anchored provenance, zero migration (`errorReason` is a
+ * free TEXT column with no `rowStatus='error'` CHECK and is not surfaced by the
+ * generic batch read). Never touches a promoted row.
+ */
+async function persistSureHeldReason(
+  runInTenantTransaction: RunInTenantTransaction,
+  familyId: string,
+  user: { id: string; familyId?: string | null },
+  auditCtx: Awaited<ReturnType<typeof createAuditContext>>,
+  row: StagedTransferRow,
+  reason: SureTransferHeldReason
+): Promise<void> {
+  await runInTenantTransaction(familyId, user.id, async (tx) => {
+    const current = await tx.rawImportedTransaction.findFirst({
+      where: { id: row.id, familyId },
+      select: { rowStatus: true, errorReason: true },
+    })
+    if (!current || current.rowStatus === "promoted") return
+    if (current.errorReason === reason) return
+    await tx.rawImportedTransaction.update({
+      where: { id: row.id },
+      data: { errorReason: reason },
+    })
+    await auditLogs(
+      tx,
+      auditCtx,
+      withFamily(
+        [
+          {
+            action: "update",
+            entityType: "RawImportedTransaction",
+            entityId: row.id,
+            before: { errorReason: current.errorReason },
+            after: { errorReason: reason },
+          },
+        ],
+        familyId
+      )
+    )
   })
 }
 

--- a/tests/integration/support/sure-fixtures.ts
+++ b/tests/integration/support/sure-fixtures.ts
@@ -38,6 +38,8 @@
 // the arithmetic.
 // ============================================================================
 
+import type { SureTransferHeldReason } from "@/lib/sure-migration"
+
 const envelope = (type: string, data: Record<string, unknown>): string =>
   JSON.stringify({ type, data })
 
@@ -383,7 +385,10 @@ export function buildSureBundleV2Complete(): SureBundleManifest {
       transactionsTotal: 6,
       staged: 5, // all 6 minus the zero-amount row
       promotedThisRun: 2, // expense + income on the importable IDR depository
-      held: 3, // invest + non-standard kind + currency mismatch
+      // STANDARD held only (ADR-0042): invest + currency mismatch. The
+      // `funds_movement` leg is now owned by the `transfers` block (it pairs to
+      // nothing → unpaired_orphan), so it leaves `transactions.held`.
+      held: 2,
       zeroAmountSkipped: 1,
       malformedLines: 0,
       // Valuation is now a typed sink (opening source), no longer ignored.
@@ -556,5 +561,514 @@ export function buildSureBundleV1Degraded(): SureBundleManifest {
     promotableExpenseMinor: 0n, // no promotable expense in the degraded bundle
     // Sure "-12345.0" → wallet income, ledger +1_234_500 minor.
     promotableIncomeMinor: 1_234_500n,
+  }
+}
+
+// ===========================================================================
+// Transfer fixtures (ADR-0042 — dual-leg pairing). Separate builders from the
+// opening-balance fixtures above so each fixture exercises ONE concern cleanly
+// (no scatter — same file, table-driven manifest). Sure stores outflow POSITIVE,
+// inflow NEGATIVE; both legs of a transfer carry the same transfer `kind`.
+// ===========================================================================
+
+export interface SureTransferFixture {
+  ndjson: string
+  /** Sure account id → key, for binding lookups + balance assertions. */
+  accountIds: Record<string, string>
+  /** Sure transaction (leg) id → key, for self-heal row targeting. */
+  legIds: Record<string, string>
+  expected: {
+    accountsCreated: number
+    transferLegsSeen: number
+    transferLegsStaged: number
+    pairsPromotedThisRun: number
+    legsPromotedTotal: number
+    pairedByTier: {
+      deterministic: number
+      clean: number
+      resolvedCluster: number
+    }
+    heldLegsByReason: Record<SureTransferHeldReason, number>
+  }
+  /** Expected FINAL balance (minor units) per account key after the migration. */
+  balancesMinor: Record<string, bigint>
+}
+
+const sureAccount = (
+  id: string,
+  name: string,
+  accountableType: string,
+  subtype: string,
+  currency = "IDR"
+): string =>
+  envelope("Account", {
+    id,
+    name,
+    accountable_type: accountableType,
+    classification: accountableType === "CreditCard" ? "liability" : "asset",
+    subtype,
+    currency,
+    balance: "0.0",
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-06-25T00:00:00Z",
+  })
+
+const sureTxn = (args: {
+  id: string
+  accountId: string
+  amount: string
+  kind: string
+  name: string
+  date: string
+  currency?: string
+}): string =>
+  envelope("Transaction", {
+    id: args.id,
+    account_id: args.accountId,
+    entry_id: `entry-${args.id}`,
+    category_id: null,
+    merchant_id: null,
+    date: args.date,
+    amount: args.amount,
+    currency: args.currency ?? "IDR",
+    name: args.name,
+    kind: args.kind,
+    notes: null,
+    excluded: false,
+    tag_ids: [],
+    created_at: `${args.date}T00:00:00Z`,
+    updated_at: `${args.date}T00:00:00Z`,
+  })
+
+const sureVal = (args: {
+  accountId: string
+  amount: string
+  date: string
+  kind?: string
+  currency?: string
+}): string =>
+  envelope("Valuation", {
+    id: `val-${args.accountId}-${args.date}`,
+    account_id: args.accountId,
+    entry_id: `entry-val-${args.accountId}-${args.date}`,
+    name: "Valuation",
+    ...(args.kind ? { kind: args.kind } : {}),
+    amount: args.amount,
+    currency: args.currency ?? "IDR",
+    date: args.date,
+    created_at: `${args.date}T00:00:00Z`,
+    updated_at: `${args.date}T00:00:00Z`,
+  })
+
+const sureTransfer = (outflowId: string, inflowId: string): string =>
+  envelope("Transfer", {
+    id: `xfer-${outflowId}`,
+    outflow_transaction_id: outflowId,
+    inflow_transaction_id: inflowId,
+    status: "confirmed",
+  })
+
+const emptyHeld = (): Record<SureTransferHeldReason, number> => ({
+  not_staged: 0,
+  non_importable: 0,
+  currency_mismatch: 0,
+  kind_divergence: 0,
+  db_rejected: 0,
+  unpaired_orphan: 0,
+  ambiguous_cluster: 0,
+})
+
+// ---------------------------------------------------------------------------
+// Mode A — v2 complete (carries the `Transfer` entity → Tier-0 DETERMINISTIC).
+// Exercises: deterministic funds_movement promote, deterministic cc_payment
+// promote (liability moves toward zero), currency_mismatch (cross-currency
+// Transfer), not_staged (Transfer references a never-staged leg), unpaired_orphan.
+// ---------------------------------------------------------------------------
+
+export function buildSureBundleV2Transfers(): SureTransferFixture {
+  const accountIds = {
+    checking: "sure-acc-t-checking",
+    savings: "sure-acc-t-savings",
+    card: "sure-acc-t-card",
+    usd: "sure-acc-t-usd",
+  }
+  const legIds = {
+    cardSpend: "sure-txn-t-cardspend",
+    fmOut: "sure-txn-t-fm-out",
+    fmIn: "sure-txn-t-fm-in",
+    ccOut: "sure-txn-t-cc-out",
+    ccIn: "sure-txn-t-cc-in",
+    cmOut: "sure-txn-t-cm-out",
+    cmIn: "sure-txn-t-cm-in",
+    nsIn: "sure-txn-t-ns-in",
+    orphan: "sure-txn-t-orphan",
+  }
+
+  const lines = [
+    sureAccount(accountIds.checking, "BCA Checking", "Depository", "checking"),
+    sureAccount(accountIds.savings, "BCA Savings", "Depository", "savings"),
+    sureAccount(accountIds.card, "Visa Card", "CreditCard", "credit_card"),
+    sureAccount(accountIds.usd, "Wise USD", "Depository", "checking", "USD"),
+    // checking opens from an `opening_anchor` (kind-bearing → v2 mode).
+    sureVal({
+      accountId: accountIds.checking,
+      amount: "200000.0",
+      date: "2026-01-01",
+      kind: "opening_anchor",
+    }),
+    // Standard card spend → −10_000_000 debt so the cc_payment can move toward 0.
+    sureTxn({
+      id: legIds.cardSpend,
+      accountId: accountIds.card,
+      amount: "100000.0",
+      kind: "standard",
+      name: "Card purchase",
+      date: "2026-05-01",
+    }),
+    // Deterministic funds_movement: checking → savings (promotes).
+    sureTxn({
+      id: legIds.fmOut,
+      accountId: accountIds.checking,
+      amount: "40000.0",
+      kind: "funds_movement",
+      name: "Transfer to BCA Savings",
+      date: "2026-05-02",
+    }),
+    sureTxn({
+      id: legIds.fmIn,
+      accountId: accountIds.savings,
+      amount: "-40000.0",
+      kind: "funds_movement",
+      name: "Transfer from BCA Checking",
+      date: "2026-05-02",
+    }),
+    sureTransfer(legIds.fmOut, legIds.fmIn),
+    // Deterministic cc_payment: checking → card (promotes; derived cc_payment).
+    sureTxn({
+      id: legIds.ccOut,
+      accountId: accountIds.checking,
+      amount: "50000.0",
+      kind: "cc_payment",
+      name: "Visa payment",
+      date: "2026-05-03",
+    }),
+    sureTxn({
+      id: legIds.ccIn,
+      accountId: accountIds.card,
+      amount: "-50000.0",
+      kind: "cc_payment",
+      name: "Visa payment",
+      date: "2026-05-03",
+    }),
+    sureTransfer(legIds.ccOut, legIds.ccIn),
+    // Cross-currency Transfer (IDR ↔ USD) → currency_mismatch HELD (FX deferred).
+    sureTxn({
+      id: legIds.cmOut,
+      accountId: accountIds.checking,
+      amount: "10000.0",
+      kind: "funds_movement",
+      name: "Transfer to Wise USD",
+      date: "2026-05-04",
+    }),
+    sureTxn({
+      id: legIds.cmIn,
+      accountId: accountIds.usd,
+      amount: "-1.0",
+      kind: "funds_movement",
+      name: "Transfer from BCA Checking",
+      date: "2026-05-04",
+      currency: "USD",
+    }),
+    sureTransfer(legIds.cmOut, legIds.cmIn),
+    // Transfer references a never-staged outflow id → present leg HELD not_staged.
+    sureTxn({
+      id: legIds.nsIn,
+      accountId: accountIds.savings,
+      amount: "-15000.0",
+      kind: "funds_movement",
+      name: "Transfer from ghost",
+      date: "2026-05-05",
+    }),
+    sureTransfer("sure-txn-t-ghost-missing", legIds.nsIn),
+    // A lone funds_movement leg with no counterpart → unpaired_orphan.
+    sureTxn({
+      id: legIds.orphan,
+      accountId: accountIds.checking,
+      amount: "20000.0",
+      kind: "funds_movement",
+      name: "Unmatched move",
+      date: "2026-05-06",
+    }),
+  ]
+
+  const held = emptyHeld()
+  held.currency_mismatch = 2
+  held.not_staged = 1
+  held.unpaired_orphan = 1
+
+  return {
+    ndjson: lines.join("\n"),
+    accountIds,
+    legIds,
+    expected: {
+      accountsCreated: 4,
+      transferLegsSeen: 8,
+      transferLegsStaged: 8,
+      pairsPromotedThisRun: 2,
+      legsPromotedTotal: 4,
+      pairedByTier: { deterministic: 2, clean: 0, resolvedCluster: 0 },
+      heldLegsByReason: held,
+    },
+    balancesMinor: {
+      // 20_000_000 open − 4_000_000 (fm) − 5_000_000 (cc) = 11_000_000.
+      checking: 11_000_000n,
+      // 0 + 4_000_000 (fm in); the ns inflow is HELD, never posted.
+      savings: 4_000_000n,
+      // −10_000_000 debt + 5_000_000 (cc payment) = −5_000_000 (toward zero).
+      card: -5_000_000n,
+      usd: 0n,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mode B — v1 degraded (NO `Transfer` entity, NO `kind` on valuations → date
+// heuristic). Populates EVERY heuristic held bucket so the spanning reconcile is
+// exercised with all buckets active, AND a held-transfer-only account whose
+// opening proves the ADR-0042 double-count fix.
+// ---------------------------------------------------------------------------
+
+export function buildSureBundleV1DegradedTransfers(): SureTransferFixture {
+  const accountIds = {
+    main: "sure-acc-d-main",
+    nikah: "sure-acc-d-nikah",
+    wallet: "sure-acc-d-wallet",
+    gopay: "sure-acc-d-gopay",
+    dana: "sure-acc-d-dana",
+    ovo: "sure-acc-d-ovo",
+    loan: "sure-acc-d-loan",
+    invest: "sure-acc-d-invest",
+    cash: "sure-acc-d-cash",
+  }
+  const legIds = {
+    cleanOut: "sure-txn-d-clean-out",
+    cleanIn: "sure-txn-d-clean-in",
+    clOut1: "sure-txn-d-cl-out1",
+    clIn1: "sure-txn-d-cl-in1",
+    clOut2: "sure-txn-d-cl-out2",
+    clIn2: "sure-txn-d-cl-in2",
+    ambOut1: "sure-txn-d-amb-out1",
+    ambIn1: "sure-txn-d-amb-in1",
+    ambOut2: "sure-txn-d-amb-out2",
+    ambIn2: "sure-txn-d-amb-in2",
+    kdOut: "sure-txn-d-kd-out",
+    kdIn: "sure-txn-d-kd-in",
+    niOut: "sure-txn-d-ni-out",
+    niIn: "sure-txn-d-ni-in",
+    orphan: "sure-txn-d-orphan",
+  }
+
+  const lines = [
+    sureAccount(accountIds.main, "Main", "Depository", "checking"),
+    sureAccount(accountIds.nikah, "Nikah", "Depository", "savings"),
+    sureAccount(accountIds.wallet, "Wallet", "Depository", "checking"),
+    sureAccount(accountIds.gopay, "Gopay", "Depository", "checking"),
+    sureAccount(accountIds.dana, "Dana", "Depository", "checking"),
+    sureAccount(accountIds.ovo, "Ovo", "Depository", "checking"),
+    sureAccount(accountIds.loan, "KTA Loan", "Loan", "personal_loan"),
+    sureAccount(accountIds.invest, "Bibit", "Investment", "mutual_fund"),
+    sureAccount(accountIds.cash, "Cash", "Depository", "checking"),
+    // Valuations WITHOUT `kind` (degraded → date heuristic). Sources that POST a
+    // transfer get an early valuation (strictly before → opening); Nikah's is
+    // AFTER its inbound transfer (the double-count trap).
+    sureVal({
+      accountId: accountIds.main,
+      amount: "50000.0",
+      date: "2026-01-01",
+    }),
+    sureVal({
+      accountId: accountIds.wallet,
+      amount: "30000.0",
+      date: "2026-01-01",
+    }),
+    sureVal({
+      accountId: accountIds.dana,
+      amount: "30000.0",
+      date: "2026-01-01",
+    }),
+    // Nikah: a CURRENT-value valuation dated AFTER the inbound transfer. With the
+    // ADR-0042 fix (the transfer now posts) → posting-exists branch → this is not
+    // strictly-before → gap(0); final = 0 + 3_700_000. WITHOUT the fix it would be
+    // the "latest valuation" opening (3_700_000) + the transfer = 7_400_000 (double).
+    sureVal({
+      accountId: accountIds.nikah,
+      amount: "37000.0",
+      date: "2026-06-01",
+    }),
+    // Clean Tier-1 pair: Main → Nikah (promotes).
+    sureTxn({
+      id: legIds.cleanOut,
+      accountId: accountIds.main,
+      amount: "37000.0",
+      kind: "funds_movement",
+      name: "Transfer to Nikah",
+      date: "2026-05-01",
+    }),
+    sureTxn({
+      id: legIds.cleanIn,
+      accountId: accountIds.nikah,
+      amount: "-37000.0",
+      kind: "funds_movement",
+      name: "Transfer from Main",
+      date: "2026-05-01",
+    }),
+    // Resolvable cluster (day+amount collide → 2 outflows + 2 inflows): resolved by
+    // bidirectional exact name hints Wallet↔Gopay, Dana↔Ovo (both promote).
+    sureTxn({
+      id: legIds.clOut1,
+      accountId: accountIds.wallet,
+      amount: "12000.0",
+      kind: "funds_movement",
+      name: "Transfer to Gopay",
+      date: "2026-05-02",
+    }),
+    sureTxn({
+      id: legIds.clIn1,
+      accountId: accountIds.gopay,
+      amount: "-12000.0",
+      kind: "funds_movement",
+      name: "Transfer from Wallet",
+      date: "2026-05-02",
+    }),
+    sureTxn({
+      id: legIds.clOut2,
+      accountId: accountIds.dana,
+      amount: "12000.0",
+      kind: "funds_movement",
+      name: "Transfer to Ovo",
+      date: "2026-05-02",
+    }),
+    sureTxn({
+      id: legIds.clIn2,
+      accountId: accountIds.ovo,
+      amount: "-12000.0",
+      kind: "funds_movement",
+      name: "Transfer from Dana",
+      date: "2026-05-02",
+    }),
+    // Ambiguous cluster (same day+amount, NO directional hints) → whole cluster HELD.
+    sureTxn({
+      id: legIds.ambOut1,
+      accountId: accountIds.wallet,
+      amount: "8000.0",
+      kind: "funds_movement",
+      name: "Cash move",
+      date: "2026-05-09",
+    }),
+    sureTxn({
+      id: legIds.ambIn1,
+      accountId: accountIds.gopay,
+      amount: "-8000.0",
+      kind: "funds_movement",
+      name: "Cash move",
+      date: "2026-05-09",
+    }),
+    sureTxn({
+      id: legIds.ambOut2,
+      accountId: accountIds.dana,
+      amount: "8000.0",
+      kind: "funds_movement",
+      name: "Cash move",
+      date: "2026-05-09",
+    }),
+    sureTxn({
+      id: legIds.ambIn2,
+      accountId: accountIds.ovo,
+      amount: "-8000.0",
+      kind: "funds_movement",
+      name: "Cash move",
+      date: "2026-05-09",
+    }),
+    // kind_divergence: a loan-SOURCED funds_movement → Permoney derives liability_draw
+    // ≠ Sure funds_movement → HELD (never invents a borrowing event).
+    sureTxn({
+      id: legIds.kdOut,
+      accountId: accountIds.loan,
+      amount: "25000.0",
+      kind: "funds_movement",
+      name: "Transfer to Cash",
+      date: "2026-05-05",
+    }),
+    sureTxn({
+      id: legIds.kdIn,
+      accountId: accountIds.cash,
+      amount: "-25000.0",
+      kind: "funds_movement",
+      name: "Transfer from KTA Loan",
+      date: "2026-05-05",
+    }),
+    // non_importable: an Investment-SOURCED transfer → HELD (its real postings are
+    // Trades/Holdings, deferred).
+    sureTxn({
+      id: legIds.niOut,
+      accountId: accountIds.invest,
+      amount: "18000.0",
+      kind: "funds_movement",
+      name: "Transfer to Cash",
+      date: "2026-05-06",
+    }),
+    sureTxn({
+      id: legIds.niIn,
+      accountId: accountIds.cash,
+      amount: "-18000.0",
+      kind: "funds_movement",
+      name: "Transfer from Bibit",
+      date: "2026-05-06",
+    }),
+    // Lone outflow → unpaired_orphan.
+    sureTxn({
+      id: legIds.orphan,
+      accountId: accountIds.cash,
+      amount: "9000.0",
+      kind: "funds_movement",
+      name: "Unmatched",
+      date: "2026-05-07",
+    }),
+  ]
+
+  const held = emptyHeld()
+  held.ambiguous_cluster = 4
+  held.kind_divergence = 2
+  held.non_importable = 2
+  held.unpaired_orphan = 1
+
+  return {
+    ndjson: lines.join("\n"),
+    accountIds,
+    legIds,
+    expected: {
+      accountsCreated: 9,
+      transferLegsSeen: 15,
+      transferLegsStaged: 15,
+      pairsPromotedThisRun: 3,
+      legsPromotedTotal: 6,
+      pairedByTier: { deterministic: 0, clean: 1, resolvedCluster: 2 },
+      heldLegsByReason: held,
+    },
+    balancesMinor: {
+      // 5_000_000 open (earliest val strictly before) − 3_700_000 (clean out).
+      main: 1_300_000n,
+      // gap(0) + 3_700_000 (clean in) — the double-count fix: NOT 7_400_000.
+      nikah: 3_700_000n,
+      // 3_000_000 open − 1_200_000 (resolved out); amb leg HELD.
+      wallet: 1_800_000n,
+      dana: 1_800_000n,
+      gopay: 1_200_000n, // 0 + 1_200_000 (resolved in)
+      ovo: 1_200_000n,
+      loan: 0n, // kd leg HELD, never posted
+      invest: 0n, // ni leg HELD
+      cash: 0n, // all Cash legs HELD (kd in, ni in, orphan)
+    },
   }
 }

--- a/tests/integration/support/sure-fixtures.ts
+++ b/tests/integration/support/sure-fixtures.ts
@@ -691,14 +691,18 @@ export function buildSureBundleV2Transfers(): SureTransferFixture {
     checking: "sure-acc-t-checking",
     savings: "sure-acc-t-savings",
     card: "sure-acc-t-card",
+    loan: "sure-acc-t-loan",
     usd: "sure-acc-t-usd",
   }
   const legIds = {
     cardSpend: "sure-txn-t-cardspend",
+    loanSpend: "sure-txn-t-loanspend",
     fmOut: "sure-txn-t-fm-out",
     fmIn: "sure-txn-t-fm-in",
     ccOut: "sure-txn-t-cc-out",
     ccIn: "sure-txn-t-cc-in",
+    loanOut: "sure-txn-t-loan-out",
+    loanIn: "sure-txn-t-loan-in",
     cmOut: "sure-txn-t-cm-out",
     cmIn: "sure-txn-t-cm-in",
     nsIn: "sure-txn-t-ns-in",
@@ -709,6 +713,7 @@ export function buildSureBundleV2Transfers(): SureTransferFixture {
     sureAccount(accountIds.checking, "BCA Checking", "Depository", "checking"),
     sureAccount(accountIds.savings, "BCA Savings", "Depository", "savings"),
     sureAccount(accountIds.card, "Visa Card", "CreditCard", "credit_card"),
+    sureAccount(accountIds.loan, "KTA Loan", "Loan", "personal_loan"),
     sureAccount(accountIds.usd, "Wise USD", "Depository", "checking", "USD"),
     // checking opens from an `opening_anchor` (kind-bearing → v2 mode).
     sureVal({
@@ -717,13 +722,21 @@ export function buildSureBundleV2Transfers(): SureTransferFixture {
       date: "2026-01-01",
       kind: "opening_anchor",
     }),
-    // Standard card spend → −10_000_000 debt so the cc_payment can move toward 0.
+    // Standard spends seed liability DEBT so the payments below move toward zero.
     sureTxn({
       id: legIds.cardSpend,
       accountId: accountIds.card,
       amount: "100000.0",
       kind: "standard",
       name: "Card purchase",
+      date: "2026-05-01",
+    }),
+    sureTxn({
+      id: legIds.loanSpend,
+      accountId: accountIds.loan,
+      amount: "200000.0",
+      kind: "standard",
+      name: "Loan principal",
       date: "2026-05-01",
     }),
     // Deterministic funds_movement: checking → savings (promotes).
@@ -745,6 +758,8 @@ export function buildSureBundleV2Transfers(): SureTransferFixture {
     }),
     sureTransfer(legIds.fmOut, legIds.fmIn),
     // Deterministic cc_payment: checking → card (promotes; derived cc_payment).
+    // ASYMMETRIC kind like the real export: only the cash-side leg is `cc_payment`;
+    // the CreditCard-side leg is the generic `funds_movement`.
     sureTxn({
       id: legIds.ccOut,
       accountId: accountIds.checking,
@@ -757,11 +772,30 @@ export function buildSureBundleV2Transfers(): SureTransferFixture {
       id: legIds.ccIn,
       accountId: accountIds.card,
       amount: "-50000.0",
-      kind: "cc_payment",
+      kind: "funds_movement",
       name: "Visa payment",
       date: "2026-05-03",
     }),
     sureTransfer(legIds.ccOut, legIds.ccIn),
+    // Deterministic loan_payment: checking → loan (promotes; derived loan_payment).
+    // ASYMMETRIC: cash-side `loan_payment`, Loan-side `funds_movement`.
+    sureTxn({
+      id: legIds.loanOut,
+      accountId: accountIds.checking,
+      amount: "60000.0",
+      kind: "loan_payment",
+      name: "Loan installment",
+      date: "2026-05-13",
+    }),
+    sureTxn({
+      id: legIds.loanIn,
+      accountId: accountIds.loan,
+      amount: "-60000.0",
+      kind: "funds_movement",
+      name: "Loan installment",
+      date: "2026-05-13",
+    }),
+    sureTransfer(legIds.loanOut, legIds.loanIn),
     // Cross-currency Transfer (IDR ↔ USD) → currency_mismatch HELD (FX deferred).
     sureTxn({
       id: legIds.cmOut,
@@ -812,21 +846,23 @@ export function buildSureBundleV2Transfers(): SureTransferFixture {
     accountIds,
     legIds,
     expected: {
-      accountsCreated: 4,
-      transferLegsSeen: 8,
-      transferLegsStaged: 8,
-      pairsPromotedThisRun: 2,
-      legsPromotedTotal: 4,
-      pairedByTier: { deterministic: 2, clean: 0, resolvedCluster: 0 },
+      accountsCreated: 5,
+      transferLegsSeen: 10,
+      transferLegsStaged: 10,
+      pairsPromotedThisRun: 3,
+      legsPromotedTotal: 6,
+      pairedByTier: { deterministic: 3, clean: 0, resolvedCluster: 0 },
       heldLegsByReason: held,
     },
     balancesMinor: {
-      // 20_000_000 open − 4_000_000 (fm) − 5_000_000 (cc) = 11_000_000.
-      checking: 11_000_000n,
+      // 20_000_000 open − 4_000_000 (fm) − 5_000_000 (cc) − 6_000_000 (loan).
+      checking: 5_000_000n,
       // 0 + 4_000_000 (fm in); the ns inflow is HELD, never posted.
       savings: 4_000_000n,
       // −10_000_000 debt + 5_000_000 (cc payment) = −5_000_000 (toward zero).
       card: -5_000_000n,
+      // −20_000_000 debt + 6_000_000 (loan payment) = −14_000_000 (toward zero).
+      loan: -14_000_000n,
       usd: 0n,
     },
   }

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -432,7 +432,10 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
     // Atomic dual-leg balances on BOTH accounts; cc_payment toward zero.
     await assertBalances(tenant, fixture.accountIds, fixture.balancesMinor)
 
-    // Two promoted pairs → two Transfer rows + four transfer-type legs, with FX set.
+    // Three promoted pairs (fm + cc + loan) → three Transfer rows + six
+    // transfer-type legs, with FX set. The cc/loan legs are tagged ASYMMETRICALLY
+    // (liability-side = funds_movement) exactly like the real export, so the
+    // asymmetric-aware kind gate is exercised end-to-end.
     const { transferCount, legs } = await harness.withMember(
       tenant.familyId,
       tenant.userId,
@@ -443,11 +446,15 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
         }),
       })
     )
-    expect(transferCount).toBe(2)
-    expect(legs).toHaveLength(4)
+    expect(transferCount).toBe(3)
+    expect(legs).toHaveLength(6)
     // PER-159 / ADR-0035: base projection materialized on every promoted leg.
     expect(legs.every((leg) => leg.baseAmount !== null)).toBe(true)
     expect(legs.every((leg) => leg.baseCurrency === "IDR")).toBe(true)
+    // The cc_payment and loan_payment pairs promoted, deriving the right kinds and
+    // moving each liability toward zero (asserted via balancesMinor above).
+    expect(legs.filter((leg) => leg.kind === "cc_payment")).toHaveLength(2)
+    expect(legs.filter((leg) => leg.kind === "loan_payment")).toHaveLength(2)
   })
 
   test("Mode B — degraded heuristic: clean + cluster promote, every held bucket reconciles", async () => {

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -16,7 +16,9 @@ import {
 import { createTestFactories, type TestFactories } from "./support/factories"
 import {
   buildSureBundleV1Degraded,
+  buildSureBundleV1DegradedTransfers,
   buildSureBundleV2Complete,
+  buildSureBundleV2Transfers,
 } from "./support/sure-fixtures"
 
 // PER-170 / PER-173 / PER-174 / ADR-0041 — Real-Postgres proof of the Sure
@@ -166,9 +168,26 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
         }),
       })
     )
-    expect(staged).toBe(fixture.expected.held) // 4 held remain normalized
+    // 3 rows remain normalized: 2 STANDARD held (invest + currency) + the 1
+    // transfer leg, now an unpaired_orphan in the transfers block (ADR-0042).
+    expect(staged).toBe(3)
     expect(promotedRows).toBe(2)
     expect(txnCount).toBe(2)
+
+    // The lone `funds_movement` leg pairs to nothing → held as unpaired_orphan,
+    // never fabricated into a one-sided transfer.
+    expect(result.transfers.legsSeen).toBe(1)
+    expect(result.transfers.legsStaged).toBe(1)
+    expect(result.transfers.legsPromotedTotal).toBe(0)
+    expect(result.transfers.pairsPromotedThisRun).toBe(0)
+    expect(result.transfers.heldLegsByReason.unpaired_orphan).toBe(1)
+    // Reconcile: every staged transfer leg is promoted or held with one reason.
+    const heldTransferLegs = Object.values(
+      result.transfers.heldLegsByReason
+    ).reduce((a, b) => a + b, 0)
+    expect(result.transfers.legsPromotedTotal + heldTransferLegs).toBe(
+      result.transfers.legsStaged
+    )
 
     // Lossless artifact retained (gzip BYTEA, hash + size provenance).
     const artifact = await harness.withMember(
@@ -362,5 +381,233 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
     )
     expect(leaked.accounts).toBe(0)
     expect(leaked.artifacts).toBe(0)
+  })
+
+  // ======================================================================
+  // Transfers (PER-175 / ADR-0042) — dual-leg pairing + liability kinds.
+  // ======================================================================
+
+  const assertBalances = async (
+    tenant: Tenant,
+    accountIds: Record<string, string>,
+    balancesMinor: Record<string, bigint>
+  ): Promise<void> => {
+    for (const [key, expected] of Object.entries(balancesMinor)) {
+      const account = await accountByBinding(tenant, accountIds[key]!)
+      expect({ key, balance: account?.balance }).toEqual({
+        key,
+        balance: expected,
+      })
+    }
+  }
+
+  const sumHeld = (byReason: Record<string, number>): number =>
+    Object.values(byReason).reduce((a, b) => a + b, 0)
+
+  test("Mode A — Transfer entity pairs deterministically; cc_payment moves the liability toward zero", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV2Transfers()
+    const result = await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    const t = result.transfers
+    expect(t.legsSeen).toBe(fixture.expected.transferLegsSeen)
+    expect(t.legsStaged).toBe(fixture.expected.transferLegsStaged)
+    expect(t.pairsPromotedThisRun).toBe(fixture.expected.pairsPromotedThisRun)
+    expect(t.legsPromotedTotal).toBe(fixture.expected.legsPromotedTotal)
+    expect(t.pairedByTier).toEqual(fixture.expected.pairedByTier)
+    expect(t.heldLegsByReason).toEqual(fixture.expected.heldLegsByReason)
+
+    // Internal reconcile: every staged leg promoted or held with one reason.
+    expect(t.legsPromotedTotal + sumHeld(t.heldLegsByReason)).toBe(t.legsStaged)
+    // Spanning cross-block reconcile: every bundle transaction in exactly one place.
+    expect(
+      result.transactions.promotedThisRun +
+        result.transactions.held +
+        result.transactions.zeroAmountSkipped +
+        result.transactions.invalidDateSkipped +
+        t.legsPromotedTotal +
+        sumHeld(t.heldLegsByReason)
+    ).toBe(result.transactions.total)
+
+    // Atomic dual-leg balances on BOTH accounts; cc_payment toward zero.
+    await assertBalances(tenant, fixture.accountIds, fixture.balancesMinor)
+
+    // Two promoted pairs → two Transfer rows + four transfer-type legs, with FX set.
+    const { transferCount, legs } = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      async (tx) => ({
+        transferCount: await tx.transfer.count(),
+        legs: await tx.transaction.findMany({
+          where: { familyId: tenant.familyId, type: "transfer" },
+        }),
+      })
+    )
+    expect(transferCount).toBe(2)
+    expect(legs).toHaveLength(4)
+    // PER-159 / ADR-0035: base projection materialized on every promoted leg.
+    expect(legs.every((leg) => leg.baseAmount !== null)).toBe(true)
+    expect(legs.every((leg) => leg.baseCurrency === "IDR")).toBe(true)
+  })
+
+  test("Mode B — degraded heuristic: clean + cluster promote, every held bucket reconciles", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV1DegradedTransfers()
+    const result = await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    expect(result.bundleHasKind).toBe(false)
+    expect(result.accounts.created).toBe(fixture.expected.accountsCreated)
+
+    const t = result.transfers
+    expect(t.pairsPromotedThisRun).toBe(fixture.expected.pairsPromotedThisRun)
+    expect(t.legsPromotedTotal).toBe(fixture.expected.legsPromotedTotal)
+    expect(t.pairedByTier).toEqual(fixture.expected.pairedByTier)
+    // Every heuristic held bucket is populated and disjoint.
+    expect(t.heldLegsByReason).toEqual(fixture.expected.heldLegsByReason)
+    expect(t.legsPromotedTotal + sumHeld(t.heldLegsByReason)).toBe(t.legsStaged)
+    expect(
+      result.transactions.promotedThisRun +
+        result.transactions.held +
+        result.transactions.zeroAmountSkipped +
+        result.transactions.invalidDateSkipped +
+        t.legsPromotedTotal +
+        sumHeld(t.heldLegsByReason)
+    ).toBe(result.transactions.total)
+
+    await assertBalances(tenant, fixture.accountIds, fixture.balancesMinor)
+
+    // Held legs stay normalized (never a Transaction); promoted legs are paired.
+    const { normalized, transferLegs } = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      async (tx) => ({
+        normalized: await tx.rawImportedTransaction.count({
+          where: { familyId: tenant.familyId, rowStatus: "normalized" },
+        }),
+        transferLegs: await tx.transaction.count({
+          where: { familyId: tenant.familyId, type: "transfer" },
+        }),
+      })
+    )
+    expect(normalized).toBe(sumHeld(fixture.expected.heldLegsByReason))
+    expect(transferLegs).toBe(fixture.expected.legsPromotedTotal)
+  })
+
+  test("transfers must NOT double-count the opening balance (ADR-0042 regression)", async () => {
+    // `Nikah` is a held-transfer-only account: its sole activity is one inbound
+    // transfer, and it carries a CURRENT-value valuation dated AFTER that
+    // transfer. The PER-174 opening for "nothing posts" would be the latest
+    // valuation (3_700_000); promoting the transfer on top WITHOUT the ADR-0042
+    // posting-predicate fix would yield 7_400_000 (double). The fix flips Nikah to
+    // "posting exists" → opening gap(0) → final = exactly the transfer (3_700_000).
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV1DegradedTransfers()
+    await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    const nikah = await accountByBinding(tenant, fixture.accountIds.nikah!)
+    expect(nikah?.balance).toBe(3_700_000n)
+    expect(nikah?.balance).not.toBe(7_400_000n)
+  })
+
+  test("idempotent re-run: no second Transfer, balances stable, held stays held", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV1DegradedTransfers()
+
+    const first = await migrate(tenant, "all.ndjson", fixture.ndjson)
+    const second = await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    // The pure pairing is stable; re-promotion is a no-op at the stable key.
+    expect(second.transfers.pairsPromotedThisRun).toBe(0)
+    expect(second.transfers.legsPromotedTotal).toBe(
+      first.transfers.legsPromotedTotal
+    )
+    expect(second.transfers.heldLegsByReason).toEqual(
+      first.transfers.heldLegsByReason
+    )
+
+    const { transferLegs, transferCount } = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      async (tx) => ({
+        transferLegs: await tx.transaction.count({
+          where: { familyId: tenant.familyId, type: "transfer" },
+        }),
+        transferCount: await tx.transfer.count(),
+      })
+    )
+    expect(transferLegs).toBe(fixture.expected.legsPromotedTotal) // no double-book
+    expect(transferCount).toBe(fixture.expected.pairsPromotedThisRun)
+    await assertBalances(tenant, fixture.accountIds, fixture.balancesMinor)
+  })
+
+  test("self-heal 2B: a created leg with unmarked rows re-promotes via the stable key (no double)", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleV1DegradedTransfers()
+    await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    const nikahBefore = await accountByBinding(
+      tenant,
+      fixture.accountIds.nikah!
+    )
+
+    // Simulate a crash AFTER the canonical core created the legs+Transfer but
+    // BEFORE the two staged rows were marked promoted: revert the clean-pair rows
+    // to `normalized`. The leg + Transfer remain, keyed by the stable idempotency
+    // key (the outflow row's persisted promotionIdempotencyKey).
+    await harness.withMember(tenant.familyId, tenant.userId, async (tx) => {
+      await tx.rawImportedTransaction.updateMany({
+        where: {
+          familyId: tenant.familyId,
+          externalId: {
+            in: [fixture.legIds.cleanOut!, fixture.legIds.cleanIn!],
+          },
+        },
+        data: { rowStatus: "normalized", promotedTransactionId: null },
+      })
+    })
+
+    // Re-run: re-pairs the still-normalized clean pair, calls the core with the
+    // SAME stable key → replay returns the existing leg (zero new leg/balance) →
+    // marks the rows. Self-healing, no double.
+    await migrate(tenant, "all.ndjson", fixture.ndjson)
+
+    const { transferLegs, transferCount, nikah } = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      async (tx) => ({
+        transferLegs: await tx.transaction.count({
+          where: { familyId: tenant.familyId, type: "transfer" },
+        }),
+        transferCount: await tx.transfer.count(),
+        nikah: await tx.account.findUniqueOrThrow({
+          where: { id: nikahBefore!.id },
+        }),
+      })
+    )
+    expect(transferLegs).toBe(fixture.expected.legsPromotedTotal) // no extra leg
+    expect(transferCount).toBe(fixture.expected.pairsPromotedThisRun)
+    expect(nikah.balance).toBe(nikahBefore!.balance) // balance unchanged
+  })
+
+  test("tenant isolation: family B cannot pair or read family A's transfer legs", async () => {
+    const a = await setupTenant()
+    const b = await setupTenant()
+    const fixture = buildSureBundleV1DegradedTransfers()
+    await migrate(a, "all.ndjson", fixture.ndjson)
+
+    const leaked = await harness.withMember(
+      b.familyId,
+      b.userId,
+      async (tx) => ({
+        transferLegs: await tx.transaction.count({
+          where: { familyId: b.familyId, type: "transfer" },
+        }),
+        rawRows: await tx.rawImportedTransaction.count({
+          where: { familyId: b.familyId },
+        }),
+      })
+    )
+    expect(leaked.transferLegs).toBe(0)
+    expect(leaked.rawRows).toBe(0)
   })
 })


### PR DESCRIPTION
Closes PER-175 (PER-163 Phase 2). Promotes held Sure transfer-kind legs as proper **dual-leg Permoney transfers** through the **unchanged** canonical core `createTransactionForFamily({type:"transfer"})` — **no new ledger writer**. Pairing is precise-first, heuristic-fallback, hold-on-ambiguity, and **never fabricates a counterparty**. Design locked with head-eng via a 9-branch `grill_me` before any code.

## What's here
- **Pure pairer** (`src/lib/sure-migration.ts`): Tier 0 deterministic (`Transfer` entity) → Tier 1 strict clean pair `(day, |amount|, currency, opposite-sign, diff-account)` **no fuzzing** → Tier 2 cluster resolution by **unique bidirectional exact-normalized** name hints, else HELD. Typed held reasons, deterministic id-sort, exhaustive.
- **Orchestration** (`src/server/sure-migration.ts`): per-pair gate (`staged → importable → currency → strict kind cross-check`; `liability_draw` divergence HELD); **self-healing 2B** idempotency keyed by the outflow leg's stable `promotionIdempotencyKey`; per-pair `try/catch` (`db_rejected`); both staged rows marked promoted via `stable-key → Transfer → inflow-leg` lookup; leg-based, **DB-anchored** `transfers` result block with internal + spanning reconcile invariants.
- **Opening-balance double-count fix** (amends ADR-0041 §5): pairing runs **up-front** so the posting predicate is transfer-aware (`gateSet === promoteSet`); the "latest valuation" branch now only applies to genuinely-no-posting accounts. Without this, promoting transfers on held-transfer-only accounts (14/35 on the real export) silently **doubles** the balance.
- **ADR-0042** (Accepted) records the full decision + consequences; **ADR-0041 §5/§10** amended (the "separate heuristic-pairing ADR" §10 forward-referenced).

## Tests (real Postgres green)
Pure edge matrix (unit) + real-PG **Mode A** (deterministic; `cc_payment` moves the liability toward zero; FX/baseAmount set) / **Mode B** (every held bucket reconciles) / **dedicated double-count regression** / **self-heal 2B** / **idempotent re-run** / **tenant isolation**. `vp run check && vp test run && vp build` clean; 11 integration + 397 unit pass. **No real bundle committed** (PII; gitignored).

## ⚠️ Two items for your review
1. **Honest-bucket placement (mechanism correction):** `currency_mismatch` and `not_staged` are **structurally Tier-0** (`Transfer`-entity) outcomes — a degraded bundle can't produce them heuristically (cross-currency legs differ in amount → `unpaired_orphan`; every degraded leg is staged). So they live in **Mode A**'s reconcile; **Mode B** exercises the 4 genuinely-heuristic held buckets. The spanning reconcile is proven across both modes. (Consistent with the Q3/Q5 locks; flagged rather than silently forcing them into Mode B.)
2. **Dedicated transfer fixtures** were added to the **same** `sure-fixtures.ts` (no new files) instead of overloading the opening-balance builders, to avoid destabilizing the ledger-critical PER-170/174 balance assertions. The one required change to the existing v2 fixture: the lone `funds_movement` leg correctly migrates from `transactions.held` into the `transfers` block as an `unpaired_orphan`.

## Adversarial review ask
Please re-run against the real `all.ndjson`: target **≥83% legs auto-paired** (projected ~96% with cluster resolution), the remainder **HELD honestly per-reason** (never fabricated), **zero double-count**, and the **928-leg spanning tie-out** exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)