### PR TITLE
feat(import): PER-199 — per-transaction cross-batch idempotency (re-import is add-only)

### DIFF
--- a/prisma/migrations/20260726120000_transaction_provider_binding/migration.sql
+++ b/prisma/migrations/20260726120000_transaction_provider_binding/migration.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- PER-199 — Per-transaction cross-batch import idempotency.
+--
+-- Additive + backward-compatible. `Transaction` gains the same durable
+-- external-provider binding already used by Account/Category/Merchant
+-- (PER-170 / ADR-0041 §3), so a re-imported Sure transaction can be
+-- recognized as already-canonical by (familyId, externalProvider, externalId)
+-- instead of only by whole-bundle contentHash. New columns are nullable, so
+-- existing (manual and manually-imported CSV) rows are untouched — they stay
+-- externalProvider = NULL and are exempt from the partial unique below.
+-- ============================================================================
+
+ALTER TABLE "Transaction"
+  ADD COLUMN "externalProvider" TEXT,
+  ADD COLUMN "externalId" TEXT;
+
+-- Partial UNIQUE (WHERE externalProvider IS NOT NULL): Postgres treats NULLs
+-- as DISTINCT by default, so manual/CSV rows (externalProvider = NULL) are
+-- already unique under any composite index — the predicate keeps the index
+-- small (provider-bound rows only) and makes the binding uniqueness an
+-- EXPLICIT, import-only invariant, mirroring account_provider_binding /
+-- category_provider_binding / merchant_provider_binding exactly.
+--
+-- Deliberately NOT scoped by deletedAt: a soft-deleted transaction's
+-- externalId identity must still block a duplicate live re-promotion of the
+-- same provider row (ADD-ONLY means "never re-create", not "re-create once
+-- the old one is deleted"). The app-layer dedup check (loadCanonicalDedupIndex,
+-- src/server/imports.ts) mirrors this exactly: its externalId lookup is also
+-- NOT deletedAt-scoped, so an imported-then-deleted row still counts as a
+-- duplicate and skips re-promotion — it never inserts a second row that would
+-- collide with this index.
+CREATE UNIQUE INDEX "transaction_provider_binding"
+  ON "Transaction" ("familyId", "externalProvider", "externalId")
+  WHERE "externalProvider" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -318,6 +318,17 @@ model Transaction {
   notes       String?
   excluded    Boolean @default(false)
 
+  // Durable external-provider binding (PER-199, mirrors Account/Category/
+  // Merchant — ADR-0041 §3). NULL for manually-created and manually-imported
+  // (CSV) transactions. A PARTIAL UNIQUE (familyId, externalProvider,
+  // externalId) WHERE externalProvider IS NOT NULL is created in raw SQL
+  // (migration `transaction_provider_binding`) — Prisma cannot express the
+  // predicate. This is the cross-batch, per-transaction dedup identity that
+  // makes re-importing a fresh Sure export ADD-ONLY instead of duplicating
+  // every overlapping transaction (PER-199 / ADR-0039 §9 amendment).
+  externalProvider String?
+  externalId       String?
+
   // Running Balance Snapshot: Saldo akun setelah transaksi ini dicatat (untuk grafik historis instan).
   // Stored in MINOR UNITS of `currency`.
   accountBalanceAfter BigInt?

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1796,6 +1796,10 @@ function useTransactionFormModalController({
             baseCurrency: null,
             fxRateScaled: null,
             fxRateSnapshotId: null,
+            // PER-199: provider-identity binding is import-only; UI-created
+            // transactions never carry one.
+            externalProvider: null,
+            externalId: null,
             // splitEntries di optimistic payload adalah versi ringkas (tanpa relasi Prisma)
             splitEntries:
               payload.splitEntries as TransactionRecord["splitEntries"],

--- a/src/lib/sure-migration.ts
+++ b/src/lib/sure-migration.ts
@@ -694,11 +694,18 @@ export type SureTransferHeldReason =
   | "db_rejected"
   | "unpaired_orphan"
   | "ambiguous_cluster"
+  // PER-199: TERMINAL, not "pending retry" like the reasons above — this leg's
+  // externalId is already bound to a live-or-deleted canonical Transaction
+  // from a PRIOR import run (staging-time provider dedup). It will never be
+  // promoted, by design (ADD-ONLY), so it must still be counted here to keep
+  // `legsStaged === legsPromotedTotal + Σ heldLegsByReason` exact.
+  | "already_imported"
 
-/** Reasons the pure pairer can assign (everything but the runtime `db_rejected`). */
+/** Reasons the pure pairer can assign (everything but the runtime-only,
+ * DB-anchored `db_rejected` / `already_imported`). */
 export type SureTransferPureHeldReason = Exclude<
   SureTransferHeldReason,
-  "db_rejected"
+  "db_rejected" | "already_imported"
 >
 
 /** Gate failures for a formed candidate pair (precedence: importable→currency→kind). */

--- a/src/routes/_protected/-sure-import-ui.test.tsx
+++ b/src/routes/_protected/-sure-import-ui.test.tsx
@@ -40,6 +40,7 @@ function makeResult(
       staged: 6,
       promotedThisRun: 0,
       held: 6,
+      duplicateSkipped: 0,
       zeroAmountSkipped: 0,
       invalidDateSkipped: 0,
       ...txnOverrides,
@@ -63,6 +64,7 @@ function makeResult(
         db_rejected: 0,
         unpaired_orphan: 0,
         ambiguous_cluster: 0,
+        already_imported: 0,
       },
     },
     timings: {
@@ -167,6 +169,7 @@ describe("DoneStage", () => {
               db_rejected: 0,
               unpaired_orphan: 0,
               ambiguous_cluster: 0,
+              already_imported: 0,
             },
           },
         })}
@@ -202,6 +205,7 @@ describe("DoneStage", () => {
               db_rejected: 0,
               unpaired_orphan: 1,
               ambiguous_cluster: 0,
+              already_imported: 0,
             },
           },
         })}

