### PR TITLE
feat(ledger): PER-196 Phase 4 — transfer UI adapts + valuation-linked delete

### DIFF
--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -102,6 +102,11 @@ const transactionSchema = z.object({
   // expense row server-side. Optional category for that expense.
   fxFeeAmount: z.number().nonnegative().optional(),
   fxFeeCategoryId: z.string().optional(),
+  // PER-196 / ADR-0048 §1: valuation-linked transfer. Only meaningful when
+  // either transfer side is a balanceSource="valuation" account — prefilled
+  // client-side as latest ∓ amount (see NewValuationValueField), editable.
+  // Left undefined, the server computes the same prefill from fresher data.
+  newValuationValue: z.number().optional(),
   // Enterprise: Proof of Purchase (URL struk dari S3/R2)
   attachmentUrl: z.string().optional(),
 })
@@ -752,6 +757,105 @@ function FxFeeField({
                 </form.Field>
               </div>
             )}
+          </form.Field>
+        )
+      }}
+    </form.Subscribe>
+  )
+}
+
+// PER-196 / ADR-0048 §1 — the valuation-linked transfer field. Shown only
+// when exactly one transfer side is a balanceSource="valuation" account
+// (a TRACKED_ASSET like a mutual fund or gold holding — see
+// docs/account-taxonomy.md). Two valuation-tracked sides is an explicit v1
+// scope boundary (ADR-0048 §2), rejected server-side with a typed error, so
+// this field intentionally does not render for that shape either.
+//
+// Prefill is a pure derived value (no-use-effect Rule 1): `trackedBalance ∓
+// amount`, recomputed on every render from the live form state via
+// form.Subscribe. The field itself only holds the user's manual override
+// (undefined until they type); `field.state.value ?? prefill` is what's
+// shown, so the box always displays a real, editable number without ever
+// needing an effect to "sync" the prefill into field state.
+function NewValuationValueField({
+  activeTab,
+  form,
+  formData,
+}: Pick<TransactionFormSectionProps, "activeTab" | "form" | "formData">) {
+  if (activeTab !== "transfer") return null
+
+  return (
+    <form.Subscribe
+      selector={(state) => ({
+        accountId: state.values.accountId,
+        toAccountId: state.values.toAccountId,
+        amount: state.values.amount,
+      })}
+    >
+      {({ accountId, toAccountId, amount }) => {
+        const srcAccount = formData?.accounts.find((a) => a.id === accountId)
+        const dstAccount = formData?.accounts.find((a) => a.id === toAccountId)
+        const srcIsValuation = srcAccount?.balanceSource === "valuation"
+        const dstIsValuation = dstAccount?.balanceSource === "valuation"
+
+        if (
+          !srcAccount ||
+          !dstAccount ||
+          srcIsValuation === dstIsValuation // neither, or both — out of scope
+        ) {
+          return null
+        }
+
+        const trackedAccount = srcIsValuation ? srcAccount : dstAccount
+        const trackedCurrency = trackedAccount.currency as CurrencyCode
+        const trackedDisplayBalance = toDisplayNumber(
+          trackedAccount.balance,
+          trackedCurrency
+        )
+        // Redemption (tracked -> cash): the withdrawal reduces the tracked
+        // value. Contribution (cash -> tracked): it increases it.
+        const prefill = srcIsValuation
+          ? trackedDisplayBalance - amount
+          : trackedDisplayBalance + amount
+
+        return (
+          <form.Field name="newValuationValue">
+            {(field) => {
+              const displayValue = field.state.value ?? prefill
+              return (
+                <div className="space-y-2 rounded-lg border border-emerald-200 bg-emerald-50/40 p-3 dark:border-emerald-800 dark:bg-emerald-950/20">
+                  <Label
+                    htmlFor="new-valuation-value"
+                    className="text-sm font-semibold text-emerald-700 dark:text-emerald-400"
+                  >
+                    New value of {trackedAccount.name}
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    {srcIsValuation
+                      ? "Prefilled as the current value minus this withdrawal. Edit if the fund's real remaining value differs — this captures any market gain or loss since the last valuation."
+                      : "Prefilled as the current value plus this contribution. Edit if the fund's real value differs — this captures any market gain or loss since the last valuation."}
+                  </p>
+                  <div className="relative">
+                    <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
+                      {getCurrencySymbol(trackedCurrency)}
+                    </span>
+                    <Input
+                      id="new-valuation-value"
+                      name="new-valuation-value"
+                      type="number"
+                      className="pl-8 text-lg font-bold"
+                      value={displayValue}
+                      onBlur={field.handleBlur}
+                      onChange={(e) =>
+                        field.handleChange(
+                          e.target.value ? Number(e.target.value) : undefined
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+              )
+            }}
           </form.Field>
         )
       }}
@@ -1522,6 +1626,25 @@ function useTransactionFormModalController({
           value.fxFeeAmount > 0
             ? toMoney(value.fxFeeAmount, sourceCurrency)
             : null
+        // PER-196 / ADR-0048 §1: only sent when the user manually edited the
+        // prefill (NewValuationValueField leaves the field undefined until
+        // touched) — an absolute value in whichever side is
+        // balanceSource="valuation", never a delta. Harmlessly ignored
+        // server-side for a non-valuation-linked transfer.
+        const newValuationValueString: string | null =
+          value.type === "transfer" && value.newValuationValue != null
+            ? (() => {
+                const trackedCurrency =
+                  formData?.accounts.find((a) => a.id === value.accountId)
+                    ?.balanceSource === "valuation"
+                    ? sourceCurrency
+                    : (destCurrency ?? sourceCurrency)
+                return toMoney(
+                  value.newValuationValue as number,
+                  trackedCurrency
+                ).toString()
+              })()
+            : null
         const selectedAccount = formData?.accounts.find(
           (a) => a.id === value.accountId
         )
@@ -1595,6 +1718,7 @@ function useTransactionFormModalController({
           fxFeeAmount: fxFeeMoney,
           fxFeeAccountId: fxFeeMoney ? value.accountId : null,
           fxFeeCategoryId: fxFeeMoney ? value.fxFeeCategoryId || null : null,
+          newValuationValue: newValuationValueString,
           accountBalanceAfter: null, // Computed server-side
           attachmentUrl: value.attachmentUrl || null,
           deletedAt: null,
@@ -1824,6 +1948,11 @@ export function TransactionFormModal({
             isLoading={isLoading}
           />
           <DestinationAmountField
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+          />
+          <NewValuationValueField
             activeTab={activeTab}
             form={form}
             formData={formData}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -139,6 +139,13 @@ export const transactionCollection = createCollection(
         // off the raw change set and forward to the server (ADR-0035 §6).
         const feeFields = payload as Record<string, unknown>
         const fxFeeAmount = feeFields.fxFeeAmount as Money | null | undefined
+        // PER-196 / ADR-0048 §1: valuation-linked transfer value override —
+        // also a write-only ephemeral field, not a collection column (see
+        // the transaction form modal's NewValuationValueField).
+        const newValuationValue = feeFields.newValuationValue as
+          | string
+          | null
+          | undefined
 
         await createTransactionFn({
           data: {
@@ -186,6 +193,7 @@ export const transactionCollection = createCollection(
               (feeFields.fxFeeAccountId as string | null | undefined) ?? null,
             fxFeeCategoryId:
               (feeFields.fxFeeCategoryId as string | null | undefined) ?? null,
+            newValuationValue: newValuationValue ?? undefined,
             attachmentUrl:
               (payload.attachmentUrl as string | null | undefined) ?? null,
           },

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -49,7 +49,9 @@ import {
 } from "./mutation-kit"
 import {
   createValuationWithinTx,
+  fetchAccountFacts,
   latestValuation,
+  rebuildWithinTx,
   valueMagnitudeSchema,
   ValuationError,
   type CreateValuationInput,
@@ -441,14 +443,32 @@ export async function findLedgerTransactionsForFamily(
     where: {
       familyId,
       deletedAt: null,
-      transferIn: {
-        is: null,
-      },
-      // PER-20 / ADR-0012: defense-in-depth against any future drift between
-      // Transaction.deletedAt and Transfer.deletedAt. A non-transfer row
-      // (`transferOut: null`) passes; an outflow leg only passes when its
-      // Transfer row is also alive.
-      OR: [{ transferOut: { is: null } }, { transferOut: { deletedAt: null } }],
+      AND: [
+        {
+          // A classic dual-leg transfer's inflow leg is hidden — its outflow
+          // twin represents the movement in the list. PER-196 / ADR-0048 §4:
+          // a valuation-linked redemption's cash leg can ALSO sit in the
+          // inflow FK slot, but has no outflow twin at all (the other side
+          // is a Valuation, not a Transaction) — hiding it would reproduce
+          // PER-196's original "hidden from the list" bug through a new
+          // mechanism. Only hide an inflow leg when a real outflow twin
+          // exists to show instead.
+          OR: [
+            { transferIn: { is: null } },
+            { transferIn: { outflowTransactionId: null } },
+          ],
+        },
+        {
+          // PER-20 / ADR-0012: defense-in-depth against any future drift
+          // between Transaction.deletedAt and Transfer.deletedAt. A
+          // non-transfer row (`transferOut: null`) passes; an outflow leg
+          // only passes when its Transfer row is also alive.
+          OR: [
+            { transferOut: { is: null } },
+            { transferOut: { deletedAt: null } },
+          ],
+        },
+      ],
     },
   })
   const transactionIds = transactions.map((transaction) => transaction.id)
@@ -599,17 +619,18 @@ export class ValuationAccountLedgerError extends Error {
   }
 }
 
-// PER-196 / ADR-0048 §4: a valuation-linked transfer (one Transaction leg +
-// one Valuation leg) does not yet support the update/delete
-// reversal-and-replace path — that machinery assumes two Transaction legs.
-// Raised by `findTransferGraph`, the single choke point every mutation of an
-// EXISTING transfer reads its graph through, so this never reaches deeper
-// null-unsafe code. Creating a new valuation-linked transfer is unaffected.
+// PER-196 / ADR-0048 §4: editing a valuation-linked transfer (one
+// Transaction leg + one Valuation leg) is not yet supported — the
+// reversal-and-replace path (replaceTransactionWithinTenantTransaction)
+// assumes two Transaction legs. Raised by `findTransferGraph`, the choke
+// point the update path reads a transfer's graph through. Deleting a
+// valuation-linked transfer IS supported (softDeleteValuationLinkedTransferWithinTx)
+// — this error's message reflects that split.
 export class ValuationLinkedTransferUnsupportedError extends Error {
   override readonly name = "ValuationLinkedTransferUnsupportedError"
   readonly statusCode = 422
   constructor(
-    message = "Editing or deleting a valuation-linked transfer is not yet supported. Delete it and record a new transfer instead."
+    message = "Editing a valuation-linked transfer is not yet supported. Delete it and record a new transfer instead."
   ) {
     super(message)
   }
@@ -2132,6 +2153,127 @@ export const createTransactionFn = createServerFn({ method: "POST" })
 // Exported for reuse by src/server/accounts.ts (PER-183 cascade account
 // delete): this is the canonical, transfer-symmetric, audited, balance-
 // correct per-transaction soft delete. Do not reimplement it elsewhere.
+// PER-196 / ADR-0048 §4: symmetric reversal for a valuation-linked transfer
+// (one Transaction leg + one Valuation leg, joined by one Transfer row).
+// Mirrors the classic dual-leg reversal in
+// softDeleteTransactionWithinTenantTransaction: reverse the cash leg's
+// balance delta, tombstone the cash Transaction, tombstone the Valuation,
+// re-materialize the tracked account's balance from whatever Valuation is
+// now the latest non-deleted one (rebuildWithinTx — the same primitive
+// createValuationForFamily and rebuildFamilyBalances already route every
+// legitimate tracked-account balance write through), then tombstone the
+// Transfer row itself. Every step is idempotent at the call-site level via
+// deleteTransactionForFamily's IdempotencyRecord and the `deletedAt: null`
+// guard on each updateMany below (a replayed delete cannot double-reverse).
+async function softDeleteValuationLinkedTransferWithinTx(
+  tx: TenantTransactionClient,
+  {
+    auditCtx,
+    familyId,
+    cashTx,
+  }: {
+    auditCtx: AuditContext
+    familyId: string
+    cashTx: NonNullable<Awaited<ReturnType<typeof findTransactionAuditGraph>>>
+  }
+): Promise<void> {
+  const transfer = cashTx.transferOut ?? cashTx.transferIn
+  if (!transfer || transfer.valuationId === null) {
+    throw new Error(
+      `softDeleteValuationLinkedTransferWithinTx called on Transaction ${cashTx.id} without a valuation-linked Transfer`
+    )
+  }
+  if (transfer.deletedAt !== null) {
+    throw new TransactionGoneError()
+  }
+
+  const oldValuation = await tx.valuation.findUniqueOrThrow({
+    where: { id: transfer.valuationId },
+  })
+  const trackedAccountFacts = await fetchAccountFacts(
+    tx,
+    familyId,
+    oldValuation.accountId
+  )
+  if (!trackedAccountFacts) {
+    throw new Error(`Tracked-asset account ${oldValuation.accountId} not found`)
+  }
+  const oldCashAccount = await tx.account.findUniqueOrThrow({
+    where: { id: cashTx.accountId },
+  })
+
+  // 1. Reverse the cash leg's balance delta (single formula regardless of
+  // direction: cashTx.amount is already signed, negating it undoes exactly
+  // what creating it applied).
+  await applyAccountBalanceDelta(tx, {
+    accountId: cashTx.accountId,
+    delta: negateMoney(cashTx.amount),
+    familyId,
+    notFoundMessage: "Cash account not found or access denied!",
+  })
+
+  const deletedAt = new Date()
+
+  // 2. Tombstone the cash Transaction.
+  const cashTxUpdate = await tx.transaction.updateMany({
+    where: { id: cashTx.id, familyId, deletedAt: null },
+    data: { deletedAt },
+  })
+  if (cashTxUpdate.count !== 1) throw new TransactionGoneError()
+
+  // 3. Tombstone the Valuation (never hard-deleted, ADR-0034).
+  const valuationUpdate = await tx.valuation.updateMany({
+    where: { id: oldValuation.id, familyId, deletedAt: null },
+    data: { deletedAt },
+  })
+  if (valuationUpdate.count !== 1) throw new TransactionGoneError()
+
+  // 4. Re-materialize the tracked account from whatever Valuation is now the
+  // latest non-deleted one (rebuildWithinTx writes its own Account audit
+  // entry when the balance actually changes).
+  await rebuildWithinTx(tx, familyId, trackedAccountFacts, auditCtx)
+
+  // 5. Tombstone the Transfer row itself.
+  const transferUpdate = await tx.transfer.updateMany({
+    where: { id: transfer.id, deletedAt: null },
+    data: { deletedAt },
+  })
+  if (transferUpdate.count !== 1) throw new TransactionGoneError()
+
+  const [newCashAccount, updatedCashTx, updatedValuation, updatedTransfer] =
+    await runTenantTransactionQueriesInOrder([
+      () => tx.account.findUniqueOrThrow({ where: { id: cashTx.accountId } }),
+      () => tx.transaction.findUniqueOrThrow({ where: { id: cashTx.id } }),
+      () => tx.valuation.findUniqueOrThrow({ where: { id: oldValuation.id } }),
+      () => tx.transfer.findUniqueOrThrow({ where: { id: transfer.id } }),
+    ] as const)
+
+  await auditLogs(tx, auditCtx, [
+    ...accountBalanceAuditEntries([oldCashAccount], [newCashAccount]),
+    {
+      action: "soft_delete",
+      entityType: "Transaction",
+      entityId: cashTx.id,
+      before: cashTx,
+      after: updatedCashTx,
+    },
+    {
+      action: "soft_delete",
+      entityType: "Valuation",
+      entityId: oldValuation.id,
+      before: oldValuation,
+      after: updatedValuation,
+    },
+    {
+      action: "soft_delete",
+      entityType: "Transfer",
+      entityId: transfer.id,
+      before: transfer,
+      after: updatedTransfer,
+    },
+  ])
+}
+
 export async function softDeleteTransactionWithinTenantTransaction(
   tx: TenantTransactionClient,
   {
@@ -2157,24 +2299,33 @@ export async function softDeleteTransactionWithinTenantTransaction(
   // can sit in either FK slot (outflow for a contribution, inflow for a
   // redemption) with no Transaction at all on the other side. Detect that
   // shape before the classic-transfer redirect/reversal logic below, which
-  // assumes two Transaction legs, ever runs.
+  // assumes two Transaction legs, ever runs, and route to the symmetric
+  // valuation-linked reversal instead.
   if (
     oldTx.type === "transfer" &&
     ((oldTx.transferIn && oldTx.transferIn.outflowTransactionId === null) ||
       (oldTx.transferOut && oldTx.transferOut.inflowTransactionId === null))
   ) {
-    throw new ValuationLinkedTransferUnsupportedError()
+    await softDeleteValuationLinkedTransferWithinTx(tx, {
+      auditCtx,
+      familyId,
+      cashTx: oldTx,
+    })
+    return
   }
 
   // PER-20 / ADR-0012: a transfer is one money movement. If the user clicked
   // the inflow leg, redirect to the outflow leg so the symmetric handler logic
   // below treats outflow as the source of truth.
   if (oldTx.type === "transfer" && oldTx.transferIn && !oldTx.transferOut) {
-    // Guaranteed non-null by the valuation-linked check above (would have
-    // thrown otherwise) — narrows the type for the lookup below.
+    // The valuation-linked branch above already returned for a null
+    // outflowTransactionId, so this is guaranteed non-null here — an
+    // internal invariant, not a reachable "unsupported" case.
     const outflowTransactionId = oldTx.transferIn.outflowTransactionId
     if (!outflowTransactionId) {
-      throw new ValuationLinkedTransferUnsupportedError()
+      throw new Error(
+        `Invariant violated: Transfer ${oldTx.transferIn.id} reached the classic-transfer redirect with a null outflowTransactionId`
+      )
     }
     const outflowAuditGraph = await findTransactionAuditGraph(
       tx,

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -214,7 +214,7 @@ export interface ServerActor {
 }
 
 // Just enough of an Account to derive balance semantics.
-interface AccountBalanceFacts {
+export interface AccountBalanceFacts {
   id: string
   accountClass: string
   accountType: AccountType
@@ -392,7 +392,7 @@ async function setAccountBalanceTo(
   }
 }
 
-async function fetchAccountFacts(
+export async function fetchAccountFacts(
   tx: TenantTransactionClient,
   familyId: string,
   accountId: string
@@ -623,7 +623,7 @@ export const createValuationFn = createServerFn({ method: "POST" })
 // REBUILD (re-materialize the cached balance from canonical rows)
 // =============================================================================
 
-async function rebuildWithinTx(
+export async function rebuildWithinTx(
   tx: TenantTransactionClient,
   familyId: string,
   account: AccountBalanceFacts,

--- a/tests/e2e/valuation-linked-transfer.e2e.ts
+++ b/tests/e2e/valuation-linked-transfer.e2e.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-196 / ADR-0048 — real-browser proof of the valuation-linked transfer
+// flow: the original bug repro was "record a redemption from a mutual-fund
+// account to a bank account" producing a hidden transaction + a balance-drift
+// badge. This drives the actual adaptive Transfer form end to end: create a
+// cash account and a Tracked Asset account, submit a redemption transfer,
+// and assert the cash Transaction is visible, the tracked account's balance
+// is correct, and no drift badge appears — then delete it and assert the
+// symmetric reversal.
+
+test.describe("valuation-linked transfer (PER-196 / ADR-0048)", () => {
+  test("redemption via the adaptive transfer form: visible transaction, correct balances, zero drift, then delete reverses it", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const cashName = `E2E Bank ${suffix}`
+    const trackedName = `E2E Reksadana ${suffix}`
+
+    // --- Create the cash account ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(cashName)
+    await page.getByLabel("Opening balance").fill("5000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Create the Tracked Asset (valuation-tracked) account ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(trackedName)
+    await page.getByRole("dialog").getByRole("combobox").first().click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByLabel("Opening balance").fill("1000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // No drift on a freshly created tracked account.
+    await expect(page.getByText("Balance drift")).toHaveCount(0)
+
+    // --- Record the redemption: tracked -> cash ---
+    await page.goto("/transactions")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    await page.getByRole("tab", { name: "Transfer" }).click()
+    await page.getByLabel("Transfer Note *").fill(`Pencairan ${suffix}`)
+    await page.getByLabel("Amount *").fill("400000")
+    await page
+      .locator('select[name="accountId"]')
+      .selectOption({ label: `${trackedName} (IDR)` })
+    await page
+      .locator('select[name="toAccountId"]')
+      .selectOption({ label: `${cashName} (IDR)` })
+
+    // The adaptive field: prefilled latest (1,000,000) - amount (400,000).
+    const newValueField = page.getByLabel(`New value of ${trackedName}`)
+    await expect(newValueField).toBeVisible()
+    await expect(newValueField).toHaveValue("600000")
+
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // The cash-side Transaction is visible in the ledger — not hidden, the
+    // original bug's other symptom.
+    await expect(page.getByText(`Pencairan ${suffix}`)).toBeVisible()
+
+    // --- Verify balances + zero drift on the accounts page ---
+    // Fresh onboarded user with exactly these two accounts — a global text
+    // check unambiguously proves the correct figure rendered somewhere.
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText("Balance drift")).toHaveCount(0)
+    await expect(page.getByText("Rp 600,000.00")).toBeVisible()
+    await expect(page.getByText("Rp 5,400,000.00")).toBeVisible()
+
+    // --- Delete it and verify symmetric reversal ---
+    await page.goto("/transactions")
+    await waitForHydration(page)
+    // Only transaction on this fresh user's ledger — no scoping needed.
+    // The inline delete button confirms via a native window.confirm().
+    page.once("dialog", (dialog) => void dialog.accept())
+    await page.getByRole("button", { name: "Delete Transaction" }).click()
+    await expect(page.getByText(`Pencairan ${suffix}`)).toHaveCount(0)
+
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText("Rp 1,000,000.00")).toBeVisible()
+    await expect(page.getByText("Rp 5,000,000.00")).toBeVisible()
+    await expect(page.getByText("Balance drift")).toHaveCount(0)
+  })
+})

--- a/tests/integration/valuation-linked-transfer.integration.ts
+++ b/tests/integration/valuation-linked-transfer.integration.ts
@@ -6,9 +6,13 @@ import {
   expect,
   test,
 } from "vite-plus/test"
+import { createAccountForFamily } from "@/server/accounts"
 import {
+  bulkDeleteTransactionsForFamily,
   createTransactionForFamily,
   deleteTransactionForFamily,
+  findLedgerTransactionsForFamily,
+  TransactionGoneError,
   updateTransactionForFamily,
   ValuationLinkedTransferUnsupportedError,
 } from "@/server/transactions"
@@ -85,6 +89,39 @@ describe("PER-196 / ADR-0048 — valuation-linked transfer", () => {
         },
       })
     )
+  }
+
+  // Real account-creation (not the raw-insert factory): a TRACKED_ASSET
+  // account always gets a genuine "opening" Valuation (ADR-0034 §3), so
+  // deleting a later valuation-linked transfer correctly falls back to that
+  // opening value — the realistic shape every production account has.
+  async function createRealisticFixture(
+    options: {
+      trackedOpening?: bigint
+    } = {}
+  ) {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await createAccountForFamily({
+      data: {
+        accountType: "DEPOSITORY",
+        idempotencyKey: factories.createIdempotencyKey(),
+        name: "Bank Jago",
+        openingBalance: "5000000",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const tracked = await createAccountForFamily({
+      data: {
+        accountType: "TRACKED_ASSET",
+        idempotencyKey: factories.createIdempotencyKey(),
+        name: "Hasil Jualan",
+        openingBalance: (options.trackedOpening ?? 1_000_000n).toString(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    return { cash, familyId: owner.family.id, tracked, user: owner.user }
   }
 
   test("contribution (cash -> tracked asset): one Transaction leg + one Valuation, prefilled latest + amount", async () => {
@@ -174,6 +211,57 @@ describe("PER-196 / ADR-0048 — valuation-linked transfer", () => {
 
     // Not hidden from the ledger: it is a normal, visible cash-side Transaction.
     expect(txRow.type).toBe("transfer")
+  })
+
+  test("the ledger list query (findLedgerTransactionsForFamily) shows both a contribution's and a redemption's cash leg — regression for the 'hidden from list' half of PER-196", async () => {
+    // The list query historically hid a Transaction sitting in a Transfer's
+    // inflowTransactionId slot, assuming its outflow twin would represent it
+    // (true for a classic dual-leg transfer). A redemption's cash leg IS the
+    // inflow leg with no outflow twin at all (the other side is a Valuation)
+    // — hiding it reproduces PER-196's "transaction did not appear in the
+    // ledger list" symptom through a brand-new mechanism. Caught by the e2e
+    // suite; this integration test pins the fix at the query layer.
+    const fx = await createFixture({ trackedOpening: 1_000_000n })
+
+    const contribution = await createTransactionForFamily({
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.tracked.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+    const redemption = await createTransactionForFamily({
+      data: {
+        accountId: fx.tracked.id,
+        amount: 400_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Pencairan reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.cash.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    const ledger = await harness.withFamily(fx.familyId, (tx) =>
+      findLedgerTransactionsForFamily(tx, fx.familyId)
+    )
+    const ledgerIds = ledger.map((row) => row.id)
+    expect(ledgerIds).toContain(contribution.id)
+    expect(ledgerIds).toContain(redemption.id)
   })
 
   test("editable prefill: newValuationValue overrides the computed latest ∓ amount", async () => {
@@ -345,8 +433,147 @@ describe("PER-196 / ADR-0048 — valuation-linked transfer", () => {
     expect(transferCount).toBe(1)
   })
 
-  test("deleting a valuation-linked transfer's Transaction is not yet supported — fails loud, nothing changes", async () => {
-    const fx = await createFixture({ trackedOpening: 1_000_000n })
+  test("deleting a contribution valuation-linked transfer symmetrically reverses both sides", async () => {
+    const fx = await createRealisticFixture({ trackedOpening: 1_000_000n })
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.tracked.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+    const transfer = await transferForTransaction(fx.familyId, result.id)
+    const valuationId = transfer.valuationId ?? ""
+
+    await deleteTransactionForFamily({
+      familyId: fx.familyId,
+      id: result.id,
+      idempotencyKey: factories.createIdempotencyKey(),
+      user: fx.user,
+    })
+
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n
+    )
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_000_000n
+    )
+
+    const [txRow, valuationRow, transferRow] = await Promise.all([
+      harness.withFamily(fx.familyId, (tx) =>
+        tx.transaction.findUniqueOrThrow({ where: { id: result.id } })
+      ),
+      harness.withFamily(fx.familyId, (tx) =>
+        tx.valuation.findUniqueOrThrow({ where: { id: valuationId } })
+      ),
+      harness.withFamily(fx.familyId, (tx) =>
+        tx.transfer.findUniqueOrThrow({ where: { id: transfer.id } })
+      ),
+    ])
+    expect(txRow.deletedAt).not.toBeNull()
+    expect(valuationRow.deletedAt).not.toBeNull()
+    expect(transferRow.deletedAt).not.toBeNull()
+  })
+
+  test("deleting a redemption valuation-linked transfer symmetrically reverses both sides", async () => {
+    const fx = await createRealisticFixture({ trackedOpening: 1_000_000n })
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.tracked.id,
+        amount: 400_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Pencairan reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.cash.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    await deleteTransactionForFamily({
+      familyId: fx.familyId,
+      id: result.id,
+      idempotencyKey: factories.createIdempotencyKey(),
+      user: fx.user,
+    })
+
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n
+    )
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_000_000n
+    )
+  })
+
+  test("deleting a valuation-linked transfer twice does not double-reverse (idempotent)", async () => {
+    const fx = await createRealisticFixture({ trackedOpening: 1_000_000n })
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: fx.cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Top up reksadana",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.tracked.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+    const deleteKey = factories.createIdempotencyKey()
+
+    await deleteTransactionForFamily({
+      familyId: fx.familyId,
+      id: result.id,
+      idempotencyKey: deleteKey,
+      user: fx.user,
+    })
+    // Same idempotency key -> pure replay, returns the same cached response.
+    await expect(
+      deleteTransactionForFamily({
+        familyId: fx.familyId,
+        id: result.id,
+        idempotencyKey: deleteKey,
+        user: fx.user,
+      })
+    ).resolves.toEqual({ success: true })
+    // A different key on an already-deleted transaction is a fresh attempt,
+    // not a replay -> must fail loud, never a second reversal.
+    await expect(
+      deleteTransactionForFamily({
+        familyId: fx.familyId,
+        id: result.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+        user: fx.user,
+      })
+    ).rejects.toThrow(TransactionGoneError)
+
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n
+    )
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_000_000n
+    )
+  })
+
+  test("deleting via the general bulk-delete endpoint (the UI's actual delete path) also reverses symmetrically", async () => {
+    const fx = await createRealisticFixture({ trackedOpening: 1_000_000n })
     const result = await createTransactionForFamily({
       data: {
         accountId: fx.cash.id,
@@ -364,20 +591,19 @@ describe("PER-196 / ADR-0048 — valuation-linked transfer", () => {
       user: fx.user,
     })
 
-    await expect(
-      deleteTransactionForFamily({
-        familyId: fx.familyId,
-        id: result.id,
-        idempotencyKey: factories.createIdempotencyKey(),
-        user: fx.user,
-      })
-    ).rejects.toThrow(ValuationLinkedTransferUnsupportedError)
+    const response = await bulkDeleteTransactionsForFamily({
+      familyId: fx.familyId,
+      idempotencyKey: factories.createIdempotencyKey(),
+      ids: [result.id],
+      user: fx.user,
+    })
+    expect(response).toEqual({ count: 1, success: true })
 
     expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
-      5_000_000n - 250_000n
+      5_000_000n
     )
     expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
-      1_250_000n
+      1_000_000n
     )
   })
 


### PR DESCRIPTION
## Summary

Fourth PR of PER-196. **Base = main** (not stacked — per-196-guard and per-196-model are already merged, so this branches cleanly off main and gets full CI, learning from #177's stacked-base CI-blind spot).

Closes the two gaps left after the server-side model (#175/#176/#178, merged): the Transfer form now surfaces the valuation-linked flow, and deleting one is supported end to end — the blocking requirement, since the prior `ValuationLinkedTransferUnsupportedError` message ("delete it and record a new transfer instead") was contradictory while delete itself was unsupported.

### UI (`transaction-form-modal.tsx`, `collections.ts`)
- New `NewValuationValueField`, shown only when exactly one transfer side is `balanceSource="valuation"`. Prefill is a pure derived value (no-use-effect Rule 1 — `latest tracked balance ∓ amount`, recomputed via `form.Subscribe` on every render); the field only holds the user's manual override, so it's always a real, editable number with no effect needed to sync a default into it.
- Forwards to the existing `newValuationValue` input (already wired server-side in #178) only when the user actually typed a value — otherwise omitted so the server computes the freshest prefill at write time.

### Delete (`transactions.ts`)
`softDeleteValuationLinkedTransferWithinTx`: reverses the cash leg's balance delta, tombstones the cash Transaction and the linked Valuation (never hard-deleted, ADR-0034), re-materializes the tracked account via `rebuildWithinTx`, tombstones the Transfer row, audits every step. Wired into `softDeleteTransactionWithinTenantTransaction`, so both `deleteTransactionFn` and `bulkDeleteTransactionsFn` (the UI's actual delete path) get it for free. `ValuationLinkedTransferUnsupportedError` is now edit-only, and its message is no longer contradictory.

### A second production bug, caught by the real-browser e2e test
While verifying the UI end to end, `tests/e2e/valuation-linked-transfer.e2e.ts` caught a live regression: `findLedgerTransactionsForFamily` unconditionally hid any Transaction sitting in a Transfer's `inflowTransactionId` slot, assuming its outflow twin would represent it in the list — true for a classic dual-leg transfer, but a **redemption's cash leg IS the inflow leg with no outflow twin at all** (the other side is a Valuation, not a Transaction). That reproduced PER-196's original "transaction did not appear in the ledger list" symptom through a brand-new mechanism. Fixed by only hiding an inflow leg when a real outflow twin exists to show instead. Pinned with both a fast integration test and the e2e test that found it.

## Test plan
- [x] `vp check --fix` clean
- [x] `tests/integration/valuation-linked-transfer.integration.ts`: 14 tests (was 10 — added contribution/redemption/idempotent-delete/bulk-delete-path/ledger-visibility-regression)
- [x] Full regression: 89 tests across 8 related integration suites (transfer-soft-delete, transfer-graph-invariants, idempotent-mutations, audit-log, account-delete, bulk-mutation-parity, valuation-primitive, valuation-account-balance-guard)
- [x] `tests/e2e/valuation-linked-transfer.e2e.ts`: real browser, real Postgres — create both account types via the UI, submit a redemption through the adaptive form, verify the prefilled field, verify the cash transaction is visible + correct balances + zero drift badge, delete it, verify symmetric reversal
- [x] Existing e2e regression check: `transaction-quick-create.e2e.ts` + `account-delete.e2e.ts` (both exercise the shared ledger list query) — pass

## Next
Phase 5 (separate PR): one-time audited cleanup migration for the creator's 2 pre-guard phantom classic-transfer legs on their reksadana account (drift + Bank Jago over-count). Phase 6: full e2e suite run before claiming the whole PER-196 effort done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqMxWy8d2MB3B3pKLvj8Y3