### PR TITLE
fix(accounts): PER-207 — Update-value & opening-balance crash on formatted input

### DIFF
--- a/src/routes/_protected/accounts.tsx
+++ b/src/routes/_protected/accounts.tsx
@@ -64,7 +64,7 @@ import {
   type AccountType,
 } from "@/lib/accounts"
 import { CURRENCY_OPTIONS, formatCurrency } from "@/lib/currency"
-import { negateMoney, toMinorUnits } from "@/lib/money"
+import { negateMoney, parseUserInput } from "@/lib/money"
 import { normalizeNetWorthAt, type PointBalance } from "@/lib/net-worth"
 import { getFxOverviewFn } from "@/server/fx"
 import type { CurrencyCode } from "@/lib/data/currencies"
@@ -546,13 +546,21 @@ function AccountFormDialog({
           },
         })
       } else {
-        const openingMinor =
-          openingBalance.trim() === ""
-            ? "0"
-            : toMinorUnits(
-                openingBalance.trim(),
-                currency as CurrencyCode
-              ).toString()
+        // PER-207: parse the user-typed opening balance with `parseUserInput`
+        // (handles thousands separators / locale decimal, returns null on
+        // malformed) — NOT `toMinorUnits`, which expects a canonical decimal
+        // and throws on user-formatted strings.
+        let openingMinor = "0"
+        if (openingBalance.trim() !== "") {
+          const parsed = parseUserInput(
+            openingBalance.trim(),
+            currency as CurrencyCode
+          )
+          if (parsed === null) {
+            throw new Error("Enter a valid opening balance.")
+          }
+          openingMinor = parsed.toString()
+        }
         await createAccountFn({
           data: {
             name: name.trim(),
@@ -765,10 +773,14 @@ function ValuationActionDialog({
   })
 
   const currentMinor = BigInt(account.balance)
+  // PER-207: `parseUserInput` (locale-aware, returns null on malformed) — NOT
+  // `toMinorUnits`, which throws on user-formatted strings. This runs at RENDER
+  // on every keystroke, so a throw here crashes the dialog into the error
+  // boundary; null is the safe "not a valid amount yet" state instead.
   const targetMagnitude =
     valueInput.trim() === ""
       ? null
-      : toMinorUnits(valueInput.trim(), account.currency as CurrencyCode)
+      : parseUserInput(valueInput.trim(), account.currency as CurrencyCode)
   const signedTarget =
     targetMagnitude === null
       ? null

--- a/tests/e2e/valuation-formatted-input.e2e.ts
+++ b/tests/e2e/valuation-formatted-input.e2e.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-207 — the "Update value" dialog (and the account-create opening balance)
+// parsed the user's typed amount with `toMinorUnits`, which expects a canonical
+// decimal and THROWS on user-formatted strings. Because the parse runs at
+// RENDER on every keystroke, a formatted input (e.g. Indonesian "5.571.313,20")
+// crashed the dialog into the error boundary and broke the Accounts page. Fixed
+// by parsing with the locale-aware `parseUserInput` (returns null on malformed,
+// never throws). This drives the real dialog end to end with a formatted value.
+
+test.describe("valuation formatted input (PER-207)", () => {
+  test("Update value accepts an Indonesian-formatted amount without crashing", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const goldName = `E2E Gold ${suffix}`
+
+    // --- Create a Tracked Asset (valuation-tracked) account, opening value 0 ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(goldName)
+    await page.getByRole("dialog").getByRole("combobox").first().click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByLabel("Opening balance").fill("0")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Update value with an Indonesian-formatted amount (the repro) ---
+    await page.getByRole("button", { name: "Update value" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    // Typing the formatted value must NOT crash the dialog (the PER-207 bug).
+    await page.getByLabel(/New value/).fill("5.571.313,20")
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Update value" })
+      .click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // The account page still renders (no error boundary) and shows the parsed
+    // value: "5.571.313,20" → Rp 5,571,313.20.
+    await waitForHydration(page)
+    await expect(page.getByText("Rp 5,571,313.20")).toBeVisible()
+    await expect(page.getByText(goldName)).toBeVisible()
+  })
+})

--- a/tests/e2e/valuation-formatted-input.e2e.ts
+++ b/tests/e2e/valuation-formatted-input.e2e.ts
@@ -42,9 +42,11 @@ test.describe("valuation formatted input (PER-207)", () => {
     await expect(page.getByRole("dialog")).toHaveCount(0)
 
     // The account page still renders (no error boundary) and shows the parsed
-    // value: "5.571.313,20" → Rp 5,571,313.20.
+    // value: "5.571.313,20" → Rp 5,571,313.20. The amount appears more than once
+    // (account card + net-worth summary), so assert at least one is visible —
+    // the point is that it parsed and rendered at all, not the exact count.
     await waitForHydration(page)
-    await expect(page.getByText("Rp 5,571,313.20")).toBeVisible()
+    await expect(page.getByText("Rp 5,571,313.20").first()).toBeVisible()
     await expect(page.getByText(goldName)).toBeVisible()
   })
 })


### PR DESCRIPTION
## Problem

Reported while dogfooding: opening the **Update value** dialog on a Tracked Asset (gold) account and typing an Indonesian-formatted amount (`5.571.313,20`) crashed the dialog into the error boundary and broke the whole Accounts page:

```
TypeError: toMinorUnits: malformed decimal: "5.571.313"
```

## Root cause

Two sites in `src/routes/_protected/accounts.tsx` parsed the user's typed amount with `toMinorUnits`, which expects a **canonical** decimal string and **throws** on user-formatted input (thousands separators, locale decimal comma). The valuation dialog does this parse at **render** on every keystroke, so the throw surfaced as a render-time crash — not a catchable submit error.

## Fix

Swap both sites to the locale-aware `parseUserInput` (`money.ts`), which handles thousands separators / decimal comma and returns `null` on malformed input instead of throwing:

- **ValuationActionDialog** (render-time): `null` becomes the safe "not a valid amount yet" state — no crash.
- **Opening balance** (submit handler): `null` throws a friendly `Enter a valid opening balance.` validation error.

Both return the same branded `Money` (bigint) type, so all downstream arithmetic (`signedTarget`, `negateMoney`, drift) is unchanged.

## Test

Adds `tests/e2e/valuation-formatted-input.e2e.ts` — creates a Tracked Asset account, opens **Update value**, fills `5.571.313,20`, submits, and asserts the account reconciles to **Rp 5,571,313.20** with no error boundary.

Verified locally: `vp check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1