### PR TITLE
fix(reporting): PER-204 — net-worth fold recognizes reconciliation/manual anchors (dashboard showed 0)

### DIFF
--- a/src/lib/net-worth.test.ts
+++ b/src/lib/net-worth.test.ts
@@ -39,8 +39,12 @@ const valuation = (
   accountId: string,
   value: bigint,
   valuationDate: string,
-  type = "opening"
-): SeriesValuation => ({ accountId, value, valuationDate, type })
+  type = "opening",
+  // Defaults to the valuation's own date at midnight UTC. `afterAnchor` uses
+  // strict `>`, so a same-instant flow is NOT "after" — existing date-only
+  // expectations are preserved unless a test passes explicit createdAt values.
+  createdAt: Date = new Date(`${valuationDate}T00:00:00Z`)
+): SeriesValuation => ({ accountId, value, valuationDate, type, createdAt })
 const snapshot = (
   fromCurrency: string,
   rate: string,
@@ -186,10 +190,16 @@ describe("generateSampleDates", () => {
 // =============================================================================
 
 describe("buildNetWorthSeries", () => {
-  const txn = (accountId: string, amount: bigint, iso: string) => ({
+  const txn = (
+    accountId: string,
+    amount: bigint,
+    iso: string,
+    createdAtIso: string = iso
+  ) => ({
     accountId,
     amount,
     date: new Date(iso),
+    createdAt: new Date(createdAtIso),
   })
 
   test("cash-like balance = opening anchor + Σ flow up to each sample date", () => {
@@ -208,6 +218,123 @@ describe("buildNetWorthSeries", () => {
     )
     expect(pointByDate(points, "2026-01-05").netWorth).toBe(100_000n)
     expect(pointByDate(points, "2026-01-25").netWorth).toBe(120_000n)
+  })
+
+  // PER-204: a cash account anchored by a RECONCILIATION valuation (not an
+  // `opening`) — the shape of every Sure-migrated / reconciled account — must
+  // resolve to its asserted balance, not 0. The old opening-only fold zeroed it.
+  test("reconciliation anchor (no opening) sets the cash balance — PER-204", () => {
+    const points = buildNetWorthSeries(
+      baseInput({
+        from: "2026-01-01",
+        to: "2026-03-01",
+        interval: "month",
+        accounts: [cashAccount("a")],
+        valuations: [
+          valuation("a", 210_000_000n, "2026-02-15", "reconciliation"),
+        ],
+        transactions: [txn("a", 5_000_000n, "2026-02-20T00:00:00Z")],
+      })
+    )
+    // Before the anchor's date the account has no anchor yet → 0.
+    expect(pointByDate(points, "2026-01-01").netWorth).toBe(0n)
+    // At/after: asserted value + post-anchor flow (dated after the anchor).
+    expect(pointByDate(points, "2026-03-01").netWorth).toBe(215_000_000n)
+  })
+
+  // A later reconciliation asserts a fresh balance that ABSORBS all flow dated
+  // at/before it and already recorded — mirrors `computeCanonicalBalance`.
+  test("a later reconciliation anchor overrides accumulated flow (absorbs prior)", () => {
+    const points = buildNetWorthSeries(
+      baseInput({
+        from: "2026-01-01",
+        to: "2026-03-01",
+        interval: "month",
+        accounts: [cashAccount("a")],
+        valuations: [
+          valuation("a", 100_000n, "2026-01-01", "opening"),
+          valuation("a", 500_000n, "2026-02-10", "reconciliation"),
+        ],
+        transactions: [
+          txn("a", 999_999n, "2026-01-15T00:00:00Z"), // absorbed by the reconciliation
+          txn("a", 20_000n, "2026-02-20T00:00:00Z"), // after it → counted
+        ],
+      })
+    )
+    // Jan (opening active): 100k + the 01-15 flow.
+    expect(pointByDate(points, "2026-01-01").netWorth).toBe(100_000n)
+    expect(pointByDate(points, "2026-02-01").netWorth).toBe(1_099_999n)
+    // Mar (reconciliation active): asserts 500k, prior flow absorbed, +20k after.
+    expect(pointByDate(points, "2026-03-01").netWorth).toBe(520_000n)
+  })
+
+  // The `afterAnchor` createdAt disjunct (PER-201): a txn dated BEFORE the anchor
+  // but RECORDED after it is genuine post-anchor activity and must be counted;
+  // the same-date txn recorded before the anchor is absorbed.
+  test("a back-dated txn recorded after the anchor is counted (createdAt disjunct)", () => {
+    const anchorCreatedAt = new Date("2026-02-10T09:00:00Z")
+    const points = buildNetWorthSeries(
+      baseInput({
+        from: "2026-02-01",
+        to: "2026-03-01",
+        interval: "month",
+        accounts: [cashAccount("a")],
+        valuations: [
+          valuation(
+            "a",
+            500_000n,
+            "2026-02-10",
+            "reconciliation",
+            anchorCreatedAt
+          ),
+        ],
+        transactions: [
+          // dated before the anchor date, recorded AFTER it → post-anchor.
+          txn("a", 7_000n, "2026-02-05T00:00:00Z", "2026-02-11T00:00:00Z"),
+          // dated before AND recorded before the anchor → absorbed.
+          txn("a", 3_000n, "2026-02-05T00:00:00Z", "2026-02-09T00:00:00Z"),
+        ],
+      })
+    )
+    expect(pointByDate(points, "2026-03-01").netWorth).toBe(507_000n)
+  })
+
+  // No-anchor edge: `computeCanonicalBalance` falls back to the stored balance,
+  // which for a canonically-created account equals opening-0 + Σ all flow. The
+  // fold never reads Account.balance, so it folds an anchor-less cash account as
+  // an implicit opening-0: 0 + Σ all flow ≤ T.
+  test("an account with no anchor of any type folds as opening-0 (Σ all flow)", () => {
+    const points = buildNetWorthSeries(
+      baseInput({
+        from: "2026-01-01",
+        to: "2026-02-01",
+        interval: "month",
+        accounts: [cashAccount("a")],
+        valuations: [], // no opening / reconciliation / manual
+        transactions: [
+          txn("a", 40_000n, "2026-01-10T00:00:00Z"),
+          txn("a", -15_000n, "2026-01-20T00:00:00Z"),
+        ],
+      })
+    )
+    expect(pointByDate(points, "2026-01-01").netWorth).toBe(0n) // no flow yet
+    expect(pointByDate(points, "2026-02-01").netWorth).toBe(25_000n)
+  })
+
+  // A `market` valuation is an OBSERVATION, never a cash anchor, so it must not
+  // assert a transaction_flow balance — the account folds as opening-0 here.
+  test("a market valuation is not a cash anchor (observation only)", () => {
+    const points = buildNetWorthSeries(
+      baseInput({
+        from: "2026-01-01",
+        to: "2026-01-01",
+        interval: "day",
+        accounts: [cashAccount("a")],
+        valuations: [valuation("a", 9_000_000n, "2026-01-01", "market")],
+        transactions: [txn("a", 25_000n, "2026-01-01T00:00:00Z")],
+      })
+    )
+    expect(pointByDate(points, "2026-01-01").netWorth).toBe(25_000n)
   })
 
   test("tracked balance carries forward the latest valuation <= T", () => {

--- a/src/lib/net-worth.ts
+++ b/src/lib/net-worth.ts
@@ -16,6 +16,20 @@ import { convertMinor } from "@/lib/fx"
 //     per point. FX is as-of-date mark-to-market: the rate resolver is clamped to
 //     the greatest snapshot `asOfDate <= T`; a future-dated rate never leaks.
 //
+// Cash (transaction_flow) balance-as-of-T mirrors `computeCanonicalBalance`
+// (ADR-0043 §2 / PER-201) EXACTLY, so the series' last point equals the
+// materialized `Account.balance` by construction (ADR-0038 §6). The anchor is the
+// LATEST balance-assertion valuation (opening | reconciliation | manual) with
+// `valuationDate <= T`; the balance is `anchor.value + Σ afterAnchor(anchor, ≤ T)`
+// where a flow is "after the anchor" iff `date > anchor.date` OR
+// `createdAt > anchor.createdAt` (both disjuncts load-bearing — a live
+// reconciliation asserts a value that ABSORBS all prior-and-already-recorded
+// flow, while a back-dated txn added after that anchor is still counted; see
+// PER-201). A cash account with no anchor at T contributes 0 (pre-inception).
+// Recognizing reconciliation/manual anchors — not just `opening` — is what fixes
+// PER-204: migrated/reconciled accounts are anchored by `reconciliation`, never
+// `opening`, so the old opening-only fold zeroed every one of them.
+//
 // All money is signed minor units (ASSET balance >= 0, LIABILITY balance <= 0),
 // the same sign convention as `Account.balance` / `Valuation.value`.
 // =============================================================================
@@ -23,6 +37,44 @@ import { convertMinor } from "@/lib/fx"
 export const MAX_SERIES_POINTS = 366
 
 export type SeriesInterval = "day" | "week" | "month"
+
+/**
+ * Balance-assertion valuation types — the anchors a cash (transaction_flow)
+ * account's balance is derived from. The SINGLE source of truth for this set;
+ * `computeCanonicalBalance` (src/server/valuations.ts) imports it so the batch
+ * in-memory fold here and the per-account DB derivation there can never drift on
+ * which valuation types reset a cash balance (ADR-0043 §1). `market` is excluded
+ * — it never asserts a cash balance. Kept in this Prisma-free module so the
+ * server file depends on the pure one, never the reverse.
+ */
+export const ANCHOR_VALUATION_TYPES = [
+  "opening",
+  "reconciliation",
+  "manual",
+] as const
+
+const ANCHOR_VALUATION_TYPE_SET: ReadonlySet<string> = new Set(
+  ANCHOR_VALUATION_TYPES
+)
+
+/**
+ * The `afterAnchor` predicate (ADR-0043 §2 / PER-201), the in-memory twin of the
+ * Prisma `OR: [{ date: { gt } }, { createdAt: { gt } }]` in
+ * `sumTransactionFlowAfterAnchor` (src/server/valuations.ts). A flow counts
+ * toward the post-anchor sum iff it is dated after the anchor OR was recorded
+ * after it — the disjunction is load-bearing in BOTH directions (a future-dated
+ * txn recorded before a live reconciliation; a back-dated txn recorded after
+ * one). Keep the two shapes identical; the ADR-0038 §6 invariant test enforces
+ * parity. Dates are compared as YYYY-MM-DD strings (lexicographic == calendar).
+ */
+function isAfterAnchor(
+  anchorDate: string,
+  anchorCreatedAt: Date,
+  txnDate: string,
+  txnCreatedAt: Date
+): boolean {
+  return txnDate > anchorDate || txnCreatedAt > anchorCreatedAt
+}
 
 // ---- shared point normalizer ------------------------------------------------
 
@@ -161,6 +213,7 @@ export interface SeriesValuation {
   accountId: string
   value: bigint
   valuationDate: string // YYYY-MM-DD (date-only anchor)
+  createdAt: Date // recorded-at instant; the `afterAnchor` createdAt disjunct
   type: string
 }
 
@@ -168,6 +221,7 @@ export interface SeriesTransaction {
   accountId: string
   amount: bigint
   date: Date // instant; localized to the family timezone for the day boundary
+  createdAt: Date // recorded-at instant; the `afterAnchor` createdAt disjunct
 }
 
 export interface SeriesSnapshot {
@@ -214,32 +268,48 @@ export function buildNetWorthSeries(
   const sampleDates = generateSampleDates(input.from, input.to, input.interval)
 
   // --- index canonical rows per account / currency, all sorted ascending -----
-  const openingByAccount = new Map<string, { date: string; value: bigint }>()
+  // Cash accounts key off ANCHOR-type valuations (opening | reconciliation |
+  // manual); tracked accounts carry the latest valuation of ANY type. Both come
+  // from the same `input.valuations`, split by type here.
+  const anchorsByAccount = new Map<string, CashAnchor[]>()
   const valuationsByAccount = new Map<
     string,
     { date: string; value: bigint }[]
   >()
   for (const valuation of input.valuations) {
-    if (valuation.type === "opening") {
-      openingByAccount.set(valuation.accountId, {
+    if (ANCHOR_VALUATION_TYPE_SET.has(valuation.type)) {
+      const anchors = anchorsByAccount.get(valuation.accountId) ?? []
+      anchors.push({
         date: valuation.valuationDate,
+        createdAt: valuation.createdAt,
         value: valuation.value,
       })
+      anchorsByAccount.set(valuation.accountId, anchors)
     }
     const list = valuationsByAccount.get(valuation.accountId) ?? []
     list.push({ date: valuation.valuationDate, value: valuation.value })
     valuationsByAccount.set(valuation.accountId, list)
   }
+  // Sort anchors by (date, createdAt) ascending — the last one with date <= T is
+  // the active anchor, mirroring `latestValuation`'s (valuationDate desc,
+  // createdAt desc) tie-break (src/server/valuations.ts).
+  for (const anchors of anchorsByAccount.values()) {
+    anchors.sort((a, b) =>
+      a.date !== b.date
+        ? a.date < b.date
+          ? -1
+          : 1
+        : a.createdAt.getTime() - b.createdAt.getTime()
+    )
+  }
   for (const list of valuationsByAccount.values()) byDateAsc(list)
 
-  const transactionsByAccount = new Map<
-    string,
-    { date: string; amount: bigint }[]
-  >()
+  const transactionsByAccount = new Map<string, CashFlowRow[]>()
   for (const transaction of input.transactions) {
     const list = transactionsByAccount.get(transaction.accountId) ?? []
     list.push({
       date: calendarDateInTimezone(transaction.date, input.timezone),
+      createdAt: transaction.createdAt,
       amount: transaction.amount,
     })
     transactionsByAccount.set(transaction.accountId, list)
@@ -258,7 +328,7 @@ export function buildNetWorthSeries(
   for (const list of snapshotsByCurrency.values()) byDateAsc(list)
 
   // --- per-account / per-currency advancing pointers (single pass) -----------
-  const cashState = new Map<string, { idx: number; running: bigint }>()
+  const cashState = new Map<string, CashFoldState>()
   const trackedState = new Map<
     string,
     { idx: number; current: bigint | null }
@@ -267,7 +337,12 @@ export function buildNetWorthSeries(
     if (account.balanceSource === "valuation") {
       trackedState.set(account.id, { idx: 0, current: null })
     } else {
-      cashState.set(account.id, { idx: 0, running: 0n })
+      cashState.set(account.id, {
+        anchorIdx: 0,
+        active: null,
+        tIdx: 0,
+        sumThroughT: 0n,
+      })
     }
   }
   const rateState = new Map<string, { idx: number; rate: bigint | null }>()
@@ -292,7 +367,7 @@ export function buildNetWorthSeries(
       accountClass: account.accountClass,
       currency: account.currency,
       native: nativeBalanceAt(account, sampleDate, {
-        openingByAccount,
+        anchorsByAccount,
         cashState,
         trackedState,
         transactionsByAccount,
@@ -315,11 +390,41 @@ export function buildNetWorthSeries(
   return points
 }
 
+interface CashAnchor {
+  date: string
+  createdAt: Date
+  value: bigint
+}
+
+interface CashFlowRow {
+  date: string
+  createdAt: Date
+  amount: bigint
+}
+
+/** Memoized summary of the currently-active anchor (recomputed on activation). */
+interface ActiveAnchor {
+  value: bigint
+  // Σ flow dated at/before the anchor date (subtracted from `sumThroughT` to
+  // leave only strictly-after-date flow — the first `afterAnchor` disjunct).
+  sumThroughAnchorDate: bigint
+  // Σ flow dated at/before the anchor date BUT recorded after it — the second
+  // (createdAt) disjunct, which the date subtraction above would otherwise drop.
+  backdatedAfterAnchor: bigint
+}
+
+interface CashFoldState {
+  anchorIdx: number
+  active: ActiveAnchor | null
+  tIdx: number
+  sumThroughT: bigint
+}
+
 interface FoldState {
-  openingByAccount: Map<string, { date: string; value: bigint }>
-  cashState: Map<string, { idx: number; running: bigint }>
+  anchorsByAccount: Map<string, CashAnchor[]>
+  cashState: Map<string, CashFoldState>
   trackedState: Map<string, { idx: number; current: bigint | null }>
-  transactionsByAccount: Map<string, { date: string; amount: bigint }[]>
+  transactionsByAccount: Map<string, CashFlowRow[]>
   valuationsByAccount: Map<string, { date: string; value: bigint }[]>
 }
 
@@ -340,16 +445,67 @@ function nativeBalanceAt(
     return tracked.current ?? 0n
   }
 
-  // cash-like: opening anchor + Σ flow (date <= T). Pointer accumulates the
-  // running flow (including any activity before `from`); the opening date gates
-  // existence so the account contributes 0 before inception (ADR-0038 §4).
+  // cash-like (ADR-0043 §2 / PER-201, twin of `computeCanonicalBalance`):
+  //   balance(T) = anchor.value + Σ { afterAnchor(anchor)(t) ∧ t.date <= T }
+  // The counted set splits into two disjoint pieces (see `isAfterAnchor`):
+  //   (a) strictly-after-date flow: Σ{ anchorDate < date <= T }
+  //         = sumThroughT − sumThroughAnchorDate
+  //   (b) back-dated-but-later-recorded flow: Σ{ date <= anchorDate ∧
+  //         createdAt > anchorCreatedAt }  — constant per anchor.
   const cash = state.cashState.get(account.id)!
-  const list = state.transactionsByAccount.get(account.id) ?? []
-  while (cash.idx < list.length && list[cash.idx].date <= sampleDate) {
-    cash.running += list[cash.idx].amount
-    cash.idx += 1
+  const txns = state.transactionsByAccount.get(account.id) ?? []
+  const anchors = state.anchorsByAccount.get(account.id) ?? []
+
+  // Advance the active anchor to the latest one with date <= T. Each activation
+  // recomputes its constant pieces (both bounded by the anchor date) once.
+  while (
+    cash.anchorIdx < anchors.length &&
+    anchors[cash.anchorIdx].date <= sampleDate
+  ) {
+    cash.active = summarizeAnchor(anchors[cash.anchorIdx], txns)
+    cash.anchorIdx += 1
   }
-  const opening = state.openingByAccount.get(account.id)
-  if (!opening || opening.date > sampleDate) return 0n
-  return opening.value + cash.running
+
+  // Advance the running Σ flow dated <= T (single pass across sample dates).
+  while (cash.tIdx < txns.length && txns[cash.tIdx].date <= sampleDate) {
+    cash.sumThroughT += txns[cash.tIdx].amount
+    cash.tIdx += 1
+  }
+
+  if (cash.active === null) {
+    // No anchor yet at T. A cash account created the canonical way always has an
+    // `opening` anchor (accounts.ts), so this is reached only BEFORE the first
+    // anchor's date, or for an anchor-less account (e.g. a raw insert). Mirror
+    // `computeCanonicalBalance`'s no-anchor intent as an implicit opening-0: 0 +
+    // Σ all flow <= T. Before any flow this is 0 (pre-inception, ADR-0038 §4).
+    return anchors.length === 0 ? cash.sumThroughT : 0n
+  }
+  return (
+    cash.active.value +
+    (cash.sumThroughT - cash.active.sumThroughAnchorDate) +
+    cash.active.backdatedAfterAnchor
+  )
+}
+
+/**
+ * Precompute an anchor's two constant flow pieces (both Σ bounded by the anchor
+ * date). The strictly-after-DATE disjunct of `afterAnchor` is handled by the
+ * caller via `sumThroughT − sumThroughAnchorDate`; here we only classify the
+ * at/before-date rows, for which `isAfterAnchor` collapses to its createdAt
+ * disjunct — the exact rows the date subtraction would otherwise drop.
+ */
+function summarizeAnchor(
+  anchor: CashAnchor,
+  txns: CashFlowRow[]
+): ActiveAnchor {
+  let sumThroughAnchorDate = 0n
+  let backdatedAfterAnchor = 0n
+  for (const txn of txns) {
+    if (txn.date > anchor.date) break // txns are date-sorted ascending
+    sumThroughAnchorDate += txn.amount
+    if (isAfterAnchor(anchor.date, anchor.createdAt, txn.date, txn.createdAt)) {
+      backdatedAfterAnchor += txn.amount
+    }
+  }
+  return { value: anchor.value, sumThroughAnchorDate, backdatedAfterAnchor }
 }

--- a/src/server/reporting.ts
+++ b/src/server/reporting.ts
@@ -25,8 +25,10 @@ import type { RunInTenantTransaction } from "./mutation-kit"
 // PER-154 / ADR-0038 — Reporting engine: net-worth time series.
 //
 // Computed-on-read from canonical rows (no BalanceSnapshot table). For each
-// sampled date the per-account NATIVE balance is derived (cash = opening anchor
-// + Σ flow ≤ T; tracked = latest valuation ≤ T, carried forward) and normalized
+// sampled date the per-account NATIVE balance is derived (cash = latest anchor
+// valuation ≤ T [opening | reconciliation | manual] + Σ afterAnchor flow ≤ T,
+// the twin of `computeCanonicalBalance`; tracked = latest valuation ≤ T) and
+// normalized
 // to the family base currency by as-of-date mark-to-market FX (greatest snapshot
 // asOfDate ≤ T). The heavy lifting is the pure `buildNetWorthSeries` fold in
 // `src/lib/net-worth.ts`, shared with the live `NetWorthInBaseCard` via
@@ -143,12 +145,13 @@ export async function getNetWorthSeriesForFamily({
           accountId: true,
           value: true,
           valuationDate: true,
+          createdAt: true,
           type: true,
         },
       }),
       tx.transaction.findMany({
         where: { familyId, deletedAt: null, date: { lt: upperBound } },
-        select: { accountId: true, amount: true, date: true },
+        select: { accountId: true, amount: true, date: true, createdAt: true },
       }),
       tx.fxRateSnapshot.findMany({
         where: {
@@ -171,12 +174,14 @@ export async function getNetWorthSeriesForFamily({
         accountId: row.accountId,
         value: row.value,
         valuationDate: toDateOnly(row.valuationDate),
+        createdAt: row.createdAt,
         type: row.type,
       })),
       transactions: transactions.map((row) => ({
         accountId: row.accountId,
         amount: row.amount,
         date: row.date,
+        createdAt: row.createdAt,
       })),
       snapshots: snapshots.map((row) => ({
         fromCurrency: row.fromCurrency,

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -2,6 +2,7 @@ import { createServerFn } from "@tanstack/react-start"
 import type { Valuation } from "@prisma/client"
 import { z } from "zod"
 import { allowsNegativeAssetBalance, type AccountType } from "@/lib/accounts"
+import { ANCHOR_VALUATION_TYPES } from "@/lib/net-worth"
 import {
   absMoney,
   addMoney,
@@ -74,7 +75,13 @@ const PUBLIC_VALUATION_TYPE_SET: ReadonlySet<string> = new Set(
 // observation-only and must never silently override a cash account's
 // ledger-derived balance. "opening" needs no special-casing here: it is
 // simply the earliest anchor in the chain.
-const ANCHOR_VALUATION_TYPES = ["opening", "reconciliation", "manual"] as const
+//
+// The set itself lives in the Prisma-free `@/lib/net-worth` so the batch
+// in-memory net-worth fold (`buildNetWorthSeries`) and this per-account DB
+// derivation share ONE source of truth — the two must stay in exact parity
+// (same anchor types, same `afterAnchor` date-OR-createdAt predicate). The
+// ADR-0038 §6 invariant test (series last point == Σ Account.balance) is the
+// guard that keeps them from drifting.
 
 /**
  * Raised for valuation-specific rejections (unknown/forbidden type, currency

--- a/tests/integration/net-worth-series.integration.ts
+++ b/tests/integration/net-worth-series.integration.ts
@@ -126,6 +126,28 @@ describe("net-worth time series (PER-154 / ADR-0038)", () => {
       user: owner.user,
     })
 
+  // Assert a fresh balance at a date — a `reconciliation` anchor. Pass the
+  // POSITIVE magnitude; the server signs it for the account class (a LIABILITY
+  // magnitude becomes a negative signed value). This is the Sure-migrated shape:
+  // the effective anchor is a reconciliation, never the `opening`.
+  const reconcile = (
+    owner: AuthenticatedOnboardedUser,
+    accountId: string,
+    magnitude: string,
+    date: string
+  ) =>
+    createValuationForFamily({
+      data: {
+        accountId,
+        value: magnitude,
+        type: "reconciliation",
+        valuationDate: new Date(`${date}T00:00:00.000Z`),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
   const series = (
     owner: AuthenticatedOnboardedUser,
     from: string,
@@ -146,6 +168,42 @@ describe("net-worth time series (PER-154 / ADR-0038)", () => {
     const point = points.find((p) => p.date === date)
     if (!point) throw new Error(`no point for ${date}`)
     return point
+  }
+
+  // Recompute the live card total exactly as `NetWorthInBaseCard` does (shared
+  // `normalizeNetWorthAt` over materialized balances + latest rate per currency),
+  // and the raw Σ signed Account.balance. For an all-base-currency family the two
+  // coincide; both must equal the series' last point (ADR-0038 §6).
+  const materializedCardTotal = async (owner: AuthenticatedOnboardedUser) => {
+    const accounts = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.account.findMany({
+        where: { familyId: owner.family.id },
+        select: { accountClass: true, currency: true, balance: true },
+      })
+    )
+    const sumSignedBalance = accounts.reduce((acc, a) => acc + a.balance, 0n)
+    const overview = await getFxOverviewForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    const latest = new Map<string, bigint>()
+    for (const rate of overview.rates) {
+      if (rate.toCurrency !== overview.baseCurrency) continue
+      if (!latest.has(rate.fromCurrency)) {
+        latest.set(rate.fromCurrency, BigInt(rate.rateScaled))
+      }
+    }
+    const balances: PointBalance[] = accounts.map((a) => ({
+      accountClass: a.accountClass,
+      currency: a.currency,
+      native: a.balance,
+    }))
+    const cardTotal = normalizeNetWorthAt(
+      balances,
+      (currency) => latest.get(currency) ?? null,
+      overview.baseCurrency
+    ).netWorth
+    return { cardTotal, sumSignedBalance }
   }
 
   // A rich mixed family used by several assertions.
@@ -383,6 +441,128 @@ describe("net-worth time series (PER-154 / ADR-0038)", () => {
     ).netWorth
 
     expect(last.netWorth).toBe(cardTotal.toString())
+  })
+
+  // ---- ADR-0038 §6 invariant: the reconciliation-anchor regression -----------
+  //
+  // The bug PER-204 fixes: the fold only recognized `opening` anchors, so any
+  // account whose effective anchor is a RECONCILIATION (every Sure-migrated /
+  // reconciled account) folded to 0. This is the guard that keeps the batch
+  // fold and `computeCanonicalBalance` in exact parity: the series' last point
+  // must equal the live card AND Σ Account.balance, on data that mirrors the
+  // failure — reconciliation-anchored accounts, a back-dated post-anchor txn
+  // (the createdAt disjunct), and a liability (the sign path).
+  test("last point == Σ Account.balance == card for reconciliation-anchored accounts (PER-204)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+
+    // Sure-migrated shape: opening 0, then the REAL anchor is a reconciliation.
+    const cash = await makeAccount(owner, {
+      name: "Migrated cash",
+      accountType: "DEPOSITORY",
+      openingBalance: "0",
+      openingDate: "2025-07-24",
+    })
+    const loan = await makeAccount(owner, {
+      name: "Migrated loan",
+      accountType: "LOAN",
+      openingBalance: "0",
+      openingDate: "2025-07-24",
+    })
+
+    // Pre-reconciliation activity the anchor absorbs (dated + recorded before it).
+    await expense(owner, cash.id, 999_999n, "2026-01-10")
+
+    // The effective anchors (latest <= now): a reconciliation on each account.
+    await reconcile(owner, cash.id, "210000000", "2026-06-30")
+    await reconcile(owner, loan.id, "128000000", "2026-06-30") // signed → -128,000,000
+
+    // Post-anchor flow, dated after the anchor.
+    await expense(owner, cash.id, 5_000_000n, "2026-07-05")
+    // Back-dated flow RECORDED after the reconciliation: dated before the anchor
+    // but created now → genuine post-anchor activity (the createdAt disjunct).
+    await expense(owner, cash.id, 1_000_000n, "2026-06-01")
+
+    const today = new Date().toISOString().slice(0, 10)
+    const result = await series(owner, "2025-07-01", today, "month")
+    const last = result.points[result.points.length - 1]
+    expect(last.date).toBe(today)
+
+    const { cardTotal, sumSignedBalance } = await materializedCardTotal(owner)
+    // The invariant (ADR-0038 §6). Under the old opening-only fold this was 0.
+    expect(last.netWorth).toBe(cardTotal.toString())
+    expect(last.netWorth).toBe(sumSignedBalance.toString())
+
+    // Materially non-zero, with the liability REDUCING net worth (sign path):
+    // cash 210,000,000 − 5,000,000 − 1,000,000 = 204,000,000; loan −128,000,000.
+    expect(last.netWorth).toBe("76000000")
+    expect(last.assets).toBe("204000000")
+    expect(last.liabilities).toBe("128000000")
+  })
+
+  // No-anchor edge (head-eng point 3): an account with NO anchor of any type
+  // must not be dropped. The fold folds it as an implicit opening-0 (Σ all flow),
+  // which equals the stored `Account.balance` that `computeCanonicalBalance`
+  // falls back to — so the invariant still holds.
+  test("no-anchor account: last point == Σ Account.balance (opening-0 fallback)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await setFamilyDefaults(owner, "IDR", "UTC")
+    const cash = await makeAccount(owner, {
+      name: "Anchor-less",
+      openingBalance: "0",
+      openingDate: "2026-01-01",
+    })
+    await expense(owner, cash.id, 40_000n, "2026-01-10")
+    // Soft-delete the opening valuation → the account now has zero anchors, while
+    // its materialized balance (−40,000) is untouched. Mirrors a raw/legacy row.
+    await harness.withFamily(owner.family.id, async (tx) =>
+      tx.valuation.updateMany({
+        where: { accountId: cash.id, type: "opening" },
+        data: { deletedAt: new Date() },
+      })
+    )
+
+    const today = new Date().toISOString().slice(0, 10)
+    const result = await series(owner, "2026-01-01", today, "month")
+    const last = result.points[result.points.length - 1]
+
+    const { cardTotal, sumSignedBalance } = await materializedCardTotal(owner)
+    expect(last.netWorth).toBe(sumSignedBalance.toString())
+    expect(last.netWorth).toBe(cardTotal.toString())
+    expect(last.netWorth).toBe("-40000") // opening-0 + Σ flow, not dropped to 0
+  })
+
+  // ---- interval bucketing ----------------------------------------------------
+  //
+  // day / week / month must each produce strictly time-ascending buckets, end at
+  // `to`, and agree with the live card at the last point (here `to` is past the
+  // family's last activity, so the last point equals the current balance). A
+  // date sampled by two intervals resolves to one identical value.
+  test("interval bucketing: day/week/month are monotonic and agree at the last point", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    await seedMixedFamily(owner)
+    const to = "2026-03-01" // no activity after this → last point == current balance
+    const [byDay, byWeek, byMonth] = await Promise.all([
+      series(owner, "2026-01-01", to, "day"),
+      series(owner, "2026-01-01", to, "week"),
+      series(owner, "2026-01-01", to, "month"),
+    ])
+    const { cardTotal } = await materializedCardTotal(owner)
+    for (const s of [byDay, byWeek, byMonth]) {
+      for (let i = 1; i < s.points.length; i++) {
+        // strictly ascending calendar dates (monotonic in time)
+        expect(s.points[i].date > s.points[i - 1].date).toBe(true)
+      }
+      expect(s.points[s.points.length - 1].date).toBe(to)
+      expect(s.points[s.points.length - 1].netWorth).toBe(cardTotal.toString())
+    }
+    // Finer intervals never yield fewer buckets than coarser ones.
+    expect(byDay.points.length).toBeGreaterThanOrEqual(byWeek.points.length)
+    expect(byWeek.points.length).toBeGreaterThanOrEqual(byMonth.points.length)
+    // A date sampled by both day and month resolves to one identical value.
+    expect(pointAt(byDay.points, "2026-02-01").netWorth).toBe(
+      pointAt(byMonth.points, "2026-02-01").netWorth
+    )
   })
 
   // ---- tenant isolation ------------------------------------------------------


### PR DESCRIPTION
## PER-204 — Dashboard Net Worth shows 0 (should be ~Rp 10.7M) + wrong period/interval data

### Root cause
The dashboard **Net Worth card is fed purely by the net-worth *series*** (`getNetWorthSeriesFn` → last point); it does **not** read `Account.balance`. That series is recomputed on-read by the pure fold `buildNetWorthSeries` / `nativeBalanceAt` in `src/lib/net-worth.ts`.

That fold still implemented the **pre-PER-201 single-anchor model**: for a cash (`transaction_flow`) account it recognized **only** `type="opening"` valuations as the balance anchor (`openingByAccount`), then added Σ *all* flow ≤ T. When an account has no `opening` valuation it hit `if (!opening) return 0n` and contributed **0 forever**.

But `computeCanonicalBalance` (`src/server/valuations.ts`, ADR-0043 §2 / PER-201) anchors cash accounts on the **latest of `opening | reconciliation | manual` ≤ now**, then adds Σ flow *after* that anchor (`date > anchorDate` **OR** `createdAt > anchorCreatedAt`). Every **Sure-migrated / reconciled** account is anchored by `reconciliation`, never `opening` — so the fold zeroed all of them while the materialized `Account.balance` was correct.

The "period/interval (day/week/month) shows wrong data" was the **same** bug: every bucket is produced by the same zeroed fold, so every point read ~0. The interval selectors are not independently broken.

**Not FX** (family + all accounts IDR → identity passthrough). **Not PER-201** (that fixed the server materializer; this is the separate in-memory reporting fold).

### Evidence (read-only, dev DB, family `cms1l3yb3…`)
- 43 live accounts; valuations = **1 `opening`** (value 0, on a 0-balance e-wallet) + **128 `reconciliation`**. Every ASSET/`transaction_flow` (37) + LIABILITY (4) account is reconciliation-anchored.
- Σ `Account.balance` = ASSET/transaction_flow `1,240,067,267` + ASSET/valuation `0` + LIABILITY `−171,000,000` = **`1,069,067,267`** minor (Rp 10,690,672.67) — the true net worth. Fold produced ~0.

### Fix
Rewrote the cash path in the fold to mirror `computeCanonicalBalance` exactly:
- active anchor = latest `ANCHOR_VALUATION_TYPES` valuation with `valuationDate ≤ T`;
- `balance(T) = anchor.value + Σ{anchorDate < date ≤ T} + Σ{date ≤ anchorDate ∧ createdAt > anchorCreatedAt}` — the two disjoint pieces of the PER-201 `afterAnchor` predicate (date disjunct + createdAt disjunct);
- **no-anchor** account → implicit **opening-0** (`0 + Σ all flow ≤ T`), matching `computeCanonicalBalance`'s stored-balance fallback (an account made the canonical way always has an `opening`, so this is only reached before the first anchor or for a raw/legacy row).

**Parity guardrails (two implementations of the anchor model):**
- `ANCHOR_VALUATION_TYPES` now lives in the Prisma-free `@/lib/net-worth` and is **imported by `valuations.ts`** — one source of truth for which types reset a cash balance (server depends on the pure module, never the reverse).
- A shared `isAfterAnchor(date OR createdAt)` predicate shape mirrors the Prisma `OR:[{date:{gt}},{createdAt:{gt}}]`. Cross-linking comments in both files; the ADR-0038 §6 invariant test is the enforcement.

Threaded `createdAt` on valuations + transactions through the `reporting.ts` selects.

### Tests
**Unit** (`src/lib/net-worth.test.ts`, 23 pass): reconciliation anchor with no opening (PER-204 regression); a later reconciliation absorbs prior flow; createdAt disjunct (back-dated txn recorded after the anchor is counted, absorbed otherwise); no-anchor opening-0 fallback; `market` is not a cash anchor.

**Integration — real Postgres** (`tests/integration/net-worth-series.integration.ts`, 12 pass):
- **ADR-0038 §6 invariant (mandatory):** series' **LAST point == live card == Σ `Account.balance`** on data mirroring the failure — reconciliation-anchored accounts, a back-dated post-anchor txn (createdAt disjunct), and a **liability** (sign path). Asserts `76,000,000` (cash 210M − 5M − 1M = 204M; loan −128M). Under the old opening-only fold this was 0.
- **No-anchor parity:** last point == Σ balance == card (`−40,000`), account not dropped.
- **Interval bucketing:** day/week/month strictly time-ascending, end at `to`, agree with the live card at the last point; a shared sample date resolves identically across intervals.

Also re-ran `valuation-primitive.integration.ts` (39 pass) to confirm the `ANCHOR_VALUATION_TYPES` constant-move didn't regress `computeCanonicalBalance`.

`vp check` green (format + lint + types, 227 files). Full integration + e2e delegated to CI (authoritative).

### No-anchor + liability-sign confirmation (head-eng asks)
- **Account creation always writes an `opening` valuation** (`src/server/accounts.ts:331`), so the no-anchor path is only reachable before the first anchor or for a raw insert; the fold folds it as opening-0, matching the stored-balance fallback — covered by unit + integration tests.
- **Liability sign:** `normalizeNetWorthAt` negates LIABILITY contributions (`liabilities += -base`), so net worth = assets − |liabilities|; the −128,000,000 loan **reduces** net worth in the invariant test (asserts `liabilities = 128,000,000`, `netWorth = 76,000,000`).

### Period/interval UX (assessment, not gold-plated)
The "wrong interval data" was the zeroed-fold symptom, now fixed. The control itself is DESIGN.md-consistent (shadcn `ToggleGroup` + `Label` + date-range-picker, URL-synced search params). One minor, separate rough edge worth a follow-up (not changed here to avoid scope creep): a very wide range × `day` interval exceeds `MAX_SERIES_POINTS` and surfaces a generic error card whose copy wrongly hints at DB migrations. Recommend a targeted "narrow the range or widen the interval" message in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
