### PR TITLE
fix(ledger): PER-181 — Sure migration transfers per-pair scaling (RLS + gzip stream fix)

### DIFF
--- a/docs/adr/0036-family-membership-and-role-authorization.md
+++ b/docs/adr/0036-family-membership-and-role-authorization.md
@@ -1,15 +1,15 @@
 # ADR-0036 — Family membership and role authorization model
 
-|                   |                                                           |
-| ----------------- | --------------------------------------------------------- |
-| **Status**        | Accepted                                                  |
-| **Date**          | 2026-06-20                                                |
-| **Accepted**      | 2026-06-20                                                |
-| **Deciders**      | Hendri Permana                                            |
-| **Supersedes**    | PER-98, PER-114 (design)                                  |
-| **Superseded by** | —                                                         |
-| **Amended by**    | ADR-0037 (§2 adds `budget:write`)                         |
-| **Amends**        | ADR-0008 §8; ADR-0010 (User actor); ADR-0014 (role split) |
+|                   |                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Status**        | Accepted                                                                                                     |
+| **Date**          | 2026-06-20                                                                                                   |
+| **Accepted**      | 2026-06-20                                                                                                   |
+| **Deciders**      | Hendri Permana                                                                                               |
+| **Supersedes**    | PER-98, PER-114 (design)                                                                                     |
+| **Superseded by** | —                                                                                                            |
+| **Amended by**    | ADR-0037 (§2 adds `budget:write`); ADR-0044 §7 (PER-181 — §4 `SplitEntry`/`Transfer` policy shape corrected) |
+| **Amends**        | ADR-0008 §8; ADR-0010 (User actor); ADR-0014 (role split)                                                    |
 
 ## Context
 
