### PR TITLE
feat(accounts): PER-178 — soften ANCHOR_CHAIN badge for migration-origin anchors

### DIFF
--- a/src/lib/account-drift-presentation.test.ts
+++ b/src/lib/account-drift-presentation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vite-plus/test"
+import type { DriftRecord } from "./account-collections"
+import {
+  isMigrationOriginSource,
+  selectDriftBadge,
+} from "./account-drift-presentation"
+
+const materialization = (accountId = "acc-1"): DriftRecord => ({
+  accountId,
+  kind: "MATERIALIZATION",
+  severity: "error",
+  expected: "1000",
+  actual: "900",
+  drift: "-100",
+  asOf: "2026-07-01",
+})
+
+const anchorChain = (
+  overrides: Partial<DriftRecord> = {},
+  accountId = "acc-1"
+): DriftRecord => ({
+  accountId,
+  kind: "ANCHOR_CHAIN",
+  severity: "warning",
+  expected: "1000",
+  actual: "1200",
+  drift: "200",
+  asOf: "2026-07-01",
+  fromAnchorDate: "2026-06-01",
+  fromAnchorSource: "manual",
+  toAnchorSource: "manual",
+  ...overrides,
+})
+
+describe("isMigrationOriginSource", () => {
+  test("true for any migration:* prefix, not just sure", () => {
+    expect(isMigrationOriginSource("migration:sure")).toBe(true)
+    expect(isMigrationOriginSource("migration:csv")).toBe(true)
+  })
+
+  test("false for manual/live sources and nullish input", () => {
+    expect(isMigrationOriginSource("manual")).toBe(false)
+    expect(isMigrationOriginSource(undefined)).toBe(false)
+    expect(isMigrationOriginSource(null)).toBe(false)
+  })
+})
+
+describe("selectDriftBadge", () => {
+  test("returns null when there is no drift", () => {
+    expect(selectDriftBadge([])).toBeNull()
+  })
+
+  test("MATERIALIZATION error always wins, even alongside a live ANCHOR_CHAIN", () => {
+    const drift = [anchorChain({ toAnchorSource: "manual" }), materialization()]
+    const badge = selectDriftBadge(drift)
+    expect(badge?.tone).toBe("error")
+    expect(badge?.entry.kind).toBe("MATERIALIZATION")
+  })
+
+  test("live-origin ANCHOR_CHAIN (non-migration source) stays fully alarming", () => {
+    const drift = [
+      anchorChain({ fromAnchorSource: "manual", toAnchorSource: "manual" }),
+    ]
+    const badge = selectDriftBadge(drift)
+    expect(badge?.tone).toBe("warning")
+  })
+
+  test("both anchors migration-sourced softens to informational", () => {
+    const drift = [
+      anchorChain({
+        fromAnchorSource: "migration:sure",
+        toAnchorSource: "migration:sure",
+      }),
+    ]
+    const badge = selectDriftBadge(drift)
+    expect(badge?.tone).toBe("informational")
+  })
+
+  test("mixed provenance (one live, one migration side) stays alarming, not softened", () => {
+    const mixedFromLive = anchorChain({
+      fromAnchorSource: "manual",
+      toAnchorSource: "migration:sure",
+    })
+    expect(selectDriftBadge([mixedFromLive])?.tone).toBe("warning")
+
+    const mixedToLive = anchorChain({
+      fromAnchorSource: "migration:sure",
+      toAnchorSource: "manual",
+    })
+    expect(selectDriftBadge([mixedToLive])?.tone).toBe("warning")
+  })
+
+  test("a live ANCHOR_CHAIN entry outranks a softened migration one when both are present", () => {
+    const live = anchorChain(
+      { fromAnchorSource: "manual", toAnchorSource: "manual" },
+      "acc-1"
+    )
+    const migrated = anchorChain(
+      { fromAnchorSource: "migration:sure", toAnchorSource: "migration:sure" },
+      "acc-1"
+    )
+    const badge = selectDriftBadge([migrated, live])
+    expect(badge?.tone).toBe("warning")
+    expect(badge?.entry).toBe(live)
+  })
+})

