### PR TITLE
feat(ledger): PER-189 — quick-create Merchant & Category from the transaction form

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "better-auth": "^1.6.22",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
     "lucide-react": "^1.21.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -3705,6 +3708,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -9311,6 +9320,18 @@ snapshots:
   cli-spinners@2.9.2: {}
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
 

--- a/prisma/migrations/20260712120000_merchant_category_name_dedup/migration.sql
+++ b/prisma/migrations/20260712120000_merchant_category_name_dedup/migration.sql
@@ -1,0 +1,25 @@
+-- PER-189: quick-create Merchant/Category from the transaction form needs a
+-- durable dedup boundary, not just an app-level check, so a double-submit or
+-- two concurrent requests can never produce two rows for "Starbucks" and
+-- "starbucks " in the same family. Case- and whitespace-insensitive per
+-- family (ADR-0003 tenant scoping). Verified against the current dev/staging
+-- data set before writing this migration: zero existing case-insensitive
+-- collisions in either table (2026-07-12).
+--
+-- Category system rows (isSystem=true, familyId NULL) are out of scope: the
+-- category_system_familyid_consistency CHECK (see
+-- 20260527120000_harden_category_system_rls) already guarantees isSystem=false
+-- implies familyId IS NOT NULL, so the partial index only ever dedups
+-- tenant-owned rows.
+--
+-- Prisma schema cannot express a functional/expression index, so — like the
+-- externalProvider partial-unique indexes added in
+-- 20260627120000_sure_migration_bindings — this lives only in raw SQL and is
+-- documented with a comment on the Prisma model.
+
+CREATE UNIQUE INDEX "Merchant_familyId_lower_name_key"
+  ON "Merchant" ("familyId", lower(btrim(name)));
+
+CREATE UNIQUE INDEX "Category_familyId_lower_name_key"
+  ON "Category" ("familyId", lower(btrim(name)))
+  WHERE "familyId" IS NOT NULL;