@@ -185,9 +185,9 @@ upgraded so the **database independently enforces membership** (defense in depth
   $$;
   ```
 
-- Every **data-table** policy (`Account`, `Merchant`, `Transaction`,
-  `SmartRule`, `SplitEntry`, `Transfer`, `Valuation`, `FxRateSnapshot`,
-  `IdempotencyRecord`, `AuditLog`) gains the guard:
+- Every **data-table** policy on a table that carries its own `familyId`
+  column (`Account`, `Merchant`, `Transaction`, `SmartRule`, `Valuation`,
+  `FxRateSnapshot`, `IdempotencyRecord`, `AuditLog`) gains the guard:
 
   ```sql
   USING (
@@ -202,6 +202,36 @@ upgraded so the **database independently enforces membership** (defense in depth
   Because both GUCs are constants, the `app_is_active_member(...)` call is a
   once-per-query InitPlan, not a per-row correlated subquery — the per-row cost
   is negligible.
+
+  > **Amended 2026-07-05, PER-181 (ADR-0044 §7).** `SplitEntry` and `Transfer`
+  > have no `familyId` column of their own — they are scoped indirectly
+  > through their parent `Transaction`. The original migration expressed that
+  > indirection as `"transactionId"`/`"outflowTransactionId"` `IN (SELECT id
+FROM "Transaction" WHERE "familyId" = ...)`. That shape is a
+  > **non-correlated** subquery: Postgres cannot push the outer row's id into
+  > it, so it plans a hashed SubPlan that materializes every `Transaction` row
+  > owned by the family on **every** `SplitEntry`/`Transfer` access — cost
+  > that grows with the family's total transaction count regardless of
+  > indexes. This made Sure-migration transfer promotion (one `Transfer`
+  > read/write per pair, against a `Transaction` table growing throughout the
+  > same run) cost O(pairs²) — see ADR-0044 §7 for the measured evidence. The
+  > corrected shape is a **correlated** `EXISTS`, anchored on
+  > `Transaction.id` (its primary key):
+  >
+  > ```sql
+  > EXISTS (
+  >   SELECT 1 FROM "Transaction"
+  >   WHERE "Transaction"."id" = "Transfer"."outflowTransactionId"
+  >     AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+  > )
+  > ```
+  >
+  > A correlated `EXISTS` cannot be hash-materialized independently of the
+  > outer row, so Postgres evaluates a per-row Index Scan on
+  > `Transaction_pkey` instead — O(log n) regardless of ledger size. Same two
+  > columns checked, same membership guard, same security semantics — only
+  > the query shape changed (migration
+  > `20260705120000_fix_transfer_split_entry_rls_full_scan`).
 
 - `Category` keeps its `OR "isSystem" = true` branch **outside** the membership
   guard so global system categories stay readable:

--- a/docs/adr/0044-chunked-bulk-ledger-writes.md
+++ b/docs/adr/0044-chunked-bulk-ledger-writes.md
@@ -1,14 +1,14 @@
 # ADR-0044 — Chunked bulk ledger writes (bounded transactions + resumable staging)
 
-|                   |                                                                                                                   |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Status**        | Accepted                                                                                                          |
-| **Date**          | 2026-07-04                                                                                                        |
-| **Accepted**      | 2026-07-04                                                                                                        |
-| **Deciders**      | Hendri Permana                                                                                                    |
-| **Supersedes**    | —                                                                                                                 |
-| **Superseded by** | —                                                                                                                 |
-| **Amends**        | ADR-0039 §1/§9 (staging insert + promotion orchestration become chunked); ADR-0041 §1 (step 5 orchestration loop) |
+|                   |                                                                                                                                                                                     |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**        | Accepted                                                                                                                                                                            |
+| **Date**          | 2026-07-04                                                                                                                                                                          |
+| **Accepted**      | 2026-07-04                                                                                                                                                                          |
+| **Deciders**      | Hendri Permana                                                                                                                                                                      |
+| **Supersedes**    | —                                                                                                                                                                                   |
+| **Superseded by** | —                                                                                                                                                                                   |
+| **Amends**        | ADR-0039 §1/§9 (staging insert + promotion orchestration become chunked); ADR-0041 §1 (step 5 orchestration loop); ADR-0036 §4 (`SplitEntry`/`Transfer` RLS policy shape, §7 below) |
 
 ## Context
 
@@ -250,6 +250,87 @@ transfer-pair round-trips — are **not** built speculatively. The methodology:
    `createTransactionForFamily`'s own P2002 recovery. Any such change needs
    its own design grill against the measured number, not a guess made
    alongside this ADR.
+
+### 7. Outcome (PER-181): the `transfers` phase gate fired, root cause was an RLS query shape, not the write pattern
+
+The scale test built for this ADR (§5's `timings`, run at a real-shape
+≥1500-txn bundle) showed the `transfers` phase was material — not a trivial
+fraction of total time, the opposite of the `valuations`-phase outcome. Per §6,
+this triggered a **profile-first, no-guessing** investigation (PER-181,
+`/diagnose`), rather than jumping to the shared-transaction/SAVEPOINT batching
+approach §6.5 explicitly declined to pre-design.
+
+**Measured before any fix**, real-shape bundles: 222ms/pair @75 pairs → 400–
+578ms/pair @225 pairs → did not finish in 900s (synthetic) / 1800s (real
+`all.ndjson`, ~324 pairs) @~450 pairs. Hypotheses ruled out with evidence, not
+guesses: FX cross-currency (fixture is single-currency, short-circuits before
+any query), hot-row/account density (spreading pairs over more accounts made
+it _worse_), container staleness (a fresh Postgres restart gave only ~26%
+improvement, did not fix the trend), and — the two most likely candidates
+given `createTransactionForFamily`'s transfer branch runs under
+`scopedTenantTransaction`'s forced `SERIALIZABLE` isolation —
+**Postgres SSI/retry overhead**: `withSerializableRetry`'s retry counter was
+**zero** at every scale tested (no retries at all — not a retry storm), and
+re-running the identical path under `ReadCommitted` isolation reproduced the
+**same** growth curve, proving the isolation level was not the driver.
+
+**Root cause, proven via `EXPLAIN (ANALYZE, BUFFERS)`** against a populated
+test database: the `Transfer` and `SplitEntry` RLS policies (ADR-0036 §4)
+authorize each row via a **non-correlated** `outflowTransactionId IN (SELECT
+id FROM "Transaction" WHERE "familyId" = ...)` subquery. Postgres cannot
+decorrelate this — it plans a hashed SubPlan that materializes **every**
+`Transaction` row belonging to the family, on **every** `Transfer`/
+`SplitEntry` SELECT or INSERT. Measured cost: 493 existing transactions →
+subplan `rows=493`, query total 28.6ms; 1493 existing transactions → subplan
+`rows=1493`, query total 86.2ms (≈0.058ms per existing family transaction,
+i.e. linear in **current ledger size**, not pair count). Since
+`pairAndPromoteSureTransfers` reads/writes `Transfer` once per pair while the
+family's `Transaction` table is simultaneously growing throughout the same
+run, total transfer-phase cost is the sum over an increasing table size —
+**O(pairs²)** — exactly matching the measured cliff (a quadratic curve looks
+mild, then explodes, which is why 1500→3000 was a DNF rather than gradual
+growth).
+
+**Fix: a bounded-query/index-class change, not a write-pattern change.**
+Migration `20260705120000_fix_transfer_split_entry_rls_full_scan` rewrites
+both policies' `USING`/`WITH CHECK` predicates as a **correlated** `EXISTS`
+anchored on `Transaction.id` (its primary key) instead of the non-correlated
+`IN (subquery)` — same two columns checked, same membership guard, same
+security semantics, only the query shape changes. A correlated `EXISTS`
+cannot be hash-materialized independently of the outer row, so Postgres
+evaluates a per-row Index Scan on `Transaction_pkey` — O(log n) regardless of
+ledger size. **No change to `createTransactionForFamily`, no batching, no
+SAVEPOINTs, no shared transaction** — §6.5's declined approach was correctly
+declined; the per-pair write pattern and its `db_rejected` try/catch isolation
+are untouched. Re-measured post-fix: msPerPair did not grow with scale
+(≈140–315ms/pair across 500/1500-txn runs, noise-dominated rather than
+trending upward) — the O(pairs²) mechanism this ticket set out to fix is
+confirmed gone. See ADR-0036 §4 (amended alongside) for the corrected policy
+shape.
+
+**A second, unrelated bug was found (and fixed alongside) while validating at
+3000-txn scale.** With the RLS fix alone, a 3000-txn run still did not
+complete — but per-phase tracing showed it now hung much earlier, between the
+`transactionsStage` and `transactionsPromote` phases, with zero Postgres
+backend activity and ~0% CPU (idle, not busy — not a query problem at all).
+Isolated to `gzipBytes` (this file, §"Retain the raw bundle" step): it called
+`writer.write(input)` / `writer.close()` on a `CompressionStream` and only
+started `stream.readable.getReader()` afterward — a classic WHATWG-streams
+write-before-read deadlock. Reproduced standalone (outside Postgres/Prisma
+entirely): highly-compressible input (repeated bytes) never hung even at 8MB,
+but realistic incompressible/JSON-shaped input hung from a few hundred KB up,
+because the transform's internal readable-side queue fills faster than it
+can be drained when nothing is reading concurrently. This is almost certainly
+**why the original pre-fix investigation attributed the entire 3000-txn DNF
+to the `transfers` phase** — no per-phase trace existed at the time, and this
+`gzipBytes` hang triggers earlier in the pipeline, before `transfers` is ever
+reached, independent of the RLS bug above. Fixed by starting the reader loop
+concurrently with the write instead of after it (same file). This is a
+distinct file/mechanism from the RLS fix — a stream-handling bug, not a
+ledger-write-pattern change — so it carries none of §6.5's write-pattern
+concerns. Re-measured post-both-fixes: the 3000-txn scale test (previously
+DNF at 900s) completes in ~123s wall-time, with msPerPair=102.53 — still not
+growing with scale.
 
 ## Consequences
 

--- a/prisma/migrations/20260705120000_fix_transfer_split_entry_rls_full_scan/migration.sql
+++ b/prisma/migrations/20260705120000_fix_transfer_split_entry_rls_full_scan/migration.sql
@@ -1,0 +1,84 @@
+-- PER-181: `Transfer` and `SplitEntry` have no `familyId` column of their own
+-- (ADR-0036 §4 describes the general `"familyId" = GUC` guard, but these two
+-- tables are scoped indirectly through their parent `Transaction`). The
+-- original `20260620044436_family_membership` migration expressed that
+-- indirection as a NON-correlated `IN (subquery)`:
+--
+--   "outflowTransactionId" IN (SELECT id FROM "Transaction" WHERE "familyId" = ...)
+--
+-- Postgres cannot decorrelate this: it plans it as a hashed SubPlan that
+-- materializes EVERY "Transaction" row belonging to the family, on every
+-- single `Transfer`/`SplitEntry` SELECT or INSERT — cost grows linearly with
+-- the family's total transaction count, regardless of indexes, because the
+-- subquery result doesn't depend on the outer row at all.
+--
+-- Proven via EXPLAIN ANALYZE against a real-shape populated bundle:
+--   493 existing transactions   -> subplan rows=493,  query total  28.6ms
+--   1493 existing transactions  -> subplan rows=1493, query total  86.2ms
+-- (~0.058ms per existing family transaction, confirmed independent of
+-- SERIALIZABLE vs ReadCommitted isolation — this is a planner/plan-shape
+-- cost, not a concurrency/retry cost). This made
+-- `pairAndPromoteSureTransfers`'s per-pair transfer promotion (which reads
+-- and writes `Transfer` once per pair while the family's `Transaction` table
+-- is simultaneously growing) cost O(pairs^2) in total, matching the measured
+-- 222ms/pair @75 pairs -> 400-578ms/pair @225 pairs -> DNF @~450 pairs cliff.
+--
+-- Fix: rewrite both predicates as a CORRELATED `EXISTS`, anchored on
+-- "Transaction".id (its primary key). Postgres cannot hash-materialize a
+-- correlated subplan — it evaluates a per-outer-row Index Scan on
+-- Transaction_pkey instead, which is O(log n) regardless of how large the
+-- family's ledger is. Semantics are unchanged (same two columns checked, same
+-- membership guard) — only the query shape changes. See ADR-0044 §6 (the
+-- measurement-gate this ticket closes) and ADR-0036 §4 (amended alongside).
+
+DROP POLICY IF EXISTS split_entry_tenant_isolation ON "SplitEntry";
+CREATE POLICY split_entry_tenant_isolation ON "SplitEntry"
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM "Transaction"
+      WHERE "Transaction"."id" = "SplitEntry"."transactionId"
+        AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+    )
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM "Transaction"
+      WHERE "Transaction"."id" = "SplitEntry"."transactionId"
+        AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+    )
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  );
+
+DROP POLICY IF EXISTS transfer_tenant_isolation ON "Transfer";
+CREATE POLICY transfer_tenant_isolation ON "Transfer"
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM "Transaction"
+      WHERE "Transaction"."id" = "Transfer"."outflowTransactionId"
+        AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+    )
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM "Transaction"
+      WHERE "Transaction"."id" = "Transfer"."outflowTransactionId"
+        AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+    )
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  );

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -178,19 +178,33 @@ async function gzipBytes(
 ): Promise<Uint8Array<ArrayBuffer>> {
   const stream = new CompressionStream("gzip")
   const writer = stream.writable.getWriter()
-  await writer.write(input)
-  await writer.close()
   const reader = stream.readable.getReader()
+
+  // The reader MUST drain concurrently with the write below, not after
+  // (PER-181). A CompressionStream's internal readable-side queue has bounded
+  // capacity; write()/close() can block on backpressure until it's drained.
+  // Starting the read loop only after write()+close() deadlocks once the
+  // compressed output exceeds that internal queue — reproduced standalone
+  // with ordinary incompressible/JSON-shaped input from a few hundred KB up
+  // (never triggers with highly-compressible input, which is why small
+  // fixtures never caught this).
   const chunks: Uint8Array[] = []
   let total = 0
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (value) {
-      chunks.push(value)
-      total += value.length
+  const drain = (async () => {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        chunks.push(value)
+        total += value.length
+      }
     }
-  }
+  })()
+
+  await writer.write(input)
+  await writer.close()
+  await drain
+
   const out = new Uint8Array(total)
   let offset = 0
   for (const chunk of chunks) {

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -886,23 +886,30 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
     }
   }
 
