### PR TITLE
fix(import): PER-184 — Sure migration honors the excluded (split-parent) flag

### DIFF
--- a/docs/adr/0041-sure-full-family-migration.md
+++ b/docs/adr/0041-sure-full-family-migration.md
@@ -1,17 +1,17 @@
 # ADR-0041 — Sure full-family migration (accounts + categories + merchants + transactions)
 
-|                   |                                                                                                                                                                                                                                                                            |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**        | Accepted                                                                                                                                                                                                                                                                   |
-| **Date**          | 2026-06-27                                                                                                                                                                                                                                                                 |
-| **Accepted**      | 2026-06-27                                                                                                                                                                                                                                                                 |
-| **Deciders**      | Hendri Permana                                                                                                                                                                                                                                                             |
-| **Supersedes**    | —                                                                                                                                                                                                                                                                          |
-| **Superseded by** | —                                                                                                                                                                                                                                                                          |
-| **Builds on**     | ADR-0039 (import staging spine, PER-82), ADR-0008 §5, `docs/account-taxonomy.md`                                                                                                                                                                                           |
-| **Amends**        | ADR-0039 §1/§10 (adds `migration` source kind + bundle artifact retention)                                                                                                                                                                                                 |
-| **Amended by**    | ADR-0042 (2026-06-28, PER-175): §5 posting predicate + §10 Phase 1.5; ADR-0043 (2026-07-04, PER-176): §5 superseded by the reconciliation-anchor calculator, §2/§6 Investment importable; ADR-0044 (2026-07-04, PER-179): §1 step 5's confirm→promote is chunked, lockstep |
-| **Reserves for**  | Phase 2 transfers/trades (PER-150/PER-146), Phase 3 rules (smart-rule engine)                                                                                                                                                                                              |
+|                   |                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**        | Accepted                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| **Date**          | 2026-06-27                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| **Accepted**      | 2026-06-27                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| **Deciders**      | Hendri Permana                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **Supersedes**    | —                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Superseded by** | —                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Builds on**     | ADR-0039 (import staging spine, PER-82), ADR-0008 §5, `docs/account-taxonomy.md`                                                                                                                                                                                                                                                                                                                                                  |
+| **Amends**        | ADR-0039 §1/§10 (adds `migration` source kind + bundle artifact retention)                                                                                                                                                                                                                                                                                                                                                        |
+| **Amended by**    | ADR-0042 (2026-06-28, PER-175): §5 posting predicate + §10 Phase 1.5; ADR-0043 (2026-07-04, PER-176): §5 superseded by the reconciliation-anchor calculator, §2/§6 Investment importable; ADR-0044 (2026-07-04, PER-179): §1 step 5's confirm→promote is chunked, lockstep; ADR-0045 (2026-07-11, PER-184): §4 `excluded` field semantics corrected (Sure split-parent, not user-exclusion), §6 promotion gate gains a 5th branch |
+| **Reserves for**  | Phase 2 transfers/trades (PER-150/PER-146), Phase 3 rules (smart-rule engine)                                                                                                                                                                                                                                                                                                                                                     |
 
 ## Context
 
@@ -197,18 +197,19 @@ extra audited `merchantId` relink on already-promoted transactions).
 
 ### 4. Transaction mapping (through the PER-82 seam, unchanged)
 
