### PR TITLE
fix(deploy): PER-192 — Dockerfile missing git/openssl, breaking the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,14 @@
 FROM node:24-bookworm-slim AS build
 WORKDIR /app
 
+# git: the package.json "prepare" lifecycle script (`vp config`) shells out to
+# git. openssl: Prisma's engine-selection at `prisma generate` time probes
+# libssl and silently defaults to the wrong variant without it (CI's
+# ubuntu-latest runners have both preinstalled already, which is why this
+# never surfaced there).
+RUN apt-get update && apt-get install -y --no-install-recommends git openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable
 
 # Layer-cache dependency install separately from source changes.
@@ -38,6 +46,12 @@ RUN pnpm run build
 # -----------------------------------------------------------------------------
 FROM node:24-bookworm-slim AS runtime
 WORKDIR /app
+
+# Prisma's query engine binary needs libssl at RUNTIME too, not just at
+# `prisma generate` time — same reason as the build stage.
+RUN apt-get update && apt-get install -y --no-install-recommends openssl \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3005


### PR DESCRIPTION
## Summary

Discovered building live on the production VM (node:24-bookworm-slim, ARM64): the build failed outright with `pnpm install --frozen-lockfile` exiting 1.

Root cause: two Debian-slim gaps that CI never hits (`ubuntu-latest` runners have both preinstalled):

1. **git missing** — package.json's `prepare` lifecycle script runs `vp config`, which shells out to git. `pnpm install` fails hard on this before the build even gets to app code.
2. **openssl missing** — Prisma's engine-selection at `prisma generate` time couldn't probe the real libssl version and silently defaulted to `openssl-1.1.x`. `prisma generate` itself didn't fail, so this would have been a *latent* runtime landmine (wrong engine binary) rather than a build-time failure — worth fixing even though it wasn't the blocking error.

Installs both `git` and `openssl` in the build stage, and `openssl` again in the runtime stage (the query engine binary needs libssl at runtime too, not just at generate time).

## Test plan

- [x] Rebuilding on the production VM now with this fix applied (live verification in progress as part of PER-192 deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)