### PR TITLE
fix(ledger): PER-201 — createdAt-aware post-anchor flow (no false MATERIALIZATION drift from back-dated txns)

### DIFF
--- a/docs/adr/0043-reconciliation-anchor-valuations.md
+++ b/docs/adr/0043-reconciliation-anchor-valuations.md
@@ -1,15 +1,15 @@
 # ADR-0043 — Reconciliation-anchor valuations (balance calculator)
 
-|                   |                                                                                                             |
-| ----------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Status**        | Accepted                                                                                                    |
-| **Date**          | 2026-07-04                                                                                                  |
-| **Accepted**      | 2026-07-04                                                                                                  |
-| **Deciders**      | Hendri Permana                                                                                              |
-| **Supersedes**    | —                                                                                                           |
-| **Superseded by** | —                                                                                                           |
-| **Amends**        | ADR-0034 §4 (cash balance derivation) + §7 (drift detector); reverses ADR-0034 "Alternatives considered" #2 |
-| **Amended by**    | ADR-0048 §3 (valuation-tracked accounts never accept a raw transaction-flow leg; guard + Transfer schema)   |
+|                   |                                                                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**        | Accepted                                                                                                                                                                     |
+| **Date**          | 2026-07-04                                                                                                                                                                   |
+| **Accepted**      | 2026-07-04                                                                                                                                                                   |
+| **Deciders**      | Hendri Permana                                                                                                                                                               |
+| **Supersedes**    | —                                                                                                                                                                            |
+| **Superseded by** | —                                                                                                                                                                            |
+| **Amends**        | ADR-0034 §4 (cash balance derivation) + §7 (drift detector); reverses ADR-0034 "Alternatives considered" #2                                                                  |
+| **Amended by**    | ADR-0048 §3 (valuation-tracked accounts never accept a raw transaction-flow leg; guard + Transfer schema); PER-201 amendment below (createdAt-aware post-anchor flow, §2/§6) |
 
 ## Context
 
@@ -310,3 +310,108 @@ for that filtering to be built without further calculator changes.
   it changes which valuations are authoritative balance assertions)
 - PER-154 (net-worth time series — future consumer of the anchor-chain
   primitive for arbitrary as-of-date queries)