-| Sure `Transaction` field       | Handling                                                                                  |
-| ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `id`                           | retained in `rawPayload` (provenance); not a Permoney PK                                  |
-| `account_id`                   | → per-row `StagedRowInput.accountId` via account id-map (**ADR-0039 §1 per-row account**) |
-| `category_id`                  | → `suggestedCategoryId` via category id-map; re-validated at promote                      |
-| `merchant_id`                  | → `suggestedMerchantId` via merchant id-map; re-validated at promote                      |
-| `date`                         | → `StagedRowInput.date`; bucketed family-tz at normalize (`calendarDateInZone`, §4.B)     |
-| `amount` + `currency`          | → `type` + **abs** minor units (§4.C)                                                     |
-| `name`                         | → `StagedRowInput.description`                                                            |
-| `kind`                         | gates promotion: `standard`→promote; transfer kinds→**held** (§6)                         |
-| `notes`, `excluded`, `tag_ids` | retained in `rawPayload`; no Permoney `excluded` field in Phase 1 (deferred fidelity)     |
-| `split_lines` (v2)             | **out of scope** Phase 1 (PER-82 is income/expense only); held + retained                 |
+| Sure `Transaction` field | Handling                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `id`                     | retained in `rawPayload` (provenance); not a Permoney PK                                                           |
+| `account_id`             | → per-row `StagedRowInput.accountId` via account id-map (**ADR-0039 §1 per-row account**)                          |
+| `category_id`            | → `suggestedCategoryId` via category id-map; re-validated at promote                                               |
+| `merchant_id`            | → `suggestedMerchantId` via merchant id-map; re-validated at promote                                               |
+| `date`                   | → `StagedRowInput.date`; bucketed family-tz at normalize (`calendarDateInZone`, §4.B)                              |
+| `amount` + `currency`    | → `type` + **abs** minor units (§4.C)                                                                              |
+| `name`                   | → `StagedRowInput.description`                                                                                     |
+| `kind`                   | gates promotion: `standard`→promote; transfer kinds→**held** (§6)                                                  |
+| `notes`, `tag_ids`       | retained in `rawPayload`; no Permoney equivalent field in Phase 1 (deferred fidelity)                              |
+| `excluded`               | **Corrected 2026-07-11, PER-184** — see §4.E; gates promotion (§6), no new Permoney field                          |
+| `split_lines` (v2)       | **out of scope** Phase 1 (PER-82 is income/expense only); held + retained; real exports never populate this (§4.E) |
 
 **A. Currency.** Per ADR-0039 §4, the staged row's currency is **the target
 account's currency**. A Sure transaction whose `currency` differs from its account
@@ -237,6 +238,36 @@ classifies. `sureMinor == 0` is treated as `expense` and flagged for review.
 (`getFamilyBaseCurrency` + `computeBaseProjectionForAmount`) exactly as PER-82 §9
 — no migration-specific FX. The integration test **asserts `baseAmount` is set**
 (PER-159 lesson).
+
+**E. `excluded` — corrected 2026-07-11, PER-184 (root cause corrected during
+dogfooding, verified to the rupiah).** The original assumption above (`excluded`
+is a deferred user-exclusion flag with no Permoney effect) was **wrong**.
+`excluded: true` is Sure's own SPLIT-transaction representation: Sure exports a
+split as the PARENT row (full receipt amount, `excluded: true`) plus the CHILD
+rows as separate, normal, categorized transactions that sum **exactly** to the
+parent — verified on three real cases (57,000 = 22,000 + 35,000; 83,000 =
+45,000 + 38,000; 89,500 = 11,900 + 77,600). Permoney previously ignored the
+flag, promoted the parent AND the children, and double-counted the flow —
+balances were low by exactly Σ(excluded parents). This also resolves PER-173's
+"real exports never populate `split_lines`" finding: splits appear as
+excluded-parent + sibling children instead of nested `split_lines`, so both
+representations are held (§6), but for different, now-documented reasons.
+
+Fix: `excluded: true` gates promotion exactly like every other §6 branch — the
+parent is held as pure provenance (`rowStatus` stays `normalized`, never
+`promoted`; `rawPayload` retains the original Sure row), same treatment as a
+non-importable-account or currency-mismatch hold. The children carry their own
+money and category already, so they promote completely unchanged. Permoney
+gains **no new "excluded transaction" concept** — there is deliberately no live
+Transaction row for the parent, no new column, and no balance-skip branch added
+to `createTransactionForFamily`. The same `excluded` check is also applied in
+`projectSureMigrationBalances` (the pre-flight/final-reconciliation-anchor
+forward-calc, ADR-0045 §6) so the promotion gate and the forward-calc can never
+disagree about a split parent — see ADR-0045 §6's dated amendment for the
+forward-calc side of this fix. Reconstructing a real Permoney `SplitEntry`
+(parent + children, matched by account/date/Σamount) is explicitly deferred to
+a follow-up slice — this fix only needs the balance to be correct, which
+requires no matching logic at all.
 
 ### 5. Opening balance for cash-like accounts (transfer-independent, additive)
 
@@ -378,7 +409,11 @@ Phase 1 promotes a transaction row only when **all** hold:
    (Amended 2026-07-04, PER-176: only `TRACKED_ASSET` accounts — `PreciousMetal`/
    `OtherAsset` — are held by this gate now; Investment is importable, §2),
 3. row currency == account currency (foreign-into-domestic held — §4.A),
