### PR TITLE
fix(identity): PER-186 — sidebar and Sure importer show the real signed-in identity

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
 import {
   IconChartBar,
   IconDashboard,
@@ -23,18 +24,13 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { getSettingsOverviewFn, SETTINGS_OVERVIEW_KEY } from "@/server/settings"
 
 // Kita ubah data navigasinya khusus untuk Permoney
 const data: {
-  user: { name: string; email: string; avatar: string }
   navMain: NavItem[]
   navSecondary: NavItem[]
 } = {
-  user: {
-    name: "Hendri Permana",
-    email: "hendripermana13@gmail.com",
-    avatar: "/avatars/shadcn.jpg", // Nanti bisa diganti foto profilmu
-  },
   navMain: [
     {
       title: "Dashboard",
@@ -77,6 +73,16 @@ const data: {
 }
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  // PER-186 — the sidebar is the one surface visible on every protected page,
+  // so it's the canonical place to show WHICH account is live. Reading the
+  // real session identity (instead of a hardcoded name/email) is the actual
+  // fix: a multi-account user must never see a plausible-looking identity
+  // that isn't the one they're actually acting as.
+  const { data: overview } = useQuery({
+    queryKey: SETTINGS_OVERVIEW_KEY,
+    queryFn: () => getSettingsOverviewFn(),
+  })
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
@@ -105,7 +111,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        <NavUser
+          user={
+            overview
+              ? {
+                  name: overview.profile.name,
+                  email: overview.profile.email,
+                  avatar: overview.profile.image,
+                }
+              : undefined
+          }
+        />
       </SidebarFooter>
     </Sidebar>
   )

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   RiMore2Line,
   RiUserLine,
@@ -27,15 +28,29 @@ import { useServerFn } from "@tanstack/react-start"
 import { toast } from "sonner"
 import { logoutFn } from "@/server/auth-fns"
 
-export function NavUser({
-  user,
-}: {
-  user: {
-    name: string
-    email: string
-    avatar: string
+// PER-186 — a multi-account user cannot tell which account is live from a name
+// alone (two Permoney accounts belonging to the same person share a display
+// name). Initials come from the email local-part when it's ambiguous, so the
+// avatar itself doesn't repeat the same misleading "same person" impression.
+function initialsFor(name: string, email: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length >= 2) {
+    return (words[0][0] + words[1][0]).toUpperCase()
   }
-}) {
+  if (words.length === 1 && words[0].length >= 2) {
+    return words[0].slice(0, 2).toUpperCase()
+  }
+  const local = email.split("@")[0] ?? ""
+  return (local.slice(0, 2) || "?").toUpperCase()
+}
+
+export interface NavUserIdentity {
+  name: string
+  email: string
+  avatar?: string | null
+}
+
+export function NavUser({ user }: { user: NavUserIdentity | undefined }) {
   const { isMobile } = useSidebar()
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -71,6 +86,29 @@ export function NavUser({
     },
   })
 
+  // PER-186 — the sidebar identity is fetched from the server on mount (see
+  // AppSidebar), so there's a brief window with no data yet. Show a skeleton
+  // rather than a placeholder name/email: a fake-but-plausible identity in
+  // that gap is exactly the kind of "looks like a real account" ambiguity
+  // this ticket exists to remove.
+  if (!user) {
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton size="lg" disabled className="cursor-default">
+            <Skeleton className="h-8 w-8 shrink-0 rounded-lg" />
+            <div className="grid flex-1 gap-1.5">
+              <Skeleton className="h-3.5 w-24 rounded" />
+              <Skeleton className="h-3 w-32 rounded" />
+            </div>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    )
+  }
+
+  const initials = initialsFor(user.name, user.email)
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
@@ -81,8 +119,10 @@ export function NavUser({
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
               <Avatar className="h-8 w-8 rounded-lg grayscale">
-                <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
+                <AvatarFallback className="rounded-lg">
+                  {initials}
+                </AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
@@ -102,8 +142,10 @@ export function NavUser({
             <DropdownMenuLabel className="p-0 font-normal">
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
-                  <AvatarImage src={user.avatar} alt={user.name} />
-                  <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                  <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
+                  <AvatarFallback className="rounded-lg">
+                    {initials}
+                  </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">{user.name}</span>

--- a/src/routes/_protected/-sure-import-ui.test.tsx
+++ b/src/routes/_protected/-sure-import-ui.test.tsx
@@ -2,8 +2,9 @@
 import { afterEach, describe, expect, it } from "vite-plus/test"
 import { cleanup, render, screen } from "@testing-library/react"
 
-import { DoneStage } from "./-sure-import-ui"
+import { DoneStage, ReviewStage } from "./-sure-import-ui"
 import type { SureMigrationResult } from "@/server/sure-migration"
+import type { SureBundlePreview } from "@/lib/sure-migration"
 
 // PER-171 — the Done screen must read as success in the real-world degraded case
 // where a bundle stages accounts/categories/merchants but promotes ZERO
@@ -128,5 +129,79 @@ describe("DoneStage", () => {
     expect(screen.getByText("Already imported")).toBeTruthy()
     expect(screen.getByText(/nothing was duplicated/i)).toBeTruthy()
     expect(screen.queryByText("Accounts & details imported")).toBeNull()
+  })
+})
+
+// PER-186 — the confirm step is exactly where the original incident happened
+// (import landed in the wrong account, silently). These prove the acting
+// identity is always named at that step, never silently omitted.
+function makePreview(
+  overrides: Partial<SureBundlePreview> = {}
+): SureBundlePreview {
+  return {
+    accounts: { total: 2, importable: 2, held: 0 },
+    categories: 3,
+    merchants: 1,
+    transactions: {
+      total: 5,
+      promotable: 5,
+      held: 0,
+      heldByReason: {
+        transfer: 0,
+        split: 0,
+        splitParent: 0,
+        nonImportableAccount: 0,
+        currencyMismatch: 0,
+      },
+      zeroAmountSkipped: 0,
+      invalidDateSkipped: 0,
+      unmappable: 0,
+    },
+    transfers: 0,
+    valuations: 0,
+    malformedLines: 0,
+    ignoredEntities: {},
+    ...overrides,
+  }
+}
+
+describe("ReviewStage", () => {
+  it("names the acting identity the import will land under", () => {
+    render(
+      <ReviewStage
+        fileName="all.ndjson"
+        preview={makePreview()}
+        actingEmail="hendri@permana.icu"
+        onBack={noop}
+        onConfirm={noop}
+        running={false}
+      />
+    )
+
+    expect(screen.getByText("hendri@permana.icu")).toBeTruthy()
+    expect(
+      screen.getByText(
+        (_, el) =>
+          el?.tagName === "SPAN" &&
+          el.textContent === "Importing into hendri@permana.icu's family."
+      )
+    ).toBeTruthy()
+  })
+
+  it("falls back to a neutral message while the identity is still loading", () => {
+    render(
+      <ReviewStage
+        fileName="all.ndjson"
+        preview={makePreview()}
+        actingEmail={undefined}
+        onBack={noop}
+        onConfirm={noop}
+        running={false}
+      />
+    )
+
+    expect(
+      screen.getByText("Importing into your family.", { selector: "span" })
+    ).toBeTruthy()
   })
 })

--- a/src/routes/_protected/-sure-import-ui.tsx
+++ b/src/routes/_protected/-sure-import-ui.tsx
@@ -18,6 +18,7 @@ import {
   ShieldCheck,
   Store,
   Tags,
+  UserRound,
   Wallet,
 } from "lucide-react"
 
@@ -203,12 +204,15 @@ export function UploadStage({
 export function ReviewStage({
   fileName,
   preview,
+  actingEmail,
   onBack,
   onConfirm,
   running,
 }: {
   fileName: string
   preview: SureBundlePreview
+  /** The signed-in identity this import will land under (PER-186). */
+  actingEmail: string | undefined
   onBack: () => void
   onConfirm: () => void
   running: boolean
@@ -229,6 +233,24 @@ export function ReviewStage({
       <p className="text-sm text-muted-foreground">
         Reviewing <span className="font-semibold">{fileName}</span>
       </p>
+
+      {/* PER-186 — a mistaken-identity import feels identical to a data leak
+          from the user's seat, so the acting account is named right where the
+          user commits to importing, not buried in a menu they'd have to think
+          to check. */}
+      <div className="flex items-center gap-2 rounded-2xl border border-border bg-muted/40 px-4 py-3 text-sm">
+        <UserRound size={16} className="shrink-0 text-muted-foreground" />
+        {actingEmail ? (
+          <span>
+            Importing into <span className="font-semibold">{actingEmail}</span>
+            &apos;s family.
+          </span>
+        ) : (
+          <span className="text-muted-foreground">
+            Importing into your family.
+          </span>
+        )}
+      </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Crossing now */}

--- a/src/routes/_protected/import_.sure.tsx
+++ b/src/routes/_protected/import_.sure.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
 
 import { AppSidebar } from "@/components/app-sidebar"
@@ -9,6 +9,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { parseSureBundle, summarizeSureBundle } from "@/lib/sure-migration"
 import { runSureMigrationFn } from "@/server/sure-migration"
+import { getSettingsOverviewFn, SETTINGS_OVERVIEW_KEY } from "@/server/settings"
 import { transactionCollection } from "@/lib/collections"
 import {
   DoneStage,
@@ -47,6 +48,16 @@ const MAX_BUNDLE_BYTES = 64 * 1024 * 1024
 
 function SureImportPage() {
   const router = useRouter()
+
+  // PER-186 — the confirm step is the exact place the original incident
+  // happened (import landed in the wrong account, silently, because nothing on
+  // screen said which family it was going into). Shares the sidebar's
+  // SETTINGS_OVERVIEW_KEY cache entry, so this is normally already resolved by
+  // the time the user reaches the review stage — no extra request.
+  const { data: overview } = useQuery({
+    queryKey: SETTINGS_OVERVIEW_KEY,
+    queryFn: () => getSettingsOverviewFn(),
+  })
 
   const [stage, setStage] = React.useState<Stage>("upload")
   const [fileName, setFileName] = React.useState("")
@@ -132,6 +143,7 @@ function SureImportPage() {
               <ReviewStage
                 fileName={fileName}
                 preview={preview}
+                actingEmail={overview?.profile.email}
                 onBack={restart}
                 onConfirm={() => runMutation.mutate()}
                 running={runMutation.isPending}

--- a/src/routes/_protected/settings/family.tsx
+++ b/src/routes/_protected/settings/family.tsx
@@ -27,9 +27,9 @@ import {
 } from "@/components/ui/select"
 import {
   getSettingsOverviewFn,
+  SETTINGS_OVERVIEW_KEY,
   updateFamilyPreferencesFn,
 } from "@/server/settings"
-import { SETTINGS_OVERVIEW_KEY } from "./index"
 
 export const Route = createFileRoute("/_protected/settings/family")({
   ssr: false,

--- a/src/routes/_protected/settings/index.tsx
+++ b/src/routes/_protected/settings/index.tsx
@@ -24,9 +24,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
-import { getSettingsOverviewFn } from "@/server/settings"
-
-export const SETTINGS_OVERVIEW_KEY = ["settings-overview"] as const
+import { getSettingsOverviewFn, SETTINGS_OVERVIEW_KEY } from "@/server/settings"
 
 export const Route = createFileRoute("/_protected/settings/")({
   ssr: false,

--- a/src/routes/_protected/settings/profile.tsx
+++ b/src/routes/_protected/settings/profile.tsx
@@ -23,10 +23,10 @@ import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import {
   getSettingsOverviewFn,
+  SETTINGS_OVERVIEW_KEY,
   updateProfileFn,
   type Theme,
 } from "@/server/settings"
-import { SETTINGS_OVERVIEW_KEY } from "./index"
 
 export const Route = createFileRoute("/_protected/settings/profile")({
   ssr: false,

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -63,12 +63,20 @@ export interface FamilyPreferences {
 export interface ProfilePreferences {
   name: string
   email: string
+  image: string | null
   theme: Theme
 }
 export interface SettingsOverview {
   family: FamilyPreferences
   profile: ProfilePreferences
 }
+
+// PER-186 — shared react-query key for the current user's identity (name,
+// email, avatar). Defined once here, next to `getSettingsOverviewFn`, so every
+// consumer (settings pages, the sidebar identity indicator, the Sure importer
+// confirm step) reads the SAME cache entry instead of re-fetching or drifting
+// out of sync with each other.
+export const SETTINGS_OVERVIEW_KEY = ["settings-overview"] as const
 
 // ---------------------------------------------------------------------------
 // Domain helpers (test-injectable tenant runner, exactly like family-members).
@@ -90,13 +98,14 @@ export async function readSettingsOverviewForFamily({
     })
     const user = await tx.user.findUniqueOrThrow({
       where: { id: userId },
-      select: { name: true, email: true, theme: true },
+      select: { name: true, email: true, image: true, theme: true },
     })
     return {
       family: { currency: family.currency, timezone: family.timezone },
       profile: {
         name: user.name,
         email: user.email,
+        image: user.image,
         theme: normalizeTheme(user.theme),
       },
     }
@@ -155,12 +164,12 @@ export async function updateProfileForUser({
   return await runInTenantTransaction(familyId, userId, async (tx) => {
     const before = await tx.user.findUniqueOrThrow({
       where: { id: userId },
-      select: { name: true, email: true, theme: true },
+      select: { name: true, email: true, image: true, theme: true },
     })
     const after = await tx.user.update({
       where: { id: userId },
       data: { name: data.name, theme: data.theme },
-      select: { name: true, email: true, theme: true },
+      select: { name: true, email: true, image: true, theme: true },
     })
     await auditLog(tx, auditCtx, {
       action: "update",
@@ -172,6 +181,7 @@ export async function updateProfileForUser({
     return {
       name: after.name,
       email: after.email,
+      image: after.image,
       theme: normalizeTheme(after.theme),
     }
   })

--- a/tests/e2e/public-surface.e2e.ts
+++ b/tests/e2e/public-surface.e2e.ts
@@ -109,14 +109,19 @@ test.describe("public surface & auth UX cohesion", () => {
   })
 
   test("logout from the app lands on the public landing", async ({ page }) => {
-    await onboard(page)
+    const identity = await onboard(page)
     await page.goto("/dashboard")
     await waitForHydration(page)
 
     // Open the sidebar user menu, then choose Log out. Goes through the logoutFn
     // server function (relative path) — proves it no longer silently fails the
     // way the old :3006-pinned auth-client signOut did off the dev port.
-    await page.getByRole("button", { name: /Hendri Permana/ }).click()
+    // PER-186 — the trigger's accessible name is now the REAL signed-in
+    // identity (previously a hardcoded "Hendri Permana" that every account
+    // showed regardless of who was actually logged in).
+    await page
+      .getByRole("button", { name: new RegExp(identity.fullName) })
+      .click()
     await page.getByRole("menuitem", { name: "Log out" }).click()
 
     await expect(page).toHaveURL(/\/(?:\?.*)?$/)

--- a/tests/e2e/settings.e2e.ts
+++ b/tests/e2e/settings.e2e.ts
@@ -82,4 +82,32 @@ test.describe("settings hub & nav cohesion", () => {
     await page.getByRole("button", { name: "Save timezone" }).click()
     await expect(page.getByText("Timezone updated.")).toBeVisible()
   })
+
+  // PER-186 — dogfooding incident: the sidebar showed a hardcoded name/email
+  // on every account, so a multi-account user genuinely could not tell which
+  // account a tab was signed in as. This proves the sidebar reads the REAL
+  // signed-in identity, and that it survives a real logout → login round trip
+  // (not just whatever session state happened to exist right after signup).
+  test("shows the real signed-in identity in the sidebar after logging back in", async ({
+    page,
+  }) => {
+    const identity = await onboard(page)
+
+    await page
+      .getByRole("button", { name: new RegExp(identity.fullName) })
+      .click()
+    await page.getByRole("menuitem", { name: "Log out" }).click()
+    await expect(page).toHaveURL(/\/(?:\?.*)?$/)
+
+    await page.goto("/login")
+    await waitForHydration(page)
+    await page.getByLabel("Email").fill(identity.email)
+    await page.getByLabel("Password").fill(identity.password)
+    await page.getByRole("button", { name: "Login" }).click()
+    await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
+    await waitForHydration(page)
+
+    await expect(page.getByText(identity.email)).toBeVisible()
+    await expect(page.getByText(new RegExp(identity.fullName))).toBeVisible()
+  })
 })

--- a/tests/e2e/support/onboarding.ts
+++ b/tests/e2e/support/onboarding.ts
@@ -32,7 +32,7 @@ export async function waitForHydration(page: Page): Promise<void> {
 }
 
 /** Sign up a fresh user and complete onboarding, ending on /dashboard. */
-export async function onboard(page: Page): Promise<void> {
+export async function onboard(page: Page): Promise<Identity> {
   const identity = createIdentity()
   await page.goto("/signup")
   await waitForHydration(page)
@@ -46,4 +46,5 @@ export async function onboard(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Get Started" }).click()
   await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
   await waitForHydration(page)
+  return identity
 }

--- a/tests/e2e/sure-migration.e2e.ts
+++ b/tests/e2e/sure-migration.e2e.ts
@@ -15,7 +15,7 @@ test.describe("Sure guided migration", () => {
   test("upload → honest preview → promote → idempotent re-run", async ({
     page,
   }) => {
-    await onboard(page)
+    const identity = await onboard(page)
 
     // 1. The CSV import page links to the guided Sure importer (entry point).
     await page.goto("/import")
@@ -40,6 +40,14 @@ test.describe("Sure guided migration", () => {
     await expect(page.getByText(/A few balances won't match yet/)).toBeVisible()
     // Every bucket reconciles back to the file total — no unexplained gap.
     await expect(page.getByText(/transactions in this file/)).toBeVisible()
+
+    // 3b. PER-186 — the confirm step is exactly where the original incident
+    // happened (import silently landed in the wrong account). The acting
+    // identity must be named right here, not just somewhere in the sidebar.
+    // Scoped to <main> (SidebarInset) since the sidebar's own identity
+    // indicator shows the SAME email at the same time — both are correct,
+    // but the assertion needs to target the confirm-step banner specifically.
+    await expect(page.getByRole("main").getByText(identity.email)).toBeVisible()
 
     // 4. Confirm: the 3 promotable standard rows import (expense + income on
     // the depository, plus the Investment account's standard txn — ADR-0043


### PR DESCRIPTION
## Summary

- `AppSidebar`/`NavUser` no longer show a hardcoded name/email/avatar — they read the real signed-in identity via `getSettingsOverviewFn`, with a loading skeleton (not a plausible-looking placeholder) while it resolves.
- The Sure importer's confirm step ("Review") now names the acting identity — "Importing into `<email>`'s family" — right where the original incident happened.
- Fixed a now-stale `public-surface.e2e.ts` assertion that hardcoded the old fake "Hendri Permana" name (a real regression this PR would otherwise have introduced).

## Context (PER-186, P1)

Dogfooding finding #5: the creator had 3 local accounts, imported his Sure bundle while unknowingly logged in as the wrong one, then saw "another user's data" and reported a suspected tenant leak. Head-eng verified at the DB level: isolation is perfect. The real bug — nothing in the UI showed which account/email was live, so a multi-account user genuinely could not tell. Recurred a second time while testing the PER-187 fix (2026-07-17), confirming this is not a nice-to-have.

Root cause: `src/components/app-sidebar.tsx` had a hardcoded `data.user = { name: "Hendri Permana", email: "hendripermana13@gmail.com", avatar: "/avatars/shadcn.jpg" }` object — every account, on every page, showed the exact same fake identity regardless of who was actually logged in.

Out of scope (per ticket): account switcher / multi-session UI. This PR only makes the current identity always visible and correct.

## Testing

- [x] `vp check`
- [x] `vp test` (427 unit tests)
- [x] `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:integration` (294 tests, real Postgres)
- [x] `PERMONEY_TEST_ADMIN_PASSWORD=permoney vp run test:e2e` — full local suite, 24/24 passing (not a subset — PER-187 logout regression precedent)
- [x] `vp build`

New coverage:
- `src/routes/_protected/-sure-import-ui.test.tsx` — `ReviewStage` names the acting identity, falls back to a neutral message while it's loading.
- `tests/e2e/settings.e2e.ts` — sidebar shows the real signed-in identity after a genuine logout → login round trip.
- `tests/e2e/sure-migration.e2e.ts` — confirm step shows the acting identity's email.

## Critical Finance Impact

- [x] This PR does not touch ledger mutation, balance updates, RLS, idempotency, audit logging, or auth guards.

This is a UI-only identity-visibility fix: it reads the existing tenant-scoped `getSettingsOverviewFn` (already RLS/tenant-guarded) and adds one field (`User.image`) to its select. No ledger, balance, or auth-guard code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3iKRpgBPM8PwRTCw6QzPM