-  // NOTE on scale (1500, not the originally-targeted ~3000): a PER-179 root-
-  // cause probe (2026-07-05) found the UNTOUCHED transfers phase
-  // (`pairAndPromoteSureTransfers`) has a real, reproducible superlinear cost
-  // per pair (222ms/pair @75 pairs -> ~427ms/pair @225 pairs, confirmed on a
-  // freshly-restarted Postgres with realistic account density — hot-row
-  // bloat and container staleness were both ruled out as the primary cause).
-  // At the full ~3000-txn/~450-pair mirror this makes the whole migration
-  // exceed 900s, which is impractical for a committed test. Root cause is
-  // NOT yet isolated (needs EXPLAIN ANALYZE-level profiling) and transfers is
-  // explicitly out of THIS ticket's scope per ADR-0044 §6's measurement-gate
-  // (material -> re-grill, don't build blind) — tracked as a follow-up
-  // ticket. 1500 txns still proves the load-bearing claim (multiple staging
-  // AND promote chunks, real per-account-density proportions) in a wall-time
-  // this suite can reliably run.
-  test("scale: ~1500-txn bundle completes without exceeding a single chunk-bound transaction", async () => {
+  // NOTE on scale: PER-179 first found the UNTOUCHED transfers phase
+  // (`pairAndPromoteSureTransfers`) had a real, reproducible superlinear cost
+  // per pair (222ms/pair @75 pairs -> ~427ms/pair @225 pairs), which made the
+  // full ~3000-txn/~450-pair mirror exceed 900s — impractical for a committed
+  // test, so this test was capped at 1500 and the root cause tracked as
+  // PER-181. PER-181 (2026-07-05) proved via EXPLAIN ANALYZE that the cause
+  // was NOT the per-pair write pattern (createTransactionForFamily, its
+  // try/catch isolation, and SERIALIZABLE retries were all cleared — zero
+  // retries measured at every scale, and the identical growth curve
+  // reproduced under ReadCommitted isolation) but a non-correlated `IN
+  // (subquery)` RLS predicate on `Transfer`/`SplitEntry` (ADR-0036 §4) that
+  // forced Postgres to re-scan the family's ENTIRE `Transaction` table on
+  // every single `Transfer` read/write, making the whole loop O(pairs²).
+  // Fixed as a bounded-query/index-class change (migration
+  // `20260705120000_fix_transfer_split_entry_rls_full_scan`, ADR-0044 §7):
+  // the predicate is now a correlated `EXISTS` anchored on `Transaction`'s
+  // primary key, so cost no longer grows with ledger size. A second,
+  // unrelated `gzipBytes` stream write-before-read deadlock (same ADR §7)
+  // was found and fixed alongside once the RLS fix exposed it as the next
+  // blocker at this scale. The test is restored to the originally-targeted
+  // ~3000 txns / ~450 pairs (measured: completes in ~123s wall-time).
+  test("scale: ~3000-txn bundle completes without exceeding a single chunk-bound transaction", async () => {
     const tenant = await setupTenant()
-    const fixture = buildLargeSureBundle(1500)
+    const fixture = buildLargeSureBundle(3000)
     const tracker = createChunkBoundTracker()
 
     const startedAt = Date.now()
@@ -959,11 +966,9 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
     expect(tracker.maxRawDelta()).toBeLessThanOrEqual(STAGING_CHUNK_SIZE)
     expect(tracker.maxTxnDelta()).toBeLessThanOrEqual(PROMOTE_CHUNK_SIZE)
     // The tracker doubles round-trips (1 extra query transaction per real
-    // one) on top of the transfers phase's own already-slow, separately-
-    // tracked cost (see the scale-note above) — this generous budget covers
-    // THAT combined test-harness overhead, not the production migration
-    // itself (which stays governed by the untouched 5s Prisma default per
-    // ADR-0044 §1).
+    // one) — this generous budget covers that test-harness overhead, not the
+    // production migration itself (which stays governed by the untouched 5s
+    // Prisma default per ADR-0044 §1).
   }, 600_000)
 
   test("crash-resume: mid-staging crash resumes via count-prefix skip, matches a clean control run", async () => {


### PR DESCRIPTION
## Summary

- **Root cause proven via `EXPLAIN ANALYZE`** (not guessed): the `Transfer`/`SplitEntry` RLS policies (`20260620044436_family_membership`) authorized rows via a non-correlated `outflowTransactionId IN (SELECT id FROM "Transaction" WHERE "familyId" = ...)` subquery. Postgres plans this as a hashed SubPlan that re-scans the family's **entire** `Transaction` table on every `Transfer`/`SplitEntry` access — measured cost linear in current ledger size (28.6ms @493 txns, 86.2ms @1493 txns) — making `pairAndPromoteSureTransfers`'s per-pair transfer promotion **O(pairs²)**. This matches the reported cliff exactly: 222ms/pair @75 pairs → 400–578ms/pair @225 pairs → DNF @~450 pairs.
- SERIALIZABLE/retry-storm was cleared as the cause: `withSerializableRetry` retry count was **zero** at every scale tested, and re-running the identical path under `ReadCommitted` isolation reproduced the same growth curve.
- **Fix (migration `20260705120000_fix_transfer_split_entry_rls_full_scan`)**: rewrite both policies' `USING`/`WITH CHECK` predicates as a **correlated** `EXISTS` anchored on `Transaction.id` (its primary key) instead of the non-correlated `IN (subquery)`. Same columns checked, same membership guard, same security semantics — only the query shape changes, so Postgres uses a per-row Index Scan (O(log n)) instead of materializing the whole table. **No change to `createTransactionForFamily`, no batching, no SAVEPOINTs, no shared transaction** — per-pair `db_rejected` try/catch isolation (PER-175/ADR-0042) is untouched, per the ticket's explicit branching (index/bounded-query fix → implement directly; write-pattern change → re-grill first — this was the former).
- **A second, unrelated bug found while validating at 3000-txn scale**: `gzipBytes` wrote+closed a `CompressionStream` before ever starting to read it — a classic write-before-read stream deadlock that only manifests once compressed output exceeds the stream's internal queue (reproduced standalone: highly-compressible input never hangs even at 8MB, but realistic/incompressible input hangs from a few hundred KB up). This is almost certainly why the original investigation attributed the whole 3000-txn DNF to the transfers phase. Fixed by draining the reader concurrently with the write.
- Scale test restored to the originally-targeted ~3000 txns / ~450 pairs (previously capped at 1500); now completes in ~123s wall-time, msPerPair flat/improving across 500→1500→3000 (no longer growing with scale).
- ADR-0036 §4 and ADR-0044 §7 document the full evidence trail (measurements, ruled-out hypotheses, both fixes).

## Testing

- [x] `vp check`
- [x] `vp run test:unit:coverage` (382 unit tests green)
- [x] `vp run test:integration` (29 files / 271 tests green, incl. restored 3000-txn scale test)
- [ ] `vp run test:e2e` (not run this session — no UI-visible surface touched; RLS policy + internal stream helper only)
- [x] `vp build`

## Critical Finance Impact

- [x] This PR touches a critical finance/auth path (RLS policy on `Transfer`/`SplitEntry`) and includes deterministic tests in the relevant suite.

Existing tests covering this change: `tests/integration/sure-migration.integration.ts`'s full 17+1 test suite, in particular the tenant-isolation tests ("family B cannot pair or read family A's transfer legs") which exercise the exact RLS policies rewritten here and still pass unchanged — proving the security semantics are preserved, only the query shape changed. The restored `scale: ~3000-txn bundle` test proves the O(pairs²) mechanism is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)