-4. not a split parent (`split_lines` held — §4).
+4. not a `split_lines` parent (§4 — real exports have never populated this),
+5. not an `excluded` split parent (Amended 2026-07-11, PER-184: `excluded == true`
+   is Sure's ACTUAL split-parent marker — see §4.E. Applied identically inside
+   `projectSureMigrationBalances`'s forward-calc, ADR-0045 §6, so this gate and
+   the forward-calc can never disagree about which rows post).
 
 "Held" rows are **staged and retained** (`rowStatus` stays `normalized`/`skipped`,
 never `promoted`) as provenance, exactly per ADR-0039 §3/§7 — what was deliberately

--- a/docs/adr/0045-negative-balance-carve-out.md
+++ b/docs/adr/0045-negative-balance-carve-out.md
@@ -246,6 +246,27 @@ The one carve-out from "all legs": a `balanceSource="valuation"` account
 (ADR-0034 §5) — the projection skips flow entirely for these regardless of
 promoted/held status, matching the real calculator.
 
+> **Second carve-out added (2026-07-11, PER-184).** `excluded: true` on a Sure
+> `Transaction` is NOT an ordinary "Permoney couldn't place this" hold — it is
+> Sure's own split-transaction PARENT representation (full receipt amount;
+> the child rows are separate, normal, categorized legs that sum exactly to
+> it — verified to the rupiah on real data: 57,000 = 22,000 + 35,000; 83,000 =
+> 45,000 + 38,000; 89,500 = 11,900 + 77,600; this also explains PER-173's
+> "real exports never populate `split_lines`" finding — splits appear as
+> excluded-parent + sibling children instead). Because the money is _already_
+> counted once via the children, an excluded leg is skipped in the flow sum
+> unconditionally — unlike every other held reason (non-importable
+> counterpart, currency mismatch, ambiguous cluster…), where the money is
+> real and uncounted elsewhere, so the final anchor must absorb it. Applying
+> this skip identically inside `isPromotable` (the promotion gate,
+> `src/server/sure-migration.ts`) and `projectSureMigrationBalances` (the
+> forward-calc) keeps §6's "one segmentation function" discipline intact —
+> pre-flight, the final reconciliation anchor, and the actual promoted set
+> can never disagree about an excluded parent. See ADR-0041 §4/§6 (amended)
+> for the corrected field semantics and the promotion-gate change; Permoney
+> gains no new "excluded transaction" concept — the parent is simply held as
+> provenance, exactly like any other held row (ADR-0039 §3/§7).
+
 ### 7. Final reconciliation anchor closes the promoted/held gap (new, 2026-07-06)
 
 Companion fix to §6.2, and the mechanism that makes "all legs" true of the