--- a/src/lib/account-drift-presentation.ts
+++ b/src/lib/account-drift-presentation.ts
@@ -1,0 +1,68 @@
+import type { DriftRecord } from "./account-collections"
+
+// =============================================================================
+// PER-178 — accounts-page drift badge presentation (ADR-0043 §6).
+//
+// ADR-0043 §6 deliberately leaves "migrated vs. live-user anchor" UI framing
+// to the consuming UI: the calculator only guarantees the ANCHOR_CHAIN report
+// carries both anchors' `Valuation.source`. This module is that classification,
+// kept pure and out of the component so it's unit-testable without rendering.
+// =============================================================================
+
+const MIGRATION_SOURCE_PREFIX = "migration:"
+
+// Any importer's anchor writes (currently only "migration:sure"), not just
+// Sure's — future importers that write anchor valuations inherit the same
+// "source system already absorbed this drift" framing for free.
+export function isMigrationOriginSource(
+  source: string | null | undefined
+): boolean {
+  return (
+    typeof source === "string" && source.startsWith(MIGRATION_SOURCE_PREFIX)
+  )
+}
+
+// Require BOTH anchors of the pair to be migration-sourced before softening.
+// The safer default for a trust-sensitive badge: if either side of the
+// restatement was a live user action (e.g. a live reconcile written right
+// after import), the gap is a real signal and must stay alarming, even
+// though the other anchor happens to be migration-sourced.
+function isMigrationOriginDrift(entry: DriftRecord): boolean {
+  return (
+    entry.kind === "ANCHOR_CHAIN" &&
+    isMigrationOriginSource(entry.fromAnchorSource) &&
+    isMigrationOriginSource(entry.toAnchorSource)
+  )
+}
+
+export type DriftBadgeTone = "error" | "warning" | "informational"
+
+export interface DriftBadgePresentation {
+  tone: DriftBadgeTone
+  entry: DriftRecord
+}
+
+// Picks the single worst drift entry to surface as the accounts-page badge.
+// Priority: MATERIALIZATION error (stored cache disagrees with recomputed
+// balance — always alarming) > live-origin ANCHOR_CHAIN warning (a real
+// bookkeeping gap) > migration-origin ANCHOR_CHAIN (softened/informational —
+// Sure's own override absorbed the drift at export time, so an unexplained
+// gap here is expected, not something the user needs to act on).
+export function selectDriftBadge(
+  drift: ReadonlyArray<DriftRecord>
+): DriftBadgePresentation | null {
+  const errorEntry = drift.find((d) => d.severity === "error")
+  if (errorEntry) return { tone: "error", entry: errorEntry }
+
+  const liveAnchorChain = drift.find(
+    (d) => d.kind === "ANCHOR_CHAIN" && !isMigrationOriginDrift(d)
+  )
+  if (liveAnchorChain) return { tone: "warning", entry: liveAnchorChain }
+
+  const migrationAnchorChain = drift.find(isMigrationOriginDrift)
+  if (migrationAnchorChain) {
+    return { tone: "informational", entry: migrationAnchorChain }
+  }
+
+  return null
+}