--- a/prisma/migrations/20260712130000_merchant_category_name_dedup_exempt_migrated/migration.sql
+++ b/prisma/migrations/20260712130000_merchant_category_name_dedup_exempt_migrated/migration.sql
@@ -1,0 +1,34 @@
+-- PER-189 follow-up (head-eng review, PR #158): the quick-create dedup index
+-- from `merchant_category_name_dedup` was scoped too broadly and would break
+-- Sure full-family migration. Real Sure exports bind Category/Merchant
+-- identity by `externalId`, NEVER by name (ADR-0041 §3) — a Sure bundle can
+-- legitimately carry two DIFFERENT entities named "Food" and "food" (a
+-- renamed category, or merged data from two Sure workspaces). The prior
+-- index had no such carve-out and would raise a unique-constraint violation
+-- mid-import for tx.merchant.create/tx.category.create in sure-migration.ts,
+-- silently corrupting the import rather than the user's own quick-create
+-- flow it was meant to protect.
+--
+-- Fix: rebuild both indexes with an added `WHERE "externalProvider" IS NULL`
+-- predicate. Manually-created (quick-create) rows are always
+-- externalProvider IS NULL, so they keep full DB-enforced race protection —
+-- the original goal is unaffected. Migration-bound rows (externalProvider
+-- set) are exempt from the DB constraint, matching their externalId-bound
+-- identity.
+--
+-- The app-level pre-check in createMerchantForFamily/createCategoryForFamily
+-- is UNCHANGED and still scans every row regardless of externalProvider — a
+-- manual quick-create still gets a clear DuplicateNameError against an
+-- existing migrated entity of the same name; only the concurrent-request DB
+-- backstop is scoped to manual-vs-manual races.
+
+DROP INDEX "Merchant_familyId_lower_name_key";
+DROP INDEX "Category_familyId_lower_name_key";
+
+CREATE UNIQUE INDEX "Merchant_familyId_lower_name_key"
+  ON "Merchant" ("familyId", lower(btrim(name)))
+  WHERE "externalProvider" IS NULL;
+
+CREATE UNIQUE INDEX "Category_familyId_lower_name_key"
+  ON "Category" ("familyId", lower(btrim(name)))
+  WHERE "familyId" IS NOT NULL AND "externalProvider" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,6 +217,10 @@ model Merchant {
   smartRules   SmartRule[]
 
   // Tenant scoping (see ADR-0003).
+  // PER-189: case/whitespace-insensitive per-family name uniqueness — a
+  // functional UNIQUE INDEX (familyId, lower(btrim(name))) is created in raw
+  // SQL (migration `merchant_category_name_dedup`); Prisma cannot express a
+  // functional index in the schema DSL.
   @@unique([id, familyId], map: "Merchant_id_familyId_key")
   @@index([familyId])
 }
@@ -252,6 +256,11 @@ model Category {
 
   // Tenant scoping (see ADR-0003). `familyId` is nullable for system
   // categories; the index still helps the common per-family scan.
+  // PER-189: case/whitespace-insensitive per-family name uniqueness — a
+  // functional UNIQUE INDEX (familyId, lower(btrim(name))) WHERE familyId IS
+  // NOT NULL is created in raw SQL (migration
+  // `merchant_category_name_dedup`); system categories (familyId NULL) are
+  // out of scope. Prisma cannot express a functional index in the schema DSL.
   @@index([familyId])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,10 +217,14 @@ model Merchant {
   smartRules   SmartRule[]
 
   // Tenant scoping (see ADR-0003).
-  // PER-189: case/whitespace-insensitive per-family name uniqueness — a
-  // functional UNIQUE INDEX (familyId, lower(btrim(name))) is created in raw
-  // SQL (migration `merchant_category_name_dedup`); Prisma cannot express a
-  // functional index in the schema DSL.
+  // PER-189: case/whitespace-insensitive per-family name uniqueness for
+  // MANUALLY-created merchants only — a functional UNIQUE INDEX (familyId,
+  // lower(btrim(name))) WHERE externalProvider IS NULL is created in raw SQL
+  // (migration `merchant_category_name_dedup`, narrowed by the follow-up
+  // `merchant_category_name_dedup_exempt_migrated`). Migration-bound rows are
+  // exempt: Sure identity is externalId-bound, not name-bound, so two
+  // distinct Sure merchants may share a case-insensitive name. Prisma cannot
+  // express a functional index in the schema DSL.
   @@unique([id, familyId], map: "Merchant_id_familyId_key")
   @@index([familyId])
 }
@@ -256,11 +260,14 @@ model Category {
 
   // Tenant scoping (see ADR-0003). `familyId` is nullable for system
   // categories; the index still helps the common per-family scan.
-  // PER-189: case/whitespace-insensitive per-family name uniqueness — a
-  // functional UNIQUE INDEX (familyId, lower(btrim(name))) WHERE familyId IS
-  // NOT NULL is created in raw SQL (migration
-  // `merchant_category_name_dedup`); system categories (familyId NULL) are
-  // out of scope. Prisma cannot express a functional index in the schema DSL.
+  // PER-189: case/whitespace-insensitive per-family name uniqueness for
+  // MANUALLY-created categories only — a functional UNIQUE INDEX (familyId,
+  // lower(btrim(name))) WHERE familyId IS NOT NULL AND externalProvider IS
+  // NULL is created in raw SQL (migration `merchant_category_name_dedup`,
+  // narrowed by the follow-up `merchant_category_name_dedup_exempt_migrated`).
+  // System categories (familyId NULL) and migration-bound rows (Sure identity
+  // is externalId-bound, not name-bound) are both out of scope. Prisma cannot
+  // express a functional index in the schema DSL.
   @@index([familyId])
 }
 

--- a/src/components/blocks/entity-combobox.tsx
+++ b/src/components/blocks/entity-combobox.tsx
@@ -1,0 +1,202 @@
+import * as React from "react"
+import { IconCheck, IconChevronDown, IconPlus } from "@tabler/icons-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+export interface EntityComboboxItem {
+  id: string
+  label: string
+}
+
+interface EntityComboboxProps {
+  id?: string
+  items: Array<EntityComboboxItem>
+  value: string
+  onChange: (id: string) => void
+  onCreate: (name: string) => Promise<EntityComboboxItem>
+  placeholder: string
+  searchPlaceholder: string
+  emptyLabel: string
+  createLabel: (query: string) => string
+  disabled?: boolean
+  "aria-invalid"?: boolean
+  /** Optional fields (e.g. Merchant) surface a "-- clear --" item. */
+  clearLabel?: string
+}
+
+/**
+ * Searchable select with an inline "Create '<query>' " affordance (PER-189).
+ * The caller owns persistence (`onCreate`) and item refresh — this component
+ * only owns the popover/search/pending-state UI contract.
+ */
+export function EntityCombobox({
+  id,
+  items,
+  value,
+  onChange,
+  onCreate,
+  placeholder,
+  searchPlaceholder,
+  emptyLabel,
+  createLabel,
+  disabled,
+  "aria-invalid": ariaInvalid,
+  clearLabel,
+}: EntityComboboxProps) {
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+  const [pending, setPending] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  // Bridges the gap between "create resolved" and "the refetched items list
+  // actually contains the new row" so the trigger shows the right label
+  // immediately instead of falling back to the placeholder for a beat.
+  const [optimisticItem, setOptimisticItem] =
+    React.useState<EntityComboboxItem | null>(null)
+
+  const selected =
+    items.find((item) => item.id === value) ??
+    (optimisticItem?.id === value ? optimisticItem : undefined)
+  const trimmedSearch = search.trim()
+  const hasExactMatch = items.some(
+    (item) => item.label.toLowerCase() === trimmedSearch.toLowerCase()
+  )
+  const canCreate = trimmedSearch.length > 0 && !hasExactMatch
+
+  const resetAndClose = () => {
+    setOpen(false)
+    setSearch("")
+    setError(null)
+  }
+
+  const handleCreate = async () => {
+    if (!canCreate || pending) return
+    setPending(true)
+    setError(null)
+    try {
+      const created = await onCreate(trimmedSearch)
+      setOptimisticItem(created)
+      onChange(created.id)
+      resetAndClose()
+    } catch (creationError: unknown) {
+      setError(
+        creationError instanceof Error
+          ? creationError.message
+          : "Could not create this entry. Please try again."
+      )
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) {
+          setSearch("")
+          setError(null)
+        }
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={ariaInvalid}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+        >
+          <span className={cn(!selected && "text-muted-foreground")}>
+            {selected ? selected.label : placeholder}
+          </span>
+          <IconChevronDown className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder={searchPlaceholder}
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            {clearLabel && !trimmedSearch && value && (
+              <CommandItem
+                value="__clear__"
+                onSelect={() => {
+                  onChange("")
+                  resetAndClose()
+                }}
+              >
+                {clearLabel}
+              </CommandItem>
+            )}
+            {items
+              .filter((item) =>
+                item.label.toLowerCase().includes(trimmedSearch.toLowerCase())
+              )
+              .map((item) => (
+                <CommandItem
+                  key={item.id}
+                  value={item.id}
+                  onSelect={() => {
+                    onChange(item.id)
+                    resetAndClose()
+                  }}
+                  data-checked={item.id === value}
+                >
+                  <IconCheck
+                    className={cn(
+                      "size-4",
+                      item.id === value ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  {item.label}
+                </CommandItem>
+              ))}
+            {!trimmedSearch && items.length === 0 && (
+              <CommandEmpty>{emptyLabel}</CommandEmpty>
+            )}
+            {canCreate && (
+              <CommandGroup>
+                <CommandItem
+                  value={`__create__${trimmedSearch}`}
+                  disabled={pending}
+                  onSelect={() => void handleCreate()}
+                >
+                  <IconPlus className="size-4" />
+                  {pending ? "Creating…" : createLabel(trimmedSearch)}
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+          {error && (
+            <p
+              role="alert"
+              className="border-t border-destructive/20 px-3 py-2 text-xs text-destructive"
+            >
+              {error}
+            </p>
+          )}
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/blocks/entity-combobox.tsx
+++ b/src/components/blocks/entity-combobox.tsx
@@ -22,19 +22,19 @@ export interface EntityComboboxItem {
 }
 
 interface EntityComboboxProps {
-  id?: string
-  items: Array<EntityComboboxItem>
-  value: string
-  onChange: (id: string) => void
-  onCreate: (name: string) => Promise<EntityComboboxItem>
-  placeholder: string
-  searchPlaceholder: string
-  emptyLabel: string
-  createLabel: (query: string) => string
-  disabled?: boolean
-  "aria-invalid"?: boolean
+  readonly id?: string
+  readonly items: Array<EntityComboboxItem>
+  readonly value: string
+  readonly onChange: (id: string) => void
+  readonly onCreate: (name: string) => Promise<EntityComboboxItem>
+  readonly placeholder: string
+  readonly searchPlaceholder: string
+  readonly emptyLabel: string
+  readonly createLabel: (query: string) => string
+  readonly disabled?: boolean
+  readonly "aria-invalid"?: boolean
   /** Optional fields (e.g. Merchant) surface a "-- clear --" item. */
-  clearLabel?: string
+  readonly clearLabel?: string
 }
 
 /**

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { useForm, type ReactFormExtendedApi } from "@tanstack/react-form"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   IconArrowDownLeft,
   IconArrowUpRight,
@@ -21,9 +21,15 @@ import { format } from "date-fns"
 import { getCurrencySymbol } from "@/lib/currency"
 import { cn } from "@/lib/utils"
 import { getTransactionFormData } from "@/server/transactions"
+import { createMerchantFn } from "@/server/merchants"
+import { createCategoryFn } from "@/server/categories"
 import { toDisplayNumber, toMinorUnits, type Money } from "@/lib/money"
 import { CURRENCIES, type CurrencyCode } from "@/lib/data/currencies"
 import { createUuidV7 } from "@/lib/uuid-v7"
+import {
+  EntityCombobox,
+  type EntityComboboxItem,
+} from "@/components/blocks/entity-combobox"
 
 type TransactionFormData = Awaited<ReturnType<typeof getTransactionFormData>>
 type FormAccount = TransactionFormData["accounts"][number]
@@ -835,29 +841,35 @@ function MerchantField({
   form,
   formData,
   isLoading,
-}: TransactionFormSectionProps) {
+  onCreateMerchant,
+}: TransactionFormSectionProps & {
+  onCreateMerchant: (name: string) => Promise<EntityComboboxItem>
+}) {
   if (activeTab === "transfer") return null
+
+  const items: Array<EntityComboboxItem> =
+    formData?.merchants.map((m) => ({ id: m.id, label: m.name })) ?? []
 
   return (
     <form.Field name="merchantId">
       {(field) => (
         <div className="space-y-2">
           <Label htmlFor={field.name}>Merchant (Optional)</Label>
-          <select
+          <EntityCombobox
             id={field.name}
-            name={field.name}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            value={field.state.value}
-            onChange={(e) => field.handleChange(e.target.value)}
+            items={items}
+            value={field.state.value ?? ""}
+            onChange={field.handleChange}
+            onCreate={onCreateMerchant}
             disabled={isLoading}
-          >
-            <option value="">-- No Merchant / General --</option>
-            {formData?.merchants.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.name}
-              </option>
-            ))}
-          </select>
+            placeholder={
+              isLoading ? "Loading..." : "-- No Merchant / General --"
+            }
+            searchPlaceholder="Search merchants..."
+            emptyLabel="No merchants yet"
+            createLabel={(query) => `Create merchant "${query}"`}
+            clearLabel="-- No Merchant / General --"
+          />
         </div>
       )}
     </form.Field>
@@ -906,8 +918,16 @@ function CategoryField({
   formData,
   isLoading,
   isSplit,
-}: TransactionFormSectionProps & { isSplit: boolean }) {
+  onCreateCategory,
+}: TransactionFormSectionProps & {
+  isSplit: boolean
+  onCreateCategory: (name: string) => Promise<EntityComboboxItem>
+}) {
   if (activeTab === "transfer" || isSplit) return null
+
+  const items: Array<EntityComboboxItem> = (formData?.categories ?? [])
+    .filter((c) => c.type === activeTab)
+    .map((c) => ({ id: c.id, label: c.name }))
 
   return (
     <form.Field
@@ -919,28 +939,19 @@ function CategoryField({
       {(field) => (
         <div className="space-y-2">
           <Label htmlFor={field.name}>Category *</Label>
-          <select
+          <EntityCombobox
             id={field.name}
-            name={field.name}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/30"
-            value={field.state.value}
-            onChange={(e) => field.handleChange(e.target.value)}
+            items={items}
+            value={field.state.value ?? ""}
+            onChange={field.handleChange}
+            onCreate={onCreateCategory}
             disabled={isLoading}
+            placeholder={isLoading ? "Loading..." : "Select Category"}
+            searchPlaceholder="Search categories..."
+            emptyLabel="No categories yet"
+            createLabel={(query) => `Create category "${query}"`}
             aria-invalid={field.state.meta.errors.length > 0}
-            aria-describedby={
-              field.state.meta.errors.length > 0
-                ? `${field.name}-error`
-                : undefined
-            }
-          >
-            <option value="" disabled>
-              {isLoading ? "Loading..." : "Select Category"}
-            </option>
-            <CategoryOptions
-              categories={formData?.categories}
-              type={activeTab}
-            />
-          </select>
+          />
           <FieldError
             id={`${field.name}-error`}
             errors={field.state.meta.errors}
@@ -1340,6 +1351,42 @@ function useTransactionFormModalController({
     queryFn: () => getTransactionFormData(),
   })
 
+  // Quick-create (PER-189): the combobox calls these, then the lookup query
+  // is invalidated so the newly created merchant/category is immediately
+  // selectable — the canonical createMerchantFn/createCategoryFn server fns
+  // own tenant scoping, audit, idempotency, and duplicate-name rejection.
+  const queryClient = useQueryClient()
+
+  const createMerchantOption = React.useCallback(
+    async (name: string): Promise<EntityComboboxItem> => {
+      const created = await createMerchantFn({
+        data: { name, idempotencyKey: createUuidV7() },
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ["transactionFormData"],
+      })
+      return { id: created.id, label: created.name }
+    },
+    [queryClient]
+  )
+
+  const createCategoryOption = React.useCallback(
+    async (name: string): Promise<EntityComboboxItem> => {
+      const created = await createCategoryFn({
+        data: {
+          name,
+          type: activeTab === "income" ? "income" : "expense",
+          idempotencyKey: createUuidV7(),
+        },
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ["transactionFormData"],
+      })
+      return { id: created.id, label: created.name }
+    },
+    [activeTab, queryClient]
+  )
+
   const defaultFormValues: TransactionFormValues = isEditMode
     ? {
         type: editData.type,
@@ -1687,6 +1734,8 @@ function useTransactionFormModalController({
 
   return {
     activeTab,
+    createCategoryOption,
+    createMerchantOption,
     form,
     formData,
     formError,
@@ -1711,6 +1760,8 @@ export function TransactionFormModal({
 }: TransactionFormModalProps) {
   const {
     activeTab,
+    createCategoryOption,
+    createMerchantOption,
     form,
     formData,
     formError,
@@ -1784,6 +1835,7 @@ export function TransactionFormModal({
             form={form}
             formData={formData}
             isLoading={isLoading}
+            onCreateMerchant={createMerchantOption}
           />
           <SplitModeToggle
             activeTab={activeTab}
@@ -1796,6 +1848,7 @@ export function TransactionFormModal({
             formData={formData}
             isLoading={isLoading}
             isSplit={isSplit}
+            onCreateCategory={createCategoryOption}
           />
           <SplitEntriesPanel
             activeTab={activeTab}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,190 @@
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { InputGroup, InputGroupAddon } from "@/components/ui/input-group"
+import { RiSearchLine, RiCheckLine } from "@remixicon/react"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex size-full flex-col overflow-hidden rounded-4xl bg-popover p-1 text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = false,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn(
+          "top-1/3 translate-y-0 overflow-hidden rounded-4xl! p-0",
+          className
+        )}
+        showCloseButton={showCloseButton}
+      >
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div data-slot="command-input-wrapper" className="p-1 pb-0">
+      <InputGroup className="h-9 bg-input/50">
+        <CommandPrimitive.Input
+          data-slot="command-input"
+          className={cn(
+            "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+            className
+          )}
+          {...props}
+        />
+        <InputGroupAddon>
+          <RiSearchLine className="size-4 shrink-0 opacity-50" />
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className={cn("py-6 text-center text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1.5 text-foreground **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:py-2 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("my-1.5 h-px bg-border/50", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none in-data-[slot=dialog-content]:rounded-3xl data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <RiCheckLine className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+    </CommandPrimitive.Item>
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-9 w-full min-w-0 items-center rounded-4xl border border-transparent bg-input/50 transition-[color,box-shadow,background-color] outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-data-[align=block-end]:rounded-3xl has-data-[align=block-start]:rounded-3xl has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[textarea]:rounded-2xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-2 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 **:data-[slot=kbd]:rounded-3xl **:data-[slot=kbd]:bg-muted-foreground/10 **:data-[slot=kbd]:px-1.5 [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start": "order-first pl-3 has-[>button]:-ml-1 has-[>kbd]:-ml-1",
+        "inline-end": "order-last pr-3 has-[>button]:-mr-1 has-[>kbd]:-mr-1",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-3.5 [.border-b]:pb-3.5",
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-3.5 [.border-t]:pt-3.5",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 rounded-4xl text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-xl px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs": "size-6 rounded-xl p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2.5 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -46,6 +46,14 @@ function InputGroupAddon({
   align = "inline-start",
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  // Clicking anywhere in the addon focuses the sibling input — a mouse-only
+  // convenience mirrored here for keyboard users too (Enter/Space), so a
+  // visible click handler on this non-interactive wrapper is never
+  // keyboard-inoperable (WCAG 2.1.1 / SonarCloud S1082, S6847).
+  const focusSiblingInput = (target: HTMLElement) => {
+    target.parentElement?.querySelector("input")?.focus()
+  }
+
   return (
     <div
       role="group"
@@ -56,7 +64,13 @@ function InputGroupAddon({
         if ((e.target as HTMLElement).closest("button")) {
           return
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus()
+        focusSiblingInput(e.currentTarget)
+      }}
+      onKeyDown={(e) => {
+        if (e.key !== "Enter" && e.key !== " ") return
+        if ((e.target as HTMLElement).closest("button")) return
+        e.preventDefault()
+        focusSiblingInput(e.currentTarget)
       }}
       {...props}
     />

--- a/src/server/categories.test.ts
+++ b/src/server/categories.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vite-plus/test"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import { createCategoryInputSchema } from "./categories"
+
+describe("createCategoryInputSchema", () => {
+  const idempotencyKey = createUuidV7()
+
+  it("accepts a minimal payload (name + type only)", () => {
+    const parsed = createCategoryInputSchema.parse({
+      name: "Coffee",
+      type: "expense",
+      idempotencyKey,
+    })
+    expect(parsed.name).toBe("Coffee")
+    expect(parsed.type).toBe("expense")
+    expect(parsed.color).toBeUndefined()
+    expect(parsed.icon).toBeUndefined()
+    expect(parsed.parentId).toBeUndefined()
+  })
+
+  it("accepts explicit color, icon, and parentId", () => {
+    const parsed = createCategoryInputSchema.parse({
+      name: "Coffee Shops",
+      type: "expense",
+      color: "#e07a5f",
+      icon: "coffee",
+      parentId: "clxyz123",
+      idempotencyKey,
+    })
+    expect(parsed.color).toBe("#e07a5f")
+    expect(parsed.icon).toBe("coffee")
+    expect(parsed.parentId).toBe("clxyz123")
+  })
+
+  it("only accepts 'expense' or 'income' as type", () => {
+    expect(() =>
+      createCategoryInputSchema.parse({
+        name: "Coffee",
+        type: "transfer",
+        idempotencyKey,
+      })
+    ).toThrow()
+  })
+
+  it("rejects an empty name", () => {
+    expect(() =>
+      createCategoryInputSchema.parse({
+        name: "",
+        type: "expense",
+        idempotencyKey,
+      })
+    ).toThrow()
+  })
+
+  it("rejects a malformed hex color", () => {
+    expect(() =>
+      createCategoryInputSchema.parse({
+        name: "Coffee",
+        type: "expense",
+        color: "not-a-color",
+        idempotencyKey,
+      })
+    ).toThrow()
+  })
+
+  it("rejects a non-UUIDv7 idempotency key", () => {
+    expect(() =>
+      createCategoryInputSchema.parse({
+        name: "Coffee",
+        type: "expense",
+        idempotencyKey: "not-a-uuid",
+      })
+    ).toThrow()
+  })
+})

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -1,0 +1,239 @@
+import { createServerFn } from "@tanstack/react-start"
+import type { Category } from "@prisma/client"
+import { z } from "zod"
+import { auditLog, createAuditContext } from "./middleware/audit"
+import {
+  requireCapability,
+  scopedTenantTransaction,
+} from "./middleware/with-family"
+import { hashCanonicalPayload } from "./idempotency"
+import {
+  persistIdempotentEndpointResponse,
+  replayIdempotentEndpointResponse,
+} from "./idempotency-records"
+import {
+  DuplicateNameError,
+  isNameDedupConstraintError,
+  isUniqueConstraintError,
+  uuidV7Schema,
+  type RunInTenantTransaction,
+} from "./mutation-kit"
+
+// =============================================================================
+// PER-189 — quick-create Category from the transaction form.
+//
+// Same mutation contract as every other ledger-adjacent write (ADR-0008): an
+// interactive `prisma.$transaction` with the `app.family_id` RLS GUC set on
+// the same transaction, an accepted idempotency key replayed through
+// `IdempotencyRecord`, and an append-only `AuditLog` row written inside the
+// same transaction.
+//
+// Quick-created categories are always tenant-owned (isSystem=false,
+// familyId set) — the DB CHECK `category_system_familyid_consistency`
+// (migration `harden_category_system_rls`) backstops this. `parentId` is
+// accepted (and tenant/type validated) so a caller with more context than the
+// inline transaction-form combobox can nest a category, but the quick-create
+// UI itself only offers a flat/top-level create — full parent management
+// stays in PER-167.
+// =============================================================================
+
+const CREATE_CATEGORY_ENDPOINT = "createCategoryFn"
+const CATEGORY_NAME_DEDUP_INDEX = "Category_familyId_lower_name_key"
+const DEFAULT_COLOR = "#6172F3"
+const DEFAULT_ICON = "shapes"
+
+/**
+ * Raised when a create references a `parentId` that does not resolve to a
+ * tenant-owned category of the same family. Foreign keys alone are not
+ * tenant isolation (CLAUDE.md ledger core rules) — this is validated inside
+ * the same transaction before any write.
+ */
+export class CategoryNotFoundError extends Error {
+  override readonly name = "CategoryNotFoundError"
+  readonly statusCode = 404
+  constructor(readonly categoryId: string) {
+    super(`Category ${categoryId} not found for this family`)
+  }
+}
+
+/**
+ * Raised for category-input rejections that are real domain violations, not
+ * schema shape errors (e.g. a parent/child type mismatch).
+ */
+export class CategoryValidationError extends Error {
+  override readonly name = "CategoryValidationError"
+  readonly statusCode = 422
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+const nameSchema = z.string().trim().min(1).max(120)
+const hexColorSchema = z
+  .string()
+  .trim()
+  .regex(/^#[0-9a-fA-F]{6}$/, "color must be a #RRGGBB hex value")
+const iconSchema = z.string().trim().min(1).max(64)
+const categoryTypeSchema = z.enum(["expense", "income"])
+
+export const createCategoryInputSchema = z.object({
+  name: nameSchema,
+  type: categoryTypeSchema,
+  color: hexColorSchema.optional(),
+  icon: iconSchema.optional(),
+  parentId: z.string().min(1).optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+type CreateCategoryInput = z.infer<typeof createCategoryInputSchema>
+
+export interface SerializedCategory {
+  id: string
+  name: string
+  type: string
+  color: string
+  icon: string
+  parentId: string | null
+}
+
+function serializeCategory(category: Category): SerializedCategory {
+  return {
+    id: category.id,
+    name: category.name,
+    type: category.type,
+    color: category.color,
+    icon: category.icon,
+    parentId: category.parentId,
+  }
+}
+
+interface ServerUser {
+  id: string
+}
+
+export async function createCategoryForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof createCategoryInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedCategory> {
+  const data: CreateCategoryInput = createCategoryInputSchema.parse(rawData)
+  const trimmedName = data.name.trim()
+  const color = data.color ?? DEFAULT_COLOR
+  const icon = data.icon ?? DEFAULT_ICON
+  const requestHash = await hashCanonicalPayload({
+    color,
+    icon,
+    name: trimmedName,
+    parentId: data.parentId ?? null,
+    type: data.type,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<SerializedCategory>(
+        tx,
+        {
+          endpoint: CREATE_CATEGORY_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      if (data.parentId) {
+        const parent = await tx.category.findFirst({
+          where: { id: data.parentId, familyId, isSystem: false },
+        })
+        if (!parent) throw new CategoryNotFoundError(data.parentId)
+        if (parent.type !== data.type) {
+          throw new CategoryValidationError(
+            `Parent category type (${parent.type}) does not match the new category's type (${data.type})`
+          )
+        }
+      }
+
+      // Pre-check catches the common case with a clean, well-typed error. The
+      // functional unique index (migration `merchant_category_name_dedup`) is
+      // the durable backstop for the concurrent-double-submit race.
+      const existing = await tx.category.findFirst({
+        where: { familyId, name: { equals: trimmedName, mode: "insensitive" } },
+      })
+      if (existing) throw new DuplicateNameError("Category", trimmedName)
+
+      const category = await tx.category.create({
+        data: {
+          familyId,
+          name: trimmedName,
+          type: data.type,
+          color,
+          icon,
+          parentId: data.parentId ?? null,
+          isSystem: false,
+        },
+      })
+
+      const serialized = serializeCategory(category)
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "Category",
+        entityId: category.id,
+        after: serialized,
+      })
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: CREATE_CATEGORY_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response: serialized,
+      })
+      return serialized
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (isNameDedupConstraintError(error, CATEGORY_NAME_DEDUP_INDEX)) {
+      throw new DuplicateNameError("Category", trimmedName)
+    }
+    // A concurrent request with the same key may win the IdempotencyRecord
+    // unique race; resolve it by replaying the stored response.
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(
+      familyId,
+      user.id,
+      async (tx) =>
+        replayIdempotentEndpointResponse<SerializedCategory>(tx, {
+          endpoint: CREATE_CATEGORY_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const createCategoryFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof createCategoryInputSchema>) =>
+    createCategoryInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await createCategoryForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -63,9 +63,6 @@ export class CategoryNotFoundError extends Error {
 export class CategoryValidationError extends Error {
   override readonly name = "CategoryValidationError"
   readonly statusCode = 422
-  constructor(message: string) {
-    super(message)
-  }
 }
 
 const nameSchema = z.string().trim().min(1).max(120)

--- a/src/server/merchants.test.ts
+++ b/src/server/merchants.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import { createMerchantInputSchema } from "./merchants"
+
+describe("createMerchantInputSchema", () => {
+  const idempotencyKey = createUuidV7()
+
+  it("accepts a minimal payload (name only)", () => {
+    const parsed = createMerchantInputSchema.parse({
+      name: "Starbucks",
+      idempotencyKey,
+    })
+    expect(parsed.name).toBe("Starbucks")
+    expect(parsed.color).toBeUndefined()
+  })
+
+  it("accepts an optional hex color", () => {
+    const parsed = createMerchantInputSchema.parse({
+      name: "Starbucks",
+      color: "#00704A",
+      idempotencyKey,
+    })
+    expect(parsed.color).toBe("#00704A")
+  })
+
+  it("accepts an explicit null color (clears it)", () => {
+    const parsed = createMerchantInputSchema.parse({
+      name: "Starbucks",
+      color: null,
+      idempotencyKey,
+    })
+    expect(parsed.color).toBeNull()
+  })
+
+  it("rejects an empty name", () => {
+    expect(() =>
+      createMerchantInputSchema.parse({ name: "", idempotencyKey })
+    ).toThrow()
+  })
+
+  it("rejects a name over 120 characters", () => {
+    expect(() =>
+      createMerchantInputSchema.parse({
+        name: "x".repeat(121),
+        idempotencyKey,
+      })
+    ).toThrow()
+  })
+
+  it("rejects a malformed hex color", () => {
+    expect(() =>
+      createMerchantInputSchema.parse({
+        name: "Starbucks",
+        color: "green",
+        idempotencyKey,
+      })
+    ).toThrow()
+  })
+
+  it("rejects a non-UUIDv7 idempotency key", () => {
+    expect(() =>
+      createMerchantInputSchema.parse({
+        name: "Starbucks",
+        idempotencyKey: "not-a-uuid",
+      })
+    ).toThrow()
+  })
+
+  it("lower-cases the idempotency key", () => {
+    const upper = createUuidV7().toUpperCase()
+    const parsed = createMerchantInputSchema.parse({
+      name: "Starbucks",
+      idempotencyKey: upper,
+    })
+    expect(parsed.idempotencyKey).toBe(upper.toLowerCase())
+  })
+})

--- a/src/server/merchants.ts
+++ b/src/server/merchants.ts
@@ -1,0 +1,175 @@
+import { createServerFn } from "@tanstack/react-start"
+import type { Merchant } from "@prisma/client"
+import { z } from "zod"
+import { auditLog, createAuditContext } from "./middleware/audit"
+import {
+  requireCapability,
+  scopedTenantTransaction,
+} from "./middleware/with-family"
+import { hashCanonicalPayload } from "./idempotency"
+import {
+  persistIdempotentEndpointResponse,
+  replayIdempotentEndpointResponse,
+} from "./idempotency-records"
+import {
+  DuplicateNameError,
+  isNameDedupConstraintError,
+  isUniqueConstraintError,
+  uuidV7Schema,
+  type RunInTenantTransaction,
+} from "./mutation-kit"
+
+// =============================================================================
+// PER-189 — quick-create Merchant from the transaction form.
+//
+// Merchant is a first-class analytics dimension (spend-by-merchant stats,
+// SmartRule keys, recurring detection, future bank-sync matching), so it gets
+// the same mutation contract as every other ledger-adjacent write (ADR-0008):
+// an interactive `prisma.$transaction` with the `app.family_id` RLS GUC set on
+// the same transaction, an accepted idempotency key replayed through
+// `IdempotencyRecord`, and an append-only `AuditLog` row written inside the
+// same transaction.
+//
+// Domain scope (head-eng decision recorded on PER-189): persons who are mere
+// payment destinations are Merchants (one counterparty concept, YNAB-payee
+// style). Persons with debt relationships are ACCOUNTS (loan/receivable). No
+// "People" entity exists; a future `kind` discriminator on Merchant is the
+// extension point if analytics ever needs the business/person split.
+//
+// Full management (rename/merge/delete) is out of scope here — PER-167.
+// =============================================================================
+
+const CREATE_MERCHANT_ENDPOINT = "createMerchantFn"
+const MERCHANT_NAME_DEDUP_INDEX = "Merchant_familyId_lower_name_key"
+
+const nameSchema = z.string().trim().min(1).max(120)
+const hexColorSchema = z
+  .string()
+  .trim()
+  .regex(/^#[0-9a-fA-F]{6}$/, "color must be a #RRGGBB hex value")
+
+export const createMerchantInputSchema = z.object({
+  name: nameSchema,
+  color: hexColorSchema.nullable().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+type CreateMerchantInput = z.infer<typeof createMerchantInputSchema>
+
+export interface SerializedMerchant {
+  id: string
+  name: string
+  color: string | null
+}
+
+function serializeMerchant(merchant: Merchant): SerializedMerchant {
+  return {
+    id: merchant.id,
+    name: merchant.name,
+    color: merchant.color,
+  }
+}
+
+interface ServerUser {
+  id: string
+}
+
+export async function createMerchantForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof createMerchantInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedMerchant> {
+  const data: CreateMerchantInput = createMerchantInputSchema.parse(rawData)
+  const trimmedName = data.name.trim()
+  const color = data.color ?? null
+  const requestHash = await hashCanonicalPayload({ color, name: trimmedName })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<SerializedMerchant>(
+        tx,
+        {
+          endpoint: CREATE_MERCHANT_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      // Pre-check catches the common case with a clean, well-typed error. The
+      // functional unique index (migration `merchant_category_name_dedup`) is
+      // the durable backstop for the concurrent-double-submit race.
+      const existing = await tx.merchant.findFirst({
+        where: { familyId, name: { equals: trimmedName, mode: "insensitive" } },
+      })
+      if (existing) throw new DuplicateNameError("Merchant", trimmedName)
+
+      const merchant = await tx.merchant.create({
+        data: { familyId, name: trimmedName, color },
+      })
+
+      const serialized = serializeMerchant(merchant)
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "Merchant",
+        entityId: merchant.id,
+        after: serialized,
+      })
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: CREATE_MERCHANT_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response: serialized,
+      })
+      return serialized
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (isNameDedupConstraintError(error, MERCHANT_NAME_DEDUP_INDEX)) {
+      throw new DuplicateNameError("Merchant", trimmedName)
+    }
+    // A concurrent request with the same key may win the IdempotencyRecord
+    // unique race; resolve it by replaying the stored response.
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(
+      familyId,
+      user.id,
+      async (tx) =>
+        replayIdempotentEndpointResponse<SerializedMerchant>(tx, {
+          endpoint: CREATE_MERCHANT_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const createMerchantFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof createMerchantInputSchema>) =>
+    createMerchantInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await createMerchantForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })

--- a/src/server/mutation-kit.test.ts
+++ b/src/server/mutation-kit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test"
+import {
+  DuplicateNameError,
+  isNameDedupConstraintError,
+  isUniqueConstraintError,
+} from "./mutation-kit"
+
+describe("isUniqueConstraintError", () => {
+  it("recognizes a Prisma P2002 error", () => {
+    expect(isUniqueConstraintError({ code: "P2002" })).toBe(true)
+  })
+
+  it("rejects non-P2002 errors and non-objects", () => {
+    expect(isUniqueConstraintError({ code: "P2025" })).toBe(false)
+    expect(isUniqueConstraintError(new Error("boom"))).toBe(false)
+    expect(isUniqueConstraintError(null)).toBe(false)
+    expect(isUniqueConstraintError("P2002")).toBe(false)
+  })
+})
+
+describe("isNameDedupConstraintError", () => {
+  const indexName = "Merchant_familyId_lower_name_key"
+
+  it("matches when meta.target is the bare index name string", () => {
+    const error = { code: "P2002", meta: { target: indexName } }
+    expect(isNameDedupConstraintError(error, indexName)).toBe(true)
+  })
+
+  it("matches when meta.target is an array containing the index name", () => {
+    const error = { code: "P2002", meta: { target: [indexName] } }
+    expect(isNameDedupConstraintError(error, indexName)).toBe(true)
+  })
+
+  it("does not match a P2002 from a different constraint (e.g. IdempotencyRecord)", () => {
+    const error = {
+      code: "P2002",
+      meta: { target: "IdempotencyRecord_endpoint_familyId_key_key" },
+    }
+    expect(isNameDedupConstraintError(error, indexName)).toBe(false)
+  })
+
+  it("does not match a non-P2002 error even with a matching target", () => {
+    const error = { code: "P2025", meta: { target: indexName } }
+    expect(isNameDedupConstraintError(error, indexName)).toBe(false)
+  })
+
+  it("does not match when meta is missing", () => {
+    expect(isNameDedupConstraintError({ code: "P2002" }, indexName)).toBe(false)
+  })
+})
+
+describe("DuplicateNameError", () => {
+  it("carries the entity type, attempted name, and a 409 status", () => {
+    const error = new DuplicateNameError("Merchant", "Starbucks")
+    expect(error.name).toBe("DuplicateNameError")
+    expect(error.statusCode).toBe(409)
+    expect(error.entityType).toBe("Merchant")
+    expect(error.attemptedName).toBe("Starbucks")
+    expect(error.message).toContain("Starbucks")
+    expect(error.message).toContain("merchant")
+  })
+})

--- a/src/server/mutation-kit.ts
+++ b/src/server/mutation-kit.ts
@@ -34,6 +34,41 @@ export function isUniqueConstraintError(error: unknown): boolean {
   )
 }
 
+// Raised when a quick-create mutation targets a name that already exists
+// (case/whitespace-insensitive) within the family — Merchant and Category
+// (PER-189) both enforce this at the DB layer with a functional unique index,
+// not just an app-level check (see migration `merchant_category_name_dedup`).
+export class DuplicateNameError extends Error {
+  override readonly name = "DuplicateNameError"
+  readonly statusCode = 409
+  constructor(
+    readonly entityType: string,
+    readonly attemptedName: string
+  ) {
+    super(
+      `A ${entityType.toLowerCase()} named "${attemptedName}" already exists`
+    )
+  }
+}
+
+// P2002 raised specifically by a name-dedup functional unique index (as
+// opposed to the IdempotencyRecord unique race, which callers already handle
+// via isUniqueConstraintError + replay). Prisma reports the violated index
+// name as `meta.target` — either a bare string or an array — for indexes not
+// modeled in schema.prisma, since it cannot map back to column names.
+export function isNameDedupConstraintError(
+  error: unknown,
+  indexName: string
+): boolean {
+  if (!isUniqueConstraintError(error)) return false
+  const target = (error as { meta?: { target?: unknown } }).meta?.target
+  if (typeof target === "string") return target.includes(indexName)
+  if (Array.isArray(target)) {
+    return target.some((t) => typeof t === "string" && t.includes(indexName))
+  }
+  return false
+}
+
 // A tenant-scoped interactive transaction runner. Production callers default to
 // `scopedTenantTransaction`; tests inject a harness-scoped runner. `userId` is
 // the acting member, set into the `app.user_id` GUC for the RLS membership

--- a/tests/e2e/transaction-quick-create.e2e.ts
+++ b/tests/e2e/transaction-quick-create.e2e.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-189 — quick-create Merchant & Category inline in the transaction form.
+// Drives the real browser -> server-fn -> Postgres path: opens Add
+// Transaction, creates a brand-new merchant and a brand-new category via the
+// combobox's "Create ..." affordance, submits, and asserts the persisted
+// transaction row reflects both freshly created entities (proof they were
+// actually written, not just selected client-side).
+
+test.describe("quick-create merchant & category from the transaction form", () => {
+  test("adds a transaction with a brand-new merchant and category", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    await page.goto("/transactions")
+    await waitForHydration(page)
+
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    const uniqueSuffix = Date.now().toString(36)
+    const description = `E2E quick-create ${uniqueSuffix}`
+    const merchantName = `E2E Coffee Shop ${uniqueSuffix}`
+    const categoryName = `E2E Coffee ${uniqueSuffix}`
+
+    await page.getByLabel("Description *").fill(description)
+    await page.getByLabel("Amount *").fill("45000")
+    await page.locator('select[name="accountId"]').selectOption({ index: 1 })
+
+    // --- Quick-create Merchant ---
+    await page.getByLabel("Merchant (Optional)").click()
+    await page.getByPlaceholder("Search merchants...").fill(merchantName)
+    await page
+      .getByRole("option", { name: `Create merchant "${merchantName}"` })
+      .click()
+    await expect(page.getByLabel("Merchant (Optional)")).toContainText(
+      merchantName
+    )
+
+    // --- Quick-create Category ---
+    await page.getByLabel("Category *").click()
+    await page.getByPlaceholder("Search categories...").fill(categoryName)
+    await page
+      .getByRole("option", { name: `Create category "${categoryName}"` })
+      .click()
+    await expect(page.getByLabel("Category *")).toContainText(categoryName)
+
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // The persisted row shows the freshly created merchant + category names
+    // — this only renders once the ledger read joins to real Merchant/
+    // Category rows, so it proves the quick-created entities round-tripped
+    // through the canonical server fns rather than staying client-only.
+    await expect(page.getByText(description)).toBeVisible()
+    await expect(page.getByText(merchantName)).toBeVisible()
+    await expect(page.getByText(categoryName)).toBeVisible()
+  })
+})

--- a/tests/integration/merchant-category-quick-create.integration.ts
+++ b/tests/integration/merchant-category-quick-create.integration.ts
@@ -1,0 +1,380 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import {
+  createMerchantForFamily,
+  type SerializedMerchant,
+} from "@/server/merchants"
+import {
+  CategoryNotFoundError,
+  CategoryValidationError,
+  createCategoryForFamily,
+} from "@/server/categories"
+import { DuplicateNameError } from "@/server/mutation-kit"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+describe("quick-create Merchant & Category (PER-189)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  describe("createMerchantForFamily", () => {
+    test("creates a merchant and writes an audit row", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+
+      const created: SerializedMerchant = await createMerchantForFamily({
+        data: {
+          name: "Starbucks",
+          color: "#00704a",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      expect(created.name).toBe("Starbucks")
+      expect(created.color).toBe("#00704a")
+
+      const row = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.merchant.findUniqueOrThrow({ where: { id: created.id } })
+      )
+      expect(row.familyId).toBe(owner.family.id)
+
+      const audits = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.auditLog.findMany({
+          where: { entityType: "Merchant", entityId: created.id },
+        })
+      )
+      expect(audits).toHaveLength(1)
+      expect(audits[0]?.action).toBe("create")
+      expect(audits[0]?.familyId).toBe(owner.family.id)
+    })
+
+    test("trims the name and defaults color to null", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+
+      const created = await createMerchantForFamily({
+        data: {
+          name: "  Blue Bottle Coffee  ",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      expect(created.name).toBe("Blue Bottle Coffee")
+      expect(created.color).toBeNull()
+    })
+
+    test("rejects a case/whitespace-insensitive duplicate name within the family", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      await factories.createMerchant({
+        familyId: owner.family.id,
+        name: "Starbucks",
+      })
+
+      let captured: unknown
+      try {
+        await createMerchantForFamily({
+          data: {
+            name: "  starbucks  ",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+        expect.fail("Expected DuplicateNameError")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(DuplicateNameError)
+
+      const count = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.merchant.count({ where: { familyId: owner.family.id } })
+      )
+      expect(count).toBe(1)
+    })
+
+    test("the same name is allowed across different families", async () => {
+      const familyA = await factories.createAuthenticatedOnboardedUser()
+      const familyB = await factories.createAuthenticatedOnboardedUser()
+      await factories.createMerchant({
+        familyId: familyA.family.id,
+        name: "Starbucks",
+      })
+
+      const created = await createMerchantForFamily({
+        data: {
+          name: "Starbucks",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: familyB.family.id,
+        user: familyB.user,
+      })
+      expect(created.name).toBe("Starbucks")
+    })
+
+    test("replays the same idempotency key without creating a second merchant", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const key = factories.createIdempotencyKey()
+      const payload = {
+        data: { name: "Replay Merchant", idempotencyKey: key },
+        familyId: owner.family.id,
+        user: owner.user,
+      }
+
+      const first = await createMerchantForFamily(payload)
+      const second = await createMerchantForFamily(payload)
+
+      expect(second.id).toBe(first.id)
+      const count = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.merchant.count({
+          where: { familyId: owner.family.id, name: "Replay Merchant" },
+        })
+      )
+      expect(count).toBe(1)
+    })
+
+    describe("tenant isolation", () => {
+      test("a merchant created for one family is invisible under another family's RLS scope", async () => {
+        const owner = await factories.createAuthenticatedOnboardedUser()
+        const intruder = await factories.createAuthenticatedOnboardedUser()
+
+        const created = await createMerchantForFamily({
+          data: {
+            name: "Owner-only Merchant",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+
+        const visibleToIntruder = await harness.withFamily(
+          intruder.family.id,
+          async (tx) => tx.merchant.findUnique({ where: { id: created.id } })
+        )
+        expect(visibleToIntruder).toBeNull()
+
+        const visibleToOwner = await harness.withFamily(
+          owner.family.id,
+          async (tx) => tx.merchant.findUnique({ where: { id: created.id } })
+        )
+        expect(visibleToOwner?.id).toBe(created.id)
+      })
+    })
+  })
+
+  describe("createCategoryForFamily", () => {
+    test("creates a category with defaults and writes an audit row", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+
+      const created = await createCategoryForFamily({
+        data: {
+          name: "Coffee",
+          type: "expense",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      expect(created.name).toBe("Coffee")
+      expect(created.type).toBe("expense")
+      expect(created.color).toBe("#6172F3")
+      expect(created.icon).toBe("shapes")
+      expect(created.parentId).toBeNull()
+
+      const row = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.category.findUniqueOrThrow({ where: { id: created.id } })
+      )
+      expect(row.isSystem).toBe(false)
+      expect(row.familyId).toBe(owner.family.id)
+
+      const audits = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.auditLog.findMany({
+          where: { entityType: "Category", entityId: created.id },
+        })
+      )
+      expect(audits).toHaveLength(1)
+      expect(audits[0]?.action).toBe("create")
+    })
+
+    test("respects explicit color/icon and a same-type parent", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const parent = await factories.createCategory({
+        familyId: owner.family.id,
+        name: "Food & Drink",
+        type: "expense",
+      })
+
+      const created = await createCategoryForFamily({
+        data: {
+          name: "Coffee Shops",
+          type: "expense",
+          color: "#e07a5f",
+          icon: "coffee",
+          parentId: parent.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      expect(created.color).toBe("#e07a5f")
+      expect(created.icon).toBe("coffee")
+      expect(created.parentId).toBe(parent.id)
+    })
+
+    test("rejects a parent whose type does not match", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const incomeParent = await factories.createCategory({
+        familyId: owner.family.id,
+        type: "income",
+      })
+
+      let captured: unknown
+      try {
+        await createCategoryForFamily({
+          data: {
+            name: "Mismatched Child",
+            type: "expense",
+            parentId: incomeParent.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+        expect.fail("Expected CategoryValidationError")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(CategoryValidationError)
+    })
+
+    test("rejects a parentId belonging to another family (tenant-owned reference)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const intruderCategory = await factories.createCategory({
+        familyId: intruder.family.id,
+      })
+
+      let captured: unknown
+      try {
+        await createCategoryForFamily({
+          data: {
+            name: "Hijacked Child",
+            type: "expense",
+            parentId: intruderCategory.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+        expect.fail("Expected CategoryNotFoundError")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(CategoryNotFoundError)
+    })
+
+    test("rejects a case/whitespace-insensitive duplicate name within the family", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      await factories.createCategory({
+        familyId: owner.family.id,
+        name: "Groceries",
+        type: "expense",
+      })
+
+      let captured: unknown
+      try {
+        await createCategoryForFamily({
+          data: {
+            name: " groceries ",
+            type: "expense",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+        expect.fail("Expected DuplicateNameError")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(DuplicateNameError)
+
+      const count = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.category.count({ where: { familyId: owner.family.id } })
+      )
+      expect(count).toBe(1)
+    })
+
+    test("replays the same idempotency key without creating a second category", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const key = factories.createIdempotencyKey()
+      const payload = {
+        data: {
+          name: "Replay Category",
+          type: "income" as const,
+          idempotencyKey: key,
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      }
+
+      const first = await createCategoryForFamily(payload)
+      const second = await createCategoryForFamily(payload)
+
+      expect(second.id).toBe(first.id)
+      const count = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.category.count({
+          where: { familyId: owner.family.id, name: "Replay Category" },
+        })
+      )
+      expect(count).toBe(1)
+    })
+
+    describe("tenant isolation", () => {
+      test("a category created for one family is invisible under another family's RLS scope", async () => {
+        const owner = await factories.createAuthenticatedOnboardedUser()
+        const intruder = await factories.createAuthenticatedOnboardedUser()
+
+        const created = await createCategoryForFamily({
+          data: {
+            name: "Owner-only Category",
+            type: "expense",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+
+        const visibleToIntruder = await harness.withFamily(
+          intruder.family.id,
+          async (tx) => tx.category.findUnique({ where: { id: created.id } })
+        )
+        expect(visibleToIntruder).toBeNull()
+      })
+    })
+  })
+})

--- a/tests/integration/support/sure-fixtures.ts
+++ b/tests/integration/support/sure-fixtures.ts
@@ -1787,3 +1787,82 @@ export function buildSureBundlePer184SplitParent(): SurePer184SplitParentFixture
     expectedBalancesMinor: { checking: -89_500n },
   }
 }
+
+// ---------------------------------------------------------------------------
+// PER-189 follow-up — case-insensitive-duplicate Category/Merchant names
+// across a Sure bundle. Real Sure exports bind category/merchant identity by
+// `externalId`, NEVER by name — two DIFFERENT Sure entities in the same
+// family can legitimately be named "Food" and "food" (a user who renamed a
+// category, or merged accounts from two Sure workspaces). The PER-189
+// quick-create dedup index (`merchant_category_name_dedup_exempt_migrated`)
+// excludes `externalProvider IS NOT NULL` rows for exactly this reason — this
+// fixture is the regression proof that a migration import carrying such a
+// pair still creates BOTH rows instead of tripping the unique index.
+// ---------------------------------------------------------------------------
+
+export interface SureCiDuplicateNamesFixture {
+  ndjson: string
+  accountIds: { checking: string }
+  expected: { categoriesCreated: number; merchantsCreated: number }
+}
+
+export function buildSureBundleCiDuplicateNames(): SureCiDuplicateNamesFixture {
+  const accountIds = {
+    checking: "sure-acc-per189-checking",
+  }
+
+  const lines = [
+    sureAccount(accountIds.checking, "Bank Jago", "Depository", "checking"),
+
+    // Two DIFFERENT Sure categories that happen to be case-insensitive
+    // duplicates by name — bound by distinct externalId, not name.
+    envelope("Category", {
+      id: "sure-cat-per189-food-upper",
+      name: "Food",
+      classification: "expense",
+      parent_id: null,
+      color: "#6172F3",
+      lucide_icon: "apple",
+      key: null,
+      created_at: "2026-01-02T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    }),
+    envelope("Category", {
+      id: "sure-cat-per189-food-lower",
+      name: "food",
+      classification: "expense",
+      parent_id: null,
+      color: "#FF8A00",
+      lucide_icon: "utensils",
+      key: null,
+      created_at: "2026-01-02T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    }),
+
+    // Two DIFFERENT Sure merchants, same case-insensitive-duplicate shape.
+    envelope("Merchant", {
+      id: "sure-mer-per189-food-upper",
+      name: "Food Mart",
+      color: null,
+      logo_url: null,
+      source: "manual",
+      created_at: "2026-01-03T00:00:00Z",
+      updated_at: "2026-01-03T00:00:00Z",
+    }),
+    envelope("Merchant", {
+      id: "sure-mer-per189-food-lower",
+      name: "food mart",
+      color: null,
+      logo_url: null,
+      source: "manual",
+      created_at: "2026-01-03T00:00:00Z",
+      updated_at: "2026-01-03T00:00:00Z",
+    }),
+  ]
+
+  return {
+    ndjson: lines.join("\n"),
+    accountIds,
+    expected: { categoriesCreated: 2, merchantsCreated: 2 },
+  }
+}

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -25,6 +25,7 @@ import { createTestFactories, type TestFactories } from "./support/factories"
 import {
   buildLargeSureBundle,
   buildSureBundleAnchorEdgeCases,
+  buildSureBundleCiDuplicateNames,
   buildSureBundlePer182CarveOut,
   buildSureBundlePer182PreflightViolation,
   buildSureBundlePer184SplitParent,
@@ -1276,4 +1277,57 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
 
     await assertLedgerMatchesControl(tenant, control)
   }, 300_000)
+
+  // PER-189 follow-up (head-eng review, PR #158): the quick-create dedup
+  // index must never reach into migration-bound rows. Real Sure exports bind
+  // Category/Merchant identity by externalId, not name — two legitimately
+  // distinct entities can share a case-insensitive name ("Food" / "food").
+  // The dedup index now excludes externalProvider IS NOT NULL rows
+  // (migration `merchant_category_name_dedup_exempt_migrated`); this proves
+  // an import carrying such a pair creates BOTH rows instead of tripping the
+  // unique constraint.
+  test("PER-189: case-insensitive-duplicate Category/Merchant names across a migration import both get created", async () => {
+    const tenant = await setupTenant()
+    const fixture = buildSureBundleCiDuplicateNames()
+
+    const result = await migrate(
+      tenant,
+      "ci-duplicate-names.ndjson",
+      fixture.ndjson
+    )
+
+    expect(result.categories).toEqual({
+      created: fixture.expected.categoriesCreated,
+      reused: 0,
+    })
+    expect(result.merchants).toEqual({
+      created: fixture.expected.merchantsCreated,
+      reused: 0,
+    })
+
+    const categories = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.category.findMany({
+          where: { familyId: tenant.familyId, isSystem: false },
+          select: { name: true },
+        })
+    )
+    expect(categories.map((c) => c.name).sort()).toEqual(["Food", "food"])
+
+    const merchants = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.merchant.findMany({
+          where: { familyId: tenant.familyId },
+          select: { name: true },
+        })
+    )
+    expect(merchants.map((m) => m.name).sort()).toEqual([
+      "Food Mart",
+      "food mart",
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

- Daily bank-mutation entry was blocked whenever a merchant or category didn't exist yet: the transaction form had selectors but no way to create one inline (PER-189, P1 dogfooding finding).
- Added canonical `createMerchantFn` / `createCategoryFn` server fns (`src/server/merchants.ts`, `src/server/categories.ts`) mirroring the existing `createAccountFn` contract: `scopedTenantTransaction` + RLS GUC, Zod `.inputValidator`, `requireCapability("ledger:write")`, idempotency-key replay, append-only `AuditLog` row, and tenant-owned reference validation for `Category.parentId`.
- Added a case/whitespace-insensitive per-family duplicate-name boundary as a real DB invariant: a functional partial `UNIQUE INDEX (familyId, lower(btrim(name)))` on `Merchant` and `Category` (migration `merchant_category_name_dedup`), verified against the current dev/staging data set beforehand (zero collisions). App-level pre-check gives a clean `DuplicateNameError` (409); the index is the concurrent-request backstop, detected via a new shared `isNameDedupConstraintError` helper in `mutation-kit.ts`.
- Added a new `EntityCombobox` block (`src/components/blocks/entity-combobox.tsx`) on shadcn `Command` + `Popover` (added via `vp dlx shadcn@latest add command`) with an inline "Create merchant/category '\<name\>'" affordance, optimistic selection of the newly created row, and a "-- No Merchant / General --" clear option.
- Wired the combobox into `transaction-form-modal.tsx`'s `MerchantField` and `CategoryField` (main add/edit form, not the split-entry or FX-fee sub-pickers, which remain plain selects — out of scope for this slice). After create, the `["transactionFormData"]` query is invalidated so the new entity is immediately selectable.
- Domain scope note (head-eng decision recorded on the ticket): persons who are mere payment destinations are Merchants; persons with debt relationships are Accounts (loan/receivable). No new "People" entity.

## Testing

- [x] `vp check`
- [x] `vp test run` (425 unit tests, incl. 22 new: schema validation + `mutation-kit` dedup-error-detection helpers)
- [x] `vp run test:integration` (293 tests incl. 13 new, real Postgres — tenant isolation via RLS, audit rows, idempotency replay, duplicate-name rejection, parent/type validation)
- [x] `vp run test:e2e` (22 tests incl. 1 new — real browser → server fn → Postgres: add a transaction with a brand-new merchant *and* category, assert the persisted row renders both)
- [x] `vp build`

## Critical Finance Impact

- [x] This PR touches a critical finance/auth path and includes deterministic tests in the relevant suite.

Merchant/Category are ledger-adjacent dimensions (`Transaction.merchantId`/`categoryId`), so the new create paths follow the full mutation contract (ADR-0008): tenant-scoped transaction, RLS GUC, idempotency, audit log. Covered in `tests/integration/merchant-category-quick-create.integration.ts` (real Postgres): tenant isolation (family A cannot see or reference family B's rows), audit-row presence, idempotent-replay (no duplicate row on retry), and the new duplicate-name DB constraint.