--- a/src/lib/sure-migration.test.ts
+++ b/src/lib/sure-migration.test.ts
@@ -258,7 +258,8 @@ describe("sureHeldReason parity with the server's isPromotable", () => {
   )
 
   // One transaction per gate branch: standard, currency mismatch, transfer
-  // kinds, defaulted/blank kind, and split parent.
+  // kinds, defaulted/blank kind, split_lines parent, and PER-184 excluded
+  // (split) parent.
   const txnVariants: Array<Partial<SureTransaction>> = [
     { kind: "standard", currency: "IDR" },
     { kind: "standard", currency: "EUR" }, // currency mismatch
@@ -267,6 +268,7 @@ describe("sureHeldReason parity with the server's isPromotable", () => {
     { kind: undefined, currency: "IDR" }, // defaults to standard
     { kind: "   ", currency: "IDR" }, // blank → standard
     { kind: "standard", currency: "IDR", split_lines: [{}] }, // split parent
+    { kind: "standard", currency: "IDR", excluded: true }, // PER-184 split parent
   ]
 
   test("identical verdict for every account × transaction branch", () => {
@@ -312,6 +314,36 @@ describe("sureHeldReason parity with the server's isPromotable", () => {
       }
     }
   })
+
+  test("PER-184: excluded:true on an otherwise-standard txn is held as splitParent, never promoted", () => {
+    const account = accounts[0] // Depository, importable, transaction_flow
+    const txn: SureTransaction = {
+      id: "t",
+      account_id: account.id,
+      date: "2026-01-01",
+      amount: "895.00",
+      currency: "IDR",
+      kind: "standard",
+      excluded: true,
+    }
+    expect(sureHeldReason(txn, account)).toBe("splitParent")
+    expect(isPromotable(txn, account)).toBe(false)
+  })
+
+  test("PER-184: excluded:false (or omitted) does not affect an otherwise-promotable standard txn", () => {
+    const account = accounts[0]
+    const promotable: SureTransaction = {
+      id: "t",
+      account_id: account.id,
+      date: "2026-01-01",
+      amount: "895.00",
+      currency: "IDR",
+      kind: "standard",
+      excluded: false,
+    }
+    expect(sureHeldReason(promotable, account)).toBeNull()
+    expect(isPromotable(promotable, account)).toBe(true)
+  })
 })
 
 // The preview must fully reconcile to the SureMigrationResult: every bucket the
@@ -338,7 +370,8 @@ describe("summarizeSureBundle reconciliation", () => {
       t.heldByReason.transfer +
         t.heldByReason.nonImportableAccount +
         t.heldByReason.currencyMismatch +
-        t.heldByReason.split
+        t.heldByReason.split +
+        t.heldByReason.splitParent
     ).toBe(t.held)
 
     expect(t.promotable).toBe(manifest.expected.promotedThisRun)

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -452,6 +452,7 @@ export type SureHeldReason =
   | "nonImportableAccount"
   | "currencyMismatch"
   | "split"
+  | "splitParent"
 
 export interface SurePreviewAccount extends NormalizedSureAccount {
   currency: string
@@ -465,7 +466,21 @@ function isImportableSureAccount(account: NormalizedSureAccount): boolean {
 /**
  * Why a staged Sure transaction is held in Phase 1, or `null` if it will promote.
  * Precedence matches the server's `isPromotable`: non-standard kind, then a
- * non-importable account, then a currency mismatch, then a split parent.
+ * non-importable account, then a currency mismatch, then a `split_lines`
+ * parent, then an `excluded` split parent.
+ *
+ * PER-184: `excluded: true` is Sure's SPLIT-transaction representation, not a
+ * user-exclusion flag — Sure exports a split as the PARENT row (full receipt
+ * amount, `excluded: true`) plus the CHILD rows as separate normal, categorized
+ * transactions that sum exactly to the parent. The children already carry the
+ * money and category, so the parent must never promote (it would double the
+ * flow) — held as pure provenance, same as every other held reason, with no
+ * new Permoney "excluded transaction" concept. This is distinct from the
+ * `split_lines` (v2 embedded splits) case above: real Sure exports have never
+ * been observed populating `split_lines` (that was PER-173's "missing
+ * split_lines" mystery — splits appear as excluded-parent + sibling children
+ * instead), so the two reasons are kept separately countable rather than
+ * merged, in case a future export shape does populate `split_lines`.
  */
 export function sureHeldReason(
   txn: SureTransaction,
@@ -476,6 +491,7 @@ export function sureHeldReason(
   if (!isImportableSureAccount(account)) return "nonImportableAccount"
   if (txn.currency !== account.currency) return "currencyMismatch"
   if (txn.split_lines && txn.split_lines.length > 0) return "split"
+  if (txn.excluded === true) return "splitParent"
   return null
 }
 
@@ -530,6 +546,7 @@ export function summarizeSureBundle(
     nonImportableAccount: 0,
     currencyMismatch: 0,
     split: 0,
+    splitParent: 0,
   }
   let promotable = 0
   let held = 0

--- a/src/routes/_protected/-sure-import-ui.tsx
+++ b/src/routes/_protected/-sure-import-ui.tsx
@@ -60,6 +60,11 @@ const HELD_REASONS: Record<
     detail: "One payment divided across several categories.",
     icon: Layers,
   },
+  splitParent: {
+    label: "Split transactions",
+    detail: "One payment divided across several categories.",
+    icon: Layers,
+  },
   nonImportableAccount: {
     label: "Investment & tracked-asset activity",
     detail: "These balances are tracked by valuation, not by each transaction.",

--- a/src/server/sure-migration-projection.test.ts
+++ b/src/server/sure-migration-projection.test.ts
@@ -3,6 +3,7 @@ import { parseSureBundle } from "@/lib/sure-migration"
 import {
   buildSureBundleAnchorEdgeCases,
   buildSureBundlePer182CarveOut,
+  buildSureBundlePer184SplitParent,
   buildSureBundleV1DegradedTransfers,
   buildSureBundleV2Transfers,
 } from "../../tests/integration/support/sure-fixtures"
@@ -71,5 +72,14 @@ describe("projectSureMigrationBalances (ADR-0045/ADR-0044 §8 pre-flight math)",
         `mismatch for ${key}`
       ).toBe(fixture.balancesMinor[key as keyof typeof fixture.balancesMinor])
     }
+  })
+
+  test("PER-184: excluded split-parent is skipped, only children's flow counts (no double count)", () => {
+    const fixture = buildSureBundlePer184SplitParent()
+    const bundle = parseSureBundle(fixture.ndjson)
+    const projections = projectSureMigrationBalances(bundle)
+    expect(projections.get(fixture.accountIds.checking)?.projectedBalance).toBe(
+      fixture.expectedBalancesMinor.checking
+    )
   })
 })

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -558,7 +558,18 @@ export function projectSureMigrationBalances(
   // self-consistency check. FX conversion for a real mismatch is ADR-0035/
   // PER-147's job, not this projection's; excluding it here matches
   // `isPromotable`'s own currency gate for the promoted-only path.
+  // PER-184 carve-out from the "all legs, promoted or held alike" doctrine
+  // above: `excluded: true` marks a Sure split-transaction PARENT row (full
+  // receipt amount) whose CHILD rows are separate, normal legs in this same
+  // `bundle.transactions` array that already sum to the parent. Unlike an
+  // ordinary held leg (non-importable counterpart, currency mismatch,
+  // ambiguous cluster…) — where the money is real and uncounted anywhere else,
+  // so the final anchor must absorb it — an excluded parent's money is ALREADY
+  // counted via its children. Including it here would double it. This applies
+  // regardless of `kind` (defensive: no real-data evidence of an excluded
+  // transfer leg, but the check is free and keeps this loop's predicate exact).
   for (const txn of bundle.transactions) {
+    if (txn.excluded === true) continue
     const facts = factsById.get(txn.account_id)
     if (!facts || facts.balanceSource !== "transaction_flow") continue
     if (txn.currency !== facts.currency) continue
@@ -772,6 +783,12 @@ export function isPromotable(
   }
   if (txn.currency !== account.currency) return false
   if (txn.split_lines && txn.split_lines.length > 0) return false
+  // PER-184: `excluded: true` is Sure's split-transaction representation (the
+  // full-amount parent row); its child rows are separate normal, categorized
+  // transactions that already sum to the parent. Promoting the parent too
+  // would double the flow — hold it as provenance, mirroring `sureHeldReason`
+  // (src/lib/sure-migration.ts) precedence exactly.
+  if (txn.excluded === true) return false
   return true
 }
 

--- a/tests/integration/support/sure-fixtures.ts
+++ b/tests/integration/support/sure-fixtures.ts
@@ -646,6 +646,9 @@ const sureTxn = (args: {
   name: string
   date: string
   currency?: string
+  // PER-184: true marks a Sure split-transaction PARENT row (full receipt
+  // amount) — must never promote nor post to balance.
+  excluded?: boolean
 }): string =>
   envelope("Transaction", {
     id: args.id,
@@ -659,7 +662,7 @@ const sureTxn = (args: {
     name: args.name,
     kind: args.kind,
     notes: null,
-    excluded: false,
+    excluded: args.excluded ?? false,
     tag_ids: [],
     created_at: `${args.date}T00:00:00Z`,
     updated_at: `${args.date}T00:00:00Z`,
@@ -1719,5 +1722,68 @@ export function buildSureBundlePer182PreflightViolation(): SurePer182PreflightVi
   return {
     ndjson: lines.join("\n"),
     accountIds,
+  }
+}
+
+export interface SurePer184SplitParentFixture {
+  ndjson: string
+  accountIds: { checking: string }
+  expectedBalancesMinor: { checking: bigint }
+}
+
+/**
+ * PER-184 — a real-shaped Sure split transaction: one `excluded: true` PARENT
+ * row (full receipt amount, no category) plus two normal CHILD rows (own
+ * category, `excluded: false`) that sum exactly to the parent, mirroring the
+ * verified real cases (57,000 = 22,000 + 35,000; 83,000 = 45,000 + 38,000;
+ * 89,500 = 11,900 + 77,600). Uses the 89,500 shape. If the parent is wrongly
+ * promoted (pre-PER-184 bug), the account is short by exactly the parent's
+ * magnitude (89,500) relative to `expectedBalancesMinor`.
+ */
+export function buildSureBundlePer184SplitParent(): SurePer184SplitParentFixture {
+  const accountIds = {
+    checking: "sure-acc-per184-checking",
+  }
+
+  const lines = [
+    sureAccount(accountIds.checking, "Bank Jago", "Depository", "checking"),
+
+    // Parent: full receipt amount, excluded — must NOT promote, must NOT post.
+    sureTxn({
+      id: "sure-txn-per184-parent",
+      accountId: accountIds.checking,
+      amount: "895.00", // Sure positive (expense-shaped) minor 89_500
+      kind: "standard",
+      name: "Belanja di indomaret",
+      date: "2026-03-01",
+      excluded: true,
+    }),
+    // Children: real categorized legs, already carry the money — promote
+    // normally, unaffected by PER-184 (excluded is false / omitted).
+    sureTxn({
+      id: "sure-txn-per184-child-1",
+      accountId: accountIds.checking,
+      amount: "119.00", // minor 11_900
+      kind: "standard",
+      name: "Belanja di indomaret — Snacks",
+      date: "2026-03-01",
+    }),
+    sureTxn({
+      id: "sure-txn-per184-child-2",
+      accountId: accountIds.checking,
+      amount: "776.00", // minor 77_600
+      kind: "standard",
+      name: "Belanja di indomaret — Groceries",
+      date: "2026-03-01",
+    }),
+  ]
+
+  return {
+    ndjson: lines.join("\n"),
+    accountIds,
+    // Sure expense-shaped positive amounts → Permoney negative deltas.
+    // Only the two children post: -11_900 + -77_600 = -89_500. If the parent
+    // were also promoted (pre-fix bug), this would be -179_000 instead.
+    expectedBalancesMinor: { checking: -89_500n },
   }
 }

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -27,6 +27,7 @@ import {
   buildSureBundleAnchorEdgeCases,
   buildSureBundlePer182CarveOut,
   buildSureBundlePer182PreflightViolation,
+  buildSureBundlePer184SplitParent,
   buildSureBundleV1Degraded,
   buildSureBundleV1DegradedTransfers,
   buildSureBundleV2Complete,
@@ -698,6 +699,70 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
         projected: account?.balance,
       })
     }
+  })
+
+  test("PER-184: excluded split-parent held (never promoted), children promote normally, no double count", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundlePer184SplitParent()
+
+    const result = await migrate(tenant, "split-parent.ndjson", fixture.ndjson)
+
+    await assertBalances(
+      tenant,
+      fixture.accountIds,
+      fixture.expectedBalancesMinor
+    )
+
+    // Only the 2 children promote this run; the excluded parent stays held.
+    expect(result.transactions.promotedThisRun).toBe(2)
+    expect(result.transactions.held).toBe(1)
+
+    const checking = await accountByBinding(tenant, fixture.accountIds.checking)
+    const rawRows = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.rawImportedTransaction.findMany({
+          where: { familyId: tenant.familyId, accountId: checking!.id },
+          select: {
+            externalId: true,
+            rowStatus: true,
+            promotedTransactionId: true,
+          },
+        })
+    )
+    const parentRow = rawRows.find(
+      (r) => r.externalId === "sure-txn-per184-parent"
+    )
+    // The parent stays staged as provenance (rawPayload is retained), but is
+    // never confirmed/promoted — same treatment as every other held reason.
+    expect(parentRow?.rowStatus).not.toBe("promoted")
+    expect(parentRow?.promotedTransactionId).toBeNull()
+
+    const childRows = rawRows.filter(
+      (r) => r.externalId !== "sure-txn-per184-parent"
+    )
+    expect(childRows).toHaveLength(2)
+    expect(childRows.every((r) => r.rowStatus === "promoted")).toBe(true)
+
+    // The excluded parent must never have become a real Transaction.
+    const transactionCount = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) => tx.transaction.count({ where: { accountId: checking!.id } })
+    )
+    expect(transactionCount).toBe(2) // children only
+
+    // Equivalence: the pre-flight projection (the SAME formula the migration's
+    // preflight validator and the final-reconciliation-anchor both use) matches
+    // the real, post-rebuild account balance exactly — proving the excluded
+    // skip is applied identically in the promotion gate (isPromotable) and the
+    // forward-calc (projectSureMigrationBalances) — ONE shared predicate, per
+    // ADR-0043 §6 discipline, never two that can silently drift apart.
+    const bundle = parseSureBundle(fixture.ndjson)
+    const projections = projectSureMigrationBalances(bundle)
+    const projection = projections.get(fixture.accountIds.checking)
+    expect(projection?.projectedBalance).toEqual(checking?.balance)
   })
 
   // ======================================================================