--- a/src/routes/_protected/-sure-import-ui.tsx
+++ b/src/routes/_protected/-sure-import-ui.tsx
@@ -9,6 +9,7 @@ import {
   Coins,
   FileJson,
   FileWarning,
+  History,
   Layers,
   Link2Off,
   Loader2,
@@ -528,6 +529,12 @@ export function DoneStage({
   const t = result.transactions
   const ignoredTotal = sumValues(result.ignoredEntities)
   const nothingPromoted = t.promotedThisRun === 0
+  // PER-199: a re-import can promote nothing for two very different reasons —
+  // "everything is already in your ledger" (success, add-only dedup working
+  // as designed) vs "everything is held pending the transfer step" (the
+  // pre-existing degraded case). Conflating them would be dishonest.
+  const allAlreadyImported =
+    nothingPromoted && t.duplicateSkipped > 0 && t.held === 0
 
   let title: string
   let description: string
@@ -535,6 +542,10 @@ export function DoneStage({
     title = "Already imported"
     description =
       "This exact export was imported before — nothing was duplicated."
+  } else if (allAlreadyImported) {
+    title = "Already up to date"
+    description =
+      "Every transaction in this export was already in your ledger from an earlier import — nothing was duplicated."
   } else if (nothingPromoted) {
     // The real-world degraded/transfer-heavy case: accounts and reference data
     // land, but every transaction is held. This is success, not failure.
@@ -565,15 +576,24 @@ export function DoneStage({
           </div>
         </CardHeader>
         <CardContent className="flex flex-col gap-6">
-          {t.promotedThisRun > 0 && (
-            <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
-              <span className="text-5xl font-extrabold tracking-tight tabular-nums">
-                {t.promotedThisRun}
-              </span>
-              <span className="pb-1 text-lg text-muted-foreground">
-                transaction{t.promotedThisRun === 1 ? "" : "s"} added to your
-                ledger
-              </span>
+          {(t.promotedThisRun > 0 || t.duplicateSkipped > 0) && (
+            <div className="flex flex-col gap-1">
+              <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
+                <span className="text-5xl font-extrabold tracking-tight tabular-nums">
+                  {t.promotedThisRun}
+                </span>
+                <span className="pb-1 text-lg text-muted-foreground">
+                  transaction{t.promotedThisRun === 1 ? "" : "s"} added to your
+                  ledger
+                </span>
+              </div>
+              {/* PER-199: honest re-import copy — "X new · Y already imported
+                  (skipped)" so dedup is visible, never a silent drop. */}
+              {t.duplicateSkipped > 0 && (
+                <p className="text-sm text-muted-foreground">
+                  {t.duplicateSkipped} already imported previously (skipped)
+                </p>
+              )}
             </div>
           )}
 
@@ -604,6 +624,7 @@ export function DoneStage({
 
           {/* Full reconciliation of the transaction buckets the server returns. */}
           {(t.held > 0 ||
+            t.duplicateSkipped > 0 ||
             t.zeroAmountSkipped > 0 ||
             t.invalidDateSkipped > 0 ||
             result.malformedLines > 0 ||
@@ -620,6 +641,12 @@ export function DoneStage({
                     className="border-amber-400 text-amber-700 dark:text-amber-300"
                   >
                     {t.held} held for review
+                  </Badge>
+                )}
+                {t.duplicateSkipped > 0 && (
+                  <Badge variant="outline" className="gap-1">
+                    <History size={11} />
+                    {t.duplicateSkipped} already imported
                   </Badge>
                 )}
                 {t.zeroAmountSkipped > 0 && (
@@ -867,6 +894,11 @@ const TRANSFER_HELD_REASON_LABEL: Record<SureTransferHeldReason, string> = {
   db_rejected: "rejected by a ledger safety check",
   unpaired_orphan: "no matching counterpart found",
   ambiguous_cluster: "more than one possible match",
+  // PER-199: TERMINAL (already imported by a prior run), not "pending retry"
+  // like the reasons above — deliberately excluded from the "kept for
+  // review" grouping in BalanceReconciliationSummary, which shows it as its
+  // own honest "already imported (skipped)" line instead.
+  already_imported: "already imported previously",
 }
 
 // PER-188 — the Done-screen truth about balances. Every migration run ends
@@ -880,10 +912,17 @@ function BalanceReconciliationSummary({
 }: {
   transfers: SureMigrationResult["transfers"]
 }) {
+  // PER-199: `already_imported` is TERMINAL (done, from a prior run) — it is
+  // never "pending review", so it gets its own honest line instead of
+  // inflating the "kept for review" count.
+  const alreadyImportedTotal = transfers.heldLegsByReason.already_imported
   const heldReasons = (
     Object.keys(transfers.heldLegsByReason) as SureTransferHeldReason[]
-  ).filter((reason) => transfers.heldLegsByReason[reason] > 0)
-  const heldTotal = sumValues(transfers.heldLegsByReason)
+  ).filter(
+    (reason) =>
+      reason !== "already_imported" && transfers.heldLegsByReason[reason] > 0
+  )
+  const heldTotal = sumValues(transfers.heldLegsByReason) - alreadyImportedTotal
 
   return (
     <div className="flex flex-col gap-3">
@@ -928,6 +967,26 @@ function BalanceReconciliationSummary({
                 )
                 .join(", ")}
               .
+            </p>
+          </div>
+        </div>
+      )}
+
+      {alreadyImportedTotal > 0 && (
+        <div className="flex items-start gap-3 rounded-2xl border border-border bg-muted/40 p-4 text-sm">
+          <History
+            size={18}
+            className="mt-0.5 shrink-0 text-muted-foreground"
+          />
+          <div>
+            <p className="font-medium">
+              {alreadyImportedTotal} transfer leg
+              {alreadyImportedTotal === 1 ? "" : "s"} already imported
+              previously (skipped).
+            </p>
+            <p className="text-xs text-muted-foreground">
+              These were part of an earlier import — re-importing never
+              duplicates them.
             </p>
           </div>
         </div>

--- a/src/server/imports.ts
+++ b/src/server/imports.ts
@@ -293,12 +293,14 @@ export async function createImportBatchForFamily({
     // Existing canonical fingerprints + coarse keys, derived on read (no
     // column on Transaction). Window the ledger to the accounts + date span
     // touched.
-    const { fingerprintToTxnId, coarseToTxnId } = await loadCanonicalDedupIndex(
-      tx,
-      familyId,
-      family.timezone,
-      data.rows
-    )
+    const { fingerprintToTxnId, coarseToTxnId, externalIdToTxnId } =
+      await loadCanonicalDedupIndex(
+        tx,
+        familyId,
+        family.timezone,
+        data.rows,
+        data.provider ?? null
+      )
 
     let batchId: string
     let alreadyPersisted = 0
@@ -339,6 +341,7 @@ export async function createImportBatchForFamily({
       smartRules,
       fingerprintToTxnId,
       coarseToTxnId,
+      externalIdToTxnId,
       alreadyPersisted,
     }
   })
@@ -364,6 +367,7 @@ export async function createImportBatchForFamily({
     smartRules,
     fingerprintToTxnId,
     coarseToTxnId,
+    externalIdToTxnId,
     alreadyPersisted,
   } = setup
 
@@ -391,8 +395,15 @@ export async function createImportBatchForFamily({
       externalId: row.externalId ?? null,
     })
 
-    // Dedup verdict (ADR-0039 §4).
-    const canonicalMatch = fingerprintToTxnId.get(fingerprint)
+    // Dedup verdict (ADR-0039 §4, amended by PER-199 §1). Provider identity
+    // (externalId) is a stronger, exact signal than the content-tuple
+    // fingerprint — a row that already has a durable binding to a live-or-
+    // deleted canonical Transaction is ALWAYS a duplicate, regardless of what
+    // the content-tuple hash would say.
+    const canonicalMatch =
+      (row.externalId != null
+        ? externalIdToTxnId.get(row.externalId)
+        : undefined) ?? fingerprintToTxnId.get(fingerprint)
     const inBatchMatch = seenFingerprints.has(fingerprint)
     let rowStatus = "normalized"
     let duplicateOfTransactionId: string | null = null
@@ -497,10 +508,12 @@ async function loadCanonicalDedupIndex(
   tx: TenantTransactionClient,
   familyId: string,
   timezone: string,
-  rows: readonly StagedRow[]
+  rows: readonly StagedRow[],
+  provider: string | null
 ): Promise<{
   fingerprintToTxnId: Map<string, string>
   coarseToTxnId: Map<string, string>
+  externalIdToTxnId: Map<string, string>
 }> {
   const accountIds = Array.from(new Set(rows.map((row) => row.accountId)))
   const times = rows.map((row) => row.date.getTime())
@@ -544,7 +557,41 @@ async function loadCanonicalDedupIndex(
     const coarse = coarseKey(txn.accountId, day, txn.amount)
     if (!coarseToTxnId.has(coarse)) coarseToTxnId.set(coarse, txn.id)
   }
-  return { fingerprintToTxnId, coarseToTxnId }
+
+  // PER-199: durable provider-identity dedup, INDEPENDENT of the content-tuple
+  // fingerprint above. A direct equality lookup on the new
+  // `transaction_provider_binding` partial-unique index, not a hash match —
+  // simpler and exact, and deliberately NOT deletedAt-scoped: once a Sure
+  // transaction has been imported, re-importing the same externalId must
+  // never re-create it even if the creator later deleted it in Permoney
+  // (deletion is an edit the migration must not silently undo). This mirrors
+  // the DB constraint itself, which is also not deletedAt-scoped.
+  const externalIdToTxnId = new Map<string, string>()
+  if (provider != null) {
+    const externalIds = Array.from(
+      new Set(
+        rows
+          .map((row) => row.externalId)
+          .filter((id): id is string => id != null && id !== "")
+      )
+    )
+    if (externalIds.length > 0) {
+      const boundExisting = await tx.transaction.findMany({
+        where: {
+          familyId,
+          externalProvider: provider,
+          externalId: { in: externalIds },
+        },
+        select: { id: true, externalId: true },
+      })
+      for (const txn of boundExisting) {
+        if (txn.externalId != null)
+          externalIdToTxnId.set(txn.externalId, txn.id)
+      }
+    }
+  }
+
+  return { fingerprintToTxnId, coarseToTxnId, externalIdToTxnId }
 }
 
 // ---------------------------------------------------------------------------
@@ -817,6 +864,12 @@ export async function promoteImportBatchForFamily({
           fxRateScaled: projection.fxRateScaled,
           fxRateSnapshotId: projection.fxRateSnapshotId,
           idempotencyKey: row.promotionIdempotencyKey,
+          // PER-199: durable provider-identity binding, so a FUTURE re-import
+          // (fresh ImportBatch, new RawImportedTransaction rows) can detect
+          // this transaction as already-canonical via the staging-time
+          // externalId dedup check above, instead of duplicating it.
+          externalProvider: batch.provider,
+          externalId: row.externalId,
         })
       }
 
@@ -943,6 +996,7 @@ export async function getImportBatchForFamily({
         currency: row.currency,
         date: row.date,
         description: row.description,
+        externalId: row.externalId,
         rowStatus: row.rowStatus,
         possibleDuplicate: row.possibleDuplicate,
         duplicateOfTransactionId: row.duplicateOfTransactionId,

--- a/src/server/sure-migration.ts
+++ b/src/server/sure-migration.ts
@@ -142,6 +142,13 @@ export interface SureMigrationResult {
     staged: number
     promotedThisRun: number
     held: number
+    // PER-199: staged rows whose externalId already had a live-or-deleted
+    // canonical Transaction from a PRIOR import run (staging-time provider
+    // dedup) — ADD-ONLY skipped, never promoted. Counted separately from
+    // `held` (which means "not yet promotable, needs a future run/fix") so
+    // the Done screen can say "X new · Y already imported (skipped)" instead
+    // of silently dropping them from the reconciliation total.
+    duplicateSkipped: number
     zeroAmountSkipped: number
     invalidDateSkipped: number
   }
@@ -1373,6 +1380,22 @@ export async function runSureMigrationForFamily({
   })
   timings.transfers = Date.now() - transfersT0
 
+  // PER-199: total staged rows (standard + transfer legs) flagged `duplicate`
+  // at staging by the provider-identity dedup check, minus the transfer-leg
+  // portion (already counted in `transfers.heldLegsByReason.already_imported`
+  // — every leg is owned by exactly one bucket, mirroring the existing
+  // `held` split above).
+  const totalDuplicateRows = await runInTenantTransaction(
+    familyId,
+    user.id,
+    async (tx) =>
+      tx.rawImportedTransaction.count({
+        where: { familyId, importBatchId: batchId, rowStatus: "duplicate" },
+      })
+  )
+  const duplicateSkipped =
+    totalDuplicateRows - transfers.heldLegsByReason.already_imported
+
   // --- 10. Final reconciliation anchor (ADR-0045's PER-182 amendment) -------
   // Closes any remaining balance gap from legs Permoney's own staging gates
   // held (non-importable counterpart, ambiguous cluster, currency mismatch,
@@ -1434,7 +1457,11 @@ export async function runSureMigrationForFamily({
       promotedThisRun,
       // STANDARD held only — transfer legs are owned by the `transfers` block, so
       // every leg is counted in exactly one place (the spanning reconcile, Q7).
-      held: rows.length - promotableCount - transferLegs.length,
+      // PER-199: duplicateSkipped is subtracted out here (it has its own
+      // bucket) so it isn't silently double-counted as "held for review".
+      held:
+        rows.length - promotableCount - transferLegs.length - duplicateSkipped,
+      duplicateSkipped,
       zeroAmountSkipped,
       invalidDateSkipped,
     },
@@ -1556,6 +1583,7 @@ const EMPTY_HELD_BY_REASON = (): Record<SureTransferHeldReason, number> => ({
   db_rejected: 0,
   unpaired_orphan: 0,
   ambiguous_cluster: 0,
+  already_imported: 0,
 })
 
 const TIER_TO_RESULT_KEY: Record<
@@ -1688,6 +1716,16 @@ async function pairAndPromoteSureTransfers({
     if (outRow.rowStatus === "promoted" || inRow.rowStatus === "promoted") {
       continue
     }
+    // PER-199: a FRESH batch (different contentHash) can re-stage a pair whose
+    // externalId is already bound to a live-or-deleted canonical Transaction
+    // from a PRIOR import run — the staging-time provider dedup check
+    // (loadCanonicalDedupIndex) already flagged it `rowStatus: "duplicate"`.
+    // ADD-ONLY: never re-promote, never half-import — if EITHER leg is
+    // already bound, skip the whole pair. The finalRows pass below counts
+    // these into `already_imported`.
+    if (outRow.rowStatus === "duplicate" || inRow.rowStatus === "duplicate") {
+      continue
+    }
 
     const outMeta = transferMeta.get(pair.outflow.account_id)
     const outAccountId = accountMap.get(pair.outflow.account_id)
@@ -1732,6 +1770,13 @@ async function pairAndPromoteSureTransfers({
           date: new Date(pair.outflow.date),
           idempotencyKey: stableKey,
           status: "CLEARED",
+          // PER-199: bind BOTH legs to their own Sure externalId so a FUTURE
+          // re-import's staging-time dedup can recognize this pair as
+          // already-canonical (the DB partial-unique index protects each leg
+          // independently, since outflow/inflow have distinct externalIds).
+          externalProvider: SURE_PROVIDER,
+          externalId: pair.outflow.id,
+          toExternalId: pair.inflow.id,
         },
         familyId,
         user,
@@ -1798,10 +1843,13 @@ async function pairAndPromoteSureTransfers({
     }
   }
 
-  // --- Persist the pure pairer's held reasons (skip anything already promoted) -
+  // --- Persist the pure pairer's held reasons (skip anything already promoted
+  // OR already flagged duplicate at staging — PER-199 must not overwrite that
+  // terminal, DB-anchored verdict with the pure pairer's own guess) ----------
   for (const heldLeg of pairing.held) {
     const row = rowByExternalId.get(heldLeg.txn.id)
-    if (!row || row.rowStatus === "promoted") continue
+    if (!row || row.rowStatus === "promoted" || row.rowStatus === "duplicate")
+      continue
     await persistSureHeldReason(
       runInTenantTransaction,
       familyId,
@@ -1831,6 +1879,13 @@ async function pairAndPromoteSureTransfers({
   for (const row of finalRows) {
     if (row.rowStatus === "promoted") {
       legsPromotedTotal += 1
+      continue
+    }
+    // PER-199: staging-time provider dedup already gave this the terminal,
+    // DB-anchored verdict — trust rowStatus over errorReason (persistSureHeldReason
+    // is guarded to never touch these rows, but read defensively regardless).
+    if (row.rowStatus === "duplicate") {
+      heldLegsByReason.already_imported += 1
       continue
     }
     const reason = (row.errorReason ?? "") as SureTransferHeldReason

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -797,9 +797,26 @@ const createTransactionTransportInputSchema = transactionInputSchema.extend({
   idempotencyKey: uuidV7Schema.optional(),
 })
 
-const createTransactionInputSchema =
-  createTransactionTransportInputSchema.required({
+// PER-199: durable provider-identity binding (mirrors Account/Category/
+// Merchant/Transaction's externalProvider/externalId columns). Deliberately
+// added ONLY to this INTERNAL schema, never to `transactionInputSchema` /
+// `createTransactionTransportInputSchema` — those back the public
+// `createTransactionFn` `.inputValidator`, so a client can never set or spoof
+// a provider binding. Only internal server-side callers (e.g. Sure-migration
+// transfer-pair promotion) construct a `data` object with these fields and
+// call `createTransactionForFamily` directly, bypassing the public transport
+// layer entirely — exactly as already happens for `idempotencyKey` there.
+// `toExternalId` names the INFLOW leg's binding; `externalId` (this
+// object's own key) names the OUTFLOW leg's for a transfer, or the single
+// leg's for income/expense.
+const createTransactionInputSchema = createTransactionTransportInputSchema
+  .required({
     idempotencyKey: true,
+  })
+  .extend({
+    externalProvider: z.string().min(1).nullable().optional(),
+    externalId: z.string().min(1).nullable().optional(),
+    toExternalId: z.string().min(1).nullable().optional(),
   })
 
 const updateTransactionTransportInputSchema = transactionInputSchema.extend({
@@ -1911,6 +1928,8 @@ export async function createTransactionForFamily({
               accountBalanceAfter: sourceBalanceAfter,
               attachmentUrl: data.attachmentUrl,
               idempotencyKey: data.idempotencyKey,
+              externalProvider: data.externalProvider ?? null,
+              externalId: data.externalId ?? null,
             },
           })
 
@@ -1938,6 +1957,8 @@ export async function createTransactionForFamily({
               fxRateSnapshotId: inflowProjection.fxRateSnapshotId,
               accountBalanceAfter: destBalanceAfter,
               attachmentUrl: data.attachmentUrl,
+              externalProvider: data.externalProvider ?? null,
+              externalId: data.toExternalId ?? null,
             },
           })
 

--- a/tests/integration/import-staging.integration.ts
+++ b/tests/integration/import-staging.integration.ts
@@ -104,11 +104,17 @@ describe("import staging vertical slice (PER-82)", () => {
   const stage = async (
     tenant: Tenant,
     rows: Array<Record<string, unknown>>,
-    opts: { contentHash?: string; idempotencyKey?: string } = {}
+    opts: {
+      contentHash?: string
+      idempotencyKey?: string
+      sourceKind?: string
+      provider?: string
+    } = {}
   ) =>
     createImportBatchForFamily({
       data: {
-        sourceKind: "csv_upload",
+        sourceKind: opts.sourceKind ?? "csv_upload",
+        provider: opts.provider,
         accountId: tenant.accountId,
         contentHash: opts.contentHash ?? "hash-default",
         idempotencyKey: opts.idempotencyKey,
@@ -294,6 +300,57 @@ describe("import staging vertical slice (PER-82)", () => {
     }
   }
 
+  // Confirms every currently-"normalized" row (not just a single row) and
+  // promotes — used by the PER-199 tests below where a batch mixes duplicate
+  // and genuinely-new rows.
+  const stageConfirmPromoteAll = async (
+    tenant: Tenant,
+    rows: Array<Record<string, unknown>>,
+    opts: { contentHash: string; provider?: string; sourceKind?: string }
+  ) => {
+    const batch = await stage(tenant, rows, opts)
+    const staged = await getImportBatchForFamily({
+      data: { batchId: batch.id },
+      familyId: tenant.familyId,
+      userId: tenant.userId,
+      runInTenantTransaction: runner(),
+    })
+    const normalizedRowIds = staged.rows
+      .filter((r) => r.rowStatus === "normalized")
+      .map((r) => r.id)
+    if (normalizedRowIds.length > 0) {
+      await reviewImportRowsForFamily({
+        data: {
+          batchId: batch.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+          decisions: normalizedRowIds.map((rowId) => ({
+            rowId,
+            verdict: "confirm" as const,
+          })),
+        },
+        familyId: tenant.familyId,
+        user: { id: tenant.userId, familyId: tenant.familyId },
+        runInTenantTransaction: runner(),
+      })
+    }
+    const result = await promoteImportBatchForFamily({
+      data: {
+        batchId: batch.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: tenant.familyId,
+      user: { id: tenant.userId, familyId: tenant.familyId },
+      runInTenantTransaction: runner(),
+    })
+    const after = await getImportBatchForFamily({
+      data: { batchId: batch.id },
+      familyId: tenant.familyId,
+      userId: tenant.userId,
+      runInTenantTransaction: runner(),
+    })
+    return { batch, result, rows: after.rows }
+  }
+
   test("promotion matches single-create invariants incl. base FX projection (PER-159)", async () => {
     const tenant = await setupTenant()
     const key = factories.createIdempotencyKey()
@@ -437,5 +494,201 @@ describe("import staging vertical slice (PER-82)", () => {
     expect(roleCan("member", "ledger:write")).toBe(true)
     expect(roleCan("admin", "ledger:write")).toBe(true)
     expect(roleCan("owner", "ledger:write")).toBe(true)
+  })
+
+  // ---- PER-199: per-transaction cross-batch provider (externalId) dedup ----
+  // Root cause proof: batch-level contentHash dedup only protects a
+  // byte-identical re-upload. A FRESH Sure export (different contentHash,
+  // overlapping externalIds) used to re-promote every overlapping
+  // transaction. These tests stage TWO separate batches with different
+  // contentHash and an overlapping externalId to prove the fix.
+
+  test("PER-199: a fresh batch re-staging an already-promoted externalId is flagged duplicate and never re-promoted", async () => {
+    const tenant = await setupTenant()
+
+    const first = await stageConfirmPromoteAll(
+      tenant,
+      [row({ externalId: "sure-txn-1" })],
+      {
+        contentHash: "sure-export-1",
+        provider: "sure",
+        sourceKind: "migration",
+      }
+    )
+    expect(first.result.promotedCount).toBe(1)
+    const firstTxnId = first.result.promotedTransactionIds[0]!
+
+    // Fresh export: different contentHash, same overlapping externalId PLUS
+    // one genuinely new transaction.
+    const second = await stageConfirmPromoteAll(
+      tenant,
+      [
+        row({ externalId: "sure-txn-1" }),
+        row({ externalId: "sure-txn-2", description: "New coffee" }),
+      ],
+      {
+        contentHash: "sure-export-2",
+        provider: "sure",
+        sourceKind: "migration",
+      }
+    )
+
+    const overlapRow = second.rows.find((r) => r.externalId === "sure-txn-1")
+    const newRow = second.rows.find((r) => r.externalId === "sure-txn-2")
+    expect(overlapRow?.rowStatus).toBe("duplicate")
+    expect(overlapRow?.duplicateOfTransactionId).toBe(firstTxnId)
+    expect(newRow?.rowStatus).toBe("promoted")
+    // Only ONE new transaction promoted this run (the genuinely-new one) —
+    // the overlapping row was never re-created.
+    expect(second.result.promotedCount).toBe(1)
+
+    const liveCount = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.transaction.count({
+          where: { familyId: tenant.familyId, deletedAt: null },
+        })
+    )
+    expect(liveCount).toBe(2)
+  })
+
+  test("PER-199: promotion persists externalProvider/externalId onto the created Transaction", async () => {
+    const tenant = await setupTenant()
+    const { result } = await stageConfirmPromoteAll(
+      tenant,
+      [row({ externalId: "sure-txn-9" })],
+      {
+        contentHash: "sure-export-9",
+        provider: "sure",
+        sourceKind: "migration",
+      }
+    )
+    const txn = await harness.withMember(tenant.familyId, tenant.userId, (tx) =>
+      tx.transaction.findUniqueOrThrow({
+        where: { id: result.promotedTransactionIds[0]! },
+      })
+    )
+    expect(txn.externalProvider).toBe("sure")
+    expect(txn.externalId).toBe("sure-txn-9")
+  })
+
+  test("PER-199: manually-created (externalId-less) transactions are unaffected by provider dedup", async () => {
+    const tenant = await setupTenant()
+    const { result } = await stageConfirmPromoteAll(tenant, [row()], {
+      contentHash: "csv-plain",
+    })
+    const txn = await harness.withMember(tenant.familyId, tenant.userId, (tx) =>
+      tx.transaction.findUniqueOrThrow({
+        where: { id: result.promotedTransactionIds[0]! },
+      })
+    )
+    expect(txn.externalProvider).toBeNull()
+    expect(txn.externalId).toBeNull()
+  })
+
+  test("PER-199: a Sure transaction deleted in Permoney is not resurrected by re-import", async () => {
+    const tenant = await setupTenant()
+    const first = await stageConfirmPromoteAll(
+      tenant,
+      [row({ externalId: "sure-txn-del" })],
+      {
+        contentHash: "sure-export-del-1",
+        provider: "sure",
+        sourceKind: "migration",
+      }
+    )
+    const firstTxnId = first.result.promotedTransactionIds[0]!
+
+    // The creator deletes the imported transaction inside Permoney.
+    await harness.withMember(tenant.familyId, tenant.userId, (tx) =>
+      tx.transaction.update({
+        where: { id: firstTxnId },
+        data: { deletedAt: new Date() },
+      })
+    )
+
+    const second = await stageConfirmPromoteAll(
+      tenant,
+      [row({ externalId: "sure-txn-del" })],
+      {
+        contentHash: "sure-export-del-2",
+        provider: "sure",
+        sourceKind: "migration",
+      }
+    )
+    const overlapRow = second.rows.find((r) => r.externalId === "sure-txn-del")
+    expect(overlapRow?.rowStatus).toBe("duplicate")
+    expect(second.result.promotedCount).toBe(0)
+
+    const liveCount = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      (tx) =>
+        tx.transaction.count({
+          where: {
+            familyId: tenant.familyId,
+            externalProvider: "sure",
+            externalId: "sure-txn-del",
+          },
+        })
+    )
+    // Only the original (now soft-deleted) row — the deletion decision stuck.
+    expect(liveCount).toBe(1)
+  })
+
+  test("PER-199: the DB partial-unique index rejects two live Transactions sharing (familyId, externalProvider, externalId)", async () => {
+    const tenant = await setupTenant()
+    await factories.createTransaction({
+      familyId: tenant.familyId,
+      userId: tenant.userId,
+      accountId: tenant.accountId,
+      description: "First",
+    })
+    await harness.withMember(tenant.familyId, tenant.userId, (tx) =>
+      tx.transaction.updateMany({
+        where: { familyId: tenant.familyId },
+        data: { externalProvider: "sure", externalId: "dup-key" },
+      })
+    )
+
+    await expect(
+      harness.withMember(tenant.familyId, tenant.userId, (tx) =>
+        tx.transaction.create({
+          data: {
+            familyId: tenant.familyId,
+            userId: tenant.userId,
+            accountId: tenant.accountId,
+            amount: -1n,
+            type: "expense",
+            currency: "IDR",
+            description: "Second",
+            externalProvider: "sure",
+            externalId: "dup-key",
+          },
+        })
+      )
+    ).rejects.toThrow()
+  })
+
+  test("PER-199: family B's externalId binding never dedups against family A's transaction", async () => {
+    const a = await setupTenant()
+    const b = await setupTenant()
+
+    const forA = await stageConfirmPromoteAll(
+      a,
+      [row({ externalId: "shared-sure-id" })],
+      { contentHash: "a-export", provider: "sure", sourceKind: "migration" }
+    )
+    expect(forA.result.promotedCount).toBe(1)
+
+    const forB = await stageConfirmPromoteAll(
+      b,
+      [row({ externalId: "shared-sure-id" })],
+      { contentHash: "b-export", provider: "sure", sourceKind: "migration" }
+    )
+    // Same externalId, DIFFERENT family — must promote independently, not be
+    // flagged as a duplicate of family A's transaction.
+    expect(forB.result.promotedCount).toBe(1)
   })
 })

--- a/tests/integration/support/sure-fixtures.ts
+++ b/tests/integration/support/sure-fixtures.ts
@@ -618,7 +618,7 @@ export interface SureTransferFixture {
   balancesMinor: Record<string, bigint>
 }
 
-const sureAccount = (
+export const sureAccount = (
   id: string,
   name: string,
   accountableType: string,
@@ -638,7 +638,7 @@ const sureAccount = (
     updated_at: "2026-06-25T00:00:00Z",
   })
 
-const sureTxn = (args: {
+export const sureTxn = (args: {
   id: string
   accountId: string
   amount: string
@@ -668,7 +668,7 @@ const sureTxn = (args: {
     updated_at: `${args.date}T00:00:00Z`,
   })
 
-const sureVal = (args: {
+export const sureVal = (args: {
   accountId: string
   amount: string
   date: string
@@ -688,7 +688,7 @@ const sureVal = (args: {
     updated_at: `${args.date}T00:00:00Z`,
   })
 
-const sureTransfer = (outflowId: string, inflowId: string): string =>
+export const sureTransfer = (outflowId: string, inflowId: string): string =>
   envelope("Transfer", {
     id: `xfer-${outflowId}`,
     outflow_transaction_id: outflowId,
@@ -704,6 +704,7 @@ const emptyHeld = (): Record<SureTransferHeldReason, number> => ({
   db_rejected: 0,
   unpaired_orphan: 0,
   ambiguous_cluster: 0,
+  already_imported: 0,
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -33,6 +33,10 @@ import {
   buildSureBundleV1DegradedTransfers,
   buildSureBundleV2Complete,
   buildSureBundleV2Transfers,
+  sureAccount,
+  sureTransfer,
+  sureTxn,
+  sureVal,
 } from "./support/sure-fixtures"
 
 // PER-170 / PER-173 / PER-174 / PER-176 / ADR-0041 / ADR-0043 — Real-Postgres
@@ -928,6 +932,101 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
     expect(transferLegs).toBe(fixture.expected.legsPromotedTotal) // no double-book
     expect(transferCount).toBe(fixture.expected.pairsPromotedThisRun)
     await assertBalances(tenant, fixture.accountIds, fixture.balancesMinor)
+  })
+
+  test("PER-199: a FRESH batch (different bundle content) re-staging an already-promoted transfer pair does not double-book it", async () => {
+    const tenant = await setupTenant()
+    const accountIds = {
+      checking: "sure-acc-per199-checking",
+      savings: "sure-acc-per199-savings",
+    }
+    const legIds = {
+      fmOut: "sure-txn-per199-fm-out",
+      fmIn: "sure-txn-per199-fm-in",
+    }
+    const baseLines = [
+      sureAccount(accountIds.checking, "Checking", "Depository", "checking"),
+      sureAccount(accountIds.savings, "Savings", "Depository", "savings"),
+      // Opening buffer so checking's incremental balance never dips negative
+      // mid-migration (ADR-0043 — real balance is derived at final rebuild,
+      // but the account_normal_balance_sign CHECK is enforced immediately on
+      // every incremental write in between).
+      sureVal({
+        accountId: accountIds.checking,
+        amount: "50000.0",
+        date: "2026-01-01",
+        kind: "opening_anchor",
+      }),
+      sureTxn({
+        id: legIds.fmOut,
+        accountId: accountIds.checking,
+        amount: "40000.0",
+        kind: "funds_movement",
+        name: "Transfer to Savings",
+        date: "2026-05-02",
+      }),
+      sureTxn({
+        id: legIds.fmIn,
+        accountId: accountIds.savings,
+        amount: "-40000.0",
+        kind: "funds_movement",
+        name: "Transfer from Checking",
+        date: "2026-05-02",
+      }),
+      sureTransfer(legIds.fmOut, legIds.fmIn),
+    ]
+
+    const first = await migrate(tenant, "run1.ndjson", baseLines.join("\n"))
+    expect(first.transfers.pairsPromotedThisRun).toBe(1)
+    expect(first.transfers.legsPromotedTotal).toBe(2)
+
+    // A FRESH export (different bytes -> different contentHash): the SAME
+    // accounts + SAME transfer pair (same Sure externalIds) PLUS one
+    // genuinely new standalone transaction — exactly the real-world "Sure
+    // export grew since last import" scenario PER-199 fixes.
+    const secondLines = [
+      ...baseLines,
+      sureTxn({
+        id: "sure-txn-per199-new-expense",
+        accountId: accountIds.checking,
+        amount: "5000.0",
+        kind: "standard",
+        name: "New coffee",
+        date: "2026-05-10",
+      }),
+    ]
+    const second = await migrate(tenant, "run2.ndjson", secondLines.join("\n"))
+    expect(second.contentHash).not.toBe(first.contentHash)
+    expect(second.replayed).toBe(false)
+
+    // The pair is recognized as already-imported, not re-promoted.
+    expect(second.transfers.pairsPromotedThisRun).toBe(0)
+    expect(second.transfers.legsPromotedTotal).toBe(0)
+    expect(second.transfers.heldLegsByReason.already_imported).toBe(2)
+    // The genuinely new standalone transaction DOES promote.
+    expect(second.transactions.promotedThisRun).toBe(1)
+    expect(second.transactions.duplicateSkipped).toBe(0) // it's a transfer leg, owned by the transfers block
+
+    const { transferCount, transferLegCount } = await harness.withMember(
+      tenant.familyId,
+      tenant.userId,
+      async (tx) => ({
+        transferCount: await tx.transfer.count(),
+        transferLegCount: await tx.transaction.count({
+          where: { familyId: tenant.familyId, type: "transfer" },
+        }),
+      })
+    )
+    // Still just the ONE pair from run1 — never double-booked.
+    expect(transferCount).toBe(1)
+    expect(transferLegCount).toBe(2)
+
+    // checking: 5_000_000 (opening) − 4_000_000 (fm, run1) − 500_000 (new
+    // expense, run2) = 500_000. savings: 4_000_000 (fm in, unaffected by run2).
+    await assertBalances(tenant, accountIds, {
+      checking: 500_000n,
+      savings: 4_000_000n,
+    })
   })
 
   test("self-heal 2B: a created leg with unmarked rows re-promotes via the stable key (no double)", async () => {


### PR DESCRIPTION
Re-importing a fresh Sure export no longer duplicates every overlapping transaction. This is the fix for the double-import duplication found while dogfooding.

## Root cause
Import idempotency was **whole-bundle** (content-hash → `import_artifact_batch_content` unique). A byte-identical re-upload was a no-op, but a *different* export file (mostly the same transactions) was a new batch that re-promoted everything. Accounts/categories/merchants survived (partial-unique on `(familyId, externalProvider, externalId)`); transactions had no such binding.

## Fix (add-only, per-transaction)
- **schema + migration** `transaction_provider_binding`: `Transaction` gains nullable `externalProvider/externalId` + partial-unique `(familyId, externalProvider, externalId) WHERE externalProvider IS NOT NULL`. **Not** `deletedAt`-scoped — an imported-then-deleted row still blocks re-promotion (deletion is an edit the import must not silently undo).
- **dedup**: `loadCanonicalDedupIndex` gains a direct externalId lookup (independent of the content-tuple fingerprint, not `deletedAt`-scoped); `promoteImportBatchForFamily` persists the binding onto every promoted transaction. Held→promoted still works (dedup keys on a *promoted* Transaction's existence, not staged rows).
- **transfer atomicity**: internal-only schema accepts `externalId/toExternalId` (never the public `createTransactionFn` endpoint — no client spoofing) so both legs bind; a transfer pair is skipped as one unit if either leg is already duplicate-flagged. New terminal `already_imported` reason keeps `legsStaged === legsPromotedTotal + Σ heldLegsByReason` exact.
- **honest UX** (PER-188 precedent): Done screen shows "X new · Y already imported (skipped)" + an all-already-imported case, never a silent drop.

## Review (head-eng, verified independently — not trusting the agent report)
Reviewed line-by-line: schema/migration, the externalId dedup (confirmed NOT `deletedAt`-scoped so no unique-violation on re-import-after-delete), transfer-pair atomicity, held→promoted preservation, count bucketing, and the internal-only (unspoofable) binding schema. Fixed one misleading migration comment. `vp check` clean, `no-use-effect` 0, unit 433/433. Full integration + e2e run here (validates the agent's "331/332, one pre-existing wall-clock-flaky scale test" claim independently).

## Follow-up (separate, head-eng)
Cleaning up the creator's EXISTING duplicated prod data is a separate task — those rows predate this schema (externalId NULL), so their cleanup + one clean re-import is handled after this merges.

Closes PER-199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1