### PR TITLE
ci: fix React Doctor workflow permissions + invalid token input

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -7,6 +7,7 @@ permissions:
   checks: write # required to create/update the React Doctor check run
   contents: read
   pull-requests: write # required to post PR comments
+  statuses: write # required to publish the commit status (was missing — caused "Resource not accessible by integration")
 
 jobs:
   react-doctor:
@@ -18,4 +19,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: millionco/react-doctor@e2393c4a6b842efc72d5c225273c0de918a13450
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # `token` is not a recognized input for this action (valid inputs:
+          # directory/project/scope/blocking/comment/review-comments/
+          # commit-status/node-version/version) — it was silently ignored and
+          # the action authenticates via the default GITHUB_TOKEN env the
+          # runner already provides. Removed to stop the "Unexpected input(s)
+          # 'token'" warning on every run.
+          commit-status: true


### PR DESCRIPTION
## Summary
- react-doctor CI check has been failing on every PR — traced it to two real misconfigurations in our own workflow file, not an upstream scanner issue as I'd previously (wrongly) told the user.
- Missing `statuses: write` permission → "Resource not accessible by integration" when the action tries to publish its commit status.
- `token: ${{ secrets.GITHUB_TOKEN }}` is not a recognized input for this action version — silently ignored every run, replaced with the actual `commit-status: true` input.

## Why now
Surfaced while reviewing PR #159 (PER-187) — wanted to actually verify this advisory failure instead of continuing to wave it off.

## Test plan
- [x] Pushed to a branch; will confirm the check passes on a real PR run (this one) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1