### PR TITLE
feat(ledger): PER-196 Phase 5 — audited cleanup for pre-guard phantom valuation transfers

### DIFF
--- a/scripts/per-196-cleanup-phantom-valuation-transfers.ts
+++ b/scripts/per-196-cleanup-phantom-valuation-transfers.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S vp exec tsx
+// PER-196 / ADR-0048 §5 — one-time, audited, idempotent cleanup for phantom
+// pre-guard classic transfers touching a balanceSource="valuation" account.
+//
+// Before the ADR-0048 §3 guard shipped, a redemption/contribution transfer
+// recorded against a tracked-asset account silently mutated its stored
+// balance cache without moving its valuation-derived canonical balance,
+// leaving it drifted (a "Balance drift" badge in the UI). This script
+// reverses exactly those phantom legs — see src/server/ledger-cleanup.ts
+// for the full detection + reversal design and its real-Postgres tests
+// (tests/integration/ledger-cleanup.integration.ts).
+//
+// SAFE TO RUN MORE THAN ONCE: the underlying function is idempotent (a
+// second run finds nothing left to clean up) and self-verifying (it throws,
+// rather than reporting silent success, if drift remains after reversing
+// every matching classic transfer and rebuilding).
+//
+// This script does NOTHING until --apply is passed. Before running it:
+//   1. Open the Accounts page in the app and note which tracked-asset
+//      accounts show a "Balance drift" badge — that is the same detection
+//      signal this script uses, so you should already know what to expect.
+//   2. Find the family id and an actor user id (e.g. via `prisma studio`,
+//      or the URL/session of the account showing the drift).
+//
+// Usage:
+//   vp exec tsx scripts/per-196-cleanup-phantom-valuation-transfers.ts \
+//     --family <familyId> --user <userId> [--apply]
+//
+// Without --apply, this only validates its arguments and reminds you what
+// it will do — it makes no database calls at all. Pass --apply to actually
+// run the reversal.
+
+import { reversePhantomValuationTransfersForFamily } from "../src/server/ledger-cleanup"
+
+function parseArgs(argv: string[]): {
+  familyId: string | null
+  userId: string | null
+  apply: boolean
+} {
+  let familyId: string | null = null
+  let userId: string | null = null
+  let apply = false
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--family") familyId = argv[++i] ?? null
+    else if (arg === "--user") userId = argv[++i] ?? null
+    else if (arg === "--apply") apply = true
+  }
+  return { familyId, userId, apply }
+}
+
+async function main() {
+  const { familyId, userId, apply } = parseArgs(process.argv.slice(2))
+
+  if (!familyId || !userId) {
+    console.error(
+      "Usage: vp exec tsx scripts/per-196-cleanup-phantom-valuation-transfers.ts --family <familyId> --user <userId> [--apply]"
+    )
+    process.exitCode = 1
+    return
+  }
+
+  if (!apply) {
+    console.log(
+      "Dry run (no --apply passed) — making no database calls.\n" +
+        `Would run the PER-196 / ADR-0048 §5 cleanup for family ${familyId} as user ${userId}.\n` +
+        "Re-run with --apply to actually reverse any phantom classic transfers found."
+    )
+    return
+  }
+
+  console.log(
+    `Running PER-196 / ADR-0048 §5 cleanup for family ${familyId} as user ${userId}...`
+  )
+  const results = await reversePhantomValuationTransfersForFamily({
+    familyId,
+    user: { id: userId },
+  })
+
+  if (results.length === 0) {
+    console.log(
+      "Nothing to clean up — no valuation-tracked account in this family is both drifted and has a live classic transfer touching it."
+    )
+    return
+  }
+
+  console.log(`Reversed ${results.length} drifted account(s):`)
+  for (const result of results) {
+    console.log(
+      `  account ${result.accountId}: drift was ${result.driftBeforeMinor} minor units, ` +
+        `reversed transfer(s) [${result.reversedTransferIds.join(", ")}], now zero drift.`
+    )
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: unknown) => {
+    console.error("PER-196 cleanup failed:", error)
+    process.exit(1)
+  })

