### PR TITLE
feat(importer): PER-188 — truthful Sure-import copy + live phase progress

### DIFF
--- a/src/routes/_protected/-sure-import-ui.test.tsx
+++ b/src/routes/_protected/-sure-import-ui.test.tsx
@@ -6,6 +6,15 @@ import { DoneStage, ReviewStage } from "./-sure-import-ui"
 import type { SureMigrationResult } from "@/server/sure-migration"
 import type { SureBundlePreview } from "@/lib/sure-migration"
 
+// PER-188 — the Done screen previously told an unconditional lie ("A few
+// balances won't match yet... imported in a later step") whenever ANY
+// transaction was held, even though transfers are dual-leg promoted in the
+// SAME run (ADR-0042) and every run ends with a mandatory reconciliation
+// anchor + balance rebuild (ADR-0043/0045). These tests pin the honest
+// replacement: an unconditional balance-certainty claim, transfers-imported
+// framed as good news, and held legs framed as a history gap the balance
+// already accounts for — never a balance gap.
+
 // PER-171 — the Done screen must read as success in the real-world degraded case
 // where a bundle stages accounts/categories/merchants but promotes ZERO
 // transactions (every row is a held transfer leg). It must NOT look empty/failed.
@@ -94,8 +103,14 @@ describe("DoneStage", () => {
 
     // Entities that DID land are still shown, and the held bucket reconciles.
     expect(screen.getByText("Accounts")).toBeTruthy()
-    expect(screen.getByText(/6 held for transfers/i)).toBeTruthy()
+    expect(screen.getByText(/6 held for review/i)).toBeTruthy()
     expect(screen.getByText("View transactions")).toBeTruthy()
+
+    // The honest, unconditional balance claim — no gate on t.held.
+    expect(screen.getByText(/all account balances reconciled/i)).toBeTruthy()
+    // The old false, unconditional claim must be gone entirely.
+    expect(screen.queryByText(/won't match yet/i)).toBeNull()
+    expect(screen.queryByText(/imported in a later step/i)).toBeNull()
   })
 
   it("promoted rows read as a completed migration with the count", () => {
@@ -112,7 +127,7 @@ describe("DoneStage", () => {
     expect(screen.getByText("Migration complete")).toBeTruthy()
     expect(screen.getByText(/added to your ledger/i)).toBeTruthy()
     expect(screen.getByText("9")).toBeTruthy() // the promoted-count hero
-    expect(screen.getByText(/5 held for transfers/i)).toBeTruthy()
+    expect(screen.getByText(/5 held for review/i)).toBeTruthy()
   })
 
   it("a replayed run reads as already-imported, not an error", () => {
@@ -130,6 +145,81 @@ describe("DoneStage", () => {
     expect(screen.getByText("Already imported")).toBeTruthy()
     expect(screen.getByText(/nothing was duplicated/i)).toBeTruthy()
     expect(screen.queryByText("Accounts & details imported")).toBeNull()
+    // Balance certainty is unconditional — even a replay states it.
+    expect(screen.getByText(/all account balances reconciled/i)).toBeTruthy()
+  })
+
+  it("frames promoted transfers as good news, driven by the RESULT not the preview", () => {
+    render(
+      <DoneStage
+        result={makeResult({
+          transfers: {
+            legsSeen: 20,
+            legsStaged: 20,
+            pairsPromotedThisRun: 8,
+            legsPromotedTotal: 16,
+            pairedByTier: { deterministic: 8, clean: 0, resolvedCluster: 0 },
+            heldLegsByReason: {
+              not_staged: 0,
+              non_importable: 0,
+              currency_mismatch: 0,
+              kind_divergence: 0,
+              db_rejected: 0,
+              unpaired_orphan: 0,
+              ambiguous_cluster: 0,
+            },
+          },
+        })}
+        onViewTransactions={noop}
+        onImportAnother={noop}
+      />
+    )
+
+    expect(
+      screen.getByText(/16 transfer transactions imported as paired moves/i)
+    ).toBeTruthy()
+    // No held legs this time — the secondary "kept for review" note is absent.
+    expect(
+      screen.queryByText(/kept for review, not yet in your history/i)
+    ).toBeNull()
+  })
+
+  it("frames held transfer legs as a history gap the balance already covers, with real reasons", () => {
+    render(
+      <DoneStage
+        result={makeResult({
+          transfers: {
+            legsSeen: 10,
+            legsStaged: 10,
+            pairsPromotedThisRun: 0,
+            legsPromotedTotal: 6,
+            pairedByTier: { deterministic: 3, clean: 0, resolvedCluster: 0 },
+            heldLegsByReason: {
+              not_staged: 0,
+              non_importable: 2,
+              currency_mismatch: 0,
+              kind_divergence: 0,
+              db_rejected: 0,
+              unpaired_orphan: 1,
+              ambiguous_cluster: 0,
+            },
+          },
+        })}
+        onViewTransactions={noop}
+        onImportAnother={noop}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        /3 transfer legs kept for review, not yet in your history/i
+      )
+    ).toBeTruthy()
+    expect(
+      screen.getByText(/your balances already account for this/i)
+    ).toBeTruthy()
+    expect(screen.getByText(/counterpart account isn't imported/i)).toBeTruthy()
+    expect(screen.getByText(/no matching counterpart found/i)).toBeTruthy()
   })
 })
 
@@ -204,5 +294,99 @@ describe("ReviewStage", () => {
     expect(
       screen.getByText("Importing into your family.", { selector: "span" })
     ).toBeTruthy()
+  })
+
+  // PER-188 — the preview used to claim transfers were "imported in a later
+  // step" (false: they're dual-leg promoted THIS run, ADR-0042). Pin the
+  // reframed, future-soft copy and make sure the old lie can't creep back.
+  it("frames held transfers as paired this run, never as deferred to later", () => {
+    render(
+      <ReviewStage
+        fileName="all.ndjson"
+        preview={makePreview({
+          transactions: {
+            total: 5,
+            promotable: 3,
+            held: 2,
+            heldByReason: {
+              transfer: 2,
+              split: 0,
+              splitParent: 0,
+              nonImportableAccount: 0,
+              currencyMismatch: 0,
+            },
+            zeroAmountSkipped: 0,
+            invalidDateSkipped: 0,
+            unmappable: 0,
+          },
+        })}
+        actingEmail="hendri@permana.icu"
+        onBack={noop}
+        onConfirm={noop}
+        running={false}
+      />
+    )
+
+    expect(
+      screen.getByText(/imported this run as linked transfers/i)
+    ).toBeTruthy()
+    expect(screen.queryByText(/imported in a later step/i)).toBeNull()
+    expect(screen.queryByText(/won't match/i)).toBeNull()
+  })
+
+  it("shows no live-progress panel before the import starts running", () => {
+    render(
+      <ReviewStage
+        fileName="all.ndjson"
+        preview={makePreview()}
+        actingEmail="hendri@permana.icu"
+        onBack={noop}
+        onConfirm={noop}
+        running={false}
+        progress={null}
+      />
+    )
+
+    expect(screen.queryByText("Staging")).toBeNull()
+    expect(screen.queryByText(/keep this tab open/i)).toBeNull()
+  })
+
+  it("shows an indeterminate state while running before the first poll lands", () => {
+    render(
+      <ReviewStage
+        fileName="all.ndjson"
+        preview={makePreview()}
+        actingEmail="hendri@permana.icu"
+        onBack={noop}
+        onConfirm={noop}
+        running={true}
+        progress={{ phase: null, startedAt: Date.now() }}
+      />
+    )
+
+    expect(screen.getByText("Starting…")).toBeTruthy()
+    expect(screen.getByText("Staging")).toBeTruthy()
+    expect(screen.getByText("Finalizing")).toBeTruthy()
+  })
+
+  it("highlights the real current phase and the keep-tab-open note while running", () => {
+    render(
+      <ReviewStage
+        fileName="all.ndjson"
+        preview={makePreview()}
+        actingEmail="hendri@permana.icu"
+        onBack={noop}
+        onConfirm={noop}
+        running={true}
+        progress={{ phase: "pairing_transfers", startedAt: Date.now() }}
+      />
+    )
+
+    expect(screen.getByText("Pairing transfers")).toBeTruthy()
+    expect(
+      screen.getByText(/keep this tab open to watch progress/i)
+    ).toBeTruthy()
+    expect(screen.getByText(/closing it is safe/i)).toBeTruthy()
+    expect(screen.queryByText("Starting…")).toBeNull()
   })
 })

--- a/src/routes/_protected/-sure-import-ui.tsx
+++ b/src/routes/_protected/-sure-import-ui.tsx
@@ -33,10 +33,18 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils"
-import type { SureBundlePreview, SureHeldReason } from "@/lib/sure-migration"
+import { useMountEffect } from "@/hooks/use-mount-effect"
+import type {
+  SureBundlePreview,
+  SureHeldReason,
+  SureTransferHeldReason,
+} from "@/lib/sure-migration"
 // Type-only import — erased at build, so this presentational module stays free
 // of the server fn's runtime graph and remains unit-testable in jsdom.
-import type { SureMigrationResult } from "@/server/sure-migration"
+import type {
+  SureImportPhase,
+  SureMigrationResult,
+} from "@/server/sure-migration"
 
 // PER-171 — presentational layer for the guided Sure importer. Kept separate
 // from the route (`import_.sure.tsx`) so the orchestration (file read, server
@@ -46,6 +54,16 @@ import type { SureMigrationResult } from "@/server/sure-migration"
 
 export type Stage = "upload" | "review" | "done"
 
+// PER-188 — live progress for the running import, polled from
+// getSureImportProgressFn (see the locked polling design in the
+// per-188-importer-copy-progress-design memory). `phase: null` means the
+// poll hasn't resolved a snapshot yet (just started, or the server-side
+// entry is unknown/expired) — an indeterminate, not an error, state.
+export interface ImportProgress {
+  phase: SureImportPhase | null
+  startedAt: number
+}
+
 const HELD_REASONS: Record<
   SureHeldReason,
   { label: string; detail: string; icon: typeof ArrowRightLeft }
@@ -53,7 +71,7 @@ const HELD_REASONS: Record<
   transfer: {
     label: "Transfers",
     detail:
-      "Paired moves between your own accounts — imported in a later step.",
+      "Paired moves between your own accounts — imported this run as linked transfers. Any that can't be safely paired are kept, not dropped.",
     icon: ArrowRightLeft,
   },
   split: {
@@ -94,8 +112,8 @@ export function SureImportHeader({ stage }: { stage: Stage }) {
       </h1>
       <p className="text-lg text-muted-foreground">
         Upload your Sure export and we'll account for every line — what crosses
-        into your ledger now, and what we hold for a later step. Nothing is
-        dropped.
+        into your ledger now, and what needs extra care before it can. Nothing
+        is dropped.
       </p>
       <StageRail stage={stage} />
     </header>
@@ -198,6 +216,89 @@ export function UploadStage({
 }
 
 // ===========================================================================
+// Live import progress (PER-188) — rendered inside ReviewStage while running.
+// ===========================================================================
+
+const IMPORT_PHASES: { id: SureImportPhase; label: string }[] = [
+  { id: "staging", label: "Staging" },
+  { id: "pairing_transfers", label: "Pairing transfers" },
+  { id: "reconciling", label: "Reconciling" },
+  { id: "finalizing", label: "Finalizing" },
+]
+
+function ImportElapsedTimer({ startedAt }: { startedAt: number }) {
+  const [, forceTick] = React.useState(0)
+  // Browser-timer subscription — the documented useMountEffect escape hatch
+  // (no-use-effect skill, Rule 4), not a derived-state effect. Only ever
+  // mounted while the import is running (see ImportProgressPanel's caller),
+  // so it naturally starts/stops with the run instead of needing a guard.
+  useMountEffect(() => {
+    const id = setInterval(() => forceTick((tick) => tick + 1), 1000)
+    return () => clearInterval(id)
+  })
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - startedAt) / 1000)
+  )
+  const minutes = Math.floor(elapsedSeconds / 60)
+  const seconds = elapsedSeconds % 60
+  return (
+    <span className="font-mono text-xs text-muted-foreground tabular-nums">
+      {minutes}:{seconds.toString().padStart(2, "0")}
+    </span>
+  )
+}
+
+// Progress is OBSERVATIONAL (PER-188 locked design): the import's own
+// correctness never depends on this panel ever showing anything. A `phase:
+// null` snapshot (poll hasn't landed yet, or the server-side entry expired /
+// belongs to a different instance) degrades to an indeterminate "Starting…"
+// state rather than an error — closing this tab and reopening later, or a
+// poll that never resolves, is always safe.
+function ImportProgressPanel({ progress }: { progress: ImportProgress }) {
+  const activeIndex = progress.phase
+    ? IMPORT_PHASES.findIndex((phase) => phase.id === progress.phase)
+    : -1
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border bg-muted/30 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ol className="flex flex-wrap items-center gap-2 text-sm">
+          {IMPORT_PHASES.map((phase, index) => (
+            <li
+              key={phase.id}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium transition-colors",
+                index === activeIndex &&
+                  "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+                activeIndex !== -1 &&
+                  index < activeIndex &&
+                  "text-emerald-600 dark:text-emerald-400",
+                (activeIndex === -1 || index > activeIndex) &&
+                  "text-muted-foreground"
+              )}
+            >
+              {index === activeIndex ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                index < activeIndex && <CircleCheckBig size={12} />
+              )}
+              {phase.label}
+            </li>
+          ))}
+        </ol>
+        <ImportElapsedTimer startedAt={progress.startedAt} />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {activeIndex === -1
+          ? "Starting…"
+          : "Keep this tab open to watch progress. Closing it is safe — the import keeps running on our side, and reopening this page picks up where you left off."}
+      </p>
+    </div>
+  )
+}
+
+// ===========================================================================
 // Stage 2 — review (client preview; the honest, fully-reconciled manifest)
 // ===========================================================================
 
@@ -208,6 +309,7 @@ export function ReviewStage({
   onBack,
   onConfirm,
   running,
+  progress,
 }: {
   fileName: string
   preview: SureBundlePreview
@@ -216,6 +318,8 @@ export function ReviewStage({
   onBack: () => void
   onConfirm: () => void
   running: boolean
+  /** Live phase progress while `running` (PER-188). Absent/null = no poll yet. */
+  progress?: ImportProgress | null
 }) {
   const t = preview.transactions
   const ignoredTotal = sumValues(preview.ignoredEntities)
@@ -381,7 +485,7 @@ export function ReviewStage({
         ignoredTotal={ignoredTotal}
       />
 
-      {t.held > 0 && <ReconciliationNote />}
+      {running && progress && <ImportProgressPanel progress={progress} />}
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Button variant="ghost" onClick={onBack} disabled={running}>
@@ -515,7 +619,7 @@ export function DoneStage({
                     variant="outline"
                     className="border-amber-400 text-amber-700 dark:text-amber-300"
                   >
-                    {t.held} held for transfers
+                    {t.held} held for review
                   </Badge>
                 )}
                 {t.zeroAmountSkipped > 0 && (
@@ -541,7 +645,7 @@ export function DoneStage({
             </div>
           )}
 
-          {t.held > 0 && <ReconciliationNote />}
+          <BalanceReconciliationSummary transfers={result.transfers} />
         </CardContent>
       </Card>
 
@@ -752,19 +856,82 @@ function ResultStat({
   )
 }
 
-function ReconciliationNote() {
+// PER-188 — human-readable copy for each DB-anchored reason a transfer leg
+// couldn't be paired & promoted this run (see SureTransferHeldReason). Shown
+// only on the Done screen, sourced from the RESULT (never the preview).
+const TRANSFER_HELD_REASON_LABEL: Record<SureTransferHeldReason, string> = {
+  not_staged: "not staged for import",
+  non_importable: "counterpart account isn't imported",
+  currency_mismatch: "currency mismatch with its account",
+  kind_divergence: "conflicting transfer type",
+  db_rejected: "rejected by a ledger safety check",
+  unpaired_orphan: "no matching counterpart found",
+  ambiguous_cluster: "more than one possible match",
+}
+
+// PER-188 — the Done-screen truth about balances. Every migration run ends
+// with a mandatory final-reconciliation anchor + balance rebuild (ADR-0043,
+// ADR-0045's PER-182 amendment), so "every balance matches" is true
+// unconditionally, regardless of how many transfer legs got held — held legs
+// are a HISTORY-completeness gap, never a balance gap. Driven entirely by
+// `result.transfers`, never the step-2 preview's staging counts.
+function BalanceReconciliationSummary({
+  transfers,
+}: {
+  transfers: SureMigrationResult["transfers"]
+}) {
+  const heldReasons = (
+    Object.keys(transfers.heldLegsByReason) as SureTransferHeldReason[]
+  ).filter((reason) => transfers.heldLegsByReason[reason] > 0)
+  const heldTotal = sumValues(transfers.heldLegsByReason)
+
   return (
-    <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm dark:border-amber-900/60 dark:bg-amber-950/30">
-      <ArrowRightLeft
-        size={18}
-        className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
-      />
-      <p className="text-amber-900 dark:text-amber-100">
-        <span className="font-semibold">A few balances won't match yet.</span>{" "}
-        Transfers and split transactions aren't migrated in this step, so any
-        account that used them will finish reconciling once transfers are
-        imported in a later step. Your full export is kept safely until then.
-      </p>
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm dark:border-emerald-900/60 dark:bg-emerald-950/30">
+        <CircleCheckBig
+          size={18}
+          className="mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400"
+        />
+        <div className="text-emerald-900 dark:text-emerald-100">
+          <p className="font-semibold">
+            All account balances reconciled — every account matches your Sure
+            closing figures.
+          </p>
+          {transfers.legsPromotedTotal > 0 && (
+            <p className="mt-1 text-emerald-800/90 dark:text-emerald-200/90">
+              {transfers.legsPromotedTotal} transfer transaction
+              {transfers.legsPromotedTotal === 1 ? "" : "s"} imported as paired
+              moves between your accounts.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {heldTotal > 0 && (
+        <div className="flex items-start gap-3 rounded-2xl border border-border bg-muted/40 p-4 text-sm">
+          <CircleSlash
+            size={18}
+            className="mt-0.5 shrink-0 text-muted-foreground"
+          />
+          <div>
+            <p className="font-medium">
+              {heldTotal} transfer leg{heldTotal === 1 ? "" : "s"} kept for
+              review, not yet in your history.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Your balances already account for this — only the transaction
+              history entry is pending:{" "}
+              {heldReasons
+                .map(
+                  (reason) =>
+                    `${transfers.heldLegsByReason[reason]} ${TRANSFER_HELD_REASON_LABEL[reason]}`
+                )
+                .join(", ")}
+              .
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/routes/_protected/import_.sure.tsx
+++ b/src/routes/_protected/import_.sure.tsx
@@ -8,11 +8,16 @@ import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { parseSureBundle, summarizeSureBundle } from "@/lib/sure-migration"
-import { runSureMigrationFn } from "@/server/sure-migration"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import {
+  getSureImportProgressFn,
+  runSureMigrationFn,
+} from "@/server/sure-migration"
 import { getSettingsOverviewFn, SETTINGS_OVERVIEW_KEY } from "@/server/settings"
 import { transactionCollection } from "@/lib/collections"
 import {
   DoneStage,
+  type ImportProgress,
   ReviewStage,
   type Stage,
   SureImportHeader,
@@ -87,9 +92,19 @@ function SureImportPage() {
     setStage("review")
   }
 
+  // PER-188 — client-minted UUIDv7, the key `getSureImportProgressFn` polls
+  // by. Minted fresh per attempt (not per page load) so a retry after a
+  // failure gets its own progress lineage instead of resuming a stale one.
+  const [importId, setImportId] = React.useState<string | null>(null)
+  const [importStartedAt, setImportStartedAt] = React.useState<number | null>(
+    null
+  )
+
   const runMutation = useMutation({
-    mutationFn: () =>
-      runSureMigrationFn({ data: { filename: fileName, bundle: bundleText } }),
+    mutationFn: (id: string) =>
+      runSureMigrationFn({
+        data: { filename: fileName, bundle: bundleText, importId: id },
+      }),
     onSuccess: async (migration) => {
       setResult(migration)
       setStage("done")
@@ -108,12 +123,37 @@ function SureImportPage() {
       toast.error(error instanceof Error ? error.message : "Migration failed."),
   })
 
+  // Ephemeral, observational only (PER-188 locked design) — never awaited,
+  // never consulted for correctness. Stops the instant the mutation above
+  // resolves, which is when the typed result actually lands.
+  const { data: progressSnapshot } = useQuery({
+    queryKey: ["sure-import-progress", importId],
+    queryFn: () =>
+      getSureImportProgressFn({ data: { importId: importId as string } }),
+    enabled: runMutation.isPending && importId !== null,
+    refetchInterval: 900,
+  })
+
+  const progress: ImportProgress | null =
+    runMutation.isPending && importStartedAt !== null
+      ? { phase: progressSnapshot?.phase ?? null, startedAt: importStartedAt }
+      : null
+
+  const startImport = () => {
+    const id = createUuidV7()
+    setImportId(id)
+    setImportStartedAt(Date.now())
+    runMutation.mutate(id)
+  }
+
   const restart = () => {
     setStage("upload")
     setFileName("")
     setBundleText("")
     setPreview(null)
     setResult(null)
+    setImportId(null)
+    setImportStartedAt(null)
   }
 
   return (
@@ -145,8 +185,9 @@ function SureImportPage() {
                 preview={preview}
                 actingEmail={overview?.profile.email}
                 onBack={restart}
-                onConfirm={() => runMutation.mutate()}
+                onConfirm={startImport}
                 running={runMutation.isPending}
+                progress={progress}
               />
             )}
 

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -120,6 +120,11 @@ const sureMigrationInputSchema = z.object({
   // Raw `all.ndjson` content. Phase 1a accepts it as a UTF-8 string over the
   // server-fn POST; a future slice may switch to multipart upload.
   bundle: z.string().min(1),
+  // PER-188 — client-minted UUIDv7, the key into the ephemeral progress Map
+  // below. Optional so existing callers (integration tests, any future
+  // caller that doesn't care about live progress) don't have to pass one;
+  // the function mints its own fallback when absent.
+  importId: z.string().min(1).optional(),
 })
 
 export type SureMigrationInput = z.input<typeof sureMigrationInputSchema>
@@ -800,6 +805,99 @@ export function isPromotable(
 // Orchestration (testable entry — mirrors createImportBatchForFamily shape)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// PER-188 — ephemeral, observational import progress (polling side-channel).
+//
+// Grilled decision (see per-188-importer-copy-progress-design memory, locked
+// decision 4): NOT a streamed Response. `runSureMigrationFn` stays a normal
+// awaited call returning the typed `SureMigrationResult` above — that typed
+// contract is load-bearing (CLAUDE.md "return values are the type
+// contract") and a long-lived streaming response sits behind Cloudflare's
+// ~100s origin timeout for no benefit here. Instead: the client polls
+// `getSureImportProgressFn` every ~1s while the main request is in flight.
+//
+// This Map is a side-effect-free module-scope singleton (same discipline as
+// `fallbackMap` in `middleware/rate-limit.ts`) — NEVER the source of truth.
+// The import's actual correctness comes entirely from the idempotent,
+// awaited `runSureMigrationForFamily` call; if the client's poll never sees a
+// single update (process restart, wrong instance, tab closed and reopened),
+// the import itself is unaffected and a re-call with the same `importId`
+// replays safely (PER-179/190 structural idempotency).
+//
+// CAVEAT (documented, not hidden): this Map is single-instance. Permoney
+// runs one prod container today, so "poll lands on the instance running the
+// migration" always holds. If Permoney horizontal-scales, a poll can land on
+// a different instance and see nothing — move this to Redis/DB at that point
+// (the client already degrades gracefully to an indeterminate state on a
+// miss, so this isn't a correctness cliff, just a UX one).
+export type SureImportPhase =
+  | "staging"
+  | "pairing_transfers"
+  | "reconciling"
+  | "finalizing"
+
+export interface SureImportProgressSnapshot {
+  phase: SureImportPhase
+  staged: number
+  promoted: number
+  heldSoFar: number
+  updatedAt: number
+}
+
+interface SureImportProgressEntry extends SureImportProgressSnapshot {
+  familyId: string
+}
+
+const IMPORT_PROGRESS_MAX_AGE_MS = 10 * 60 * 1000 // 10 min — sweep window
+
+const importProgress = new Map<string, SureImportProgressEntry>()
+
+function sweepStaleImportProgress(): void {
+  const cutoff = Date.now() - IMPORT_PROGRESS_MAX_AGE_MS
+  for (const [id, entry] of importProgress) {
+    if (entry.updatedAt < cutoff) importProgress.delete(id)
+  }
+}
+
+function setImportProgress(
+  importId: string,
+  familyId: string,
+  patch: Partial<Omit<SureImportProgressSnapshot, "updatedAt">> & {
+    phase: SureImportPhase
+  }
+): void {
+  sweepStaleImportProgress()
+  const previous = importProgress.get(importId)
+  importProgress.set(importId, {
+    staged: previous?.staged ?? 0,
+    promoted: previous?.promoted ?? 0,
+    heldSoFar: previous?.heldSoFar ?? 0,
+    ...patch,
+    familyId,
+    updatedAt: Date.now(),
+  })
+}
+
+const sureImportProgressInputSchema = z.object({
+  importId: z.string().min(1),
+})
+
+// GET, not POST — this is a pure, cheap, idempotent read (no DB, no mutation).
+export const getSureImportProgressFn = createServerFn({ method: "GET" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: unknown) => sureImportProgressInputSchema.parse(data))
+  .handler(
+    async ({ data, context }): Promise<SureImportProgressSnapshot | null> => {
+      const entry = importProgress.get(data.importId)
+      // Tenant isolation even though a UUIDv7 importId is practically
+      // unguessable: never let one family's poll read another family's
+      // in-flight progress counters.
+      if (!entry || entry.familyId !== context.familyId) return null
+      const { familyId: _familyId, ...snapshot } = entry
+      return snapshot
+    }
+  )
+
 export async function runSureMigrationForFamily({
   data: rawData,
   familyId,
@@ -812,6 +910,13 @@ export async function runSureMigrationForFamily({
   runInTenantTransaction?: RunInTenantTransaction
 }): Promise<SureMigrationResult> {
   const data = sureMigrationInputSchema.parse(rawData)
+  const importId = data.importId ?? createUuidV7()
+  setImportProgress(importId, familyId, {
+    phase: "staging",
+    staged: 0,
+    promoted: 0,
+    heldSoFar: 0,
+  })
 
   const rawBytes = new TextEncoder().encode(data.bundle)
   if (rawBytes.length > MAX_BUNDLE_BYTES) {
@@ -1233,6 +1338,14 @@ export async function runSureMigrationForFamily({
       })
       timings.transactionsPromote += Date.now() - chunkPromoteT0
       promotedThisRun += promotion.promotedCount
+
+      // PER-188 — emitted at the existing PER-179 chunk boundary, between
+      // the confirm and promote transactions above, never inside either one.
+      setImportProgress(importId, familyId, {
+        phase: "staging",
+        staged: rows.length,
+        promoted: promotedThisRun,
+      })
     }
   }
 
@@ -1244,6 +1357,7 @@ export async function runSureMigrationForFamily({
   // Reuses the SAME pure pairing computed up-front; promotes each pair through the
   // canonical `createTransactionForFamily` core (no new ledger writer), holding
   // anything ambiguous/orphan/gated with a DB-anchored typed reason.
+  setImportProgress(importId, familyId, { phase: "pairing_transfers" })
   const transfersT0 = Date.now()
   const transfers = await pairAndPromoteSureTransfers({
     pairing: transferPairing,
@@ -1267,6 +1381,13 @@ export async function runSureMigrationForFamily({
   // per account. See writeSureFinalReconciliationAnchors for the full
   // reasoning. Runs under the bulk-replay bypass like step 4 (another
   // anchor-writing phase in the same transient-until-rebuild window).
+  setImportProgress(importId, familyId, {
+    phase: "reconciling",
+    heldSoFar: Object.values(transfers.heldLegsByReason).reduce(
+      (sum, n) => sum + n,
+      0
+    ),
+  })
   const reconciliationT0 = Date.now()
   const finalReconciliation = await writeSureFinalReconciliationAnchors(
     bundle,
@@ -1288,9 +1409,14 @@ export async function runSureMigrationForFamily({
   // from canonical rows (latest anchor + Σ post-anchor flow, or the existing
   // no-anchor-found fallback for the rare account with no valuations at all)
   // — overriding the incremental journey with the calculator's actual answer.
+  setImportProgress(importId, familyId, { phase: "finalizing" })
   const rebuildT0 = Date.now()
   await rebuildFamilyBalances({ familyId, user, runInTenantTransaction })
   timings.rebuild = Date.now() - rebuildT0
+
+  // Success — the typed result below is the source of truth from here on;
+  // the observational progress entry has served its purpose.
+  importProgress.delete(importId)
 
   return {
     batchId,

--- a/tests/e2e/sure-migration.e2e.ts
+++ b/tests/e2e/sure-migration.e2e.ts
@@ -33,11 +33,14 @@ test.describe("Sure guided migration", () => {
       buffer: Buffer.from(bundle.ndjson),
     })
 
-    // 3. Preview honestly splits crossing-now from held, with the gap note.
+    // 3. Preview honestly splits crossing-now from held. PER-188 removed the
+    // old "A few balances won't match yet" note here — it was false (transfers
+    // are dual-leg promoted in the same run and every balance reconciles via
+    // the final anchor + rebuild). The honest disclosure is now the bucket
+    // breakdown reconciling back to the file total, asserted below.
     await expect(page.getByText("Crossing into your ledger")).toBeVisible()
     await expect(page.getByText("Held for a later step")).toBeVisible()
     await expect(page.getByText("Transfers", { exact: true })).toBeVisible()
-    await expect(page.getByText(/A few balances won't match yet/)).toBeVisible()
     // Every bucket reconciles back to the file total — no unexplained gap.
     await expect(page.getByText(/transactions in this file/)).toBeVisible()
 
@@ -56,6 +59,12 @@ test.describe("Sure guided migration", () => {
 
     // 5. Done screen reports the authoritative result and a manual navigate.
     await expect(page.getByText("Migration complete")).toBeVisible()
+    // PER-188 — the Done screen now leads with the TRUTH (unconditional,
+    // guaranteed by the mandatory final anchor + rebuild) instead of the old
+    // "balances won't match" lie.
+    await expect(
+      page.getByText(/All account balances reconciled/)
+    ).toBeVisible()
     await page.getByRole("button", { name: /View transactions/ }).click()
 
     await expect(page).toHaveURL(/\/transactions(?:\?.*)?$/)


### PR DESCRIPTION
Stops a live-in-prod dishonesty and adds honest progress feedback to the Sure importer.

## Copy — truth, driven by the RESULT (never the preview)
- **Done screen leads with an unconditional "All account balances reconciled."** Architecturally guaranteed: `runSureMigrationForFamily` only returns (and DoneStage only renders) after the mandatory final-reconciliation anchor + balance rebuild (ADR-0043, ADR-0045/PER-182), so the claim holds regardless of how many transfer legs were held.
- Promoted transfers framed as good news (`transfers.legsPromotedTotal`); held legs framed as a **history-completeness** note with per-reason copy ("your balances already account for this"), never a balance caveat.
- Removed the old unconditional-false `ReconciliationNote` ("balances won't match… imported in a later step").
- **Fixed a real mislabel:** a badge read "N held for transfers" using `t.held`, which by construction **excludes** transfer legs (standard-held only) → "held for review".
- Preview + header copy reframed off "held for a later step" (transfers are dual-leg promoted in the same run).

## Live progress — polling side-channel (locked decision 4)
NOT streaming — preserves the typed `createServerFn` return contract and dodges Cloudflare's ~100s streaming-timeout class of failure.
- Ephemeral module-scope `Map` in `sure-migration.ts`, updated **only at existing PER-179 chunk boundaries** (verified: never inside `prisma.$transaction`), swept by 10-min TTL, deleted on success. **Observational only** — import correctness is the idempotent awaited call.
- Tenant-scoped `getSureImportProgressFn` (GET, `ledger:write`, `familyId`-checked, null on miss → client degrades to indeterminate, never an error).
- Client polls every 900ms while pending; phase rail + elapsed timer via the documented `useMountEffect` escape hatch. Single-instance caveat documented in code.

## Verification (head-eng, independently re-run — not trusting the agent report)
- `vp check` clean (format + lint + types).
- `no-use-effect` guard: **0 violations** (the `useMountEffect` timer is properly justified).
- Unit: **433/433** (11 new/updated cases).
- Integration + e2e: CI.

Closes PER-188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1