### PR TITLE
fix(db): PER-192 — cache Prisma singleton in production (connection-slot exhaustion on import)

### DIFF
--- a/src/server/db.server.ts
+++ b/src/server/db.server.ts
@@ -105,7 +105,6 @@ function createPrismaClient(): PrismaClient {
     log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
   })
 
-  if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = client
   return client
 }
 
@@ -120,7 +119,23 @@ export const prisma: PrismaClient = /* @__PURE__ */ new Proxy(
   {} as PrismaClient,
   {
     get(_target, prop) {
-      const client = globalForPrisma.prisma ?? createPrismaClient()
+      // Cache the singleton in ALL environments — not just dev. This getter
+      // is the ONLY place the client is memoized: because the lazy-Proxy
+      // pattern constructs the client INSIDE the getter (never at module
+      // scope), skipping the cache in production means every property access
+      // (`prisma.$transaction`, `prisma.account`, …) builds a brand-new
+      // PrismaClient + pg Pool. Under load — e.g. a Sure import's chunked
+      // bulk writes touching prisma hundreds of times — that proliferates
+      // pools until Postgres runs out of connection slots:
+      //   "remaining connection slots are reserved for roles with the
+      //    SUPERUSER attribute" (permoney_app is NOSUPERUSER by design).
+      // One process = one client. The classic Next.js "cache only in dev"
+      // HMR guard is INVERTED here: it is correct only when the client is
+      // built at module scope (evaluated once); with lazy-in-getter
+      // construction, production is exactly where the cache matters most.
+      // In production `globalForPrisma` persists for the process lifetime
+      // (no HMR), which is precisely the singleton we want.
+      const client = (globalForPrisma.prisma ??= createPrismaClient())
       const value = Reflect.get(client, prop) as unknown
       // Bind method agar `this` tetap mereferensikan client asli (penting
       // untuk `prisma.$transaction`, `prisma.$connect`, dsb).


### PR DESCRIPTION
## The incident

First real production Sure import (2133 transactions, chunked bulk writes) failed with:

> Too many database connections opened: remaining connection slots are reserved for roles with the SUPERUSER attribute

## Root cause

`src/server/db.server.ts` memoized the Prisma client only when `NODE_ENV !== "production"`:

```js
if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = client   // ← never runs in prod
...
const client = globalForPrisma.prisma ?? createPrismaClient()               // ← always misses in prod
```

That guard is the classic Next.js HMR pattern, which is correct **only when the client is instantiated at module scope** (evaluated once). Here the client is built **lazily inside the Proxy getter**, so with the cache disabled in production every property access — `prisma.$transaction`, `prisma.account`, `prisma.transaction`, … — constructs a **brand-new `PrismaClient` + `pg` Pool**. A heavy import touches `prisma` hundreds of times → hundreds of pools → Postgres runs out of non-superuser connection slots. `permoney_app` is `NOSUPERUSER` by design (ADR-0047), so it cannot use the reserved slots.

Light traffic (health check, signup) never surfaced it because each access opened only a lazy connection or two.

## Fix

Memoize the client in the getter for **all** environments:

```js
const client = (globalForPrisma.prisma ??= createPrismaClient())
```

One process = one client = one pool. In production `globalThis` persists for the process lifetime (no HMR), which is exactly the singleton we want. The lazy-Proxy pattern *inverts* the classic guard — production is where the cache matters most. Comment added so no future agent reintroduces the `NODE_ENV` guard.

## Verification
- `vp check` green (format + lint + types).
- No schema/API change; pure connection-lifecycle fix.
- Post-merge: rebuild the prod `app` image + redeploy, then re-run the import (structurally idempotent per PER-179/190 — replay-safe after the mid-flight failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1