### PR TITLE
fix(transactions): PER-205 — reset split-allocation state after submit

### DIFF
--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1432,6 +1432,19 @@ function useTransactionFormModalController({
       : [createBlankSplitEntry(), createBlankSplitEntry()]
   )
 
+  // PER-205: the "New Transaction" modal is a persistently-mounted singleton
+  // (transactions.tsx renders <TransactionFormModal /> with no key and no
+  // editData), so isSplit + splitEntries survive across open/submit cycles.
+  // TanStack Form resets itself on submit, but this split state lives OUTSIDE
+  // the form and must be cleared explicitly on the two user actions that begin
+  // a fresh entry: a successful non-edit submit, and reopening the modal for a
+  // new transaction. Edit mode never calls this — its allocation is seeded
+  // from editData in the useState initializers above and must be preserved.
+  const resetSplitState = React.useCallback(() => {
+    setIsSplit(false)
+    setSplitEntries([createBlankSplitEntry(), createBlankSplitEntry()])
+  }, [])
+
   useHotkeys([
     {
       hotkey: "Shift+N",
@@ -1821,7 +1834,13 @@ function useTransactionFormModalController({
         setIsOpen(false)
         if (onClose) onClose()
 
-        if (!isEditMode) form.reset()
+        if (!isEditMode) {
+          form.reset()
+          // Split state lives outside TanStack Form; clear it too so the next
+          // "New Transaction" open starts with a clean, inactive allocation
+          // (PER-205 — no stale rows, no phantom "Over allocated" banner).
+          resetSplitState()
+        }
       } catch (error: unknown) {
         console.error("Failed to save transaction:", error)
         setFormError(
@@ -1864,6 +1883,11 @@ function useTransactionFormModalController({
     if (open && editData) {
       setActiveTab(editData.type)
       form.reset()
+    } else if (open && !editData) {
+      // PER-205: reopening the singleton "New Transaction" modal must present a
+      // clean split allocation even if a prior split entry was never submitted
+      // (e.g. the user toggled Split on, then closed the dialog).
+      resetSplitState()
     }
   }
 

--- a/tests/e2e/transaction-split-reset.e2e.ts
+++ b/tests/e2e/transaction-split-reset.e2e.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-205 — the split-allocation state must NOT survive a submit.
+//
+// The "New Transaction" modal is a persistently-mounted singleton, so its
+// split state (isSplit toggle + the Category Allocation rows) lives in React
+// state OUTSIDE TanStack Form. TanStack Form resets on submit, but the split
+// state did not, so after submitting a split transaction and reopening the
+// form, the previous allocation rows persisted as ACTIVE — showing a stale
+// "Over allocated" banner on a brand-new entry.
+//
+// This spec drives the real browser: creates an account, records a split
+// transaction, submits it, reopens the New Transaction form, and asserts the
+// split allocation is gone (toggle off, no Category Allocation panel).
+
+test.describe("split-transaction form state resets after submit", () => {
+  test("reopening New Transaction shows a clean, inactive split allocation", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    // PER-183: onboarding no longer seeds a starter account — create one so
+    // the transaction form's account dropdown has something to select.
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill("E2E Split Reset Fixture")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.goto("/transactions")
+    await waitForHydration(page)
+
+    const uniqueSuffix = Date.now().toString(36)
+    const description = `E2E split reset ${uniqueSuffix}`
+
+    // --- Record a SPLIT transaction ---
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    await page.getByLabel("Description *").fill(description)
+    await page.getByLabel("Amount *").fill("100000")
+    await page.locator('select[name="accountId"]').selectOption({ index: 1 })
+
+    // Activate split mode; the Category Allocation panel appears with 2 rows.
+    await page.locator("#split-mode-toggle").click()
+    await expect(page.getByText("Category Allocation")).toBeVisible()
+
+    // Balance the two default rows so the total matches the parent amount
+    // (Save is disabled while the split is unbalanced).
+    const splitDescriptions = page.getByLabel("Description for split entry")
+    const splitAmounts = page.getByLabel("Amount for split entry")
+    await splitDescriptions.nth(0).fill("Groceries part")
+    await splitAmounts.nth(0).fill("60000")
+    await splitDescriptions.nth(1).fill("Household part")
+    await splitAmounts.nth(1).fill("40000")
+
+    // "Over allocated" must be gone once the split is balanced.
+    await expect(page.getByText("Perfect! All funds allocated")).toBeVisible()
+
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(description)).toBeVisible()
+
+    // --- Reopen the New Transaction form ---
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    // The split toggle must be OFF and the allocation panel gone — no stale
+    // rows, no phantom "Over allocated" banner on a fresh entry.
+    await expect(page.locator("#split-mode-toggle")).not.toBeChecked()
+    await expect(page.getByText("Category Allocation")).toHaveCount(0)
+    await expect(page.getByText(/Over allocated/)).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## PER-205 — Split-transaction form state not reset after submit

### Bug (found dogfooding)
After submitting a **split** transaction, reopening the "New Transaction" form still showed the previous split allocation as **ACTIVE** — the Category Allocation rows persisted with their amounts, surfacing a stale "Over allocated by …" banner on a brand-new entry. A fresh (non-edit) form must start with a clean, empty split state.

### Root cause
The "New Transaction" modal is a **persistently-mounted singleton** — `src/routes/_protected/transactions.tsx:566` renders `<TransactionFormModal />` with no `key` and no `editData`, so it never remounts. Its split state — the `isSplit` toggle and the `splitEntries` Category Allocation rows — lives in `React.useState` **outside** TanStack Form. On submit the code calls `form.reset()` (which only resets the TanStack Form fields); the split state was never cleared, so it survived across open → submit → reopen cycles.

The **edit** modal (`transactions.tsx:686`) is conditionally mounted (`editingTrx && …`), so it remounts per edit and was never affected — its allocation is correctly seeded from `editData`.

### Fix (client-only, declarative — no `useEffect`)
Per the repo's no-use-effect rule, the resets happen in the existing **user-action event handlers** (Rule 3 — respond to user actions), not an effect:

- New `resetSplitState` helper: `isSplit → false`, `splitEntries → two blank rows`.
- Called on the two actions that begin a fresh entry:
  - **(a)** a successful **non-edit** submit (alongside the existing `form.reset()`).
  - **(b)** reopening the modal for a **new** transaction (`handleOpenChange`, `open && !editData`).
- **Edit mode is untouched** — its allocation is still seeded from `editData` in the `useState` initializers and preserved on open.

### Testing
- Added `tests/e2e/transaction-split-reset.e2e.ts` (modeled on `transaction-quick-create.e2e.ts`): creates an account, records a balanced split transaction, submits it, reopens New Transaction, and asserts the split toggle is off with no Category Allocation panel and no stale "Over allocated" banner. Authoritative e2e run is left to CI (local dev-server-under-Playwright is slow).
- `vp check` clean (format / lint / types / no-use-effect).
- `vp test` green locally — 437 unit tests pass.

Scope: form state only. No ledger/server/DB code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1