### PR TITLE
fix(auth): PER-187 — redirect on session-loss instead of retrying UNAUTHENTICATED forever

### DIFF
--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -48,10 +48,22 @@ export function NavUser({
   // data, then land on the public landing at "/". On failure surface a toast
   // instead of leaving the user in silent limbo (the failure mode this ticket
   // exists to kill).
+  //
+  // PER-187 follow-up: this used to call `queryClient.invalidateQueries()`,
+  // which means "refetch this, it's still relevant" — but the session was
+  // just killed, so every actively-mounted query on this page (dashboard's
+  // net-worth/cash-flow/budget/etc.) immediately refetched against a dead
+  // session. `query-client.ts`'s global auth-error handler now hard-redirects
+  // to /login the instant one of those refetches fails, which raced (and
+  // beat) the `router.navigate({ to: "/" })` below. `clear()` matches what
+  // this code actually intends ("drop cached tenant data") — it empties the
+  // cache with no network calls, so there is nothing left to fail and
+  // nothing for that handler to react to.
   const logoutMutation = useMutation({
     mutationFn: () => logout(),
     onSuccess: async () => {
-      await Promise.all([queryClient.invalidateQueries(), router.invalidate()])
+      queryClient.clear()
+      await router.invalidate()
       await router.navigate({ to: "/" })
     },
     onError: () => {

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -1,0 +1,72 @@
+// PER-187: typed replacement for the bare `Error("UNAUTHENTICATED")` /
+// `Error("NOT_A_MEMBER")` / `Error("FORBIDDEN")` throws in
+// `src/server/middleware/session.ts` (the M3-5 "AppError" tech debt the
+// comments there already flagged). Lives outside `*.server.ts` on purpose:
+// it has no Prisma/secret/Node dependency, so both the server middleware and
+// the client-side query client can import it directly.
+//
+// NOTE on the client/server boundary (verified against the running dev
+// server, not assumed): TanStack Start's default seroval plugins include
+// `ShallowErrorPlugin` (@tanstack/router-core), which intercepts every
+// thrown `Error` crossing a server-fn RPC call and serializes ONLY
+// `.message` — `.name`, `.code`, and every other own property are dropped,
+// and the client deserializes to a plain `new Error(message)`. So across
+// that boundary, `.code` never survives and `instanceof AppError` is always
+// false. `.message` is the only field guaranteed to cross intact, which is
+// why `hasAuthErrorCode` below checks `.code` first (for same-process
+// callers, e.g. integration tests invoking server functions directly) and
+// falls back to `.message` (for the browser, post-RPC case this ticket is
+// about). Both checks compare against the same small closed enum below, not
+// a fuzzy substring — this is as "typed" a discriminator as this framework
+// boundary allows.
+export type AuthErrorCode = "UNAUTHENTICATED" | "NOT_A_MEMBER" | "FORBIDDEN"
+
+const AUTH_ERROR_CODES: ReadonlySet<string> = new Set<AuthErrorCode>([
+  "UNAUTHENTICATED",
+  "NOT_A_MEMBER",
+  "FORBIDDEN",
+])
+
+// Subset of AuthErrorCode that means the session itself is gone, as opposed
+// to FORBIDDEN (a valid session lacking a capability). Only this subset
+// should ever force a redirect to /login.
+const SESSION_LOSS_CODES: ReadonlySet<string> = new Set<AuthErrorCode>([
+  "UNAUTHENTICATED",
+  "NOT_A_MEMBER",
+])
+
+export class AppError extends Error {
+  readonly code: AuthErrorCode
+
+  constructor(code: AuthErrorCode, message?: string) {
+    super(message ?? code)
+    this.name = "AppError"
+    this.code = code
+  }
+}
+
+function extractAuthErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined
+  const ownCode = (error as { code?: unknown }).code
+  if (typeof ownCode === "string") return ownCode
+  // RPC-crossed errors lose everything but `.message` (see note above) —
+  // AppError's constructor defaults `message` to the code itself, so this
+  // still matches the exact canonical string, not a human sentence.
+  return error.message
+}
+
+// True for any typed auth-class error (UNAUTHENTICATED, NOT_A_MEMBER,
+// FORBIDDEN). None of these are ever transient, so callers should never
+// retry them.
+export function isAuthError(error: unknown): boolean {
+  const code = extractAuthErrorCode(error)
+  return code !== undefined && AUTH_ERROR_CODES.has(code)
+}
+
+// True only when the session itself is gone. Callers use this narrower
+// check to decide whether to force a redirect to /login; FORBIDDEN should
+// surface inline instead, since the user is still authenticated.
+export function isSessionLossError(error: unknown): boolean {
+  const code = extractAuthErrorCode(error)
+  return code !== undefined && SESSION_LOSS_CODES.has(code)
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,14 +1,49 @@
 // File: src/lib/query-client.ts
-import { QueryClient } from "@tanstack/react-query"
+import { QueryCache, QueryClient } from "@tanstack/react-query"
+import { isAuthError, isSessionLossError } from "./auth-errors"
+
+const LOGIN_PATH = "/login"
+
+// PER-187: every collection in src/lib/*-collections.ts shares this one
+// QueryClient singleton, so a single global handler here covers all of them
+// (transactions, accounts, balance-drift, and any future live collection) —
+// no per-collection auth handling needed.
+//
+// UNAUTHENTICATED/NOT_A_MEMBER mean the session itself is gone: no amount of
+// retrying fixes that, and the live query would otherwise retry forever
+// (TanStack Query's default backoff) while the app sits in a broken
+// half-authenticated state. A hard redirect (not router.navigate) is
+// deliberate: it guarantees this poisoned QueryClient singleton and every
+// collection's in-memory cache are torn down by the reload, rather than
+// risking one collection's cache surviving into the next session.
+//
+// FORBIDDEN is intentionally excluded from the redirect: that error means
+// the session is valid but the capability is missing, so sending the user to
+// /login would just bounce them straight back via _protected's guard. It
+// still skips retries below, since it is never transient either.
+function redirectToLoginOnSessionLoss(error: unknown): void {
+  if (typeof window === "undefined") return
+  if (!isSessionLossError(error)) return
+  if (window.location.pathname.startsWith(LOGIN_PATH)) return
+  window.location.assign(LOGIN_PATH)
+}
 
 // 1. ENTERPRISE SSR PATTERN: Factory pattern untuk keamanan SSR
 function makeQueryClient() {
   return new QueryClient({
+    queryCache: new QueryCache({
+      onError: redirectToLoginOnSessionLoss,
+    }),
     defaultOptions: {
       queries: {
         // Data tidak akan fetch ulang otomatis dalam 1 menit
         // untuk mencegah spam request ke backend
         staleTime: 60 * 1000,
+        // Auth-class errors are never transient — retrying UNAUTHENTICATED/
+        // NOT_A_MEMBER/FORBIDDEN can't succeed, it just spams the server
+        // until redirectToLoginOnSessionLoss above fires. Everything else
+        // keeps TanStack Query's default retry behavior (3 attempts).
+        retry: (failureCount, error) => !isAuthError(error) && failureCount < 3,
       },
     },
   })

--- a/src/server/middleware/session.ts
+++ b/src/server/middleware/session.ts
@@ -1,4 +1,5 @@
 import { createMiddleware } from "@tanstack/react-start"
+import { AppError } from "@/lib/auth-errors"
 import {
   resolveActiveMembership,
   roleCan,
@@ -21,7 +22,7 @@ export async function getSession() {
 export async function requireSession() {
   const session = await getSession()
   if (!session) {
-    throw new Error("UNAUTHENTICATED") // M3-5 will change this to AppError
+    throw new AppError("UNAUTHENTICATED")
   }
   return session
 }
@@ -48,7 +49,7 @@ export const familyMiddleware = createMiddleware()
       context.user.id
     )
     if (!membership) {
-      throw new Error("NOT_A_MEMBER")
+      throw new AppError("NOT_A_MEMBER")
     }
     const role: FamilyRole = membership.role
     return next({
@@ -72,7 +73,7 @@ export function requireCapability(capability: Capability) {
     .middleware([familyMiddleware])
     .server(async ({ next, context }) => {
       if (!roleCan(context.role, capability)) {
-        throw new Error("FORBIDDEN")
+        throw new AppError("FORBIDDEN")
       }
       return next()
     })

--- a/tests/e2e/auth-routes.e2e.ts
+++ b/tests/e2e/auth-routes.e2e.ts
@@ -1,198 +1,26 @@
-import { createHash, randomUUID } from "node:crypto"
-import type { Page, Request } from "@playwright/test"
 import { expect, test } from "./support/fixtures"
-
-const SERVER_FUNCTION_BASE_PATH = "/_serverFn/"
-
-interface SignupIdentity {
-  email: string
-  fullName: string
-  password: string
-  username: string
-}
-
-interface ServerFunctionMatcher {
-  displayName: string
-  paths: ReadonlySet<string>
-}
-
-interface ServerFunctionCall {
-  method: string
-  url: string
-}
-
-function createSignupIdentity(): SignupIdentity {
-  const suffix = randomUUID().replaceAll("-", "").slice(0, 12)
-  const generatedPassword = randomUUID().replaceAll("-", "")
-
-  return {
-    email: `e2e-${suffix}@permoney.test`,
-    fullName: `E2E User ${suffix}`,
-    password: `${generatedPassword.slice(0, 12)}A1a`,
-    username: `e2e_${suffix}`,
-  }
-}
-
-function createServerFunctionMatcher(options: {
-  exportName: string
-  sourcePath: string
-}): ServerFunctionMatcher {
-  const functionName = `${options.exportName}_createServerFn_handler`
-  const devId = Buffer.from(
-    JSON.stringify({
-      file: `/${options.sourcePath}?tss-serverfn-split`,
-      export: functionName,
-    }),
-    "utf8"
-  ).toString("base64url")
-  const buildId = createHash("sha256")
-    .update(`${options.sourcePath}--${functionName}`)
-    .digest("hex")
-
-  return {
-    displayName: options.exportName,
-    paths: new Set([
-      `${SERVER_FUNCTION_BASE_PATH}${devId}`,
-      `${SERVER_FUNCTION_BASE_PATH}${buildId}`,
-    ]),
-  }
-}
+import {
+  completeOnboarding,
+  expectDashboardRoute,
+  expectLoginRoute,
+  expectOnboardingRoute,
+  expectTransactionsErrorBoundaryAbsent,
+  expectTransactionsRoute,
+  login,
+  signUpWithoutFamily,
+  waitForHydration,
+} from "./support/auth-helpers"
+import {
+  createServerFunctionMatcher,
+  expectNoServerFunctionCalls,
+  expectServerFunctionCalled,
+  startServerFunctionRecorder,
+} from "./support/server-fn-recorder"
 
 const getTransactionsFnMatcher = createServerFunctionMatcher({
   exportName: "getTransactionsFn",
   sourcePath: "src/server/transactions.ts",
 })
-
-async function waitForHydration(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => document.documentElement.dataset.permoneyHydrated === "true"
-  )
-}
-
-function startServerFunctionRecorder(
-  page: Page,
-  matcher: ServerFunctionMatcher
-) {
-  const calls: Array<ServerFunctionCall> = []
-  const onRequest = (request: Request) => {
-    const url = new URL(request.url())
-    if (!matcher.paths.has(url.pathname)) return
-    calls.push({ method: request.method(), url: request.url() })
-  }
-
-  page.on("request", onRequest)
-
-  return {
-    calls,
-    stop: () => {
-      page.off("request", onRequest)
-    },
-  }
-}
-
-async function expectNoServerFunctionCalls(
-  recorder: ReturnType<typeof startServerFunctionRecorder>
-): Promise<void> {
-  await expect
-    .poll(() => recorder.calls.length, {
-      message: `${getTransactionsFnMatcher.displayName} must not be called`,
-      timeout: 500,
-    })
-    .toBe(0)
-}
-
-async function expectServerFunctionCalled(
-  recorder: ReturnType<typeof startServerFunctionRecorder>
-): Promise<void> {
-  await expect
-    .poll(() => recorder.calls.length, {
-      message: `${getTransactionsFnMatcher.displayName} should be called`,
-      timeout: 15_000,
-    })
-    .toBeGreaterThan(0)
-}
-
-async function expectLoginRoute(page: Page): Promise<void> {
-  await Promise.all([
-    expect(page).toHaveURL(/\/login(?:\?.*)?$/),
-    waitForHydration(page),
-  ])
-  await expect(page.getByRole("button", { name: "Login" })).toBeVisible()
-}
-
-async function expectOnboardingRoute(page: Page): Promise<void> {
-  await Promise.all([
-    expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/),
-    waitForHydration(page),
-  ])
-  await expect(
-    page.getByRole("heading", { name: "Welcome to Permoney" })
-  ).toBeVisible()
-}
-
-async function expectDashboardRoute(page: Page): Promise<void> {
-  await Promise.all([
-    expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/),
-    waitForHydration(page),
-  ])
-  // The route renders the title in the SiteHeader chrome AND as the page body
-  // heading (PER-156). Scope to the header so the assertion stays unambiguous.
-  await expect(
-    page.locator("header").getByRole("heading", { name: "Dashboard" })
-  ).toBeVisible()
-}
-
-async function expectTransactionsRoute(page: Page): Promise<void> {
-  await Promise.all([
-    expect(page).toHaveURL(/\/transactions(?:\?.*)?$/),
-    waitForHydration(page),
-  ])
-  await expect(
-    page.getByRole("heading", { name: "Transactions" })
-  ).toBeVisible()
-  await expect(page.getByLabel("Search transactions")).toBeVisible()
-}
-
-async function expectTransactionsErrorBoundaryAbsent(
-  page: Page
-): Promise<void> {
-  await expect(
-    page.getByRole("heading", { name: "Failed to load transactions" })
-  ).toHaveCount(0)
-}
-
-async function signUpWithoutFamily(page: Page): Promise<SignupIdentity> {
-  const identity = createSignupIdentity()
-
-  await page.goto("/signup")
-  await waitForHydration(page)
-  await page.getByLabel("Full Name").fill(identity.fullName)
-  await page.getByLabel("Username").fill(identity.username)
-  await page.getByLabel("Email").fill(identity.email)
-  await page.getByLabel("Password").fill(identity.password)
-  await page.getByRole("button", { name: "Create Account" }).click()
-  await expectOnboardingRoute(page)
-
-  return identity
-}
-
-async function completeOnboarding(page: Page): Promise<SignupIdentity> {
-  const identity = await signUpWithoutFamily(page)
-
-  await page.getByRole("button", { name: "Get Started" }).click()
-  await expectDashboardRoute(page)
-
-  return identity
-}
-
-async function login(page: Page, identity: SignupIdentity): Promise<void> {
-  await page.goto("/login")
-  await waitForHydration(page)
-  await page.getByLabel("Email").fill(identity.email)
-  await page.getByLabel("Password").fill(identity.password)
-  await page.getByRole("button", { name: "Login" }).click()
-  await expectDashboardRoute(page)
-}
 
 test.describe("core auth and transaction route smoke flows", () => {
   test("public user can open login and signup", async ({ page }) => {
@@ -235,7 +63,7 @@ test.describe("core auth and transaction route smoke flows", () => {
     await page.goto("/transactions")
     await expectLoginRoute(page)
     await expectTransactionsErrorBoundaryAbsent(page)
-    await expectNoServerFunctionCalls(ledgerRecorder)
+    await expectNoServerFunctionCalls(ledgerRecorder, getTransactionsFnMatcher)
     ledgerRecorder.stop()
   })
 
@@ -267,7 +95,7 @@ test.describe("core auth and transaction route smoke flows", () => {
     await page.goto("/transactions")
     await expectOnboardingRoute(page)
     await expectTransactionsErrorBoundaryAbsent(page)
-    await expectNoServerFunctionCalls(ledgerRecorder)
+    await expectNoServerFunctionCalls(ledgerRecorder, getTransactionsFnMatcher)
     ledgerRecorder.stop()
 
     await page.goto("/onboarding")
@@ -292,7 +120,7 @@ test.describe("core auth and transaction route smoke flows", () => {
 
     await page.goto("/transactions")
     await expectTransactionsRoute(page)
-    await expectServerFunctionCalled(ledgerRecorder)
+    await expectServerFunctionCalled(ledgerRecorder, getTransactionsFnMatcher)
     ledgerRecorder.stop()
 
     await page.context().clearCookies()

--- a/tests/e2e/session-expiry.e2e.ts
+++ b/tests/e2e/session-expiry.e2e.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "./support/fixtures"
+import {
+  completeOnboarding,
+  expectLoginRoute,
+  expectTransactionsRoute,
+} from "./support/auth-helpers"
+import {
+  createServerFunctionMatcher,
+  startServerFunctionRecorder,
+} from "./support/server-fn-recorder"
+
+// PER-187: deleting a transaction can hang the app. Root cause (see Linear
+// PER-187, head-eng comment 2026-07-12): `transactionCollection`
+// (src/lib/collections.ts) is an eager, always-mounted TanStack DB
+// `queryCollectionOptions` live query. `_protected.tsx`'s `beforeLoad` guard
+// only fires on fresh navigation, so once a session dies while the
+// transactions route is already mounted, the live query's background
+// observation starts failing with UNAUTHENTICATED — and with no redirect
+// handler and no retry cap, TanStack Query's default retry spun forever
+// with no escape hatch (the exact "hang" this test guards against).
+//
+// This does NOT navigate or reload to trigger the failure — that would only
+// exercise the route guard, which already worked. Instead it keeps the
+// /transactions tab mounted, kills the session under it, and fires the same
+// window-focus signal a real alt-tab-back-to-the-app produces, which is
+// what TanStack Query's `refetchOnWindowFocus` uses to decide whether to
+// re-observe an already-mounted, now-stale query.
+const getTransactionsFnMatcher = createServerFunctionMatcher({
+  exportName: "getTransactionsFn",
+  sourcePath: "src/server/transactions.ts",
+})
+
+test.describe("session expiry while a live query is mounted (PER-187)", () => {
+  test("transactions_live observing a dead session redirects to /login instead of hanging", async ({
+    page,
+  }) => {
+    // The repro needs the collection's queryClient staleTime (60s) to
+    // actually elapse before a focus event is eligible to trigger a
+    // background refetch, so this one test needs real wall-clock time.
+    test.setTimeout(120_000)
+
+    await completeOnboarding(page)
+    await page.goto("/transactions")
+    await expectTransactionsRoute(page)
+
+    const recorder = startServerFunctionRecorder(page, getTransactionsFnMatcher)
+
+    // Kill the session while the tab stays mounted and the live query keeps
+    // observing — this is the exact condition the route-level guard cannot
+    // reach, since no navigation happens here.
+    await page.context().clearCookies()
+
+    // Let the already-fetched transactions_live query cross its staleTime
+    // (60s) so the next focus signal is eligible for a background refetch,
+    // then fire that signal.
+    await page.waitForTimeout(61_000)
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    // The fix: the first observation of the now-dead session redirects
+    // immediately instead of retrying.
+    await expectLoginRoute(page)
+
+    // And it must not have spun through a retry storm to get there.
+    expect(recorder.calls.length).toBeLessThanOrEqual(2)
+    recorder.stop()
+  })
+})

--- a/tests/e2e/support/auth-helpers.ts
+++ b/tests/e2e/support/auth-helpers.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto"
+import { expect, type Page } from "@playwright/test"
+
+export interface SignupIdentity {
+  email: string
+  fullName: string
+  password: string
+  username: string
+}
+
+export function createSignupIdentity(): SignupIdentity {
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 12)
+  const generatedPassword = randomUUID().replaceAll("-", "")
+
+  return {
+    email: `e2e-${suffix}@permoney.test`,
+    fullName: `E2E User ${suffix}`,
+    password: `${generatedPassword.slice(0, 12)}A1a`,
+    username: `e2e_${suffix}`,
+  }
+}
+
+export async function waitForHydration(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => document.documentElement.dataset.permoneyHydrated === "true"
+  )
+}
+
+export async function expectLoginRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/login(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(page.getByRole("button", { name: "Login" })).toBeVisible()
+}
+
+export async function expectOnboardingRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(
+    page.getByRole("heading", { name: "Welcome to Permoney" })
+  ).toBeVisible()
+}
+
+export async function expectDashboardRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  // The route renders the title in the SiteHeader chrome AND as the page body
+  // heading (PER-156). Scope to the header so the assertion stays unambiguous.
+  await expect(
+    page.locator("header").getByRole("heading", { name: "Dashboard" })
+  ).toBeVisible()
+}
+
+export async function expectTransactionsRoute(page: Page): Promise<void> {
+  await Promise.all([
+    expect(page).toHaveURL(/\/transactions(?:\?.*)?$/),
+    waitForHydration(page),
+  ])
+  await expect(
+    page.getByRole("heading", { name: "Transactions" })
+  ).toBeVisible()
+  await expect(page.getByLabel("Search transactions")).toBeVisible()
+}
+
+export async function expectTransactionsErrorBoundaryAbsent(
+  page: Page
+): Promise<void> {
+  await expect(
+    page.getByRole("heading", { name: "Failed to load transactions" })
+  ).toHaveCount(0)
+}
+
+export async function signUpWithoutFamily(page: Page): Promise<SignupIdentity> {
+  const identity = createSignupIdentity()
+
+  await page.goto("/signup")
+  await waitForHydration(page)
+  await page.getByLabel("Full Name").fill(identity.fullName)
+  await page.getByLabel("Username").fill(identity.username)
+  await page.getByLabel("Email").fill(identity.email)
+  await page.getByLabel("Password").fill(identity.password)
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expectOnboardingRoute(page)
+
+  return identity
+}
+
+export async function completeOnboarding(page: Page): Promise<SignupIdentity> {
+  const identity = await signUpWithoutFamily(page)
+
+  await page.getByRole("button", { name: "Get Started" }).click()
+  await expectDashboardRoute(page)
+
+  return identity
+}
+
+export async function login(
+  page: Page,
+  identity: SignupIdentity
+): Promise<void> {
+  await page.goto("/login")
+  await waitForHydration(page)
+  await page.getByLabel("Email").fill(identity.email)
+  await page.getByLabel("Password").fill(identity.password)
+  await page.getByRole("button", { name: "Login" }).click()
+  await expectDashboardRoute(page)
+}

--- a/tests/e2e/support/fixtures.ts
+++ b/tests/e2e/support/fixtures.ts
@@ -8,6 +8,12 @@ const FORBIDDEN_CONSOLE_FRAGMENTS = [
   "SECURITY BREACH",
   "PrismaClient is unable to run in this browser",
   "Calling 'require' for '.prisma/client/index-browser'",
+  // PER-187: the router TypeError reported alongside the UNAUTHENTICATED
+  // live-query hang. Root-cause analysis judged it a downstream symptom of
+  // the auth-error retry storm, not an independent router bug — this
+  // fragment turns that judgment into a standing regression check across
+  // every e2e spec, instead of a one-off manual confirmation.
+  "reading '_nonReactive'",
 ] as const
 
 function containsForbiddenFragment(message: string): boolean {

--- a/tests/e2e/support/server-fn-recorder.ts
+++ b/tests/e2e/support/server-fn-recorder.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto"
+import { expect, type Page, type Request } from "@playwright/test"
+
+const SERVER_FUNCTION_BASE_PATH = "/_serverFn/"
+
+export interface ServerFunctionMatcher {
+  displayName: string
+  paths: ReadonlySet<string>
+}
+
+interface ServerFunctionCall {
+  method: string
+  url: string
+}
+
+export function createServerFunctionMatcher(options: {
+  exportName: string
+  sourcePath: string
+}): ServerFunctionMatcher {
+  const functionName = `${options.exportName}_createServerFn_handler`
+  const devId = Buffer.from(
+    JSON.stringify({
+      file: `/${options.sourcePath}?tss-serverfn-split`,
+      export: functionName,
+    }),
+    "utf8"
+  ).toString("base64url")
+  const buildId = createHash("sha256")
+    .update(`${options.sourcePath}--${functionName}`)
+    .digest("hex")
+
+  return {
+    displayName: options.exportName,
+    paths: new Set([
+      `${SERVER_FUNCTION_BASE_PATH}${devId}`,
+      `${SERVER_FUNCTION_BASE_PATH}${buildId}`,
+    ]),
+  }
+}
+
+export function startServerFunctionRecorder(
+  page: Page,
+  matcher: ServerFunctionMatcher
+) {
+  const calls: Array<ServerFunctionCall> = []
+  const onRequest = (request: Request) => {
+    const url = new URL(request.url())
+    if (!matcher.paths.has(url.pathname)) return
+    calls.push({ method: request.method(), url: request.url() })
+  }
+
+  page.on("request", onRequest)
+
+  return {
+    calls,
+    stop: () => {
+      page.off("request", onRequest)
+    },
+  }
+}
+
+export async function expectNoServerFunctionCalls(
+  recorder: ReturnType<typeof startServerFunctionRecorder>,
+  matcher: ServerFunctionMatcher
+): Promise<void> {
+  await expect
+    .poll(() => recorder.calls.length, {
+      message: `${matcher.displayName} must not be called`,
+      timeout: 500,
+    })
+    .toBe(0)
+}
+
+export async function expectServerFunctionCalled(
+  recorder: ReturnType<typeof startServerFunctionRecorder>,
+  matcher: ServerFunctionMatcher
+): Promise<void> {
+  await expect
+    .poll(() => recorder.calls.length, {
+      message: `${matcher.displayName} should be called`,
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0)
+}


### PR DESCRIPTION
## Summary

Fixes PER-187 ("Deleting a transaction can hang the app"). Root cause (traced through code, per head-eng comment on the ticket, not re-diagnosed): `requireSession()`/`familyMiddleware`/`requireCapability` in `src/server/middleware/session.ts` threw bare `Error("UNAUTHENTICATED"/"NOT_A_MEMBER"/"FORBIDDEN")` (self-flagged M3-5 tech debt). `transactionCollection` (`src/lib/collections.ts`, `queryCollectionOptions`, `syncMode: "eager"`) is a background TanStack Query live observation that the route-level `_protected.tsx` auth guard never sees (that guard only fires on fresh navigation). Once a mounted session died, the live query kept observing the auth failure with no redirect and no retry cap — `query-client.ts` had no custom `retry`/`onError` — producing an unbounded retry loop and a half-authenticated hang.

- **`src/lib/auth-errors.ts`** (new): `AppError` + `AuthErrorCode` (`UNAUTHENTICATED` / `NOT_A_MEMBER` / `FORBIDDEN`), `isAuthError` (all three — none are ever transient) and `isSessionLossError` (the `UNAUTHENTICATED`/`NOT_A_MEMBER` subset — `FORBIDDEN` means the session is *valid* but lacks a capability, so it must not redirect to login).
  - **Load-bearing finding, verified against the running dev server, not assumed**: TanStack Start's default seroval plugins include `ShallowErrorPlugin` (`@tanstack/router-core`), which intercepts every thrown `Error` crossing a server-fn RPC call and serializes **only** `.message` — `.name`, `.code`, everything else is dropped, and the client deserializes to a plain `new Error(message)`. So `.code`/`instanceof AppError` never survive the browser round trip; the client-side check matches on `.message` against the same closed enum (falling back from `.code` first, which does work for same-process callers like integration tests calling server functions directly).
- **`src/server/middleware/session.ts`**: the three bare `Error(...)` throws now throw `AppError(...)`.
- **`src/lib/query-client.ts`**: the shared `QueryClient` singleton (used by every collection — transactions, accounts, balance-drift) now has a `QueryCache.onError` that hard-redirects (`window.location.assign`, not a soft router nav — guarantees the poisoned client + every collection cache is torn down) to `/login` for session-loss errors only, and a `retry` function that skips retries for any auth-class error while preserving the default `failureCount < 3` behavior otherwise.
- **e2e**: new `tests/e2e/session-expiry.e2e.ts` mounts `/transactions` (live query active), kills the session under it (no navigation — the exact condition the route guard can't reach), forces the same window-focus signal a real alt-tab produces, and asserts a redirect to `/login` instead of a hang, with no retry storm. Shared auth helpers extracted from `auth-routes.e2e.ts` into `tests/e2e/support/auth-helpers.ts` / `server-fn-recorder.ts` for reuse. `tests/e2e/support/fixtures.ts` now hard-fails any spec that reproduces the reported router `_nonReactive` TypeError — judged a downstream symptom of the retry storm rather than an independent bug, and this turns that judgment into a standing regression check instead of a one-off manual confirmation.

Design decisions (FORBIDDEN scope, hard vs. soft redirect) were locked via an interview before implementation, since this touches every live collection, not just transactions.

## Test plan
- [x] `vp check` — clean
- [x] `vp test` (unit) — 425/425 passed
- [x] `vp test run --config vitest.integration.config.ts` (real Postgres) — 294/294 passed (one scale test needed an isolated re-run to rule out resource contention from parallel test runs; confirmed unrelated and passing)
- [x] `vp build` — succeeded
- [x] `vp exec playwright test tests/e2e/auth-routes.e2e.ts` — 7/7 passed (no regression)
- [x] `vp exec playwright test tests/e2e/session-expiry.e2e.ts` — new PER-187 regression test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)