### PR DESCRIPTION
## Summary

- Fixes [PER-184](https://linear.app/permana/issue/PER-184): Sure migration ignored the `excluded` flag, double-counting split transactions and leaving balances short by exactly Σ(excluded parents).
- **Root cause (verified to the rupiah on the user's real dogfooding export):** `excluded: true` on a Sure `Transaction` is Sure's own split-transaction representation, not user exclusion. A split posts as a full-amount PARENT row (`excluded: true`) plus normal, categorized CHILD rows that sum exactly to it — 57,000 = 22,000+35,000; 83,000 = 45,000+38,000; 89,500 = 11,900+77,600. Permoney promoted both parent and children, double-counting the flow. This also explains PER-173's "real exports never populate `split_lines`" finding: splits appear as excluded-parent + sibling children instead of nested `split_lines`.
- **Fix (grilled and locked with head-eng):** `excluded: true` now gates promotion in `isPromotable` exactly like every other held reason — the parent stays staged as pure provenance (never confirmed/promoted, `rawPayload` retained), with **no new Permoney "excluded transaction" concept**. The same check is applied identically in `projectSureMigrationBalances` (the pre-flight + final-reconciliation-anchor forward-calc), so the promotion gate and the forward-calc can never disagree about a split parent — one shared predicate, per ADR-0045 §6's existing "one segmentation function" discipline. Children already carry their own money and category and promote unchanged.
- Reconstructing a real Permoney `SplitEntry` (parent + children matched by account/date/Σamount) is explicitly **deferred to a follow-up ticket** — this fix only needs the balance to be correct, which needs no matching logic.
- ADR-0041 §4/§6 and ADR-0045 §6 amended in place with dated (2026-07-11) corrections; frontmatter `Amended by` updated.

## Testing

- [x] `vp check`
- [x] `vp test run` (full unit suite — 403/403, 25 files)
- [x] `vp run test:integration` (full real-Postgres suite — 280/280, 29/29 files, no flakes)
- [x] `vp run test:e2e` (21/21, including `sure-migration.e2e.ts`)
- [x] `vp build`

New coverage: `sureHeldReason`/`isPromotable` parity matrix + two targeted unit tests (`src/lib/sure-migration.test.ts`), a pure projection unit test (`src/server/sure-migration-projection.test.ts`), a new `buildSureBundlePer184SplitParent` fixture using the real verified 89,500=11,900+77,600 shape, and a real-Postgres integration test asserting: the parent is staged but never promoted (no `Transaction` row), children promote normally, and — per the ticket's DoD — an **equivalence assertion** that `projectSureMigrationBalances(bundle)` exactly matches the real post-rebuild account balance.

## Critical Finance Impact

- [x] This PR touches a critical finance/auth path and includes deterministic tests in the relevant suite.

Touches the Sure migration promotion gate (`isPromotable`) and the balance forward-calc (`projectSureMigrationBalances`), both of which feed real ledger balances. Covered by: `sure-migration.test.ts` (held-reason parity + splitParent unit tests), `sure-migration-projection.test.ts` (pure projection truth-table test), and a new real-Postgres integration test in `sure-migration.integration.ts` proving no double-count and gate/forward-calc equivalence.

## Pending: real-bundle adu

Per this ticket's DoD and the established Sure-migration verification process (every real `all.ndjson` round in this milestone's history has found something synthetic tests missed), **head-eng should re-run the real bundle against this branch**. Target: Bank Jago and BCA Tahapan Blue gaps close to the user's real bank balances (BCA 350.351,10; Jago 1.037.448), with no regression across the other ~38 accounts already verified correct in PER-182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)