### PR TITLE
fix(deploy): PER-192 — provision-postgres-roles.sql :'var' inside DO $$ block

### DIFF
--- a/deploy/provision-postgres-roles.sql
+++ b/deploy/provision-postgres-roles.sql
@@ -1,9 +1,24 @@
 -- =============================================================================
 -- Permoney production Postgres role provisioning (PER-192)
 -- =============================================================================
--- Run ONCE against a fresh production database, connected as the Postgres
+-- Run TWICE against a fresh production database, connected as the Postgres
 -- superuser the `postgres:16` image bootstraps (POSTGRES_USER from
--- docker-compose.prod.yml). Idempotent — safe to re-run.
+-- docker-compose.prod.yml). Idempotent — safe to re-run either pass any
+-- number of times.
+--
+--   Pass 1, BEFORE `prisma migrate deploy`: creates the login roles and sets
+--   ALTER DEFAULT PRIVILEGES. Because this runs before permoney_migrator has
+--   created any tables, every table the migration subsequently creates
+--   inherits permoney_app's grants automatically — the explicit
+--   "GRANT ... ON ALL TABLES" and the AuditLog REVOKE below will error
+--   harmlessly (no tables exist yet; psql continues past errors by default
+--   with a plain `-f` invocation) — that's expected on this pass.
+--
+--   Pass 2, AFTER `prisma migrate deploy`: re-run the same file. Role
+--   creation/password-setting and the default-privileges declaration are
+--   no-ops the second time; what actually matters on this pass is the
+--   AuditLog REVOKE, which can only succeed once the table exists (default
+--   privileges are schema-wide and cannot selectively exclude one table).
 --
 -- Usage (never puts real passwords in this file or in shell history in
 -- plaintext-on-disk; pass them as psql variables from the server-side .env):
@@ -34,12 +49,16 @@
 --     before the app is ever allowed to trust it.
 -- =============================================================================
 
+-- psql's `:'var'` client-side substitution does NOT apply inside dollar-quoted
+-- (DO $$...$$) bodies — it's plain text to the substitution engine, so a
+-- password interpolated there would send a literal, invalid ":'name'" token
+-- to the server. Split role creation (idempotent, no password, safe inside
+-- $$...$$) from attribute/password assignment (plain top-level ALTER ROLE,
+-- where substitution works, and safely re-appliable on every run).
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'permoney_migrator') THEN
-    CREATE ROLE permoney_migrator LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS PASSWORD :'migrator_password';
-  ELSE
-    ALTER ROLE permoney_migrator PASSWORD :'migrator_password';
+    CREATE ROLE permoney_migrator NOLOGIN;
   END IF;
 END
 $$;
@@ -47,12 +66,13 @@ $$;
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'permoney_app') THEN
-    CREATE ROLE permoney_app LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEROLE NOCREATEDB PASSWORD :'app_password';
-  ELSE
-    ALTER ROLE permoney_app PASSWORD :'app_password';
+    CREATE ROLE permoney_app NOLOGIN;
   END IF;
 END
 $$;
+
+ALTER ROLE permoney_migrator LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS PASSWORD :'migrator_password';
+ALTER ROLE permoney_app LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEROLE NOCREATEDB PASSWORD :'app_password';
 
 GRANT CONNECT ON DATABASE permoney_prod TO permoney_migrator;
 GRANT CONNECT ON DATABASE permoney_prod TO permoney_app;


### PR DESCRIPTION
## Summary

**The bug**: psql's `:'var'` client-side variable substitution does NOT apply inside dollar-quoted (`DO $$ ... $$`) bodies — psql treats everything between `$$` markers as opaque text for substitution purposes. The original script had:

```sql
DO $$
BEGIN
  IF NOT EXISTS (...) THEN
    CREATE ROLE permoney_migrator LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS PASSWORD :'migrator_password';
  ELSE
    ALTER ROLE permoney_migrator PASSWORD :'migrator_password';
  END IF;
END
$$;
```

Because `:'migrator_password'` sits inside the `$$...$$` body, psql never substitutes it — the literal, un-substituted `:'migrator_password'` text gets sent straight to the Postgres server, which fails immediately with `ERROR: syntax error at or near ":"`. Neither role ever got a working password or its `LOGIN` attribute.

**The fix**: split role *creation* (idempotent `CREATE ROLE ... NOLOGIN` inside `DO` blocks — needs no variable substitution, so the dollar-quoting doesn't matter) from attribute/password *assignment* (plain top-level `ALTER ROLE ... PASSWORD :'var'` statements, outside any `DO` block, where psql's substitution works correctly). The `ALTER ROLE` statements are idempotent by nature (safe to re-run, resets the password/attributes each time) so this doesn't lose the original idempotency goal.

**Verified live against the actual production database** (not just locally): applied this exact fix to `permoney_prod` on the VM, ran the script both passes as documented (once before `prisma migrate deploy`, once after — see the file's own updated header comment for why two passes are needed), and confirmed via the script's closing sanity-check query that both roles came out with the intended attributes:

```
      rolname      | rolsuper | rolbypassrls | rolcreaterole
-------------------+----------+--------------+---------------
 permoney_app      | f        | f            | f
 permoney_migrator | f        | f            | t
```

`permoney_migrator` then successfully ran all 30 pending migrations (including self-provisioning `permoney_system_maintainer` per the `20260530140000` migration). `permoney_app` is the role `permana.icu` has been serving live production traffic through since this fix was applied.

## Test plan

- [x] Live-verified against the actual production Postgres instance (this fix *is* what unblocked the one-time role provisioning during the PER-192 deploy)
- [x] Script's own closing `SELECT ... FROM pg_roles` sanity check confirms correct role attributes
- [x] Downstream: `prisma migrate deploy` (30/30 migrations) and the app's live traffic through `permoney_app` both succeeded using the roles this script created

🤖 Generated with [Claude Code](https://claude.com/claude-code)