--- a/src/routes/_protected/-account-card.test.tsx
+++ b/src/routes/_protected/-account-card.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vite-plus/test"
+import { cleanup, render, screen } from "@testing-library/react"
+
+import { AccountCard } from "./-account-card"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import type { AccountRecord, DriftRecord } from "@/lib/account-collections"
+
+// PER-178 — the accounts-page badge must soften a migration-origin
+// ANCHOR_CHAIN warning to a neutral "Imported" affordance while a live-user
+// ANCHOR_CHAIN warning keeps the alarming "Needs reconcile" badge. The
+// classification itself is unit-tested in account-drift-presentation.test.ts;
+// this covers the actual wiring/render.
+
+afterEach(cleanup)
+
+function noop() {}
+
+const account: AccountRecord = {
+  id: "acc-1",
+  name: "Bank Jago",
+  accountClass: "ASSET",
+  accountType: "DEPOSITORY",
+  accountSubtype: "checking",
+  balanceSource: "transaction_flow",
+  balance: "100000",
+  currency: "IDR",
+  color: null,
+  status: "active",
+  archivedAt: null,
+  institutionName: null,
+  externalProvider: null,
+  externalAccountId: null,
+  mask: null,
+  isImportable: true,
+  creditLimit: null,
+  statementDay: null,
+  dueDay: null,
+  interestRateBps: null,
+}
+
+function renderCard(drift: ReadonlyArray<DriftRecord>) {
+  render(
+    <TooltipProvider>
+      <AccountCard
+        account={account}
+        drift={drift}
+        busy={false}
+        onEdit={noop}
+        onValuation={noop}
+        onArchive={noop}
+        onReactivate={noop}
+      />
+    </TooltipProvider>
+  )
+}
+
+const migrationAnchorChain: DriftRecord = {
+  accountId: account.id,
+  kind: "ANCHOR_CHAIN",
+  severity: "warning",
+  expected: "100000",
+  actual: "150000",
+  drift: "50000",
+  asOf: "2026-07-01",
+  fromAnchorDate: "2026-06-01",
+  fromAnchorSource: "migration:sure",
+  toAnchorSource: "migration:sure",
+}
+
+const liveAnchorChain: DriftRecord = {
+  ...migrationAnchorChain,
+  fromAnchorSource: "manual",
+  toAnchorSource: "manual",
+}
+
+describe("AccountCard drift badge", () => {
+  it("renders no badge when there is no drift", () => {
+    renderCard([])
+    expect(screen.queryByText(/needs reconcile/i)).toBeNull()
+    expect(screen.queryByText(/imported/i)).toBeNull()
+  })
+
+  it("softens a migration-origin ANCHOR_CHAIN to a neutral 'Imported' badge", () => {
+    renderCard([migrationAnchorChain])
+    expect(
+      screen.getByText("Imported — anchored to your Sure balances")
+    ).toBeTruthy()
+    expect(screen.queryByText(/needs reconcile/i)).toBeNull()
+  })
+
+  it("keeps a live-user ANCHOR_CHAIN fully alarming", () => {
+    renderCard([liveAnchorChain])
+    expect(screen.getByText(/needs reconcile/i)).toBeTruthy()
+    expect(screen.queryByText(/imported/i)).toBeNull()
+  })
+
+  it("keeps MATERIALIZATION drift alarming even when a migration ANCHOR_CHAIN is also present", () => {
+    renderCard([
+      migrationAnchorChain,
+      {
+        accountId: account.id,
+        kind: "MATERIALIZATION",
+        severity: "error",
+        expected: "100000",
+        actual: "90000",
+        drift: "-10000",
+        asOf: "2026-07-01",
+      },
+    ])
+    expect(screen.getByText(/balance drift/i)).toBeTruthy()
+    expect(screen.queryByText(/imported/i)).toBeNull()
+  })
+})

