### PR TITLE
fix(ledger): PER-202 — per-account view shows incoming transfers

### DIFF
--- a/src/lib/transaction-filters.test.ts
+++ b/src/lib/transaction-filters.test.ts
@@ -248,6 +248,70 @@ describe("applyFilters", () => {
 
       expect(result.map((t) => t.id).sort()).toEqual(["a", "c"])
     })
+
+    // PER-202: a transfer is stored as one outflow leg (accountId = source,
+    // toAccountId = destination). Filtering by the DESTINATION account must
+    // surface it via toAccountId — otherwise "top up OVO" (BCA -> GOPAY) is
+    // visible from BCA but invisible from GOPAY.
+    it("surfaces an incoming transfer when filtering by the destination (toAccountId)", () => {
+      const transferOut = tx({
+        id: "transfer",
+        type: "transfer",
+        accountId: ACCOUNT_BCA,
+        toAccountId: ACCOUNT_GOPAY,
+      })
+      const unrelated = tx({ id: "unrelated", accountId: ACCOUNT_USD })
+
+      const result = applyFilters([transferOut, unrelated], {
+        ...baseFilters,
+        accounts: [ACCOUNT_GOPAY],
+      })
+
+      expect(result.map((t) => t.id)).toEqual(["transfer"])
+    })
+
+    it("still matches a transfer from the source side (accountId)", () => {
+      const transferOut = tx({
+        id: "transfer",
+        type: "transfer",
+        accountId: ACCOUNT_BCA,
+        toAccountId: ACCOUNT_GOPAY,
+      })
+
+      const result = applyFilters([transferOut], {
+        ...baseFilters,
+        accounts: [ACCOUNT_BCA],
+      })
+
+      expect(result.map((t) => t.id)).toEqual(["transfer"])
+    })
+
+    it("does not double-list a transfer when both legs are in the filter", () => {
+      const transferOut = tx({
+        id: "transfer",
+        type: "transfer",
+        accountId: ACCOUNT_BCA,
+        toAccountId: ACCOUNT_GOPAY,
+      })
+
+      const result = applyFilters([transferOut], {
+        ...baseFilters,
+        accounts: [ACCOUNT_BCA, ACCOUNT_GOPAY],
+      })
+
+      expect(result.map((t) => t.id)).toEqual(["transfer"])
+    })
+
+    it("ignores toAccountId for non-transfer rows (null destination)", () => {
+      const expense = tx({ id: "expense", accountId: ACCOUNT_BCA })
+
+      const result = applyFilters([expense], {
+        ...baseFilters,
+        accounts: [ACCOUNT_GOPAY],
+      })
+
+      expect(result).toEqual([])
+    })
   })
 
   describe("category filtering", () => {

--- a/src/lib/transaction-filters.ts
+++ b/src/lib/transaction-filters.ts
@@ -63,6 +63,12 @@ export interface FilterableTransaction {
   date: Date | string
   description: string
   accountId: string
+  // A transfer is stored as a single outflow leg: `accountId` is the source
+  // and `toAccountId` is the destination. Account filtering matches EITHER
+  // leg (see applyFilters) so viewing an account surfaces transfers INTO it,
+  // not only transfers out of it (PER-202). Optional so existing non-transfer
+  // fixtures/mocks stay compatible.
+  toAccountId?: string | null
   categoryId: string | null
   merchantId: string | null
   notes: string | null
@@ -134,8 +140,17 @@ export function applyFilters<T extends FilterableTransaction>(
   }
 
   // 3. Filter berdasarkan akun
+  // Match transactions FROM the account (`accountId`) OR transfers INTO it
+  // (`toAccountId`). A transfer is persisted as a single outflow leg whose
+  // `accountId` is the source; without the `toAccountId` clause, filtering by
+  // the destination account would hide the incoming transfer entirely — the
+  // "top up shows from Jago but not from OVO" bug (PER-202).
   if (filters.accounts?.length) {
-    result = result.filter((t) => filters.accounts!.includes(t.accountId))
+    result = result.filter(
+      (t) =>
+        filters.accounts!.includes(t.accountId) ||
+        (t.toAccountId != null && filters.accounts!.includes(t.toAccountId))
+    )
   }
 
   // 4. Filter berdasarkan kategori

--- a/src/routes/_protected/transactions.tsx
+++ b/src/routes/_protected/transactions.tsx
@@ -663,6 +663,7 @@ function TransactionsPage() {
                               trx={row.trx}
                               onEdit={setEditingTrx}
                               onDelete={handleInlineDelete}
+                              viewedAccountIds={filters.accounts}
                               isSelected={
                                 table.getRow(row.trx.id)?.getIsSelected() ??
                                 false
@@ -766,6 +767,7 @@ function TransactionRow({
   onDelete,
   isSelected,
   onSelect,
+  viewedAccountIds,
 }: {
   trx: TransactionData
   onEdit: (
@@ -776,10 +778,30 @@ function TransactionRow({
   onDelete: (id: string) => void
   isSelected: boolean
   onSelect: (value: boolean) => void
+  // The active account filter (URL `accounts` search param), if any. Used to
+  // decide a transfer's direction FROM the viewed account's perspective.
+  viewedAccountIds?: ReadonlyArray<string>
 }) {
   const [isExpanded, setIsExpanded] = React.useState(false)
   const hasSplits = trx.isSplit && (trx.splitEntries?.length ?? 0) > 0
   const statusBadge = STATUS_BADGE[trx.status]
+
+  // PER-202: a transfer is persisted as a single outflow leg (`accountId` =
+  // source, `toAccountId` = destination). When the ledger is filtered to the
+  // DESTINATION account, that leg surfaces via `toAccountId`, and from that
+  // account's side the money is INCOMING — so flip the sign/label/colour to
+  // read as a credit ("Transfer from <source> +Rp…") instead of a neutral
+  // "Transfer". The global (unfiltered) list passes no `viewedAccountIds`, so
+  // its rendering is unchanged. Source-side matches (`accountId` in the
+  // filter) keep the neutral transfer rendering. `amount` is an absolute
+  // magnitude here (sign lives in `type`), so we only steer the prefix/colour.
+  const isIncomingTransfer =
+    trx.type === "transfer" &&
+    viewedAccountIds != null &&
+    viewedAccountIds.length > 0 &&
+    trx.toAccountId != null &&
+    viewedAccountIds.includes(trx.toAccountId) &&
+    !viewedAccountIds.includes(trx.accountId)
 
   return (
     <div
@@ -887,9 +909,18 @@ function TransactionRow({
         {/* Category column (hidden on tablet) */}
         <div className="hidden w-44 shrink-0 px-4 pt-0.5 lg:block">
           {trx.type === "transfer" ? (
-            <span className="flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400">
+            <span
+              className={cn(
+                "flex items-center gap-1 text-sm font-medium",
+                isIncomingTransfer
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-blue-600 dark:text-blue-400"
+              )}
+            >
               <IconArrowsExchange size={15} />
-              Transfer
+              {isIncomingTransfer
+                ? `Transfer from ${trx.account.name}`
+                : "Transfer"}
             </span>
           ) : trx.isSplit ? (
             <span className="flex items-center gap-1 text-sm font-medium text-amber-600 dark:text-amber-400">
@@ -932,13 +963,17 @@ function TransactionRow({
             "w-36 shrink-0 px-4 pt-0.5 text-right font-bold",
             trx.type === "expense"
               ? "text-red-600 dark:text-red-400"
-              : trx.type === "income"
+              : trx.type === "income" || isIncomingTransfer
                 ? "text-emerald-600 dark:text-emerald-400"
                 : "text-blue-600 dark:text-blue-400"
           )}
         >
           <span>
-            {trx.type === "expense" ? "−" : trx.type === "income" ? "+" : ""}
+            {trx.type === "expense"
+              ? "−"
+              : trx.type === "income" || isIncomingTransfer
+                ? "+"
+                : ""}
             {formatCurrency(trx.amount, trx.currency)}
           </span>
 

--- a/tests/e2e/per-account-incoming-transfer.e2e.ts
+++ b/tests/e2e/per-account-incoming-transfer.e2e.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-202 — a transfer is persisted as a SINGLE outflow leg (accountId =
+// source, toAccountId = destination); the inflow twin is hidden server-side to
+// avoid double-listing in the global ledger. Before the fix the account filter
+// matched only `accountId`, so filtering the transactions view by the
+// DESTINATION account hid the incoming transfer entirely — the creator's
+// "top up OVO shows from Jago but not from OVO" report.
+//
+// This drives the real browser end to end: create two cash accounts, transfer
+// source -> destination via the form, filter the ledger by the DESTINATION,
+// and assert the transfer is VISIBLE and rendered as INCOMING (+, "Transfer
+// from <source>") from that account's perspective. This display/filter path
+// was previously untested.
+
+test.describe("per-account incoming transfer (PER-202)", () => {
+  // Widen the viewport so the (lg+) Category and (xl+) Amount columns render —
+  // the incoming label and signed amount live there.
+  test.use({ viewport: { width: 1440, height: 900 } })
+
+  test("filtering by the destination account shows the transfer as incoming", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const sourceName = `E2E Jago ${suffix}`
+    const destName = `E2E OVO ${suffix}`
+
+    // --- Create the source account (funded) ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(sourceName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Create the destination account (empty) ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(destName)
+    await page.getByLabel("Opening balance").fill("0")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Record the top-up: source -> destination ---
+    await page.goto("/transactions")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    await page.getByRole("tab", { name: "Transfer" }).click()
+    await page.getByLabel("Transfer Note *").fill(`Top up ${suffix}`)
+    await page.getByLabel("Amount *").fill("50000")
+    await page
+      .locator('select[name="accountId"]')
+      .selectOption({ label: `${sourceName} (IDR)` })
+    await page
+      .locator('select[name="toAccountId"]')
+      .selectOption({ label: `${destName} (IDR)` })
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // In the unfiltered (global) list the transfer appears exactly ONCE.
+    await expect(page.getByText(`Top up ${suffix}`)).toHaveCount(1)
+
+    // --- Filter the ledger by the DESTINATION account ---
+    await page.getByRole("button", { name: "Filter" }).click()
+    await page.getByRole("button", { name: "Account", exact: true }).click()
+    await page.getByText(`${destName} (IDR)`).click()
+    await page.getByRole("button", { name: "Apply" }).click()
+
+    // THE FIX: the transfer must be visible from the destination side...
+    await expect(page.getByText(`Top up ${suffix}`)).toBeVisible()
+    // ...rendered as INCOMING: labelled "Transfer from <source>" with a
+    // credit-signed amount (+Rp 50,000.00), not a neutral/debit transfer.
+    await expect(page.getByText(`Transfer from ${sourceName}`)).toBeVisible()
+    await expect(page.getByText("+Rp 50,000.00")).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Ticket
PER-202 — Per-account view doesn't show transfers INTO the account (only out of it)

## Bug (found dogfooding)
A "top up OVO" transfer (Bank Jago → OVO) showed when filtering by **Bank Jago** but **not** when filtering by **OVO**. A top-up should be visible from OVO's side — money came in.

## Root cause
A transfer is persisted as a **single outflow leg**: `accountId` = source, `toAccountId` = destination. The inflow twin is hidden server-side (`findLedgerTransactionsForFamily`) so the global list shows each transfer exactly once. The client-side account filter in `src/lib/transaction-filters.ts` matched **only** `t.accountId`, so filtering by the destination account never matched — its `accountId` is the source.

Note: in the client collection, `amount` is an **absolute magnitude** (`getTransactionsFn` returns `absMoney(...)`, line ~2557); the sign is conveyed by `type`. So the fix steers the display prefix/label/colour, not any stored value.

## Fix (client-side only — no ledger-math or server-query changes)
1. **`applyFilters`** — the account filter now matches `accountId` **OR** `toAccountId`, so viewing an account surfaces transactions FROM it and transfers INTO it.
2. **`TransactionRow`** — the viewed-account context (`filters.accounts`) is passed down. When the ledger is filtered to the **destination** account, the surfaced outflow leg renders as **INCOMING**: emerald `+`, labelled `Transfer from <source>`. The **global/unfiltered** list and **source-side** matches are unchanged (neutral blue "Transfer").
3. **KPIs** — deliberately left excluding transfers from income/expense. A transfer is a move between your own accounts, not income; counting a top-up as "income" would inflate income and risk double-counting when both legs are selected. This satisfies the ticket's "not expense" requirement (a destination transfer is never miscounted as an expense) without introducing questionable aggregation semantics.

## Tests
- **Unit** (`transaction-filters.test.ts`): destination-side match via `toAccountId`, source-side match via `accountId`, no double-listing when both legs are filtered, and non-transfer rows ignoring `toAccountId`.
- **E2E** (`tests/e2e/per-account-incoming-transfer.e2e.ts`): drives the real browser — onboard, create two cash accounts, transfer source→dest via the Transfer form, filter the ledger by the **destination**, and assert the transfer is VISIBLE and rendered as incoming (`+Rp 50,000.00`, `Transfer from <source>`). This display/filter path was previously untested.

## Local validation
- `vp check` — clean (format + lint + types, 227 files).
- `vp test` (unit) — all pass (398 tests across `src/`; the filter suite now 40).
- Full e2e + integration run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1