### PR TITLE
feat(ledger): PER-196 — valuation-linked transfer model

### DIFF
--- a/prisma/migrations/20260720130000_valuation_linked_transfer_schema/migration.sql
+++ b/prisma/migrations/20260720130000_valuation_linked_transfer_schema/migration.sql
@@ -1,0 +1,156 @@
+-- PER-196 / ADR-0048 §4: Transfer gains an optional valuation leg.
+--
+-- A classic transfer (both legs cash-like) is unchanged: both Transaction FKs
+-- set, valuationId null. A valuation-linked move (one leg on a
+-- balanceSource="valuation" account) sets exactly one of
+-- outflowTransactionId/inflowTransactionId (whichever side is the cash leg)
+-- plus valuationId (the new Valuation written on the tracked-asset side).
+-- This generalizes, not weakens, the ADR-0031/PER-103 dual-leg invariant: a
+-- second, equally-strict leg shape, not an unchecked one.
+--
+-- No pre-existing-row audit is needed (unlike PER-103's original migration):
+-- every existing Transfer row already has BOTH Transaction FKs NOT NULL under
+-- the old schema, and this migration only ADDS the nullable valuationId
+-- column (defaulting NULL) — every existing row trivially satisfies the new
+-- transfer_leg_shape CHECK's first branch (both legs set, valuationId null)
+-- by construction.
+
+-- ============================================================================
+-- 1. Base schema change (Prisma-generated diff).
+-- ============================================================================
+ALTER TABLE "Transfer" ADD COLUMN     "valuationId" TEXT,
+ALTER COLUMN "outflowTransactionId" DROP NOT NULL,
+ALTER COLUMN "inflowTransactionId" DROP NOT NULL;
+
+CREATE UNIQUE INDEX "Transfer_valuationId_key" ON "Transfer"("valuationId");
+
+ALTER TABLE "Transfer" ADD CONSTRAINT "Transfer_valuationId_fkey" FOREIGN KEY ("valuationId") REFERENCES "Valuation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- ============================================================================
+-- 2. Leg-shape CHECK: classic dual-Transaction XOR valuation-linked.
+-- ============================================================================
+-- transfer_no_self_reference (outflowTransactionId <> inflowTransactionId)
+-- from PER-103 is untouched and still correct: when either side is NULL
+-- (valuation-linked case), the comparison evaluates to NULL, which Postgres
+-- treats as satisfying the CHECK — no change needed there.
+ALTER TABLE "Transfer"
+  ADD CONSTRAINT "transfer_leg_shape" CHECK (
+    ("outflowTransactionId" IS NOT NULL AND "inflowTransactionId" IS NOT NULL AND "valuationId" IS NULL)
+    OR (
+      "valuationId" IS NOT NULL
+      AND (("outflowTransactionId" IS NOT NULL) <> ("inflowTransactionId" IS NOT NULL))
+    )
+  );
+
+-- ============================================================================
+-- 3. PER-103 trigger functions gain a valuation-linked branch.
+-- ============================================================================
+-- CHECK constraints validate synchronously at row-insert time, strictly
+-- before any AFTER trigger fires (both of these are "AFTER INSERT ...
+-- DEFERRABLE INITIALLY IMMEDIATE"), so by the time either function below
+-- runs, transfer_leg_shape has already guaranteed: valuationId set implies
+-- exactly one of outflowTransactionId/inflowTransactionId is set. Each
+-- function only needs to resolve "the cash leg", not re-derive that
+-- invariant.
+
+CREATE OR REPLACE FUNCTION enforce_transfer_type_shape_invariant()
+RETURNS TRIGGER AS $$
+DECLARE
+  outflow_type  TEXT;
+  inflow_type   TEXT;
+  cash_leg_id   TEXT;
+  cash_leg_type TEXT;
+BEGIN
+  IF NEW."valuationId" IS NOT NULL THEN
+    cash_leg_id := COALESCE(NEW."outflowTransactionId", NEW."inflowTransactionId");
+
+    SELECT type INTO cash_leg_type
+      FROM "Transaction" WHERE id = cash_leg_id;
+    IF NOT FOUND THEN
+      PERFORM _per104_raise_foreign_key_violation(format(
+        'PER-196 valuation-linked Transfer %s references missing cash Transaction %s',
+        NEW.id, cash_leg_id));
+    END IF;
+
+    IF cash_leg_type <> 'transfer' THEN
+      PERFORM _per104_raise_check_violation(format(
+        'PER-196 malformed valuation-linked transfer type-shape (Transfer %s): cash leg type=%s; must be ''transfer''',
+        NEW.id, cash_leg_type));
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  SELECT type INTO outflow_type
+    FROM "Transaction" WHERE id = NEW."outflowTransactionId";
+  IF NOT FOUND THEN
+    PERFORM _per104_raise_foreign_key_violation(format(
+      'PER-103 Transfer %s references missing outflow Transaction %s',
+      NEW.id, NEW."outflowTransactionId"));
+  END IF;
+
+  SELECT type INTO inflow_type
+    FROM "Transaction" WHERE id = NEW."inflowTransactionId";
+  IF NOT FOUND THEN
+    PERFORM _per104_raise_foreign_key_violation(format(
+      'PER-103 Transfer %s references missing inflow Transaction %s',
+      NEW.id, NEW."inflowTransactionId"));
+  END IF;
+
+  IF outflow_type <> 'transfer' OR inflow_type <> 'transfer' THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-103 malformed transfer type-shape (Transfer %s): outflow type=%s, inflow type=%s; both must be ''transfer''',
+      NEW.id, outflow_type, inflow_type));
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION enforce_transfer_account_distinct_invariant()
+RETURNS TRIGGER AS $$
+DECLARE
+  outflow_account   TEXT;
+  inflow_account    TEXT;
+  cash_leg_id       TEXT;
+  cash_account      TEXT;
+  valuation_account TEXT;
+BEGIN
+  IF NEW."valuationId" IS NOT NULL THEN
+    cash_leg_id := COALESCE(NEW."outflowTransactionId", NEW."inflowTransactionId");
+
+    SELECT "accountId" INTO cash_account
+      FROM "Transaction" WHERE id = cash_leg_id;
+    SELECT "accountId" INTO valuation_account
+      FROM "Valuation" WHERE id = NEW."valuationId";
+
+    IF cash_account = valuation_account THEN
+      PERFORM _per104_raise_check_violation(format(
+        'PER-196 malformed valuation-linked transfer (Transfer %s): cash leg and valuation share account %s; a transfer must move between two distinct accounts',
+        NEW.id, cash_account));
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  SELECT "accountId" INTO outflow_account
+    FROM "Transaction" WHERE id = NEW."outflowTransactionId";
+  SELECT "accountId" INTO inflow_account
+    FROM "Transaction" WHERE id = NEW."inflowTransactionId";
+
+  IF outflow_account = inflow_account THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-103 malformed transfer (Transfer %s): outflow and inflow share account %s; a transfer must move between two distinct accounts',
+      NEW.id, outflow_account));
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- enforce_transfer_typed_transaction_paired_invariant (the deferred
+-- Transaction-side trigger) is UNCHANGED: it counts Transfer rows matching
+-- "outflowTransactionId = NEW.id OR inflowTransactionId = NEW.id", which
+-- already resolves to exactly 1 for a valuation-linked transfer's one
+-- type='transfer' Transaction row (it sits in whichever FK slot is non-null),
+-- identically to the classic dual-leg case.

--- a/prisma/migrations/20260720140000_transfer_rls_valuation_linked/migration.sql
+++ b/prisma/migrations/20260720140000_transfer_rls_valuation_linked/migration.sql
@@ -1,0 +1,52 @@
+-- PER-196 / ADR-0048 §4: transfer_tenant_isolation (PER-181's correlated-EXISTS
+-- fix) checked only outflowTransactionId, matching the old always-both-legs
+-- schema. A valuation-linked transfer (20260720130000) can have
+-- outflowTransactionId NULL (redemption: only inflowTransactionId is set) —
+-- "Transaction"."id" = NULL never matches, so RLS silently rejected every
+-- redemption-direction Transfer row. Fixed by OR-ing a second correlated
+-- EXISTS against inflowTransactionId: every Transfer shape (classic dual-leg,
+-- valuation-linked contribution, valuation-linked redemption) always has AT
+-- LEAST one non-null Transaction leg with the correct familyId, so this
+-- covers all three without reintroducing PER-181's O(n) IN-subquery
+-- regression — both EXISTS clauses remain correlated on Transaction's primary
+-- key, so each is an O(log n) index scan regardless of family size.
+
+DROP POLICY IF EXISTS transfer_tenant_isolation ON "Transfer";
+CREATE POLICY transfer_tenant_isolation ON "Transfer"
+  FOR ALL
+  USING (
+    (
+      EXISTS (
+        SELECT 1 FROM "Transaction"
+        WHERE "Transaction"."id" = "Transfer"."outflowTransactionId"
+          AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+      )
+      OR EXISTS (
+        SELECT 1 FROM "Transaction"
+        WHERE "Transaction"."id" = "Transfer"."inflowTransactionId"
+          AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+      )
+    )
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  )
+  WITH CHECK (
+    (
+      EXISTS (
+        SELECT 1 FROM "Transaction"
+        WHERE "Transaction"."id" = "Transfer"."outflowTransactionId"
+          AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+      )
+      OR EXISTS (
+        SELECT 1 FROM "Transaction"
+        WHERE "Transaction"."id" = "Transfer"."inflowTransactionId"
+          AND "Transaction"."familyId" = current_setting('app.family_id', true)::text
+      )
+    )
+    AND app_is_active_member(
+      current_setting('app.family_id', true)::text,
+      current_setting('app.user_id', true)::text
+    )
+  );

--- a/prisma/migrations/20260720150000_transfer_liability_and_tenant_invariants_valuation_linked/migration.sql
+++ b/prisma/migrations/20260720150000_transfer_liability_and_tenant_invariants_valuation_linked/migration.sql
@@ -1,0 +1,212 @@
+-- PER-196 / ADR-0048 §4: two more PER-104/PER-74 constraint triggers on
+-- "Transfer" that assumed both Transaction legs always exist, found via an
+-- exhaustive grep of every migration referencing outflowTransactionId /
+-- inflowTransactionId after 20260720130000 shipped (that migration only
+-- updated the three PER-103/ADR-0031 triggers; these two were missed the
+-- first pass and surfaced immediately by real-Postgres integration tests
+-- attempting a valuation-linked insert):
+--
+--   1. enforce_transfer_leg_pair_tenant_invariant (PER-104 / ADR-0010 §4.4):
+--      required both legs to resolve a Transaction and compared their
+--      familyId. Fixed by resolving the "other side" via the linked
+--      Valuation's own familyId when valuationId is set.
+--   2. enforce_transfer_liability_kind_invariant (PER-74 / liability
+--      semantics): required both legs to resolve a Transaction (kind +
+--      account class/type) and compared them. Fixed the same way: whichever
+--      side has no Transaction row resolves its account class/type through
+--      the linked Valuation's accountId instead, and the "both legs share
+--      kind" cross-check is skipped (only one kind value exists on a
+--      valuation-linked transfer — there's nothing to cross-check against).
+
+CREATE OR REPLACE FUNCTION enforce_transfer_leg_pair_tenant_invariant()
+RETURNS TRIGGER AS $$
+DECLARE
+  outflow_family   TEXT;
+  inflow_family    TEXT;
+  cash_leg_id      TEXT;
+  cash_family      TEXT;
+  valuation_family TEXT;
+BEGIN
+  IF NEW."valuationId" IS NOT NULL THEN
+    cash_leg_id := COALESCE(NEW."outflowTransactionId", NEW."inflowTransactionId");
+
+    SELECT t."familyId" INTO cash_family
+      FROM "Transaction" t WHERE t.id = cash_leg_id;
+    IF NOT FOUND THEN
+      PERFORM _per104_raise_foreign_key_violation(format(
+        'PER-196 valuation-linked Transfer %s references missing cash Transaction %s',
+        NEW.id, cash_leg_id));
+    END IF;
+
+    SELECT v."familyId" INTO valuation_family
+      FROM "Valuation" v WHERE v.id = NEW."valuationId";
+    IF NOT FOUND THEN
+      PERFORM _per104_raise_foreign_key_violation(format(
+        'PER-196 valuation-linked Transfer %s references missing Valuation %s',
+        NEW.id, NEW."valuationId"));
+    END IF;
+
+    IF cash_family = valuation_family THEN
+      RETURN NEW;
+    END IF;
+
+    PERFORM _per104_raise_check_violation(format(
+      'PER-196 cross-tenant valuation-linked Transfer rejected (Transfer -> cash %s, valuation %s): cash family=%s, valuation family=%s',
+      cash_leg_id, NEW."valuationId", cash_family, valuation_family));
+  END IF;
+
+  SELECT t."familyId" INTO outflow_family
+    FROM "Transaction" t WHERE t.id = NEW."outflowTransactionId";
+  IF NOT FOUND THEN
+    PERFORM _per104_raise_foreign_key_violation(format(
+        'PER-104 Transfer %s references missing outflow Transaction %s',
+        NEW.id, NEW."outflowTransactionId"
+      ));
+  END IF;
+
+  SELECT t."familyId" INTO inflow_family
+    FROM "Transaction" t WHERE t.id = NEW."inflowTransactionId";
+  IF NOT FOUND THEN
+    PERFORM _per104_raise_foreign_key_violation(format(
+        'PER-104 Transfer %s references missing inflow Transaction %s',
+        NEW.id, NEW."inflowTransactionId"
+      ));
+  END IF;
+
+  IF outflow_family = inflow_family THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM _per104_raise_check_violation(format(
+      'PER-104 cross-tenant Transfer leg pair rejected (Transfer -> outflow %s, inflow %s): outflow family=%s, inflow family=%s',
+      NEW."outflowTransactionId", NEW."inflowTransactionId",
+      outflow_family, inflow_family
+    ));
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION enforce_transfer_liability_kind_invariant()
+RETURNS TRIGGER AS $$
+DECLARE
+  expected_kind TEXT;
+  cash_kind TEXT;
+  outflow_account_class TEXT;
+  outflow_account_type TEXT;
+  inflow_account_class TEXT;
+  inflow_account_type TEXT;
+  outflow_kind TEXT;
+  inflow_kind TEXT;
+BEGIN
+  IF NEW."valuationId" IS NOT NULL THEN
+    IF NEW."outflowTransactionId" IS NOT NULL THEN
+      SELECT tx.kind, a."accountClass", a."accountType"
+        INTO cash_kind, outflow_account_class, outflow_account_type
+        FROM "Transaction" tx
+        JOIN "Account" a ON a.id = tx."accountId" AND a."familyId" = tx."familyId"
+       WHERE tx.id = NEW."outflowTransactionId";
+
+      SELECT a."accountClass", a."accountType"
+        INTO inflow_account_class, inflow_account_type
+        FROM "Valuation" v
+        JOIN "Account" a ON a.id = v."accountId" AND a."familyId" = v."familyId"
+       WHERE v.id = NEW."valuationId";
+    ELSE
+      SELECT tx.kind, a."accountClass", a."accountType"
+        INTO cash_kind, inflow_account_class, inflow_account_type
+        FROM "Transaction" tx
+        JOIN "Account" a ON a.id = tx."accountId" AND a."familyId" = tx."familyId"
+       WHERE tx.id = NEW."inflowTransactionId";
+
+      SELECT a."accountClass", a."accountType"
+        INTO outflow_account_class, outflow_account_type
+        FROM "Valuation" v
+        JOIN "Account" a ON a.id = v."accountId" AND a."familyId" = v."familyId"
+       WHERE v.id = NEW."valuationId";
+    END IF;
+
+    IF inflow_account_type = 'CREDIT' THEN
+      expected_kind := 'cc_payment';
+    ELSIF inflow_account_type = 'LOAN' THEN
+      expected_kind := 'loan_payment';
+    ELSIF outflow_account_class = 'LIABILITY' AND inflow_account_class = 'ASSET' THEN
+      expected_kind := 'liability_draw';
+    ELSIF outflow_account_class = 'ASSET' AND inflow_account_class = 'ASSET' THEN
+      expected_kind := 'funds_movement';
+    ELSE
+      PERFORM _per104_raise_check_violation(format(
+        'PER-196 unsupported valuation-linked transfer direction (Transfer %s): outflow %s/%s, inflow %s/%s',
+        NEW.id, outflow_account_class, outflow_account_type, inflow_account_class, inflow_account_type));
+    END IF;
+
+    IF cash_kind IS DISTINCT FROM expected_kind THEN
+      PERFORM _per104_raise_check_violation(format(
+        'PER-196 malformed valuation-linked transfer kind (Transfer %s): expected %s for outflow %s/%s -> inflow %s/%s, got %s',
+        NEW.id, expected_kind, outflow_account_class, outflow_account_type, inflow_account_class, inflow_account_type, cash_kind));
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  SELECT
+      outflow_tx.kind,
+      outflow_account."accountClass",
+      outflow_account."accountType"
+    INTO outflow_kind, outflow_account_class, outflow_account_type
+    FROM "Transaction" outflow_tx
+    JOIN "Account" outflow_account
+      ON outflow_account.id = outflow_tx."accountId"
+     AND outflow_account."familyId" = outflow_tx."familyId"
+   WHERE outflow_tx.id = NEW."outflowTransactionId";
+
+  SELECT
+      inflow_tx.kind,
+      inflow_account."accountClass",
+      inflow_account."accountType"
+    INTO inflow_kind, inflow_account_class, inflow_account_type
+    FROM "Transaction" inflow_tx
+    JOIN "Account" inflow_account
+      ON inflow_account.id = inflow_tx."accountId"
+     AND inflow_account."familyId" = inflow_tx."familyId"
+   WHERE inflow_tx.id = NEW."inflowTransactionId";
+
+  IF outflow_kind IS DISTINCT FROM inflow_kind THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-74 malformed transfer kind pair (Transfer %s): outflow kind=%s, inflow kind=%s; both legs must share kind',
+      NEW.id, outflow_kind, inflow_kind));
+  END IF;
+
+  IF inflow_account_type = 'CREDIT' THEN
+    expected_kind := 'cc_payment';
+  ELSIF inflow_account_type = 'LOAN' THEN
+    expected_kind := 'loan_payment';
+  ELSIF outflow_account_class = 'LIABILITY'
+     AND inflow_account_class = 'ASSET' THEN
+    expected_kind := 'liability_draw';
+  ELSIF outflow_account_class = 'ASSET'
+     AND inflow_account_class = 'ASSET' THEN
+    expected_kind := 'funds_movement';
+  ELSE
+    PERFORM _per104_raise_check_violation(format(
+      'PER-74 unsupported transfer liability direction (Transfer %s): outflow %s/%s, inflow %s/%s',
+      NEW.id,
+      outflow_account_class,
+      outflow_account_type,
+      inflow_account_class,
+      inflow_account_type));
+  END IF;
+
+  IF outflow_kind IS DISTINCT FROM expected_kind THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-74 malformed transfer kind (Transfer %s): expected %s for outflow %s/%s -> inflow %s/%s, got %s',
+      NEW.id,
+      expected_kind,
+      outflow_account_class,
+      outflow_account_type,
+      inflow_account_class,
+      inflow_account_type,
+      outflow_kind));
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -422,13 +422,24 @@ model AuditLog {
 model Transfer {
   id String @id @default(cuid())
 
-  // Transaksi Uang Keluar (Sumber)
-  outflowTransactionId String      @unique
-  outflowTransaction   Transaction @relation("OutflowTransaction", fields: [outflowTransactionId], references: [id], onDelete: Restrict)
+  // Transaksi Uang Keluar (Sumber). ADR-0048 §4: nullable — a valuation-linked
+  // move (one leg cash, one leg a Valuation on a balanceSource="valuation"
+  // account) sets exactly one of outflowTransactionId/inflowTransactionId,
+  // never both null and never both set alongside valuationId. See
+  // transfer_leg_shape CHECK below.
+  outflowTransactionId String?      @unique
+  outflowTransaction   Transaction? @relation("OutflowTransaction", fields: [outflowTransactionId], references: [id], onDelete: Restrict)
 
-  // Transaksi Uang Masuk (Tujuan)
-  inflowTransactionId String      @unique
-  inflowTransaction   Transaction @relation("InflowTransaction", fields: [inflowTransactionId], references: [id], onDelete: Restrict)
+  // Transaksi Uang Masuk (Tujuan). ADR-0048 §4: nullable, see above.
+  inflowTransactionId String?      @unique
+  inflowTransaction   Transaction? @relation("InflowTransaction", fields: [inflowTransactionId], references: [id], onDelete: Restrict)
+
+  // ADR-0048 §4: the valuation-tracked side of a valuation-linked move — the
+  // NEW Valuation written on the balanceSource="valuation" account in the same
+  // $transaction as the one cash Transaction leg above. NULL for a classic
+  // dual-Transaction transfer.
+  valuationId String?    @unique
+  valuation   Valuation? @relation(fields: [valuationId], references: [id], onDelete: Restrict)
 
   // Cross-currency rate recorded on the canonical pairing record (ADR-0035 §5).
   // Implied source->dest rate, 1e12-scaled, DERIVED from the two native legs.
@@ -591,6 +602,11 @@ model Valuation {
 
   familyId String
   family   Family @relation(fields: [familyId], references: [id])
+
+  // ADR-0048 §4: back-relation for the optional Transfer.valuationId leg — a
+  // valuation-linked money move links its Valuation write here. NULL for the
+  // (still-common) standalone valuation with no linked transfer.
+  transfer Transfer?
 
   // Latest-valuation-per-account (tracked balance + rebuild) and
   // type lookups (opening anchor / reconciliation drift).

--- a/src/server/accounts.ts
+++ b/src/server/accounts.ts
@@ -799,22 +799,36 @@ export async function getAccountDeletionImpactForFamily({
           OR: [
             { outflowTransaction: { accountId: data.id, deletedAt: null } },
             { inflowTransaction: { accountId: data.id, deletedAt: null } },
+            // PER-196 / ADR-0048 §4: a valuation-linked transfer's
+            // tracked-asset side has no Transaction leg at all — only
+            // reachable via the linked Valuation's accountId.
+            { valuation: { accountId: data.id, deletedAt: null } },
           ],
         },
         select: {
           outflowTransaction: { select: { accountId: true } },
           inflowTransaction: { select: { accountId: true } },
+          valuation: { select: { accountId: true } },
         },
       }),
     ])
 
     const otherAccountIds = new Set<string>()
     for (const transfer of transfers) {
-      if (transfer.outflowTransaction.accountId !== data.id) {
+      if (
+        transfer.outflowTransaction &&
+        transfer.outflowTransaction.accountId !== data.id
+      ) {
         otherAccountIds.add(transfer.outflowTransaction.accountId)
       }
-      if (transfer.inflowTransaction.accountId !== data.id) {
+      if (
+        transfer.inflowTransaction &&
+        transfer.inflowTransaction.accountId !== data.id
+      ) {
         otherAccountIds.add(transfer.inflowTransaction.accountId)
+      }
+      if (transfer.valuation && transfer.valuation.accountId !== data.id) {
+        otherAccountIds.add(transfer.valuation.accountId)
       }
     }
 

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -1753,6 +1753,15 @@ async function pairAndPromoteSureTransfers({
           select: { inflowTransactionId: true },
         })
         if (!transfer) throw new Error("Transfer link row not found")
+        if (!transfer.inflowTransactionId) {
+          // Unreachable: this promotion path only ever creates classic
+          // dual-leg Transfer rows (PER-196 / ADR-0048's valuation-linked
+          // shape is written elsewhere, never by Sure-migration promotion).
+          // Narrows the type below without a cast.
+          throw new Error(
+            `Transfer link row for outflow leg ${outflowLeg.id} is missing its inflow leg`
+          )
+        }
 
         const entries: AuditLogEntry[] = []
         await markSureTransferRowPromoted(tx, outRow.id, outflowLeg.id, entries)

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from "@tanstack/react-start"
-import type { Prisma } from "@prisma/client"
+import type { Account, Prisma } from "@prisma/client"
 import { z } from "zod"
 import {
   deriveTransferKindForAccounts,
@@ -7,7 +7,15 @@ import {
   parseAccountType,
   TRANSACTION_KIND_VALUES,
 } from "@/lib/liability-semantics"
-import { absMoney, encodeMoney, negateMoney, type Money } from "@/lib/money"
+import {
+  absMoney,
+  addMoney,
+  encodeMoney,
+  negateMoney,
+  subMoney,
+  toMoney,
+  type Money,
+} from "@/lib/money"
 import { deriveTransferFx } from "@/lib/fx"
 import { assertSplitParity } from "@/lib/split-parity"
 import { computeBaseProjectionForAmount, getFamilyBaseCurrency } from "./fx"
@@ -39,6 +47,13 @@ import {
   uuidV7Schema,
   type RunInTenantTransaction,
 } from "./mutation-kit"
+import {
+  createValuationWithinTx,
+  latestValuation,
+  valueMagnitudeSchema,
+  ValuationError,
+  type CreateValuationInput,
+} from "./valuations"
 
 export { IdempotencyConflictError } from "./idempotency"
 
@@ -312,15 +327,31 @@ async function findTransferGraph(tx: TenantTransactionClient, id: string) {
   const transfer = await tx.transfer.findUnique({ where: { id } })
   if (!transfer) return null
 
+  // PER-196 / ADR-0048 §4: editing/deleting a valuation-linked transfer (one
+  // Transaction leg + one Valuation leg) is not yet supported — the
+  // reversal-and-replace machinery below assumes two Transaction legs. Fail
+  // loud here, the single choke point every update/delete path reads a
+  // transfer graph through, rather than let a null leg crash deeper in.
+  if (transfer.valuationId !== null) {
+    throw new ValuationLinkedTransferUnsupportedError()
+  }
+  if (!transfer.outflowTransactionId || !transfer.inflowTransactionId) {
+    // Unreachable given transfer_leg_shape (DB CHECK) once valuationId is
+    // null — narrows the type for the lookups below without a cast.
+    throw new Error(`Transfer ${id} has a malformed leg shape`)
+  }
+  const outflowTransactionId = transfer.outflowTransactionId
+  const inflowTransactionId = transfer.inflowTransactionId
+
   const [outflowTransaction, inflowTransaction] =
     await runTenantTransactionQueriesInOrder([
       () =>
         tx.transaction.findUniqueOrThrow({
-          where: { id: transfer.outflowTransactionId },
+          where: { id: outflowTransactionId },
         }),
       () =>
         tx.transaction.findUniqueOrThrow({
-          where: { id: transfer.inflowTransactionId },
+          where: { id: inflowTransactionId },
         }),
     ] as const)
 
@@ -568,6 +599,22 @@ export class ValuationAccountLedgerError extends Error {
   }
 }
 
+// PER-196 / ADR-0048 §4: a valuation-linked transfer (one Transaction leg +
+// one Valuation leg) does not yet support the update/delete
+// reversal-and-replace path — that machinery assumes two Transaction legs.
+// Raised by `findTransferGraph`, the single choke point every mutation of an
+// EXISTING transfer reads its graph through, so this never reaches deeper
+// null-unsafe code. Creating a new valuation-linked transfer is unaffected.
+export class ValuationLinkedTransferUnsupportedError extends Error {
+  override readonly name = "ValuationLinkedTransferUnsupportedError"
+  readonly statusCode = 422
+  constructor(
+    message = "Editing or deleting a valuation-linked transfer is not yet supported. Delete it and record a new transfer instead."
+  ) {
+    super(message)
+  }
+}
+
 // Reads the ADR-0044 §8 bulk-replay bypass GUC (`app.bulk_ledger_replay`,
 // SET LOCAL by `withBulkLedgerReplayBypass`, `src/server/bulk-ledger-replay.ts`
 // — the single anchor that sets it). This is a READ only; it must never call
@@ -717,6 +764,12 @@ const transactionInputSchema = z.object({
   fxFeeAmount: positiveMoneyInputSchema.nullable().optional(),
   fxFeeAccountId: z.string().nullable().optional(),
   fxFeeCategoryId: z.string().nullable().optional(),
+  // PER-196 / ADR-0048 §1: valuation-linked transfer. When either transfer
+  // side is a balanceSource="valuation" account, this is the new valuation
+  // value for that account (prefilled client-side as latest ∓ amount,
+  // editable). Ignored for non-transfer transactions and for a transfer
+  // between two transaction_flow accounts.
+  newValuationValue: valueMagnitudeSchema.optional(),
 })
 
 const createTransactionTransportInputSchema = transactionInputSchema.extend({
@@ -1139,7 +1192,16 @@ function canonicalSplitEntries(
   }))
 }
 
-function canonicalRequestPayload(data: CreateTransactionInput) {
+function canonicalRequestPayload(
+  data: CreateTransactionInput,
+  // PER-196 / ADR-0048 §4: a valuation-linked transfer has no real second
+  // Transaction leg, so there is nothing comparable to fabricate here.
+  // Defaults to true (existing classic-transfer behavior, and the update
+  // endpoint's own request-hash use at canonicalUpdateRequestPayload, which
+  // never reaches a persisted valuation-linked row anyway since that path
+  // fails loud via ValuationLinkedTransferUnsupportedError first).
+  { hasTransferPartner = true }: { hasTransferPartner?: boolean } = {}
+) {
   return {
     accountId: data.accountId,
     amount: encodeMoney(absMoney(data.amount)),
@@ -1160,7 +1222,7 @@ function canonicalRequestPayload(data: CreateTransactionInput) {
     status: data.status,
     toAccountId: data.toAccountId ?? null,
     transferPartner:
-      data.type === "transfer"
+      data.type === "transfer" && hasTransferPartner
         ? {
             accountId: data.toAccountId ?? null,
             amount: encodeMoney(
@@ -1307,8 +1369,21 @@ function assertIdempotentPayloadMatches(
   data: CreateTransactionInput,
   existing: PersistedTransactionForIdempotency
 ): void {
+  // PER-196 / ADR-0048 §4: `existing` is the Transaction row carrying the
+  // idempotency key — always the cash leg for a valuation-linked transfer,
+  // in whichever FK slot it landed in. It has a real transfer partner only
+  // when it's the outflow leg of a classic dual-leg transfer (transferOut
+  // resolves and its inflowTransaction is non-null); a valuation-linked
+  // contribution's transferOut.inflowTransaction is null, and a
+  // valuation-linked redemption's cash leg has no transferOut at all (it
+  // sits in inflowTransactionId instead).
+  const hasTransferPartner =
+    existing.type === "transfer" &&
+    existing.transferOut !== null &&
+    existing.transferOut.inflowTransaction !== null
+
   if (
-    JSON.stringify(canonicalRequestPayload(data)) !==
+    JSON.stringify(canonicalRequestPayload(data, { hasTransferPartner })) !==
     JSON.stringify(canonicalPersistedPayload(existing))
   ) {
     throw new IdempotencyConflictError()
@@ -1350,9 +1425,14 @@ async function findIdempotentTransaction(
   const transferOutWithInflowTransaction = transferOut
     ? {
         ...transferOut,
-        inflowTransaction: await tx.transaction.findUniqueOrThrow({
-          where: { id: transferOut.inflowTransactionId },
-        }),
+        // PER-196 / ADR-0048 §4: null for a valuation-linked transfer where
+        // THIS transaction is the outflow (contribution) leg — there is no
+        // inflow Transaction, only a linked Valuation.
+        inflowTransaction: transferOut.inflowTransactionId
+          ? await tx.transaction.findUniqueOrThrow({
+              where: { id: transferOut.inflowTransactionId },
+            })
+          : null,
       }
     : null
 
@@ -1500,6 +1580,149 @@ async function normalizeBulkDeleteTransactionsTransportInput(
   })
 }
 
+// PER-196 / ADR-0048 §1/§4: a transfer touching a balanceSource="valuation"
+// account is a valuation-linked move — one Transaction leg on the cash side
+// + one new Valuation on the tracked-asset side, linked by one Transfer row
+// (valuationId set, exactly one of outflowTransactionId/inflowTransactionId
+// set) — never a raw dual-leg transfer. Called from createTransactionForFamily's
+// transfer branch once it detects either side is valuation-tracked.
+async function createValuationLinkedTransferWithinTx(
+  tx: TenantTransactionClient,
+  {
+    cashAccount,
+    trackedAccount,
+    direction,
+    kind,
+    data,
+    familyId,
+    user,
+    auditCtx,
+    baseCurrency,
+  }: {
+    cashAccount: Account
+    trackedAccount: Account
+    direction: "contribution" | "redemption"
+    kind: string
+    data: CreateTransactionInput
+    familyId: string
+    user: { id: string }
+    auditCtx: AuditContext
+    baseCurrency: string
+  }
+) {
+  // v1 scope (ADR-0048 §1): the prefill formula (latest ∓ cashAmount) and the
+  // cash leg's own amount are both denominated in one currency. Cross-
+  // currency valuation-linked transfers need their own FX design and are not
+  // supported yet — fail loud rather than silently mixing currencies.
+  if (cashAccount.currency !== trackedAccount.currency) {
+    throw new ValuationError(
+      `Valuation-linked transfer requires matching currencies (cash account ${cashAccount.currency}, tracked account ${trackedAccount.currency}); cross-currency is not yet supported`
+    )
+  }
+
+  const isContribution = direction === "contribution"
+  const cashAmount = absMoney(data.amount)
+  const cashDelta = isContribution ? negateMoney(cashAmount) : cashAmount
+
+  const cashMutation = await applyAccountBalanceDelta(tx, {
+    accountId: cashAccount.id,
+    delta: cashDelta,
+    familyId,
+    notFoundMessage: "Cash account not found or access denied!",
+  })
+  const cashBalanceAfter = cashMutation.after.balance
+
+  const projection = await computeBaseProjectionForAmount(tx, familyId, {
+    amount: cashDelta,
+    currency: cashAccount.currency,
+    date: data.date,
+    baseCurrency,
+  })
+
+  const cashTx = await tx.transaction.create({
+    data: {
+      ...(data.id ? { id: data.id } : {}),
+      type: "transfer",
+      kind,
+      currency: cashAccount.currency,
+      amount: cashDelta,
+      description: data.description,
+      date: data.date,
+      notes: data.notes || null,
+      accountId: cashAccount.id,
+      toAccountId: trackedAccount.id,
+      categoryId: data.categoryId || null,
+      merchantId: data.merchantId || null,
+      userId: user.id,
+      familyId,
+      status: data.status,
+      baseAmount: projection.baseAmount,
+      baseCurrency: projection.baseCurrency,
+      fxRateScaled: projection.fxRateScaled,
+      fxRateSnapshotId: projection.fxRateSnapshotId,
+      accountBalanceAfter: cashBalanceAfter,
+      attachmentUrl: data.attachmentUrl,
+      idempotencyKey: data.idempotencyKey,
+    },
+  })
+
+  // New valuation value (ADR-0048 §1): prefilled latest ∓ cashAmount,
+  // editable via data.newValuationValue. A redemption that would drive the
+  // tracked value negative is rejected by createValuationWithinTx's existing
+  // ADR-0045 sign check — you cannot redeem more than the tracked asset is
+  // currently worth.
+  const latest = await latestValuation(tx, familyId, trackedAccount.id)
+  const latestValue = latest?.value ?? toMoney(trackedAccount.balance)
+  const prefill = isContribution
+    ? addMoney(latestValue, cashAmount)
+    : subMoney(latestValue, cashAmount)
+  const newValuationMagnitude = data.newValuationValue
+    ? BigInt(data.newValuationValue)
+    : prefill
+
+  const valuationInput: CreateValuationInput = {
+    accountId: trackedAccount.id,
+    value: newValuationMagnitude.toString(),
+    currency: trackedAccount.currency,
+    valuationDate: data.date,
+    type: "manual",
+    source: "transfer",
+    note: null,
+    idempotencyKey: data.idempotencyKey,
+  }
+  const { valuation } = await createValuationWithinTx(
+    tx,
+    familyId,
+    valuationInput,
+    user,
+    auditCtx
+  )
+
+  const createdTransfer = await tx.transfer.create({
+    data: {
+      ...(isContribution
+        ? { outflowTransactionId: cashTx.id }
+        : { inflowTransactionId: cashTx.id }),
+      valuationId: valuation.id,
+    },
+  })
+
+  const newCashAccount = await tx.account.findUniqueOrThrow({
+    where: { id: cashAccount.id },
+  })
+
+  await auditLogs(tx, auditCtx, [
+    ...accountBalanceAuditEntries([cashAccount], [newCashAccount]),
+    ...createdAuditEntries("Transaction", [cashTx]),
+    ...createdAuditEntries("Transfer", [createdTransfer]),
+  ])
+
+  return serializeTransaction({
+    ...cashTx,
+    amount: absMoney(cashTx.amount),
+  })
+}
+
 export async function createTransactionForFamily({
   data: rawData,
   familyId,
@@ -1564,6 +1787,31 @@ export async function createTransactionForFamily({
             fromAccountType: parseAccountType(oldSrcAcc.accountType),
             toAccountType: parseAccountType(oldDstAcc.accountType),
           })
+
+          // PER-196 / ADR-0048 §1/§2: route to the valuation-linked path
+          // whenever either side is balanceSource="valuation" — the classic
+          // dual-leg path below would otherwise hit applyAccountBalanceDelta's
+          // ADR-0048 §3 guard and fail on the destination leg.
+          const srcIsValuation = oldSrcAcc.balanceSource === "valuation"
+          const dstIsValuation = oldDstAcc.balanceSource === "valuation"
+          if (srcIsValuation && dstIsValuation) {
+            throw new ValuationError(
+              "Transfers between two valuation-tracked accounts are not supported (ADR-0048 §2)"
+            )
+          }
+          if (srcIsValuation || dstIsValuation) {
+            return await createValuationLinkedTransferWithinTx(tx, {
+              cashAccount: srcIsValuation ? oldDstAcc : oldSrcAcc,
+              trackedAccount: srcIsValuation ? oldSrcAcc : oldDstAcc,
+              direction: srcIsValuation ? "redemption" : "contribution",
+              kind,
+              data,
+              familyId,
+              user,
+              auditCtx,
+              baseCurrency,
+            })
+          }
 
           const sourceMutation = await applyAccountBalanceDelta(tx, {
             accountId: data.accountId,
@@ -1905,13 +2153,32 @@ export async function softDeleteTransactionWithinTenantTransaction(
     throw new TransactionGoneError()
   }
 
+  // PER-196 / ADR-0048 §4: a valuation-linked transfer's ONE Transaction leg
+  // can sit in either FK slot (outflow for a contribution, inflow for a
+  // redemption) with no Transaction at all on the other side. Detect that
+  // shape before the classic-transfer redirect/reversal logic below, which
+  // assumes two Transaction legs, ever runs.
+  if (
+    oldTx.type === "transfer" &&
+    ((oldTx.transferIn && oldTx.transferIn.outflowTransactionId === null) ||
+      (oldTx.transferOut && oldTx.transferOut.inflowTransactionId === null))
+  ) {
+    throw new ValuationLinkedTransferUnsupportedError()
+  }
+
   // PER-20 / ADR-0012: a transfer is one money movement. If the user clicked
   // the inflow leg, redirect to the outflow leg so the symmetric handler logic
   // below treats outflow as the source of truth.
   if (oldTx.type === "transfer" && oldTx.transferIn && !oldTx.transferOut) {
+    // Guaranteed non-null by the valuation-linked check above (would have
+    // thrown otherwise) — narrows the type for the lookup below.
+    const outflowTransactionId = oldTx.transferIn.outflowTransactionId
+    if (!outflowTransactionId) {
+      throw new ValuationLinkedTransferUnsupportedError()
+    }
     const outflowAuditGraph = await findTransactionAuditGraph(
       tx,
-      oldTx.transferIn.outflowTransactionId
+      outflowTransactionId
     )
     if (!outflowAuditGraph) {
       throw new Error("Transfer outflow leg missing for inflow soft-delete")
@@ -1931,10 +2198,10 @@ export async function softDeleteTransactionWithinTenantTransaction(
   }
 
   const inflowTx =
-    oldTx.type === "transfer" && oldTx.transferOut
+    oldTx.type === "transfer" && oldTransferGraph
       ? await findOptionalTransactionWithSplitEntries(
           tx,
-          oldTx.transferOut.inflowTransactionId
+          oldTransferGraph.inflowTransaction.id
         )
       : null
 
@@ -2247,10 +2514,27 @@ async function replaceTransactionWithinTenantTransaction(
   if (!oldTx) throw new Error("Original transaction not found")
   if (oldTx.deletedAt !== null) throw new TransactionGoneError()
 
+  // PER-196 / ADR-0048 §4: editing a valuation-linked transfer's one
+  // Transaction leg is not yet supported — the reversal/replace logic below
+  // assumes two Transaction legs. Fail loud before any redirect/reversal
+  // step runs.
+  if (
+    oldTx.type === "transfer" &&
+    ((oldTx.transferIn && oldTx.transferIn.outflowTransactionId === null) ||
+      (oldTx.transferOut && oldTx.transferOut.inflowTransactionId === null))
+  ) {
+    throw new ValuationLinkedTransferUnsupportedError()
+  }
+
   if (oldTx.type === "transfer" && oldTx.transferIn && !oldTx.transferOut) {
+    // Guaranteed non-null by the valuation-linked check above.
+    const outflowTransactionId = oldTx.transferIn.outflowTransactionId
+    if (!outflowTransactionId) {
+      throw new ValuationLinkedTransferUnsupportedError()
+    }
     const outflowAuditGraph = await findTransactionAuditGraph(
       tx,
-      oldTx.transferIn.outflowTransactionId
+      outflowTransactionId
     )
     if (!outflowAuditGraph) {
       throw new Error("Transfer outflow leg missing for update")
@@ -2261,13 +2545,6 @@ async function replaceTransactionWithinTenantTransaction(
     oldTx = outflowAuditGraph
   }
 
-  const oldInflowTx =
-    oldTx.type === "transfer" && oldTx.transferOut
-      ? await findTransactionWithSplitEntries(
-          tx,
-          oldTx.transferOut.inflowTransactionId
-        )
-      : null
   const oldTransferGraph =
     oldTx.type === "transfer" && oldTx.transferOut
       ? await findTransferGraph(tx, oldTx.transferOut.id)
@@ -2275,6 +2552,13 @@ async function replaceTransactionWithinTenantTransaction(
   if (oldTransferGraph?.deletedAt !== null && oldTransferGraph) {
     throw new TransactionGoneError()
   }
+  const oldInflowTx =
+    oldTx.type === "transfer" && oldTransferGraph
+      ? await findTransactionWithSplitEntries(
+          tx,
+          oldTransferGraph.inflowTransaction.id
+        )
+      : null
 
   // Kumpulkan semua akun yang terpengaruh (sebelum dan sesudah).
   const touchedAccountIds = new Set([oldTx.accountId, data.accountId])

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -11,7 +11,11 @@ import {
   type Money,
 } from "@/lib/money"
 import { computeBaseProjectionForAmount, getFamilyBaseCurrency } from "./fx"
-import { auditLog, createAuditContext } from "./middleware/audit"
+import {
+  auditLog,
+  createAuditContext,
+  type AuditContext,
+} from "./middleware/audit"
 import {
   familyMiddleware,
   requireCapability,
@@ -98,7 +102,7 @@ const currencySchema = z
 // balance); createValuationForFamily rejects a negative value at the
 // application boundary for every other accountType (validated error, never a
 // raw DB CHECK failure) before any write.
-const valueMagnitudeSchema = z
+export const valueMagnitudeSchema = z
   .string()
   .regex(/^-?\d+$/, "value must be a string of digits, optionally signed")
 
@@ -113,7 +117,7 @@ export const createValuationInputSchema = z.object({
   idempotencyKey: uuidV7Schema,
 })
 
-type CreateValuationInput = z.infer<typeof createValuationInputSchema>
+export type CreateValuationInput = z.infer<typeof createValuationInputSchema>
 
 export const accountBalanceQuerySchema = z.object({
   accountId: z.string().min(1),
@@ -205,7 +209,7 @@ export interface BalanceDriftReport {
   toAnchorSource?: string
 }
 
-interface ServerActor {
+export interface ServerActor {
   id: string
 }
 
@@ -292,7 +296,7 @@ async function sumTransactionFlowInRange(
 // flow (cash) accounts call it with `anchorTypesOnly: true, asOf` — latest
 // balance-assertion anchor (ADR-0043 §1 ANCHOR_VALUATION_TYPES) at or before
 // a given date.
-async function latestValuation(
+export async function latestValuation(
   tx: TenantTransactionClient,
   familyId: string,
   accountId: string,
@@ -406,6 +410,126 @@ async function fetchAccountFacts(
 // CREATE VALUATION
 // =============================================================================
 
+// Tx-scoped primitive shared by `createValuationForFamily` (the standalone
+// endpoint) and PER-196 / ADR-0048's valuation-linked transfer path
+// (`src/server/transactions.ts`): validates, signs, writes one Valuation row,
+// and re-materializes the account's balance if the new valuation changes it.
+// Idempotency (replay + persist) stays the caller's responsibility — each
+// entry point has its own endpoint/operation-scoped idempotency key, and the
+// valuation-linked transfer shares ONE key with its paired Transaction write
+// rather than owning a second one.
+export async function createValuationWithinTx(
+  tx: TenantTransactionClient,
+  familyId: string,
+  data: CreateValuationInput,
+  user: ServerActor,
+  auditCtx: AuditContext
+): Promise<{ serialized: SerializedValuation; valuation: Valuation }> {
+  if (!PUBLIC_VALUATION_TYPE_SET.has(data.type)) {
+    throw new ValuationError(
+      `Valuation type "${data.type}" is not allowed; use one of ${PUBLIC_VALUATION_TYPES.join(", ")}`
+    )
+  }
+  const valuationType = data.type as PublicValuationType
+  const rawValue = BigInt(data.value)
+
+  // Tenant ownership first: a cross-tenant accountId short-circuits with a
+  // typed TenantReferenceError before any write.
+  await validateTenantReferences(tx, familyId, {
+    accountId: data.accountId,
+  })
+
+  const account = await fetchAccountFacts(tx, familyId, data.accountId)
+  if (!account) {
+    throw new ValuationError(`Account ${data.accountId} not found`)
+  }
+
+  const currency = data.currency ?? account.currency
+  if (currency !== account.currency) {
+    throw new ValuationError(
+      `Valuation currency ${currency} must match account currency ${account.currency} (cross-currency is PER-147)`
+    )
+  }
+
+  // ADR-0045: a negative input is only meaningful for a carve-out ASSET
+  // account (DEPOSITORY/E_WALLET, real overdraft). Every other accountType
+  // rejects it here — a validated 422, never a raw DB CHECK failure.
+  const accountAllowsNegative = allowsNegativeAssetBalance(account.accountType)
+  if (rawValue < 0n && !accountAllowsNegative) {
+    throw new ValuationError(
+      `Valuation value cannot be negative for account type ${account.accountType}`
+    )
+  }
+  const signedValue =
+    rawValue < 0n
+      ? toMoney(rawValue)
+      : signMagnitudeForAccount(account.accountClass, rawValue)
+
+  // Base-currency projection (PER-147 / ADR-0035 §4/§7), keyed off the
+  // valuation date so historical net worth stays stable.
+  const valuationDate = data.valuationDate ?? new Date()
+  const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+  const projection = await computeBaseProjectionForAmount(tx, familyId, {
+    amount: signedValue,
+    currency,
+    date: valuationDate,
+    baseCurrency,
+  })
+
+  const valuation = await tx.valuation.create({
+    data: {
+      accountId: account.id,
+      familyId,
+      value: signedValue,
+      currency,
+      valuationDate,
+      type: valuationType,
+      source: data.source ?? "manual",
+      note: data.note ?? null,
+      normalBalance: normalBalanceForClass(account.accountClass),
+      allowsNegativeAsset: accountAllowsNegative,
+      createdById: user.id,
+      baseValue: projection.baseAmount,
+      baseCurrency: projection.baseCurrency,
+      fxRateScaled: projection.fxRateScaled,
+      fxRateSnapshotId: projection.fxRateSnapshotId,
+    },
+  })
+  const serialized = serializeValuation(valuation)
+
+  await auditLog(tx, auditCtx, {
+    action: "create",
+    entityType: "Valuation",
+    entityId: valuation.id,
+    after: serialized,
+  })
+
+  // Re-materialize the balance from canonical rows (ADR-0043). Tracked
+  // accounts always follow their latest valuation (ADR-0034 §5). Cash
+  // accounts move only when this valuation is an anchor type that is
+  // currently the effective anchor (latest <= now) — a backdated anchor
+  // superseded by a later one, or a "market" observation, leaves the
+  // materialized balance untouched, same as before.
+  const canonical = await computeCanonicalBalance(tx, familyId, account)
+  if (canonical !== toMoney(account.balance)) {
+    await setAccountBalanceTo(tx, {
+      accountId: account.id,
+      familyId,
+      target: canonical,
+      currentVersion: account.version,
+    })
+    await auditLog(tx, auditCtx, {
+      action: "update",
+      entityType: "Account",
+      entityId: account.id,
+      before: { balance: account.balance.toString() },
+      after: { balance: canonical.toString() },
+    })
+  }
+
+  return { serialized, valuation }
+}
+
 export async function createValuationForFamily({
   data: rawData,
   familyId,
@@ -419,23 +543,12 @@ export async function createValuationForFamily({
 }): Promise<SerializedValuation> {
   const data: CreateValuationInput = createValuationInputSchema.parse(rawData)
 
-  if (!PUBLIC_VALUATION_TYPE_SET.has(data.type)) {
-    throw new ValuationError(
-      `Valuation type "${data.type}" is not allowed; use one of ${PUBLIC_VALUATION_TYPES.join(", ")}`
-    )
-  }
-  const valuationType = data.type as PublicValuationType
-  // Normally a non-negative magnitude, auto-signed below by the account's
-  // normal balance. ADR-0045: a caller may pass an explicit negative value
-  // (e.g. reconciling an overdrawn e-wallet) — validated per-account below,
-  // once accountType is known, before any write.
-  const rawValue = BigInt(data.value)
   const requestHash = await hashCanonicalPayload({
     accountId: data.accountId,
     currency: data.currency ?? null,
     note: data.note ?? null,
     source: data.source ?? null,
-    type: valuationType,
+    type: data.type,
     value: data.value,
     valuationDate: data.valuationDate?.toISOString() ?? null,
   })
@@ -455,101 +568,13 @@ export async function createValuationForFamily({
         })
       if (replay) return replay
 
-      // Tenant ownership first: a cross-tenant accountId short-circuits with a
-      // typed TenantReferenceError before any write.
-      await validateTenantReferences(tx, familyId, {
-        accountId: data.accountId,
-      })
-
-      const account = await fetchAccountFacts(tx, familyId, data.accountId)
-      if (!account) {
-        throw new ValuationError(`Account ${data.accountId} not found`)
-      }
-
-      const currency = data.currency ?? account.currency
-      if (currency !== account.currency) {
-        throw new ValuationError(
-          `Valuation currency ${currency} must match account currency ${account.currency} (cross-currency is PER-147)`
-        )
-      }
-
-      // ADR-0045: a negative input is only meaningful for a carve-out ASSET
-      // account (DEPOSITORY/E_WALLET, real overdraft). Every other accountType
-      // rejects it here — a validated 422, never a raw DB CHECK failure.
-      const accountAllowsNegative = allowsNegativeAssetBalance(
-        account.accountType
+      const { serialized } = await createValuationWithinTx(
+        tx,
+        familyId,
+        data,
+        user,
+        auditCtx
       )
-      if (rawValue < 0n && !accountAllowsNegative) {
-        throw new ValuationError(
-          `Valuation value cannot be negative for account type ${account.accountType}`
-        )
-      }
-      const signedValue =
-        rawValue < 0n
-          ? toMoney(rawValue)
-          : signMagnitudeForAccount(account.accountClass, rawValue)
-
-      // Base-currency projection (PER-147 / ADR-0035 §4/§7), keyed off the
-      // valuation date so historical net worth stays stable.
-      const valuationDate = data.valuationDate ?? new Date()
-      const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
-      const projection = await computeBaseProjectionForAmount(tx, familyId, {
-        amount: signedValue,
-        currency,
-        date: valuationDate,
-        baseCurrency,
-      })
-
-      const valuation = await tx.valuation.create({
-        data: {
-          accountId: account.id,
-          familyId,
-          value: signedValue,
-          currency,
-          valuationDate,
-          type: valuationType,
-          source: data.source ?? "manual",
-          note: data.note ?? null,
-          normalBalance: normalBalanceForClass(account.accountClass),
-          allowsNegativeAsset: accountAllowsNegative,
-          createdById: user.id,
-          baseValue: projection.baseAmount,
-          baseCurrency: projection.baseCurrency,
-          fxRateScaled: projection.fxRateScaled,
-          fxRateSnapshotId: projection.fxRateSnapshotId,
-        },
-      })
-      const serialized = serializeValuation(valuation)
-
-      await auditLog(tx, auditCtx, {
-        action: "create",
-        entityType: "Valuation",
-        entityId: valuation.id,
-        after: serialized,
-      })
-
-      // Re-materialize the balance from canonical rows (ADR-0043). Tracked
-      // accounts always follow their latest valuation (ADR-0034 §5). Cash
-      // accounts move only when this valuation is an anchor type that is
-      // currently the effective anchor (latest <= now) — a backdated anchor
-      // superseded by a later one, or a "market" observation, leaves the
-      // materialized balance untouched, same as before.
-      const canonical = await computeCanonicalBalance(tx, familyId, account)
-      if (canonical !== toMoney(account.balance)) {
-        await setAccountBalanceTo(tx, {
-          accountId: account.id,
-          familyId,
-          target: canonical,
-          currentVersion: account.version,
-        })
-        await auditLog(tx, auditCtx, {
-          action: "update",
-          entityType: "Account",
-          entityId: account.id,
-          before: { balance: account.balance.toString() },
-          after: { balance: canonical.toString() },
-        })
-      }
 
       await persistIdempotentEndpointResponse(tx, {
         endpoint: CREATE_VALUATION_ENDPOINT,

--- a/tests/integration/audit-log.integration.ts
+++ b/tests/integration/audit-log.integration.ts
@@ -469,8 +469,10 @@ describe("AuditLog Integration & Security Tests", () => {
       ),
     ])
 
-    expect(transferAfterDelete.outflowTransaction.deletedAt).not.toBeNull()
-    expect(transferAfterDelete.inflowTransaction.deletedAt).not.toBeNull()
+    expect(transferAfterDelete.outflowTransaction).not.toBeNull()
+    expect(transferAfterDelete.inflowTransaction).not.toBeNull()
+    expect(transferAfterDelete.outflowTransaction?.deletedAt).not.toBeNull()
+    expect(transferAfterDelete.inflowTransaction?.deletedAt).not.toBeNull()
     expect(transferLogs.map((log) => log.action).sort()).toEqual([
       "create",
       "soft_delete",

--- a/tests/integration/fx-currency.integration.ts
+++ b/tests/integration/fx-currency.integration.ts
@@ -110,10 +110,12 @@ describe("currency + FX snapshots + cross-currency transfers (PER-147 / ADR-0035
       user: owner.user,
     })
 
-  const readTx = (owner: AuthenticatedOnboardedUser, id: string) =>
-    harness.withFamily(owner.family.id, async (tx) =>
+  const readTx = (owner: AuthenticatedOnboardedUser, id: string | null) => {
+    if (!id) throw new Error("readTx: expected a non-null transaction id")
+    return harness.withFamily(owner.family.id, async (tx) =>
       tx.transaction.findUniqueOrThrow({ where: { id } })
     )
+  }
 
   const readTransferByOutflow = (
     owner: AuthenticatedOnboardedUser,

--- a/tests/integration/idempotent-mutations.integration.ts
+++ b/tests/integration/idempotent-mutations.integration.ts
@@ -275,33 +275,34 @@ describe("idempotent update/delete ledger mutations (PER-93)", () => {
     )
     expect(newTransfer.id).not.toBe(oldTransfer.id)
 
+    // Classic dual-leg transfer fixture: both legs are always present.
+    const oldOutflowId = oldTransfer.outflowTransactionId
+    const oldInflowId = oldTransfer.inflowTransactionId
+    const newOutflowId = newTransfer.outflowTransactionId
+    const newInflowId = newTransfer.inflowTransactionId
+    if (!oldOutflowId || !oldInflowId || !newOutflowId || !newInflowId) {
+      throw new Error("Expected a classic dual-leg transfer fixture")
+    }
+
     const rows = await readSupersessionRows(fixture.owner.family.id, [
-      oldTransfer.outflowTransactionId,
-      oldTransfer.inflowTransactionId,
-      newTransfer.outflowTransactionId,
-      newTransfer.inflowTransactionId,
+      oldOutflowId,
+      oldInflowId,
+      newOutflowId,
+      newInflowId,
     ])
-    expect(
-      rows.get(oldTransfer.outflowTransactionId)?.deletedAt
-    ).toBeInstanceOf(Date)
-    expect(rows.get(oldTransfer.inflowTransactionId)?.deletedAt).toBeInstanceOf(
-      Date
-    )
-    expect(rows.get(oldTransfer.outflowTransactionId)?.supersededBy).toBe(
-      newTransfer.outflowTransactionId
-    )
-    expect(rows.get(oldTransfer.inflowTransactionId)?.supersededBy).toBe(
-      newTransfer.inflowTransactionId
-    )
-    expect(rows.get(newTransfer.outflowTransactionId)).toMatchObject({
+    expect(rows.get(oldOutflowId)?.deletedAt).toBeInstanceOf(Date)
+    expect(rows.get(oldInflowId)?.deletedAt).toBeInstanceOf(Date)
+    expect(rows.get(oldOutflowId)?.supersededBy).toBe(newOutflowId)
+    expect(rows.get(oldInflowId)?.supersededBy).toBe(newInflowId)
+    expect(rows.get(newOutflowId)).toMatchObject({
       amount: -150_000n,
       deletedAt: null,
-      supersedes: oldTransfer.outflowTransactionId,
+      supersedes: oldOutflowId,
     })
-    expect(rows.get(newTransfer.inflowTransactionId)).toMatchObject({
+    expect(rows.get(newInflowId)).toMatchObject({
       amount: 150_000n,
       deletedAt: null,
-      supersedes: oldTransfer.inflowTransactionId,
+      supersedes: oldInflowId,
     })
 
     const oldTransferAfter = await readTransferById(

--- a/tests/integration/transfer-soft-delete.integration.ts
+++ b/tests/integration/transfer-soft-delete.integration.ts
@@ -434,6 +434,9 @@ async function placeTransfer(
       where: { outflowTransactionId },
     })
   )
+  if (!transfer.inflowTransactionId) {
+    throw new Error("Expected a classic dual-leg transfer fixture")
+  }
 
   return {
     inflowTransactionId: transfer.inflowTransactionId,

--- a/tests/integration/valuation-account-balance-guard.integration.ts
+++ b/tests/integration/valuation-account-balance-guard.integration.ts
@@ -80,61 +80,17 @@ describe("PER-196 / ADR-0048 §3 — valuation account balance write guard", () 
     return account.balance
   }
 
-  test("rejects a transfer INTO a tracked-asset account (contribution) and leaves both balances untouched", async () => {
-    const fx = await createFixture()
-
-    await expect(
-      createTransactionForFamily({
-        data: {
-          accountId: fx.cash.id,
-          amount: 100_000n,
-          currency: "IDR",
-          date: TEST_DATE,
-          description: "Top up reksadana",
-          idempotencyKey: factories.createIdempotencyKey(),
-          isSplit: false,
-          status: "CLEARED",
-          toAccountId: fx.tracked.id,
-          type: "transfer",
-        },
-        familyId: fx.familyId,
-        user: fx.user,
-      })
-    ).rejects.toThrow(ValuationAccountLedgerError)
-
-    expect(await readBalance(fx.familyId, fx.cash.id)).toBe(fx.cash.balance)
-    expect(await readBalance(fx.familyId, fx.tracked.id)).toBe(
-      fx.tracked.balance
-    )
-  })
-
-  test("rejects a transfer OUT OF a tracked-asset account (redemption) and leaves both balances untouched — the PER-196 repro", async () => {
-    const fx = await createFixture()
-
-    await expect(
-      createTransactionForFamily({
-        data: {
-          accountId: fx.tracked.id,
-          amount: 250_000n,
-          currency: "IDR",
-          date: TEST_DATE,
-          description: "Pencairan reksadana",
-          idempotencyKey: factories.createIdempotencyKey(),
-          isSplit: false,
-          status: "CLEARED",
-          toAccountId: fx.cash.id,
-          type: "transfer",
-        },
-        familyId: fx.familyId,
-        user: fx.user,
-      })
-    ).rejects.toThrow(ValuationAccountLedgerError)
-
-    expect(await readBalance(fx.familyId, fx.tracked.id)).toBe(
-      fx.tracked.balance
-    )
-    expect(await readBalance(fx.familyId, fx.cash.id)).toBe(fx.cash.balance)
-  })
+  // A transfer INTO/OUT OF a tracked-asset account (contribution/redemption)
+  // no longer hits this guard as of the ADR-0048 §1/§4 valuation-linked
+  // transfer model: createTransactionForFamily routes it to
+  // createValuationLinkedTransferWithinTx, which never calls
+  // applyAccountBalanceDelta on the tracked-asset side at all (it writes a
+  // Valuation via setAccountBalanceTo instead). Full coverage of that
+  // success path — both directions, atomicity, the editable prefill, the
+  // negative-value rejection — lives in
+  // valuation-linked-transfer.integration.ts. This file's job is the
+  // invariant that remains true after that feature: no code path may ever
+  // apply an incremental delta to a valuation-tracked account's balance.
 
   test("rejects a standalone manual expense on a tracked-asset account — no carve-out", async () => {
     const fx = await createFixture()

--- a/tests/integration/valuation-linked-transfer.integration.ts
+++ b/tests/integration/valuation-linked-transfer.integration.ts
@@ -1,0 +1,448 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import {
+  createTransactionForFamily,
+  deleteTransactionForFamily,
+  updateTransactionForFamily,
+  ValuationLinkedTransferUnsupportedError,
+} from "@/server/transactions"
+import { ValuationError } from "@/server/valuations"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+// PER-196 / ADR-0048 §1/§4 — the valuation-linked transfer: a money move
+// between a cash-like account and a balanceSource="valuation" (TRACKED_ASSET)
+// account becomes one Transaction leg on the cash side + one new Valuation on
+// the tracked-asset side, linked by one Transfer row — never a raw dual-leg
+// transfer (that's PER-196's root cause, closed by the guard in the prior
+// PR). Real-Postgres coverage: both directions, the editable prefill, the
+// negative-value rejection, the both-valuation-accounts and cross-currency
+// scope boundaries, idempotent replay, and the update/delete "not yet
+// supported" fail-loud boundary.
+
+const TEST_DATE = new Date("2026-07-20T00:00:00.000Z")
+
+describe("PER-196 / ADR-0048 — valuation-linked transfer", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  async function createFixture(options: { trackedOpening?: bigint } = {}) {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 5_000_000n,
+      familyId: owner.family.id,
+      name: "Bank Jago",
+    })
+    const tracked = await factories.createAccount({
+      accountType: "TRACKED_ASSET",
+      balance: options.trackedOpening ?? 1_000_000n,
+      familyId: owner.family.id,
+      name: "Hasil Jualan",
+    })
+    return { cash, familyId: owner.family.id, tracked, user: owner.user }
+  }
+
+  async function readAccount(familyId: string, accountId: string) {
+    return harness.withFamily(familyId, (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: accountId } })
+    )
+  }
+
+  async function transferForTransaction(
+    familyId: string,
+    transactionId: string
+  ) {
+    return harness.withFamily(familyId, (tx) =>
+      tx.transfer.findFirstOrThrow({
+        where: {
+          OR: [
+            { outflowTransactionId: transactionId },
+            { inflowTransactionId: transactionId },
+          ],
+        },
+      })
+    )
+  }
+
+  test("contribution (cash -> tracked asset): one Transaction leg + one Valuation, prefilled latest + amount", async () => {
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.tracked.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    const cashAccount = await readAccount(fx.familyId, fx.cash.id)
+    const trackedAccount = await readAccount(fx.familyId, fx.tracked.id)
+    expect(cashAccount.balance).toBe(5_000_000n - 250_000n)
+    expect(trackedAccount.balance).toBe(1_000_000n + 250_000n)
+
+    const transfer = await transferForTransaction(fx.familyId, result.id)
+    expect(transfer.outflowTransactionId).toBe(result.id)
+    expect(transfer.inflowTransactionId).toBeNull()
+    expect(transfer.valuationId).not.toBeNull()
+
+    const valuation = await harness.withFamily(fx.familyId, (tx) =>
+      tx.valuation.findUniqueOrThrow({
+        where: { id: transfer.valuationId ?? "" },
+      })
+    )
+    expect(valuation.accountId).toBe(fx.tracked.id)
+    expect(valuation.value).toBe(1_250_000n)
+    expect(valuation.type).toBe("manual")
+
+    const txRow = await harness.withFamily(fx.familyId, (tx) =>
+      tx.transaction.findUniqueOrThrow({ where: { id: result.id } })
+    )
+    expect(txRow.type).toBe("transfer")
+    expect(txRow.accountId).toBe(fx.cash.id)
+    expect(txRow.toAccountId).toBe(fx.tracked.id)
+    expect(txRow.amount).toBe(-250_000n)
+  })
+
+  test("redemption (tracked asset -> cash): one Transaction leg + one Valuation, prefilled latest - amount — the PER-196 repro, now working", async () => {
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.tracked.id,
+        amount: 400_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Pencairan reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.cash.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    const cashAccount = await readAccount(fx.familyId, fx.cash.id)
+    const trackedAccount = await readAccount(fx.familyId, fx.tracked.id)
+    expect(cashAccount.balance).toBe(5_000_000n + 400_000n)
+    expect(trackedAccount.balance).toBe(1_000_000n - 400_000n)
+
+    const transfer = await transferForTransaction(fx.familyId, result.id)
+    expect(transfer.inflowTransactionId).toBe(result.id)
+    expect(transfer.outflowTransactionId).toBeNull()
+    expect(transfer.valuationId).not.toBeNull()
+
+    const txRow = await harness.withFamily(fx.familyId, (tx) =>
+      tx.transaction.findUniqueOrThrow({ where: { id: result.id } })
+    )
+    expect(txRow.accountId).toBe(fx.cash.id)
+    expect(txRow.toAccountId).toBe(fx.tracked.id)
+    expect(txRow.amount).toBe(400_000n)
+
+    // Not hidden from the ledger: it is a normal, visible cash-side Transaction.
+    expect(txRow.type).toBe("transfer")
+  })
+
+  test("editable prefill: newValuationValue overrides the computed latest ∓ amount", async () => {
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.tracked.id,
+        amount: 400_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Pencairan dengan gain",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        newValuationValue: "700000", // user knows the true remaining value (gain since last valuation)
+        status: "CLEARED",
+        toAccountId: fx.cash.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    const trackedAccount = await readAccount(fx.familyId, fx.tracked.id)
+    expect(trackedAccount.balance).toBe(700_000n)
+
+    const transfer = await transferForTransaction(fx.familyId, result.id)
+    const valuation = await harness.withFamily(fx.familyId, (tx) =>
+      tx.valuation.findUniqueOrThrow({
+        where: { id: transfer.valuationId ?? "" },
+      })
+    )
+    expect(valuation.value).toBe(700_000n)
+  })
+
+  test("redemption exceeding the tracked value is rejected; nothing is written", async () => {
+    const fx = await createFixture({ trackedOpening: 200_000n })
+
+    await expect(
+      createTransactionForFamily({
+        data: {
+          accountId: fx.tracked.id,
+          amount: 500_000n,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Over-redemption",
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: fx.cash.id,
+          type: "transfer",
+        },
+        familyId: fx.familyId,
+        user: fx.user,
+      })
+    ).rejects.toThrow(ValuationError)
+
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n
+    )
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      200_000n
+    )
+  })
+
+  test("transfers between two valuation-tracked accounts are rejected (out of scope, ADR-0048 §2)", async () => {
+    const fx = await createFixture()
+    const otherTracked = await factories.createAccount({
+      accountType: "TRACKED_ASSET",
+      balance: 500_000n,
+      familyId: fx.familyId,
+      name: "Gold",
+    })
+
+    await expect(
+      createTransactionForFamily({
+        data: {
+          accountId: fx.tracked.id,
+          amount: 100_000n,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Tracked-to-tracked",
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: otherTracked.id,
+          type: "transfer",
+        },
+        familyId: fx.familyId,
+        user: fx.user,
+      })
+    ).rejects.toThrow(ValuationError)
+  })
+
+  test("cross-currency valuation-linked transfers are rejected (v1 scope boundary)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const usdCash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 1_000_000n,
+      currency: "USD",
+      familyId: owner.family.id,
+      name: "USD checking",
+    })
+    const idrTracked = await factories.createAccount({
+      accountType: "TRACKED_ASSET",
+      balance: 1_000_000n,
+      currency: "IDR",
+      familyId: owner.family.id,
+      name: "IDR gold",
+    })
+
+    await expect(
+      createTransactionForFamily({
+        data: {
+          accountId: usdCash.id,
+          amount: 10_000n,
+          currency: "USD",
+          date: TEST_DATE,
+          description: "Cross-currency contribution",
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: idrTracked.id,
+          type: "transfer",
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(ValuationError)
+  })
+
+  test("idempotent replay: the same key returns the same result with no duplicate rows", async () => {
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+    const idempotencyKey = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey,
+        isSplit: false,
+        status: "CLEARED" as const,
+        toAccountId: fx.tracked.id,
+        type: "transfer" as const,
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    }
+
+    const first = await createTransactionForFamily(payload)
+    const second = await createTransactionForFamily(payload)
+    expect(second.id).toBe(first.id)
+
+    const trackedAccount = await readAccount(fx.familyId, fx.tracked.id)
+    expect(trackedAccount.balance).toBe(1_250_000n) // not double-applied
+
+    const valuationCount = await harness.withFamily(fx.familyId, (tx) =>
+      tx.valuation.count({ where: { accountId: fx.tracked.id } })
+    )
+    // The test fixture creates accounts via a raw insert (no auto opening
+    // valuation) — exactly one Valuation from the one contribution, not two.
+    expect(valuationCount).toBe(1)
+
+    const transferCount = await harness.withFamily(fx.familyId, (tx) =>
+      tx.transfer.count()
+    )
+    expect(transferCount).toBe(1)
+  })
+
+  test("deleting a valuation-linked transfer's Transaction is not yet supported — fails loud, nothing changes", async () => {
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.tracked.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    await expect(
+      deleteTransactionForFamily({
+        familyId: fx.familyId,
+        id: result.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+        user: fx.user,
+      })
+    ).rejects.toThrow(ValuationLinkedTransferUnsupportedError)
+
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n - 250_000n
+    )
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_250_000n
+    )
+  })
+
+  test("updating a valuation-linked transfer's Transaction is not yet supported — fails loud, nothing changes", async () => {
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.tracked.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    await expect(
+      updateTransactionForFamily({
+        data: {
+          accountId: fx.cash.id,
+          amount: 300_000n,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Top up reksadana (edited)",
+          id: result.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: fx.tracked.id,
+          type: "transfer",
+        },
+        familyId: fx.familyId,
+        user: fx.user,
+      })
+    ).rejects.toThrow(ValuationLinkedTransferUnsupportedError)
+
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n - 250_000n
+    )
+  })
+
+  test("the Transfer leg-shape CHECK rejects a malformed row (one real leg, no valuation, no partner leg)", async () => {
+    const fx = await createFixture()
+    // A real Transaction leg (passes RLS) with neither a paired inflow leg
+    // nor a valuationId — violates transfer_leg_shape's XOR, not RLS.
+    const orphanLeg = await factories.createTransaction({
+      accountId: fx.cash.id,
+      amount: 1_000n,
+      familyId: fx.familyId,
+      type: "income",
+      userId: fx.user.id,
+    })
+
+    await expect(
+      harness.withFamily(fx.familyId, (tx) =>
+        tx.transfer.create({
+          data: { outflowTransactionId: orphanLeg.id },
+        })
+      )
+    ).rejects.toThrow(/23514|check_violation|transfer_leg_shape/i)
+  })
+})


### PR DESCRIPTION
## Summary

Third PR of PER-196 (design in #175, guard in #176). **Stacked on #176** — targets that branch, not `main`, since this builds directly on the guard it introduces. Merge #176 first, then retarget/merge this one.

This is the actual fix: after #176, a transfer touching a `balanceSource="valuation"` account failed loud (correct, safe, but not a working feature). This PR makes it succeed through the ADR-0048 §1 model — one normal `Transaction` leg on the cash side + one new `Valuation` on the tracked-asset side, joined by one `Transfer` row.

### Schema (ADR-0048 §4)
- `Transfer.outflowTransactionId`/`inflowTransactionId` relax to nullable; new nullable unique `valuationId` FK to `Valuation`.
- `transfer_leg_shape` CHECK: classic = both Transaction legs + no valuation; valuation-linked = exactly one Transaction leg + valuationId.
- **Every** PER-103/PER-104/PER-74 constraint trigger and the Transfer RLS policy touching these two columns got a valuationId branch — found via an exhaustive grep across all 34 migrations after the first attempt only updated 3 of them (real-Postgres tests caught the other three immediately: RLS policy, PER-104 tenant leg-pair check, PER-74 liability-kind check).

### Orchestration
- `valuations.ts`: `createValuationForFamily` split into a shared tx-scoped primitive (`createValuationWithinTx`) so the transfer path can call it inside the same `$transaction`.
- `transactions.ts`: `createTransactionForFamily`'s transfer branch detects either side is valuation-tracked and routes to `createValuationLinkedTransferWithinTx`. New optional `newValuationValue` input field — prefills as `latest ∓ cashAmount`, editable, rejected if it would drive the tracked value negative (existing ADR-0045 sign check).
- Scope boundaries (typed `ValuationError`, not silently mishandled): tracked-to-tracked transfers, cross-currency valuation-linked transfers.
- Editing/deleting an existing valuation-linked transfer: not yet supported. `findTransferGraph` (the single choke point every update/delete reads a transfer's legs through) fails loud with `ValuationLinkedTransferUnsupportedError` instead of crashing on a null leg.
- Idempotent replay fixed: `canonicalRequestPayload`/`canonicalPersistedPayload` no longer fabricate a "transfer partner" for a shape with no second Transaction leg.

## Test plan
- [x] `vp check --fix` (format/lint/typecheck clean)
- [x] New `tests/integration/valuation-linked-transfer.integration.ts` (10 tests): both directions, editable prefill, negative-value rejection, both scope boundaries, idempotent replay, update/delete fail-loud boundary.
- [x] Updated 5 existing test files for null-safety on the now-nullable Transfer columns (all classic-transfer fixtures, narrowed with an explicit throw, never silently coerced).
- [x] Full regression: 132 tests green across every directly-touched integration suite (guard, valuation-primitive, db-constraints, transfer-graph-invariants, transfer-soft-delete, idempotent-mutations, fx-currency, liability-semantics, audit-log, account-delete) + 42 more (RLS/tenant-isolation/bulk-parity).
- [x] `sure-migration.integration.ts`: 21/22 green; the 1 failure is the same pre-existing environmental flakiness (Prisma's 5s interactive-transaction budget under host load) already A/B-verified against clean `main` in #176 — reproduced in isolation as passing cleanly.

## Next
Phase 4 (separate PR): transfer form UI adapts when either side is valuation-tracked. Phase 5: one-time audited cleanup migration for the creator's existing phantom transfer legs. Phase 6: e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqMxWy8d2MB3B3pKLvj8Y3