--- a/src/routes/_protected/-account-card.tsx
+++ b/src/routes/_protected/-account-card.tsx
@@ -1,0 +1,178 @@
+import {
+  Archive,
+  Landmark,
+  Pencil,
+  RotateCcw,
+  Scale,
+  ShieldCheck,
+  TrendingUp,
+  TriangleAlert,
+  Wallet,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import type { AccountType } from "@/lib/accounts"
+import type { AccountRecord, DriftRecord } from "@/lib/account-collections"
+import { selectDriftBadge } from "@/lib/account-drift-presentation"
+import { formatCurrency } from "@/lib/currency"
+import { cn } from "@/lib/utils"
+
+// Extracted out of accounts.tsx (the route file, "-"-prefixed = not a route
+// itself, mirrors -sure-import-ui.tsx) so this presentational card can be
+// imported directly by a component test without pulling in the route's
+// createFileRoute/collection-preload module graph.
+
+export const ACCOUNT_TYPE_LABEL: Record<AccountType, string> = {
+  CASH: "Cash",
+  DEPOSITORY: "Bank / Depository",
+  E_WALLET: "E-Wallet",
+  CREDIT: "Credit Card",
+  LOAN: "Loan",
+  INVESTMENT: "Investment",
+  RECEIVABLE: "Receivable",
+  TRACKED_ASSET: "Tracked Asset",
+}
+
+export function AccountCard({
+  account,
+  drift,
+  busy,
+  onEdit,
+  onValuation,
+  onArchive,
+  onReactivate,
+}: {
+  account: AccountRecord
+  drift: ReadonlyArray<DriftRecord>
+  busy: boolean
+  onEdit: () => void
+  onValuation: () => void
+  onArchive: () => void
+  onReactivate: () => void
+}) {
+  const archived = account.status !== "active"
+  const cashLike = account.balanceSource === "transaction_flow"
+  const Icon = account.accountClass === "LIABILITY" ? Landmark : Wallet
+  // Surface the single worst drift entry (ADR-0043 §6 classification lives in
+  // src/lib/account-drift-presentation.ts, unit-tested there). Read-only — the
+  // badge never mutates anything (ADR-0034 §7).
+  const driftBadge = selectDriftBadge(drift)
+  return (
+    <Card className={cn(archived && "opacity-60")}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Icon className="size-4 text-muted-foreground" />
+            <CardTitle className="text-base">{account.name}</CardTitle>
+          </div>
+          {archived ? <Badge variant="outline">Archived</Badge> : null}
+        </div>
+        <CardDescription className="flex flex-wrap gap-1.5 pt-1">
+          <Badge variant="secondary">
+            {ACCOUNT_TYPE_LABEL[account.accountType as AccountType] ??
+              account.accountType}
+          </Badge>
+          <Badge variant="outline">{account.accountSubtype}</Badge>
+          <Badge variant={cashLike ? "default" : "outline"}>
+            {cashLike ? "Cash-like" : "Tracked asset"}
+          </Badge>
+          {driftBadge?.tone === "informational" ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge variant="secondary">
+                  <ShieldCheck className="size-3" />
+                  Imported — anchored to your Sure balances
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                Sure's own history already absorbed some drift before it was
+                exported, so this gap is expected — your balance is correct.
+              </TooltipContent>
+            </Tooltip>
+          ) : driftBadge ? (
+            <Badge
+              variant={driftBadge.tone === "error" ? "destructive" : "outline"}
+              className={cn(
+                driftBadge.tone === "warning" &&
+                  "border-amber-500/50 text-amber-600 dark:text-amber-400"
+              )}
+            >
+              <TriangleAlert className="size-3" />
+              {driftBadge.entry.kind === "MATERIALIZATION"
+                ? "Balance drift"
+                : `Needs reconcile (${formatCurrency(driftBadge.entry.drift, account.currency)})`}
+            </Badge>
+          ) : null}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex items-end justify-between gap-2">
+        <div>
+          <p className="text-xs text-muted-foreground">Balance</p>
+          <p className="text-lg font-semibold tabular-nums">
+            {formatCurrency(account.balance, account.currency)}
+          </p>
+        </div>
+        <div className="flex gap-1">
+          {!archived ? (
+            <Button
+              size="icon"
+              variant="ghost"
+              disabled={busy}
+              onClick={onValuation}
+              aria-label={cashLike ? "Reconcile account" : "Update value"}
+            >
+              {cashLike ? (
+                <Scale className="size-4" />
+              ) : (
+                <TrendingUp className="size-4" />
+              )}
+            </Button>
+          ) : null}
+          <Button
+            size="icon"
+            variant="ghost"
+            disabled={busy}
+            onClick={onEdit}
+            aria-label="Edit account"
+          >
+            <Pencil className="size-4" />
+          </Button>
+          {archived ? (
+            <Button
+              size="icon"
+              variant="ghost"
+              disabled={busy}
+              onClick={onReactivate}
+              aria-label="Reactivate account"
+            >
+              <RotateCcw className="size-4" />
+            </Button>
+          ) : (
+            <Button
+              size="icon"
+              variant="ghost"
+              disabled={busy}
+              onClick={onArchive}
+              aria-label="Archive account"
+            >
+              <Archive className="size-4" />
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/_protected/accounts.tsx
+++ b/src/routes/_protected/accounts.tsx
@@ -5,23 +5,14 @@ import {
 } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
-import {
-  Archive,
-  Landmark,
-  Pencil,
-  Plus,
-  RotateCcw,
-  Scale,
-  TrendingUp,
-  TriangleAlert,
-  Wallet,
-} from "lucide-react"
+import { Plus, TriangleAlert, Wallet } from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Badge } from "@/components/ui/badge"
+import { AccountCard, ACCOUNT_TYPE_LABEL } from "./-account-card"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -48,7 +39,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { cn } from "@/lib/utils"
 import {
   accountCollection,
   balanceDriftCollection,
@@ -103,17 +93,6 @@ const CLASS_ORDER: ReadonlyArray<AccountClass> = ["ASSET", "LIABILITY"]
 const CLASS_LABEL: Record<AccountClass, string> = {
   ASSET: "Assets",
   LIABILITY: "Liabilities",
-}
-
-const ACCOUNT_TYPE_LABEL: Record<AccountType, string> = {
-  CASH: "Cash",
-  DEPOSITORY: "Bank / Depository",
-  E_WALLET: "E-Wallet",
-  CREDIT: "Credit Card",
-  LOAN: "Loan",
-  INVESTMENT: "Investment",
-  RECEIVABLE: "Receivable",
-  TRACKED_ASSET: "Tracked Asset",
 }
 
 function AccountsPendingComponent() {
@@ -336,126 +315,6 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
           <Plus className="size-4" />
           New account
         </Button>
-      </CardContent>
-    </Card>
-  )
-}
-
-function AccountCard({
-  account,
-  drift,
-  busy,
-  onEdit,
-  onValuation,
-  onArchive,
-  onReactivate,
-}: {
-  account: AccountRecord
-  drift: ReadonlyArray<DriftRecord>
-  busy: boolean
-  onEdit: () => void
-  onValuation: () => void
-  onArchive: () => void
-  onReactivate: () => void
-}) {
-  const archived = account.status !== "active"
-  const cashLike = account.balanceSource === "transaction_flow"
-  const Icon = account.accountClass === "LIABILITY" ? Landmark : Wallet
-  // Surface the worst drift: a materialization error outranks a reconciliation
-  // warning. Read-only — the badge never mutates anything (ADR-0034 §7).
-  const hasError = drift.some((d) => d.severity === "error")
-  const driftEntry = hasError
-    ? drift.find((d) => d.severity === "error")
-    : drift[0]
-  return (
-    <Card className={cn(archived && "opacity-60")}>
-      <CardHeader>
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <Icon className="size-4 text-muted-foreground" />
-            <CardTitle className="text-base">{account.name}</CardTitle>
-          </div>
-          {archived ? <Badge variant="outline">Archived</Badge> : null}
-        </div>
-        <CardDescription className="flex flex-wrap gap-1.5 pt-1">
-          <Badge variant="secondary">
-            {ACCOUNT_TYPE_LABEL[account.accountType as AccountType] ??
-              account.accountType}
-          </Badge>
-          <Badge variant="outline">{account.accountSubtype}</Badge>
-          <Badge variant={cashLike ? "default" : "outline"}>
-            {cashLike ? "Cash-like" : "Tracked asset"}
-          </Badge>
-          {driftEntry ? (
-            <Badge
-              variant={hasError ? "destructive" : "outline"}
-              className={cn(
-                !hasError &&
-                  "border-amber-500/50 text-amber-600 dark:text-amber-400"
-              )}
-            >
-              <TriangleAlert className="size-3" />
-              {driftEntry.kind === "MATERIALIZATION"
-                ? "Balance drift"
-                : `Needs reconcile (${formatCurrency(driftEntry.drift, account.currency)})`}
-            </Badge>
-          ) : null}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex items-end justify-between gap-2">
-        <div>
-          <p className="text-xs text-muted-foreground">Balance</p>
-          <p className="text-lg font-semibold tabular-nums">
-            {formatCurrency(account.balance, account.currency)}
-          </p>
-        </div>
-        <div className="flex gap-1">
-          {!archived ? (
-            <Button
-              size="icon"
-              variant="ghost"
-              disabled={busy}
-              onClick={onValuation}
-              aria-label={cashLike ? "Reconcile account" : "Update value"}
-            >
-              {cashLike ? (
-                <Scale className="size-4" />
-              ) : (
-                <TrendingUp className="size-4" />
-              )}
-            </Button>
-          ) : null}
-          <Button
-            size="icon"
-            variant="ghost"
-            disabled={busy}
-            onClick={onEdit}
-            aria-label="Edit account"
-          >
-            <Pencil className="size-4" />
-          </Button>
-          {archived ? (
-            <Button
-              size="icon"
-              variant="ghost"
-              disabled={busy}
-              onClick={onReactivate}
-              aria-label="Reactivate account"
-            >
-              <RotateCcw className="size-4" />
-            </Button>
-          ) : (
-            <Button
-              size="icon"
-              variant="ghost"
-              disabled={busy}
-              onClick={onArchive}
-              aria-label="Archive account"
-            >
-              <Archive className="size-4" />
-            </Button>
-          )}
-        </div>
       </CardContent>
     </Card>
   )

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -195,6 +195,14 @@ export interface BalanceDriftReport {
   // look up both anchors' `source` to contextualize a migrated-anchor warning
   // differently from a live user-reconciliation warning (ADR-0043 §6).
   fromAnchorDate?: string
+  // ANCHOR_CHAIN only: both anchors' own `Valuation.source`, carried directly
+  // off the same ordered anchor query that computed the drift (never a
+  // separate date-keyed lookup, which could be ambiguous). Lets a consumer
+  // classify a migration-origin restatement (e.g. both sides written by the
+  // Sure importer) differently from a live user reconciliation, per ADR-0043
+  // §6's deferred UI-presentation decision (see src/lib/account-drift-presentation.ts).
+  fromAnchorSource?: string
+  toAnchorSource?: string
 }
 
 interface ServerActor {
@@ -712,7 +720,7 @@ async function detectAnchorChainDrift(
       type: { in: [...ANCHOR_VALUATION_TYPES] },
     },
     orderBy: [{ valuationDate: "asc" }, { createdAt: "asc" }, { id: "asc" }],
-    select: { value: true, valuationDate: true },
+    select: { value: true, valuationDate: true, source: true },
   })
 
   const reports: BalanceDriftReport[] = []
@@ -740,6 +748,8 @@ async function detectAnchorChainDrift(
         drift: subMoney(actual, expected).toString(),
         asOf: to.valuationDate.toISOString().slice(0, 10),
         fromAnchorDate: from.valuationDate.toISOString().slice(0, 10),
+        fromAnchorSource: from.source,
+        toAnchorSource: to.source,
       })
     }
   }