+
+## Amendment — createdAt-aware post-anchor flow (PER-201)
+
+|            |                                                                   |
+| ---------- | ----------------------------------------------------------------- |
+| **Date**   | 2026-07-26                                                        |
+| **Amends** | §2 (cash balance formula) and §6 (ANCHOR_CHAIN drift) of this ADR |
+| **Ticket** | PER-201                                                           |
+
+### Problem
+
+§2 as originally written segments post-anchor flow by **date only**
+(`Transaction.date > anchor.valuationDate`). That treats the latest anchor as an
+absolute floor: any transaction dated at/before the anchor's date is assumed to
+be already baked into the anchor's asserted value and is dropped from the sum.
+
+But `Account.balance` is maintained by an **incremental delta on every
+transaction** (`applyAccountBalanceDelta`, `balance:{increment}`), regardless of
+the transaction's date. So when a user adds a **back-dated** transaction (dated
+at/before the latest anchor) _after_ an import or reconciliation, the stored
+balance counts it while the date-only canonical formula drops it — producing a
+false `MATERIALIZATION` drift error even though no money is wrong. Verified
+against real data: an OVO (`DEPOSITORY` / `transaction_flow`) account with a
+2026-07-24 import reconciliation anchor and back-dated top-ups added afterward
+reported an 8,000,000 phantom drift exactly equal to the dropped back-dated
+flow. The import's reconciliation anchor should absorb only the transactions
+that **existed when it was written** (the import's own rows), not activity the
+user records later, even if that activity is back-dated.
+
+### Decision — the `afterAnchor` predicate
+
+A transaction is **after** an anchor `A` — i.e. it is post-anchor flow, not
+absorbed into `A`'s asserted value — iff:
+
+```
+afterAnchor(A)(t)  ≡  t.date > A.valuationDate  OR  t.createdAt > A.createdAt
+```
+
+It is absorbed into `A` only when **both** disjuncts are false: it was dated
+at/before the anchor **and** already recorded (`createdAt`) when the anchor was
+written. Both disjuncts are load-bearing:
+
+- **The `createdAt` disjunct** is the fix: a back-dated transaction recorded
+  after the anchor (`date <= anchor.date` but `createdAt > anchor.createdAt`) is
+  genuine post-anchor activity the materialized balance already counts, so the
+  canonical formula must count it too.
+- **The `date` disjunct** must stay: a **future**-dated transaction recorded
+  _before_ a live reconciliation (`date > anchor.date` but
+  `createdAt <= anchor.createdAt`) is after the asserted balance and must be
+  added. A `createdAt`-only rule would wrongly absorb it — so the rule is a
+  disjunction, never `createdAt` alone.
+
+§2's cash balance formula becomes `latestAnchor.value + Σ afterAnchor(latestAnchor)`.
+
+### §6 stays "one segmentation function"
+
+The ANCHOR_CHAIN check keeps sharing the exact segmentation predicate with the
+balance formula (the load-bearing §6 invariant). The consecutive-anchor segment
+`(i → i+1)` is the complement pairing:
+
+```
+segment(i, i+1) = { t : afterAnchor(anchor[i])(t) ∧ ¬afterAnchor(anchor[i+1])(t) }
+                = afterAnchor(from) ∧ (t.date <= to.valuationDate ∧ t.createdAt <= to.createdAt)
+```
+
+Both boundaries use the one `afterAnchor` predicate, so the balance formula and
+the drift check can never silently disagree about which flows belong to which
+anchor. A consequence that falls out cleanly: a late back-dated user
+transaction (created after the latest anchor) satisfies `¬afterAnchor(next)` for
+every historical `next`, so it lands **only** in the "after the latest anchor"
+balance bucket and never perturbs a historical migrated-anchor segment's
+warning.
+
+### Why a fresh import stays zero-drift (no double-count)
+
+The Sure importer writes its **final reconciliation anchor last**
+(`writeSureFinalReconciliationAnchors`, step 10 of the orchestration), _after_
+all promoted transactions and transfers (steps 5–9), each step in its **own
+tenant transaction**. Postgres `now()` is fixed per transaction, so the final
+anchor's `createdAt` is strictly greater than every promoted transaction's
+`createdAt`. The final anchor is also dated `lastActivityDay + 1`, so no
+imported leg is dated after it either. Both `afterAnchor` disjuncts are
+therefore false for every imported row → all imported rows stay absorbed exactly
+as before → a fresh import's canonical balance is still exactly the anchor's
+asserted value, matching `projectSureMigrationBalances` with **no change to the
+projection** (which remains date-only, and is inert under the `createdAt`
+disjunct because no transaction is created after the final anchor on a fresh
+import). `createdAt` is `@default(now())` on both `Transaction` and `Valuation`
+(never null), and both the import-promote and manual-create paths let it
+default, so it reliably records insertion order.
+
+### Known limitation — re-import with genuinely new activity
+
+If a Sure bundle is re-imported with **genuinely new later activity**, the
+importer writes a **new** final reconciliation anchor (new `createdAt`, dated the
+new `lastActivityDay + 1`) whose asserted value is projected from Sure legs
+only. On the mandatory post-import rebuild, that new anchor can re-absorb a
+post-import **manual back-dated** edit (the edit's `createdAt` now precedes the
+new anchor's), silently dropping it from the balance. This is inherent to the
+one-directional "the import source owns its accounts" authority semantics and is
+**out of scope for PER-201** (tracked as a separate follow-up). Note that
+re-importing an **identical** bundle does _not_ hit this: the final anchor
+replays through idempotency as the _same_ row with its _original_ `createdAt`, so
+manual edits recorded after it stay counted — a strict improvement over the
+prior date-only rule, which dropped them on every rebuild.

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -42,8 +42,9 @@ import { validateTenantReferences } from "./validation/tenant-references"
 // `Valuation` is a dated, audited ledger entry that sits alongside `Transaction`.
 // `Account.balance` stays materialized-but-rebuildable (ADR-0034 §2):
 //   - cash-like (balanceSource="transaction_flow"): balance = the latest
-//     ANCHOR valuation (<= now) + Σ Transaction.amount strictly after that
-//     anchor's date (ADR-0043 §2). Anchors are balance-assertion types —
+//     ANCHOR valuation (<= now) + Σ Transaction.amount after that anchor —
+//     "after" = dated after it OR recorded (createdAt) after it (ADR-0043 §2,
+//     PER-201 afterAnchor predicate). Anchors are balance-assertion types —
 //     opening/reconciliation/manual (ANCHOR_VALUATION_TYPES) — while "market"
 //     stays an OBSERVATION that never overrides the ledger-derived balance.
 //     With a single anchor this degenerates to ADR-0034 §4's original
@@ -256,24 +257,60 @@ export function signMagnitudeForAccount(
 interface AnchorValuation {
   value: Money
   valuationDate: Date
+  // PER-201: the instant this anchor row was written. Half of the shared
+  // `afterAnchor` segmentation predicate — a transaction recorded after the
+  // anchor is post-anchor flow even when back-dated to at/before the anchor.
+  createdAt: Date
 }
 
-// Σ Transaction.amount strictly after `afterDate`, optionally bounded through
-// `throughDate` inclusive (ADR-0043 §2/§6 — the SAME segmentation predicate
-// backs both the balance formula and the ANCHOR_CHAIN drift check, so they can
-// never silently disagree on which flows belong to which anchor). Each amount
-// is already the signed delta to its own accountId (transfers post a separate
-// inflow row on the destination account), so per-account flow is a single sum
-// — no toAccountId. `Transaction.date` is a full timestamp and
-// `Valuation.valuationDate` is date-only, so Postgres compares it against
-// midnight of that day — any real (non-midnight) same-day transaction is
-// naturally "strictly after" its anchor with no separate tie-break needed.
-async function sumTransactionFlowInRange(
+// An anchor's identity for flow segmentation (PER-201): its asserted date
+// (date-only) and the wall-clock instant the row was written. Both
+// `AnchorValuation` (the balance path) and the raw anchor rows the drift check
+// reads satisfy it, so one predicate serves both boundaries (ADR-0043 §6).
+interface AnchorBound {
+  valuationDate: Date
+  createdAt: Date
+}
+
+// PER-201 / ADR-0043 §2 — the ONE segmentation predicate shared by the balance
+// formula and the ANCHOR_CHAIN drift check (ADR-0043 §6's load-bearing "one
+// segmentation function" invariant). A transaction is *after* an anchor iff it
+// is dated after the anchor's date OR was recorded after the anchor was written:
+//
+//   afterAnchor(A)(t)  ≡  t.date > A.valuationDate  OR  t.createdAt > A.createdAt
+//
+// It is absorbed into the anchor's asserted value only when BOTH are false —
+// i.e. it was dated at/before the anchor AND already existed when the anchor was
+// written. The createdAt disjunct is what fixes PER-201: a user's *back-dated*
+// transaction added AFTER an import/reconciliation anchor (date <= anchor.date
+// but createdAt > anchor.createdAt) is real post-anchor activity the
+// materialized balance already counts (it increments on every transaction
+// regardless of date), so the canonical formula must count it too. The date
+// disjunct is equally load-bearing: a *future*-dated transaction recorded
+// BEFORE a live reconciliation (date > anchor.date but createdAt <=
+// anchor.createdAt) is still after the asserted balance and must be added — so
+// the rule is a disjunction, never createdAt alone.
+//
+// Why a fresh Sure import stays zero-drift (no double-count): the final
+// reconciliation anchor is written LAST, each import step in its own tenant
+// transaction, so its createdAt is strictly greater than every promoted
+// transaction's createdAt, and it is dated `lastActivityDay + 1` so no imported
+// leg is dated after it either — both disjuncts are false for every imported
+// row, which are therefore absorbed exactly as before (ADR-0043 amendment).
+// `createdAt` is `@default(now())` on Transaction and Valuation (never null).
+//
+// Σ Transaction.amount over { afterAnchor(after) } — optionally intersected with
+// { NOT afterAnchor(through) } for a bounded segment (the chain check passes the
+// next anchor as `through`, yielding afterAnchor(i) ∧ ¬afterAnchor(i+1), the
+// exact complement so both boundaries use one predicate). Each amount is already
+// the signed delta to its own accountId (transfers post a separate inflow row on
+// the destination account), so per-account flow is a single sum — no toAccountId.
+async function sumTransactionFlowAfterAnchor(
   tx: TenantTransactionClient,
   familyId: string,
   accountId: string,
-  afterDate: Date,
-  throughDate: Date | null
+  after: AnchorBound,
+  through: AnchorBound | null
 ): Promise<Money> {
   const agg = await tx.transaction.aggregate({
     _sum: { amount: true },
@@ -281,9 +318,20 @@ async function sumTransactionFlowInRange(
       accountId,
       familyId,
       deletedAt: null,
-      date: throughDate
-        ? { gt: afterDate, lte: throughDate }
-        : { gt: afterDate },
+      // afterAnchor(after): dated after the anchor OR recorded after it.
+      OR: [
+        { date: { gt: after.valuationDate } },
+        { createdAt: { gt: after.createdAt } },
+      ],
+      // ¬afterAnchor(through): dated at/before the next anchor AND recorded
+      // at/before it. ANDs with the OR above (Prisma implicit-AND of top-level
+      // keys) to give the segment afterAnchor(from) ∧ ¬afterAnchor(to).
+      ...(through
+        ? {
+            date: { lte: through.valuationDate },
+            createdAt: { lte: through.createdAt },
+          }
+        : {}),
     },
   })
   return toMoney(agg._sum.amount ?? 0n)
@@ -313,10 +361,14 @@ export async function latestValuation(
       ...(options?.asOf ? { valuationDate: { lte: options.asOf } } : {}),
     },
     orderBy: [{ valuationDate: "desc" }, { createdAt: "desc" }, { id: "desc" }],
-    select: { value: true, valuationDate: true },
+    select: { value: true, valuationDate: true, createdAt: true },
   })
   return latest
-    ? { value: toMoney(latest.value), valuationDate: latest.valuationDate }
+    ? {
+        value: toMoney(latest.value),
+        valuationDate: latest.valuationDate,
+        createdAt: latest.createdAt,
+      }
     : null
 }
 
@@ -325,13 +377,16 @@ export async function latestValuation(
 // found, so a rebuild can never corrupt a balance it cannot reconstruct.
 //
 // ADR-0043: for transaction_flow accounts, balance = the latest anchor
-// valuation (<= now) + Σ flows strictly after that anchor's date. With a
-// single anchor (the common case — just `opening`) this is exactly ADR-0034
-// §4's original opening + Σflow formula; multiple anchors let a later
-// balance-assertion (reconciliation/manual) override accumulated flow, which
-// is what reproduces the real Sure UI for migrated accounts. Tracked
-// (`valuation`-sourced) accounts are unchanged: latest valuation of any type
-// wins, no transaction sum (ADR-0034 §5).
+// valuation (<= now) + Σ flows *after* that anchor, where "after" is the
+// shared `afterAnchor` predicate (PER-201): dated after the anchor OR recorded
+// after it. With a single anchor (the common case — just `opening`) this is
+// exactly ADR-0034 §4's original opening + Σflow formula; multiple anchors let
+// a later balance-assertion (reconciliation/manual) override accumulated flow,
+// which is what reproduces the real Sure UI for migrated accounts. The
+// createdAt disjunct keeps a user's back-dated transaction added after the
+// latest anchor in the sum (PER-201 — see `sumTransactionFlowAfterAnchor`).
+// Tracked (`valuation`-sourced) accounts are unchanged: latest valuation of
+// any type wins, no transaction sum (ADR-0034 §5).
 export async function computeCanonicalBalance(
   tx: TenantTransactionClient,
   familyId: string,
@@ -346,11 +401,11 @@ export async function computeCanonicalBalance(
     asOf: new Date(),
   })
   if (anchor === null) return toMoney(account.balance)
-  const flow = await sumTransactionFlowInRange(
+  const flow = await sumTransactionFlowAfterAnchor(
     tx,
     familyId,
     account.id,
-    anchor.valuationDate,
+    anchor,
     null
   )
   return addMoney(anchor.value, flow)
@@ -739,8 +794,8 @@ export const rebuildAccountBalanceFn = createServerFn({ method: "POST" })
 // assertions — the classic bookkeeping "does activity explain the
 // restatement" check, generalized to every transition in history instead of
 // only the latest one. Uses the same segmentation predicate as the balance
-// formula (`sumTransactionFlowInRange`) so the two can never silently
-// disagree about which flows belong to which anchor.
+// formula (`sumTransactionFlowAfterAnchor`'s afterAnchor rule, PER-201) so the
+// two can never silently disagree about which flows belong to which anchor.
 async function detectAnchorChainDrift(
   tx: TenantTransactionClient,
   familyId: string,
@@ -754,7 +809,7 @@ async function detectAnchorChainDrift(
       type: { in: [...ANCHOR_VALUATION_TYPES] },
     },
     orderBy: [{ valuationDate: "asc" }, { createdAt: "asc" }, { id: "asc" }],
-    select: { value: true, valuationDate: true, source: true },
+    select: { value: true, valuationDate: true, createdAt: true, source: true },
   })
 
   const reports: BalanceDriftReport[] = []
@@ -763,12 +818,17 @@ async function detectAnchorChainDrift(
     const to = anchors[index + 1]
     if (!from || !to) continue
 
-    const segmentFlow = await sumTransactionFlowInRange(
+    // PER-201: segment flow = afterAnchor(from) ∧ ¬afterAnchor(to), the exact
+    // complement pairing that keeps this drift check and the balance formula on
+    // ONE segmentation predicate (ADR-0043 §6). A late back-dated user
+    // transaction lands only in the "after latest anchor" bucket, so it never
+    // perturbs a historical migrated-anchor segment here.
+    const segmentFlow = await sumTransactionFlowAfterAnchor(
       tx,
       familyId,
       accountId,
-      from.valuationDate,
-      to.valuationDate
+      from,
+      to
     )
     const expected = addMoney(toMoney(from.value), segmentFlow)
     const actual = toMoney(to.value)

--- a/tests/integration/sure-migration.integration.ts
+++ b/tests/integration/sure-migration.integration.ts
@@ -16,7 +16,11 @@ import {
   runSureMigrationForFamily,
   SureMigrationPreflightError,
 } from "@/server/sure-migration"
-import { detectBalanceDriftForFamily } from "@/server/valuations"
+import { createTransactionForFamily } from "@/server/transactions"
+import {
+  detectBalanceDriftForFamily,
+  rebuildFamilyBalances,
+} from "@/server/valuations"
 import {
   createIntegrationHarness,
   type IntegrationHarness,
@@ -1027,6 +1031,73 @@ describe("Sure full-family migration vertical slice (PER-170)", () => {
       checking: 500_000n,
       savings: 4_000_000n,
     })
+  })
+
+  test("PER-201: a back-dated manual txn added AFTER the import produces no drift and is counted (createdAt-absorption)", async () => {
+    const tenant = await setupTenant()
+    const checkingExternalId = "sure-acc-per201-checking"
+    const lines = [
+      sureAccount(checkingExternalId, "Checking", "Depository", "checking"),
+      // One reconciliation anchor. The import writes its FINAL reconciliation
+      // anchor LAST (dated lastActivityDay+1 = 2026-06-25), in its own tenant
+      // transaction, so its createdAt is strictly greater than any promoted row
+      // — the ordering guarantee the afterAnchor rule relies on.
+      sureVal({
+        accountId: checkingExternalId,
+        amount: "480600.0",
+        date: "2026-06-24",
+      }),
+    ]
+
+    await migrate(tenant, "per201.ndjson", lines.join("\n"))
+
+    const checking = await accountByBinding(tenant, checkingExternalId)
+    expect(checking?.balanceSource).toBe("transaction_flow")
+    // Fresh import: balance is exactly the anchor's asserted value (no post-
+    // anchor flow) — the projection===balance / zero-drift baseline.
+    expect(checking?.balance).toBe(48_060_000n)
+
+    // The user adds a top-up dated 2026-06-23 (BEFORE the final anchor's
+    // 2026-06-25 date) but recorded now (createdAt AFTER the whole import).
+    await createTransactionForFamily({
+      data: {
+        type: "income",
+        amount: "8000000",
+        description: "Back-dated top-up after import",
+        accountId: checking!.id,
+        date: new Date("2026-06-23T09:00:00.000Z"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: tenant.familyId,
+      user: { id: tenant.userId },
+      runInTenantTransaction: runner(),
+    })
+
+    // Stored counted it via the incremental delta.
+    const afterTopUp = await accountByBinding(tenant, checkingExternalId)
+    expect(afterTopUp?.balance).toBe(56_060_000n)
+
+    // Canonical counts it too (createdAt disjunct) → NO materialization drift.
+    const drift = await detectBalanceDriftForFamily({
+      familyId: tenant.familyId,
+      userId: tenant.userId,
+      runInTenantTransaction: runner(),
+    })
+    expect(
+      drift.filter(
+        (d) => d.accountId === checking!.id && d.kind === "MATERIALIZATION"
+      )
+    ).toEqual([])
+
+    // Rebuild agrees: stored == canonical, so the checking rebuild is a no-op.
+    const rebuilt = await rebuildFamilyBalances({
+      familyId: tenant.familyId,
+      user: { id: tenant.userId },
+      runInTenantTransaction: runner(),
+    })
+    const checkingRebuild = rebuilt.find((r) => r.accountId === checking!.id)
+    expect(checkingRebuild?.changed).toBe(false)
+    expect(checkingRebuild?.rebuiltBalance).toBe("56060000")
   })
 
   test("self-heal 2B: a created leg with unmarked rows re-promotes via the stable key (no double)", async () => {

--- a/tests/integration/valuation-primitive.integration.ts
+++ b/tests/integration/valuation-primitive.integration.ts
@@ -718,6 +718,198 @@ describe("valuation primitive + balance rebuild & drift (PER-146/PER-177, ADR-00
   })
 
   // --------------------------------------------------------------------------
+  // PER-201 — back-dated transactions after an anchor (createdAt-absorption)
+  //
+  // The shared `afterAnchor` predicate (ADR-0043 §2, PER-201): a transaction is
+  // post-anchor iff it is dated after the anchor OR was recorded (createdAt)
+  // after it. In these tests the CALL ORDER fixes createdAt ordering — a txn
+  // added AFTER `addValuation` has a later createdAt than that anchor, so a
+  // back-dated one is still counted, while a txn added BEFORE the anchor (older
+  // createdAt, dated at/before it) stays absorbed exactly as before.
+  // --------------------------------------------------------------------------
+  describe("PER-201 back-dated flow after the latest anchor", () => {
+    const detect = (owner: AuthenticatedOnboardedUser) =>
+      detectBalanceDriftForFamily({
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+
+    // (a) + (c): the canonical bug. A back-dated top-up added AFTER an anchor is
+    // real post-anchor activity the materialized balance already counts; the
+    // canonical formula must count it too, so there is NO materialization drift
+    // and a rebuild is a no-op. Under the old date-only rule canonical would drop
+    // it (dated before the anchor) and report a false 8,000,000 MATERIALIZATION.
+    test("a back-dated txn added after the latest anchor is counted: no drift, rebuild is a no-op", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeCash(owner, "150000")
+      await backdateOpeningValuation(owner, account.id, daysAgo(30))
+
+      // Effective anchor: reconciliation 200000 dated daysAgo(5).
+      await addValuation(
+        owner,
+        account.id,
+        "200000",
+        "reconciliation",
+        daysAgo(5)
+      )
+      expect((await accountRow(owner, account.id)).balance).toBe(200000n)
+
+      // User adds a top-up dated BEFORE the anchor (daysAgo(6)) but recorded now.
+      await addTransaction(
+        owner,
+        account.id,
+        "income",
+        "8000000",
+        "Back-dated top-up",
+        daysAgo(6)
+      )
+
+      // Stored balance counted it via the incremental delta.
+      expect((await accountRow(owner, account.id)).balance).toBe(8200000n)
+
+      // Canonical now includes it too (createdAt disjunct) → no MATERIALIZATION.
+      const report = await detect(owner)
+      expect(
+        report.filter(
+          (r) => r.accountId === account.id && r.kind === "MATERIALIZATION"
+        )
+      ).toEqual([])
+
+      // Rebuild agrees: stored == canonical.
+      const rebuilt = await rebuildAccountBalanceForFamily({
+        accountId: account.id,
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(rebuilt.changed).toBe(false)
+      expect(rebuilt.rebuiltBalance).toBe("8200000")
+    })
+
+    // (f): the disjunction is OR, never createdAt-only. A FUTURE-dated txn
+    // recorded BEFORE a live reconciliation is after the asserted date and must
+    // be added — the date disjunct catches it even though its createdAt is older
+    // than the anchor. A createdAt-only rule would wrongly absorb it.
+    test("a future-dated txn recorded before a reconciliation still counts (date disjunct)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeCash(owner, "100000")
+      await backdateOpeningValuation(owner, account.id, daysAgo(30))
+
+      // Recorded FIRST (older createdAt), dated AFTER the coming anchor.
+      await addTransaction(
+        owner,
+        account.id,
+        "income",
+        "5000",
+        "Future-dated relative to the anchor",
+        daysAgo(2)
+      )
+      // Anchor recorded SECOND (newer createdAt), dated daysAgo(5).
+      await addValuation(
+        owner,
+        account.id,
+        "100000",
+        "reconciliation",
+        daysAgo(5)
+      )
+
+      // anchor(100000) + the daysAgo(2) income (date > anchor date) = 105000.
+      expect((await accountRow(owner, account.id)).balance).toBe(105000n)
+      const report = await detect(owner)
+      expect(
+        report.filter(
+          (r) => r.accountId === account.id && r.kind === "MATERIALIZATION"
+        )
+      ).toEqual([])
+    })
+
+    // The shared predicate keeps the balance formula and ANCHOR_CHAIN in lockstep
+    // (ADR-0043 §6): a late back-dated txn lands ONLY in the "after latest anchor"
+    // bucket, so it must NOT manufacture a spurious ANCHOR_CHAIN warning on the
+    // historical segment it happens to date into. (A divergent impl — date-only
+    // chain + createdAt balance — would report a false chain drift here.)
+    test("a late back-dated txn does not perturb a historical anchor-chain segment", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeCash(owner, "100000")
+      await backdateOpeningValuation(owner, account.id, daysAgo(30))
+
+      // Clean chain: opening(100000 @ daysAgo30) -> anchor(100000 @ daysAgo10),
+      // zero flow between them, so no chain drift.
+      await addValuation(
+        owner,
+        account.id,
+        "100000",
+        "reconciliation",
+        daysAgo(10)
+      )
+      expect(
+        (await detect(owner)).filter(
+          (r) => r.accountId === account.id && r.kind === "ANCHOR_CHAIN"
+        )
+      ).toEqual([])
+
+      // A back-dated txn recorded now, dated INSIDE the (daysAgo30, daysAgo10]
+      // segment.
+      await addTransaction(
+        owner,
+        account.id,
+        "income",
+        "5000",
+        "Late back-dated",
+        daysAgo(20)
+      )
+
+      // Balance counts it (after the latest anchor by createdAt); no drift of
+      // EITHER kind — the segment stays explained, the materialization matches.
+      expect((await accountRow(owner, account.id)).balance).toBe(105000n)
+      const report = await detect(owner)
+      expect(report.filter((r) => r.accountId === account.id)).toEqual([])
+    })
+
+    // (e): the valuation-tracked path (balanceSource="valuation") never touches
+    // transaction flow — it must be entirely unaffected by the afterAnchor rule.
+    test("valuation-tracked accounts are untouched: balance follows the latest valuation, no drift", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const tracked = await makeTracked(owner, "100000000")
+
+      // Latest valuation of ANY type wins for a tracked account (ADR-0034 §5);
+      // dated "now" (default) so it supersedes the opening valuation, which is
+      // also dated now, by the createdAt tie-break.
+      await addValuation(owner, tracked.id, "123456789", "market")
+      expect((await accountRow(owner, tracked.id)).balance).toBe(123456789n)
+
+      const report = await detect(owner)
+      expect(report.filter((r) => r.accountId === tracked.id)).toEqual([])
+    })
+
+    // (d): tenant isolation — the afterAnchor sum is family-scoped; another
+    // family's back-dated activity never leaks into this family's drift report.
+    test("is tenant-scoped: another family's back-dated txn never appears", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const intruderAccount = await makeCash(intruder, "150000")
+      await backdateOpeningValuation(intruder, intruderAccount.id, daysAgo(30))
+      await addValuation(
+        intruder,
+        intruderAccount.id,
+        "200000",
+        "reconciliation",
+        daysAgo(5)
+      )
+      await addTransaction(
+        intruder,
+        intruderAccount.id,
+        "income",
+        "8000000",
+        "Intruder back-dated top-up",
+        daysAgo(6)
+      )
+
+      const report = await detect(owner)
+      expect(report.some((r) => r.accountId === intruderAccount.id)).toBe(false)
+    })
+  })
+
+  // --------------------------------------------------------------------------
   // current / available / held semantics
   // --------------------------------------------------------------------------
   describe("getAccountBalanceForFamily (current / available / held)", () => {


### PR DESCRIPTION
## PER-201 — false MATERIALIZATION drift from back-dated transactions on `transaction_flow` accounts

### The bug
After importing Sure then adding a manual transaction dated **before** the account's latest reconciliation anchor (e.g. a back-dated "top up OVO"), a `transaction_flow` account showed a MATERIALIZATION drift badge. The **stored** balance was correct — the **canonical/drift formula was too strict**.

`computeCanonicalBalance` segmented post-anchor flow by **date only** (`date > anchor.valuationDate`), so a back-dated transaction was dropped from canonical, while `applyAccountBalanceDelta` increments the stored balance on **every** transaction regardless of date. `stored != canonical` → phantom error equal to the dropped back-dated flow (real case: OVO, 8,000,000).

### The fix — the `afterAnchor` predicate
One shared segmentation predicate for BOTH the balance formula and the ANCHOR_CHAIN drift check (preserving ADR-0043 §6's "one segmentation function" invariant):

```
afterAnchor(A)(t)  ≡  t.date > A.valuationDate  OR  t.createdAt > A.createdAt
```

A transaction is absorbed into an anchor only when it was dated at/before the anchor **and** already recorded (`createdAt`) when the anchor was written.

- **`createdAt` disjunct** — the fix: a user's back-dated transaction added after an anchor is real post-anchor activity the stored balance already counts, so canonical must count it too.
- **`date` disjunct** — must stay: a future-dated transaction recorded before a live reconciliation is after the asserted balance and must be added. So it is a disjunction, never `createdAt` alone.

ANCHOR_CHAIN reuses the same predicate as the complement pairing `afterAnchor(from) ∧ ¬afterAnchor(to)`, so a late back-dated txn lands only in the "after the latest anchor" bucket and never perturbs a historical migrated-anchor segment.

### Why a fresh import stays zero-drift (no double-count)
The Sure importer writes its **final reconciliation anchor last**, after all promoted rows, each step in its own tenant transaction → the final anchor's `createdAt` strictly exceeds every imported txn's `createdAt`, and it is dated `lastActivityDay+1`. Both disjuncts are false for every imported row → all stay absorbed exactly as before. `projectSureMigrationBalances` is unchanged (date-only, inert under the `createdAt` disjunct on a fresh import).

### Changes
- `src/server/valuations.ts`: `AnchorValuation`/`latestValuation` carry `createdAt`; `sumTransactionFlowInRange` → `sumTransactionFlowAfterAnchor` (afterAnchor rule); `computeCanonicalBalance` + `detectAnchorChainDrift` use it. Valuation-tracked path (`balanceSource="valuation"`) untouched.
- `docs/adr/0043-*`: amendment documenting the predicate, the createdAt-absorption semantic, the import ordering guarantee, and the re-import-clobber **known limitation** (tracked as **PER-203**).
- Real-Postgres integration tests (`valuation-primitive`, `sure-migration`): back-dated txn after anchor → no drift + rebuild no-op; future-dated pre-reconcile txn still counts; anchor-chain segment not perturbed; tracked path unaffected; tenant isolation; fresh-import zero-drift.

### Verification
- `vp check` clean (format/lint/types/no-use-effect).
- Unit suite: **437/437** passing locally.
- `valuation-primitive` integration file: **38/38** passing locally. Full integration + e2e run in CI (this dev machine is slow for heavy real-Postgres suites).

### Scope / safety
- Does not touch `applyAccountBalanceDelta`, the valuation-tracked (PER-196/ADR-0048) path, or `projectSureMigrationBalances`.
- Adjacent re-import-clobber edge case is **out of scope** and filed as **PER-203**.

Refs PER-201. Follow-up: PER-203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1