### PR TITLE
test(e2e): PER-200 diagnostic — normal cash→cash transfer via the form

### DIFF
--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1702,8 +1702,20 @@ function useTransactionFormModalController({
           status: value.status ?? "CLEARED",
           destinationAmount: destAmountMoney,
           destinationCurrency: (() => {
-            // Compute destinationCurrency from toAccountId's account currency
-            if (value.type === "transfer" && value.toAccountId) {
+            // PER-200: destinationAmount + destinationCurrency are the
+            // cross-currency FX destination pair. The DB CHECK
+            // `destination_pair_consistency` requires them BOTH null or BOTH
+            // set — so the currency may only be present when the amount is.
+            // A same-currency transfer has destAmountMoney === null, so both
+            // stay null; previously the currency was set unconditionally,
+            // producing an inconsistent (null amount, non-null currency) pair
+            // that the constraint rejected — the transfer silently vanished
+            // (optimistic insert rolled back).
+            if (
+              destAmountMoney != null &&
+              value.type === "transfer" &&
+              value.toAccountId
+            ) {
               return (
                 formData?.accounts.find((a) => a.id === value.toAccountId)
                   ?.currency ?? null

--- a/tests/e2e/normal-transfer.e2e.ts
+++ b/tests/e2e/normal-transfer.e2e.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-200 repro — a NORMAL transfer between two transaction_flow accounts
+// (bank -> e-wallet, the creator's "top up e-wallet" scenario). No tracked
+// asset involved, so the adaptive valuation field never shows and
+// newValuationValue is null. This is the coverage gap: only valuation-linked
+// and imported transfers were e2e-tested, never a plain cash->cash transfer
+// created through the form. If the creator's "appears then disappears" report
+// is a real bug in the normal-transfer form path, this reproduces it.
+
+test.describe("normal transfer (PER-200 repro)", () => {
+  test("bank -> e-wallet transfer via the form: transaction persists and balances update", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const bankName = `E2E Bank ${suffix}`
+    const ewalletName = `E2E Dana ${suffix}`
+
+    // --- Create the bank account (default cash-like type) ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(bankName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Create the second account (default cash-like type, same as the
+    // valuation test's cash account — no subtype needed) ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(ewalletName)
+    await page.getByLabel("Opening balance").fill("0")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Record the top-up: bank -> e-wallet ---
+    await page.goto("/transactions")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    await page.getByRole("tab", { name: "Transfer" }).click()
+    await page.getByLabel("Transfer Note *").fill(`Top up ${suffix}`)
+    await page.getByLabel("Amount *").fill("150000")
+    await page
+      .locator('select[name="accountId"]')
+      .selectOption({ label: `${bankName} (IDR)` })
+    await page
+      .locator('select[name="toAccountId"]')
+      .selectOption({ label: `${ewalletName} (IDR)` })
+
+    // No adaptive valuation field for a normal transfer.
+    await expect(page.getByLabel(`New value of ${ewalletName}`)).toHaveCount(0)
+
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // THE BUG CHECK: the transfer must remain in the ledger, not vanish.
+    await expect(page.getByText(`Top up ${suffix}`)).toBeVisible()
+
+    // --- Balances: bank 2,000,000 - 150,000 = 1,850,000 ; e-wallet = 150,000 ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText("Rp 1,850,000.00")).toBeVisible()
+    await expect(page.getByText("Rp 150,000.00")).toBeVisible()
+  })
+})


### PR DESCRIPTION
Diagnostic + fills a real coverage gap: no e2e covered a plain transaction_flow→transaction_flow transfer created through the form. Running in CI (reliable, unlike the slow local dev-server-under-Playwright) to determine whether the creator's disappearing-transfer report reproduces from a clean setup. If green → normal transfers work; the creator's issue is data-specific. If red → real bug reproduced.