--- a/src/server/ledger-cleanup.ts
+++ b/src/server/ledger-cleanup.ts
@@ -1,0 +1,181 @@
+import { subMoney, toMoney } from "@/lib/money"
+import { withBulkLedgerReplayBypass } from "./bulk-ledger-replay"
+import { auditLog, createAuditContext } from "./middleware/audit"
+import {
+  scopedTenantTransaction,
+  type TenantTransactionClient,
+} from "./middleware/with-family"
+import type { RunInTenantTransaction } from "./mutation-kit"
+import { softDeleteTransactionWithinTenantTransaction } from "./transactions"
+import {
+  computeCanonicalBalance,
+  fetchAccountFacts,
+  rebuildFamilyBalances,
+} from "./valuations"
+
+// =============================================================================
+// PER-196 / ADR-0048 §5 — one-time audited cleanup for the pre-guard bug.
+//
+// Before ADR-0048 §3's guard shipped, a CLASSIC dual-Transaction transfer
+// touching a balanceSource="valuation" account silently mutated that
+// account's stored balance cache while its valuation-derived canonical
+// balance stayed put (PER-196's root cause). Every account left in that
+// state still carries the resulting MATERIALIZATION drift today — the guard
+// stops it from happening again, but does not retroactively fix what
+// already happened.
+//
+// This function finds and reverses exactly those phantom legs, using drift
+// itself as the detection signal:
+//   - A tracked account with NO drift needs no cleanup, whether or not it
+//     has classic transfers in its history — that covers legitimate
+//     historical rows (e.g. PER-176 Sure-imported dual-leg transfers, which
+//     went through the bulk path and ended in an unbypassed rebuild, so they
+//     never left drift behind). Untouched, on purpose.
+//   - A tracked account WITH drift, that also has one or more live classic
+//     (valuationId IS NULL) Transfer rows touching it, is exactly the
+//     PER-196 repro shape. Every such Transfer is reversed via the existing,
+//     already-audited softDeleteTransactionWithinTenantTransaction — the
+//     same symmetric reversal a normal user-initiated delete uses.
+//
+// Reversal necessarily applies an incremental delta to the valuation-tracked
+// account (undoing the phantom leg's own incremental mutation), which
+// ADR-0048 §3's guard would otherwise reject. This reuses the existing
+// ADR-0044 §8 bypass (the SAME bulk-replay GUC the Sure migration uses) for
+// exactly that reason, and — mirroring that pattern exactly — always follows
+// up with an UNBYPASSED rebuildFamilyBalances() so every touched account's
+// final stored balance is independently re-derived from canonical rows, not
+// trusted from the bypassed arithmetic alone. If any account still shows
+// drift after that rebuild, this throws rather than reporting a silent
+// partial success — a case that would mean something other than a phantom
+// classic transfer caused the drift, and needs a human, not this script.
+//
+// Idempotent: a second run finds no accounts with both drift AND a live
+// classic transfer touching them (the first run already reversed and
+// soft-deleted every matching row), so it returns an empty result and makes
+// no writes.
+// =============================================================================
+
+export interface PhantomValuationTransferCleanupResult {
+  accountId: string
+  driftBeforeMinor: string
+  reversedTransferIds: string[]
+}
+
+async function findDriftedValuationAccountIds(
+  tx: TenantTransactionClient,
+  familyId: string
+): Promise<Map<string, string>> {
+  const accountIds = (
+    await tx.account.findMany({
+      where: { familyId, balanceSource: "valuation" },
+      select: { id: true },
+    })
+  ).map((account) => account.id)
+
+  const driftByAccountId = new Map<string, string>()
+  for (const accountId of accountIds) {
+    const account = await fetchAccountFacts(tx, familyId, accountId)
+    if (!account) continue
+    const canonical = await computeCanonicalBalance(tx, familyId, account)
+    const stored = toMoney(account.balance)
+    if (canonical !== stored) {
+      driftByAccountId.set(accountId, subMoney(canonical, stored).toString())
+    }
+  }
+  return driftByAccountId
+}
+
+export async function reversePhantomValuationTransfersForFamily({
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  familyId: string
+  user: { id: string }
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<PhantomValuationTransferCleanupResult[]> {
+  const bypassRun = withBulkLedgerReplayBypass(runInTenantTransaction)
+
+  const reversedByAccount = await bypassRun(familyId, user.id, async (tx) => {
+    const driftByAccountId = await findDriftedValuationAccountIds(tx, familyId)
+    if (driftByAccountId.size === 0)
+      return new Map<string, PhantomValuationTransferCleanupResult>()
+
+    const auditCtx = await createAuditContext({
+      user: { id: user.id, familyId },
+    })
+    const reversed = new Map<string, PhantomValuationTransferCleanupResult>()
+
+    for (const [accountId, driftBeforeMinor] of driftByAccountId) {
+      const transfers = await tx.transfer.findMany({
+        where: {
+          deletedAt: null,
+          valuationId: null,
+          OR: [
+            { outflowTransaction: { accountId } },
+            { inflowTransaction: { accountId } },
+          ],
+        },
+        select: { id: true, outflowTransactionId: true },
+      })
+      if (transfers.length === 0) continue
+
+      const reversedTransferIds: string[] = []
+      for (const transfer of transfers) {
+        if (!transfer.outflowTransactionId) {
+          throw new Error(
+            `PER-196 cleanup invariant violated: classic Transfer ${transfer.id} has a null outflowTransactionId`
+          )
+        }
+        await softDeleteTransactionWithinTenantTransaction(tx, {
+          auditCtx,
+          familyId,
+          id: transfer.outflowTransactionId,
+        })
+        reversedTransferIds.push(transfer.id)
+      }
+
+      await auditLog(tx, auditCtx, {
+        action: "update",
+        entityType: "LedgerCleanup",
+        entityId: accountId,
+        before: { driftMinor: driftBeforeMinor, reversedTransferIds: [] },
+        after: { driftMinor: "0", reversedTransferIds },
+      })
+      reversed.set(accountId, {
+        accountId,
+        driftBeforeMinor,
+        reversedTransferIds,
+      })
+    }
+
+    return reversed
+  })
+
+  if (reversedByAccount.size === 0) {
+    return []
+  }
+
+  // ADR-0044 §8 belt-and-suspenders: re-derive every account's stored
+  // balance from canonical rows in a fresh, UNBYPASSED transaction, rather
+  // than trusting the bypassed incremental reversal arithmetic alone.
+  await rebuildFamilyBalances({ familyId, user, runInTenantTransaction })
+
+  await runInTenantTransaction(familyId, user.id, async (tx) => {
+    const stillDrifted = await findDriftedValuationAccountIds(tx, familyId)
+    for (const [accountId, result] of reversedByAccount) {
+      const remainingDrift = stillDrifted.get(accountId)
+      if (remainingDrift) {
+        throw new Error(
+          `PER-196 cleanup could not fully resolve drift on account ${accountId} ` +
+            `after reversing ${result.reversedTransferIds.length} transfer(s) and ` +
+            `rebuilding (remaining drift: ${remainingDrift} minor units). Something ` +
+            "other than a phantom classic transfer is responsible — manual " +
+            "investigation required."
+        )
+      }
+    }
+  })
+
+  return Array.from(reversedByAccount.values())
+}

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -332,7 +332,7 @@ export async function latestValuation(
 // is what reproduces the real Sure UI for migrated accounts. Tracked
 // (`valuation`-sourced) accounts are unchanged: latest valuation of any type
 // wins, no transaction sum (ADR-0034 §5).
-async function computeCanonicalBalance(
+export async function computeCanonicalBalance(
   tx: TenantTransactionClient,
   familyId: string,
   account: AccountBalanceFacts
@@ -392,7 +392,7 @@ async function setAccountBalanceTo(
   }
 }
 
-async function fetchAccountFacts(
+export async function fetchAccountFacts(
   tx: TenantTransactionClient,
   familyId: string,
   accountId: string

--- a/tests/integration/ledger-cleanup.integration.ts
+++ b/tests/integration/ledger-cleanup.integration.ts
@@ -1,0 +1,339 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import { createAccountForFamily } from "@/server/accounts"
+import { createTransactionForFamily } from "@/server/transactions"
+import { createValuationForFamily } from "@/server/valuations"
+import { reversePhantomValuationTransfersForFamily } from "@/server/ledger-cleanup"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+// PER-196 / ADR-0048 §5 — the one-time audited cleanup for the creator's
+// pre-guard phantom classic transfers: a redemption/contribution recorded
+// BEFORE the ADR-0048 §3 guard shipped, which silently mutated the
+// tracked-asset account's stored balance and left it drifted from its
+// valuation-derived canonical balance. Real-Postgres coverage: detects and
+// reverses the phantom shape (drift + a live classic transfer touching the
+// drifted account), leaves drift-free classic transfers alone (the
+// legitimate Sure-imported-history case), leaves valuation-linked transfers
+// alone, is idempotent, and self-verifies (throws rather than silently
+// reporting success if drift remains after the reversal + rebuild).
+
+const TEST_DATE = new Date("2026-07-19T00:00:00.000Z")
+
+describe("PER-196 / ADR-0048 §5 — phantom valuation-transfer cleanup", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  async function createFixture() {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await createAccountForFamily({
+      data: {
+        accountType: "DEPOSITORY",
+        idempotencyKey: factories.createIdempotencyKey(),
+        name: "Bank Jago",
+        openingBalance: "5000000",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const tracked = await createAccountForFamily({
+      data: {
+        accountType: "TRACKED_ASSET",
+        idempotencyKey: factories.createIdempotencyKey(),
+        name: "Hasil Jualan",
+        openingBalance: "1000000",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    return { cash, familyId: owner.family.id, tracked, user: owner.user }
+  }
+
+  async function readAccount(familyId: string, accountId: string) {
+    return harness.withFamily(familyId, (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: accountId } })
+    )
+  }
+
+  // Simulates the pre-ADR-0048 buggy path directly: a raw dual-leg Transfer
+  // + two Transaction rows, with the incremental deltas applied by hand
+  // (bypassing the guard exactly the way production data predating the
+  // guard was already in this shape). This is what createTransactionForFamily
+  // used to produce before PER-196 was fixed.
+  async function createPhantomClassicTransfer(fx: {
+    familyId: string
+    cashAccountId: string
+    trackedAccountId: string
+    direction: "redemption" | "contribution"
+    amount: bigint
+    userId: string
+  }) {
+    const isRedemption = fx.direction === "redemption"
+    const outflowAccountId = isRedemption
+      ? fx.trackedAccountId
+      : fx.cashAccountId
+    const inflowAccountId = isRedemption
+      ? fx.cashAccountId
+      : fx.trackedAccountId
+
+    return harness.withFamily(fx.familyId, async (tx) => {
+      await tx.$executeRaw`SELECT set_config('app.bulk_ledger_replay', 'on', true)`
+      await tx.account.update({
+        where: { id: outflowAccountId },
+        data: { balance: { decrement: fx.amount } },
+      })
+      await tx.account.update({
+        where: { id: inflowAccountId },
+        data: { balance: { increment: fx.amount } },
+      })
+      const outflowTx = await tx.transaction.create({
+        data: {
+          accountId: outflowAccountId,
+          amount: -fx.amount,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Pencairan (pre-guard, phantom)",
+          familyId: fx.familyId,
+          kind: "funds_movement",
+          status: "CLEARED",
+          toAccountId: inflowAccountId,
+          type: "transfer",
+          userId: fx.userId,
+        },
+      })
+      const inflowTx = await tx.transaction.create({
+        data: {
+          accountId: inflowAccountId,
+          amount: fx.amount,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Pencairan (pre-guard, phantom)",
+          familyId: fx.familyId,
+          kind: "funds_movement",
+          status: "CLEARED",
+          toAccountId: outflowAccountId,
+          type: "transfer",
+          userId: fx.userId,
+        },
+      })
+      const transfer = await tx.transfer.create({
+        data: {
+          outflowTransactionId: outflowTx.id,
+          inflowTransactionId: inflowTx.id,
+        },
+      })
+      return { outflowTx, inflowTx, transfer }
+    })
+  }
+
+  test("reverses a redemption-shaped phantom classic transfer and resolves the drift", async () => {
+    const fx = await createFixture()
+    await createPhantomClassicTransfer({
+      amount: 250_000n,
+      cashAccountId: fx.cash.id,
+      direction: "redemption",
+      familyId: fx.familyId,
+      trackedAccountId: fx.tracked.id,
+      userId: fx.user.id,
+    })
+
+    // Confirm the drifted state actually exists before cleanup.
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      750_000n
+    )
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_250_000n
+    )
+
+    const results = await reversePhantomValuationTransfersForFamily({
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.accountId).toBe(fx.tracked.id)
+    expect(results[0]?.reversedTransferIds).toHaveLength(1)
+
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_000_000n
+    )
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n
+    )
+
+    const [outflowRow, inflowRow, transferRow] = await Promise.all([
+      harness.withFamily(fx.familyId, (tx) =>
+        tx.transaction.findFirstOrThrow({
+          where: { accountId: fx.tracked.id, type: "transfer" },
+        })
+      ),
+      harness.withFamily(fx.familyId, (tx) =>
+        tx.transaction.findFirstOrThrow({
+          where: { accountId: fx.cash.id, type: "transfer" },
+        })
+      ),
+      harness.withFamily(fx.familyId, (tx) => tx.transfer.findFirstOrThrow()),
+    ])
+    expect(outflowRow.deletedAt).not.toBeNull()
+    expect(inflowRow.deletedAt).not.toBeNull()
+    expect(transferRow.deletedAt).not.toBeNull()
+  })
+
+  test("reverses a contribution-shaped phantom classic transfer too", async () => {
+    const fx = await createFixture()
+    await createPhantomClassicTransfer({
+      amount: 100_000n,
+      cashAccountId: fx.cash.id,
+      direction: "contribution",
+      familyId: fx.familyId,
+      trackedAccountId: fx.tracked.id,
+      userId: fx.user.id,
+    })
+
+    const results = await reversePhantomValuationTransfersForFamily({
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    expect(results).toHaveLength(1)
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_000_000n
+    )
+    expect((await readAccount(fx.familyId, fx.cash.id)).balance).toBe(
+      5_000_000n
+    )
+  })
+
+  test("leaves a drift-free classic transfer touching a tracked account alone (legitimate historical shape, e.g. Sure-imported)", async () => {
+    const fx = await createFixture()
+    const { outflowTx, transfer } = await createPhantomClassicTransfer({
+      amount: 250_000n,
+      cashAccountId: fx.cash.id,
+      direction: "redemption",
+      familyId: fx.familyId,
+      trackedAccountId: fx.tracked.id,
+      userId: fx.user.id,
+    })
+    // A new valuation happens to match the account's already-mutated stored
+    // balance — drift is now zero even though the malformed classic
+    // transfer row still exists. The detection signal is drift, not shape,
+    // so cleanup must leave this alone.
+    await createValuationForFamily({
+      data: {
+        accountId: fx.tracked.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+        type: "reconciliation",
+        value: "750000",
+        // Must postdate the account's auto-created opening valuation (dated
+        // "now" at account creation) to actually become "latest" — TEST_DATE
+        // (2026-07-19) predates that, which is exactly the ordering mistake
+        // this comment now documents so it isn't repeated.
+        valuationDate: new Date(Date.now() + 60_000),
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      750_000n
+    )
+
+    const results = await reversePhantomValuationTransfersForFamily({
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    expect(results).toHaveLength(0)
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      750_000n
+    )
+    const untouchedOutflow = await harness.withFamily(fx.familyId, (tx) =>
+      tx.transaction.findUniqueOrThrow({ where: { id: outflowTx.id } })
+    )
+    expect(untouchedOutflow.deletedAt).toBeNull()
+    const untouchedTransfer = await harness.withFamily(fx.familyId, (tx) =>
+      tx.transfer.findUniqueOrThrow({ where: { id: transfer.id } })
+    )
+    expect(untouchedTransfer.deletedAt).toBeNull()
+  })
+
+  test("leaves a valuation-linked transfer untouched", async () => {
+    const fx = await createFixture()
+    const linked = await createTransactionForFamily({
+      data: {
+        accountId: fx.tracked.id,
+        amount: 200_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Pencairan (valuation-linked, correct)",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: fx.cash.id,
+        type: "transfer",
+      },
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    const results = await reversePhantomValuationTransfersForFamily({
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+
+    expect(results).toHaveLength(0)
+    const stillLive = await harness.withFamily(fx.familyId, (tx) =>
+      tx.transaction.findUniqueOrThrow({ where: { id: linked.id } })
+    )
+    expect(stillLive.deletedAt).toBeNull()
+  })
+
+  test("is idempotent: a second run after cleanup finds nothing left to do", async () => {
+    const fx = await createFixture()
+    await createPhantomClassicTransfer({
+      amount: 250_000n,
+      cashAccountId: fx.cash.id,
+      direction: "redemption",
+      familyId: fx.familyId,
+      trackedAccountId: fx.tracked.id,
+      userId: fx.user.id,
+    })
+
+    const first = await reversePhantomValuationTransfersForFamily({
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+    expect(first).toHaveLength(1)
+
+    const second = await reversePhantomValuationTransfersForFamily({
+      familyId: fx.familyId,
+      user: fx.user,
+    })
+    expect(second).toHaveLength(0)
+
+    expect((await readAccount(fx.familyId, fx.tracked.id)).balance).toBe(
+      1_000_000n
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fifth PR of PER-196. **Base = main**, not stacked on #185 (Phase 4) — this doesn't depend on any UI/delete work, only on `softDeleteTransactionWithinTenantTransaction` and `fetchAccountFacts`/`rebuildWithinTx`, which are already on main except `fetchAccountFacts` — exported here too (a trivial, non-conflicting one-line change that'll no-op cleanly whichever PR merges first).

Builds the one-time, audited cleanup for the creator's 2 pre-guard phantom transfer legs (the original PER-196 dogfooding repro: two reksadana → Bank Jago attempts, each posting a real +A to Bank Jago and drifting the reksadana account).

### Design (`src/server/ledger-cleanup.ts`)
`reversePhantomValuationTransfersForFamily` uses **drift itself** as the detection signal, not shape alone:
- A `balanceSource="valuation"` account with **no** drift needs no cleanup — this correctly leaves legitimate historical rows alone (e.g. PER-176 Sure-imported dual-leg transfers, which went through the bulk path + an unbypassed rebuild and so never drifted in the first place).
- An account **with** drift that also has a live classic (`valuationId IS NULL`) Transfer touching it is exactly the PER-196 repro shape. Each such transfer is reversed via the existing, already-audited `softDeleteTransactionWithinTenantTransaction` — the same path a normal delete uses.

Reversal necessarily applies an incremental delta to the valuation-tracked account (undoing the phantom leg's mutation), which the #176 guard would otherwise reject — reuses the existing ADR-0044 §8 bulk-replay bypass GUC for exactly that reason, followed by an **unbypassed** `rebuildFamilyBalances()` per that pattern's belt-and-suspenders requirement (mirrors how the Sure migration itself uses this same bypass). Self-verifying: throws rather than reporting silent success if drift remains after the reversal + rebuild. Idempotent: a second run finds nothing left to do.

### Deployment (`scripts/per-196-cleanup-phantom-valuation-transfers.ts`)
A thin CLI wrapper. **Makes zero database calls without an explicit `--apply` flag.** I have not run this against production — deploying it is the creator's own deliberate action once this merges and the rest of the PER-196 set (#176/#178/#185) is live.

## Test plan
- [x] `vp check --fix` clean
- [x] `tests/integration/ledger-cleanup.integration.ts` (5 tests): reverses a redemption-shaped and a contribution-shaped phantom transfer, leaves a drift-free classic transfer alone (the legitimate-history case, explicitly constructed by reconciling the account to match its already-mutated balance), leaves a valuation-linked transfer untouched, confirms idempotency
- [x] Full regression: 81 tests across 5 related suites (valuation-primitive, valuation-linked-transfer, valuation-account-balance-guard, db-constraints)

## Next
Phase 6: run the full e2e suite before claiming the whole PER-196 effort done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqMxWy8d2MB3B3pKLvj8Y3