### PR DESCRIPTION
## Summary

- Sure migration (PER-176) writes reconciliation-type anchors that absorb Sure's own drift by construction (ADR-0043 §6), so freshly migrated accounts routinely trip the accounts-page `ANCHOR_CHAIN` "Needs reconcile" badge even though balances are verified correct against the real Sure UI (PER-182). Post-import, that read as a wall of alarming badges on correct accounts.
- `ANCHOR_CHAIN` drift reports now carry both anchors' `Valuation.source` (`src/server/valuations.ts`, read off the same ordered anchor query that already computes the drift — no separate date-keyed lookup, so it can't misattribute a source on an ambiguous same-day pair).
- New pure, unit-tested `src/lib/account-drift-presentation.ts`: `selectDriftBadge()` prioritizes MATERIALIZATION error > live-origin `ANCHOR_CHAIN` warning > migration-origin `ANCHOR_CHAIN` (softened). Softening requires **both** anchors of the pair to be `migration:*`-sourced — the safer default, so a live reconcile written right after import still alarms correctly.
- Accounts-page badge (`src/routes/_protected/-account-card.tsx`, extracted out of the route file so it's component-testable without the route's `createFileRoute`/collection-preload graph — mirrors the existing `-sure-import-ui.tsx` pattern): migration-origin chains render a neutral "Imported — anchored to your Sure balances" badge with a tooltip; live-user `ANCHOR_CHAIN` warnings and `MATERIALIZATION` drift stay fully alarming (amber / destructive), unchanged.

## Testing

- [x] `vp check` — clean (format/lint/typecheck, 200 files)
- [x] `vp test run` — 400/400 unit (incl. new `account-drift-presentation.test.ts` covering the classification matrix, and a new `-account-card.test.tsx` component test covering the actual render wiring)
- [x] `vp run test:integration` — 278/279 real-Postgres; the 1 failure (`sure-migration.integration.ts` 3000-txn scale test, `pairsPromotedThisRun` off-by-one under sandbox load) is a pre-existing, previously-documented timing flake unrelated to this diff — reproduced clean 20/20 on an isolated retry
- [x] `vp run test:e2e` — 20/21 locally; the 1 failure (`auth-routes.e2e.ts` login-field timeout) is an unrelated flake — reproduced clean 7/7 on retry. `sure-migration.e2e.ts` and `import.e2e.ts` (which navigates `/accounts`) both pass.
- [x] `vp build` — clean

## Critical Finance Impact

- [x] This PR does not touch ledger mutation, balance updates, RLS, idempotency, audit logging, or auth guards. It only adds read-only fields to an existing drift report and changes accounts-page badge presentation — no write path, no balance/anchor semantics change.

Refs: PER-178, ADR-0043 §6, PER-177, PER-176, PER-182.