### PR TITLE
fix(transactions): PER-209 — hydrate split allocation on edit (+ emerald frame when balanced)

### DIFF
--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1085,142 +1085,157 @@ function SplitEntriesPanel({
       ?.currency ?? "IDR"
 
   return (
-    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50/40 p-3 dark:border-amber-800 dark:bg-amber-950/20">
-      <p className="text-xs font-semibold tracking-wider text-amber-700 uppercase dark:text-amber-400">
-        Category Allocation
-      </p>
+    <form.Subscribe selector={(state) => state.values.amount}>
+      {(parentAmount) => {
+        // PER-209 polish: when the allocation is fully balanced, promote the
+        // whole panel frame to emerald (matching the status line below), else
+        // keep the amber "still allocating" frame. Light + dark variants.
+        const splitTotal = splitEntries.reduce((s, e) => s + e.amount, 0)
+        const remaining = parentAmount - splitTotal
+        const isBalanced = remaining === 0 && parentAmount > 0
 
-      <div className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] gap-2 px-0.5">
-        <span className="text-xs font-medium text-muted-foreground">
-          Category
-        </span>
-        <span className="text-xs font-medium text-muted-foreground">
-          Item Note
-        </span>
-        <span className="text-right text-xs font-medium text-muted-foreground">
-          Amount
-        </span>
-        <span />
-      </div>
-
-      <div className="space-y-2">
-        {splitEntries.map((entry) => (
+        return (
           <div
-            key={entry.id}
-            className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] items-center gap-2"
+            className={cn(
+              "space-y-3 rounded-lg border p-3",
+              isBalanced
+                ? "border-emerald-200 bg-emerald-50/40 dark:border-emerald-800 dark:bg-emerald-950/20"
+                : "border-amber-200 bg-amber-50/40 dark:border-amber-800 dark:bg-amber-950/20"
+            )}
           >
-            <select
-              aria-label="Category for split entry"
-              name={`split-category-${entry.id}`}
-              id={`split-category-${entry.id}`}
-              className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs"
-              value={entry.categoryId ?? ""}
-              onChange={(e) =>
-                setSplitEntries((prev) =>
-                  prev.map((en) =>
-                    en.id === entry.id
-                      ? {
-                          ...en,
-                          categoryId: e.target.value,
-                        }
-                      : en
-                  )
-                )
-              }
+            <p
+              className={cn(
+                "text-xs font-semibold tracking-wider uppercase",
+                isBalanced
+                  ? "text-emerald-700 dark:text-emerald-400"
+                  : "text-amber-700 dark:text-amber-400"
+              )}
             >
-              <option value="">-- Select --</option>
-              <CategoryOptions
-                categories={formData?.categories}
-                type={activeTab}
-              />
-            </select>
+              Category Allocation
+            </p>
 
-            <Input
-              aria-label="Description for split entry"
-              name={`split-desc-${entry.id}`}
-              id={`split-desc-${entry.id}`}
-              placeholder="e.g., Soap & Shampoo"
-              className="h-8 text-sm"
-              value={entry.description}
-              onChange={(e) =>
-                setSplitEntries((prev) =>
-                  prev.map((en) =>
-                    en.id === entry.id
-                      ? {
-                          ...en,
-                          description: e.target.value,
-                        }
-                      : en
-                  )
-                )
-              }
-            />
+            <div className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] gap-2 px-0.5">
+              <span className="text-xs font-medium text-muted-foreground">
+                Category
+              </span>
+              <span className="text-xs font-medium text-muted-foreground">
+                Item Note
+              </span>
+              <span className="text-right text-xs font-medium text-muted-foreground">
+                Amount
+              </span>
+              <span />
+            </div>
 
-            <Input
-              aria-label="Amount for split entry"
-              name={`split-amount-${entry.id}`}
-              id={`split-amount-${entry.id}`}
-              type="number"
-              placeholder="0"
-              className="h-8 text-right text-sm font-semibold"
-              value={entry.amount || ""}
-              onChange={(e) =>
-                setSplitEntries((prev) =>
-                  prev.map((en) =>
-                    en.id === entry.id
-                      ? {
-                          ...en,
-                          amount: Number(e.target.value),
-                        }
-                      : en
-                  )
-                )
-              }
-            />
+            <div className="space-y-2">
+              {splitEntries.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="grid grid-cols-[1fr_1.6fr_6rem_1.5rem] items-center gap-2"
+                >
+                  <select
+                    aria-label="Category for split entry"
+                    name={`split-category-${entry.id}`}
+                    id={`split-category-${entry.id}`}
+                    className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs"
+                    value={entry.categoryId ?? ""}
+                    onChange={(e) =>
+                      setSplitEntries((prev) =>
+                        prev.map((en) =>
+                          en.id === entry.id
+                            ? {
+                                ...en,
+                                categoryId: e.target.value,
+                              }
+                            : en
+                        )
+                      )
+                    }
+                  >
+                    <option value="">-- Select --</option>
+                    <CategoryOptions
+                      categories={formData?.categories}
+                      type={activeTab}
+                    />
+                  </select>
 
-            <button
+                  <Input
+                    aria-label="Description for split entry"
+                    name={`split-desc-${entry.id}`}
+                    id={`split-desc-${entry.id}`}
+                    placeholder="e.g., Soap & Shampoo"
+                    className="h-8 text-sm"
+                    value={entry.description}
+                    onChange={(e) =>
+                      setSplitEntries((prev) =>
+                        prev.map((en) =>
+                          en.id === entry.id
+                            ? {
+                                ...en,
+                                description: e.target.value,
+                              }
+                            : en
+                        )
+                      )
+                    }
+                  />
+
+                  <Input
+                    aria-label="Amount for split entry"
+                    name={`split-amount-${entry.id}`}
+                    id={`split-amount-${entry.id}`}
+                    type="number"
+                    placeholder="0"
+                    className="h-8 text-right text-sm font-semibold"
+                    value={entry.amount || ""}
+                    onChange={(e) =>
+                      setSplitEntries((prev) =>
+                        prev.map((en) =>
+                          en.id === entry.id
+                            ? {
+                                ...en,
+                                amount: Number(e.target.value),
+                              }
+                            : en
+                        )
+                      )
+                    }
+                  />
+
+                  <button
+                    type="button"
+                    disabled={splitEntries.length <= 2}
+                    onClick={() =>
+                      setSplitEntries((prev) =>
+                        prev.filter((en) => en.id !== entry.id)
+                      )
+                    }
+                    className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-red-100 hover:text-red-600 disabled:opacity-30"
+                  >
+                    <IconX className="size-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <Button
               type="button"
-              disabled={splitEntries.length <= 2}
+              variant="ghost"
+              size="sm"
+              className="h-7 w-full border border-dashed text-xs text-muted-foreground hover:border-amber-400 hover:text-amber-700"
               onClick={() =>
-                setSplitEntries((prev) =>
-                  prev.filter((en) => en.id !== entry.id)
-                )
+                setSplitEntries((prev) => [...prev, createBlankSplitEntry()])
               }
-              className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-red-100 hover:text-red-600 disabled:opacity-30"
             >
-              <IconX className="size-3.5" />
-            </button>
-          </div>
-        ))}
-      </div>
+              <IconPlus className="mr-1 size-3" /> Add Row
+            </Button>
 
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 w-full border border-dashed text-xs text-muted-foreground hover:border-amber-400 hover:text-amber-700"
-        onClick={() =>
-          setSplitEntries((prev) => [...prev, createBlankSplitEntry()])
-        }
-      >
-        <IconPlus className="mr-1 size-3" /> Add Row
-      </Button>
-
-      <form.Subscribe selector={(state) => state.values.amount}>
-        {(parentAmount) => {
-          const splitTotal = splitEntries.reduce((s, e) => s + e.amount, 0)
-          const remaining = parentAmount - splitTotal
-
-          if (remaining === 0 && parentAmount > 0) {
-            return (
+            {isBalanced ? (
               <p className="flex items-center gap-1.5 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
                 <span>✓</span>
                 <span>Perfect! All funds allocated</span>
               </p>
-            )
-          }
-          if (remaining > 0) {
-            return (
+            ) : remaining > 0 ? (
               <p className="flex items-center gap-1.5 rounded-md bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
                 <span>○</span>
                 <span>
@@ -1232,23 +1247,22 @@ function SplitEntriesPanel({
                   unallocated
                 </span>
               </p>
-            )
-          }
-          return (
-            <p className="flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950/30 dark:text-red-400">
-              <span>✕</span>
-              <span>
-                Over allocated by{" "}
-                <strong>
-                  {getCurrencySymbol(selectedAccountCurrency)}{" "}
-                  {Math.abs(remaining).toLocaleString("en-US")}
-                </strong>
-              </span>
-            </p>
-          )
-        }}
-      </form.Subscribe>
-    </div>
+            ) : (
+              <p className="flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950/30 dark:text-red-400">
+                <span>✕</span>
+                <span>
+                  Over allocated by{" "}
+                  <strong>
+                    {getCurrencySymbol(selectedAccountCurrency)}{" "}
+                    {Math.abs(remaining).toLocaleString("en-US")}
+                  </strong>
+                </span>
+              </p>
+            )}
+          </div>
+        )
+      }}
+    </form.Subscribe>
   )
 }
 

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -1066,6 +1066,57 @@ function CategoryField({
   )
 }
 
+// PER-209 polish: the allocation status line. Extracted to a component with
+// early returns (instead of a nested ternary) so the three states — balanced /
+// under-allocated / over-allocated — stay readable and each keeps its own
+// styling + copy.
+function SplitAllocationStatus({
+  isBalanced,
+  remaining,
+  currency,
+}: {
+  isBalanced: boolean
+  remaining: number
+  currency: string
+}) {
+  if (isBalanced) {
+    return (
+      <p className="flex items-center gap-1.5 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+        <span>✓</span>
+        <span>Perfect! All funds allocated</span>
+      </p>
+    )
+  }
+
+  if (remaining > 0) {
+    return (
+      <p className="flex items-center gap-1.5 rounded-md bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
+        <span>○</span>
+        <span>
+          Remaining{" "}
+          <strong>
+            {getCurrencySymbol(currency)} {remaining.toLocaleString("en-US")}
+          </strong>{" "}
+          unallocated
+        </span>
+      </p>
+    )
+  }
+
+  return (
+    <p className="flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950/30 dark:text-red-400">
+      <span>✕</span>
+      <span>
+        Over allocated by{" "}
+        <strong>
+          {getCurrencySymbol(currency)}{" "}
+          {Math.abs(remaining).toLocaleString("en-US")}
+        </strong>
+      </span>
+    </p>
+  )
+}
+
 function SplitEntriesPanel({
   activeTab,
   form,
@@ -1084,12 +1135,24 @@ function SplitEntriesPanel({
     formData?.accounts.find((a) => a.id === form.getFieldValue("accountId"))
       ?.currency ?? "IDR"
 
+  // Panel-level mutation helpers keep the JSX event handlers shallow one-liners
+  // (avoids nesting setSplitEntries → map/filter callbacks inside the render
+  // prop, which otherwise breaches the 5-level function-nesting limit).
+  const updateSplitEntry = (id: string, patch: Partial<SplitEntryValue>) =>
+    setSplitEntries((prev) =>
+      prev.map((en) => (en.id === id ? { ...en, ...patch } : en))
+    )
+  const removeSplitEntry = (id: string) =>
+    setSplitEntries((prev) => prev.filter((en) => en.id !== id))
+  const addSplitEntry = () =>
+    setSplitEntries((prev) => [...prev, createBlankSplitEntry()])
+
   return (
     <form.Subscribe selector={(state) => state.values.amount}>
       {(parentAmount) => {
-        // PER-209 polish: when the allocation is fully balanced, promote the
-        // whole panel frame to emerald (matching the status line below), else
-        // keep the amber "still allocating" frame. Light + dark variants.
+        // When the allocation is fully balanced, promote the whole panel frame
+        // to emerald (matching the status line), else keep the amber "still
+        // allocating" frame. Light + dark variants.
         const splitTotal = splitEntries.reduce((s, e) => s + e.amount, 0)
         const remaining = parentAmount - splitTotal
         const isBalanced = remaining === 0 && parentAmount > 0
@@ -1140,16 +1203,7 @@ function SplitEntriesPanel({
                     className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs"
                     value={entry.categoryId ?? ""}
                     onChange={(e) =>
-                      setSplitEntries((prev) =>
-                        prev.map((en) =>
-                          en.id === entry.id
-                            ? {
-                                ...en,
-                                categoryId: e.target.value,
-                              }
-                            : en
-                        )
-                      )
+                      updateSplitEntry(entry.id, { categoryId: e.target.value })
                     }
                   >
                     <option value="">-- Select --</option>
@@ -1167,16 +1221,9 @@ function SplitEntriesPanel({
                     className="h-8 text-sm"
                     value={entry.description}
                     onChange={(e) =>
-                      setSplitEntries((prev) =>
-                        prev.map((en) =>
-                          en.id === entry.id
-                            ? {
-                                ...en,
-                                description: e.target.value,
-                              }
-                            : en
-                        )
-                      )
+                      updateSplitEntry(entry.id, {
+                        description: e.target.value,
+                      })
                     }
                   />
 
@@ -1189,27 +1236,16 @@ function SplitEntriesPanel({
                     className="h-8 text-right text-sm font-semibold"
                     value={entry.amount || ""}
                     onChange={(e) =>
-                      setSplitEntries((prev) =>
-                        prev.map((en) =>
-                          en.id === entry.id
-                            ? {
-                                ...en,
-                                amount: Number(e.target.value),
-                              }
-                            : en
-                        )
-                      )
+                      updateSplitEntry(entry.id, {
+                        amount: Number(e.target.value),
+                      })
                     }
                   />
 
                   <button
                     type="button"
                     disabled={splitEntries.length <= 2}
-                    onClick={() =>
-                      setSplitEntries((prev) =>
-                        prev.filter((en) => en.id !== entry.id)
-                      )
-                    }
+                    onClick={() => removeSplitEntry(entry.id)}
                     className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-red-100 hover:text-red-600 disabled:opacity-30"
                   >
                     <IconX className="size-3.5" />
@@ -1223,42 +1259,16 @@ function SplitEntriesPanel({
               variant="ghost"
               size="sm"
               className="h-7 w-full border border-dashed text-xs text-muted-foreground hover:border-amber-400 hover:text-amber-700"
-              onClick={() =>
-                setSplitEntries((prev) => [...prev, createBlankSplitEntry()])
-              }
+              onClick={addSplitEntry}
             >
               <IconPlus className="mr-1 size-3" /> Add Row
             </Button>
 
-            {isBalanced ? (
-              <p className="flex items-center gap-1.5 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
-                <span>✓</span>
-                <span>Perfect! All funds allocated</span>
-              </p>
-            ) : remaining > 0 ? (
-              <p className="flex items-center gap-1.5 rounded-md bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
-                <span>○</span>
-                <span>
-                  Remaining{" "}
-                  <strong>
-                    {getCurrencySymbol(selectedAccountCurrency)}{" "}
-                    {remaining.toLocaleString("en-US")}
-                  </strong>{" "}
-                  unallocated
-                </span>
-              </p>
-            ) : (
-              <p className="flex items-center gap-1.5 rounded-md bg-red-50 px-3 py-2 text-sm font-medium text-red-600 dark:bg-red-950/30 dark:text-red-400">
-                <span>✕</span>
-                <span>
-                  Over allocated by{" "}
-                  <strong>
-                    {getCurrencySymbol(selectedAccountCurrency)}{" "}
-                    {Math.abs(remaining).toLocaleString("en-US")}
-                  </strong>
-                </span>
-              </p>
-            )}
+            <SplitAllocationStatus
+              isBalanced={isBalanced}
+              remaining={remaining}
+              currency={selectedAccountCurrency}
+            />
           </div>
         )
       }}

--- a/src/routes/_protected/transactions.tsx
+++ b/src/routes/_protected/transactions.tsx
@@ -700,6 +700,12 @@ function TransactionsPage() {
                   | "PENDING"
                   | "CLEARED"
                   | "RECONCILED",
+                // PER-209: hydrate the split allocation on edit. Without these
+                // two fields the modal's useState initializers fall back to a
+                // blank [blank, blank] allocation with isSplit=false, so an
+                // edited split transaction loses its category rows entirely.
+                isSplit: editingTrx.isSplit,
+                splitEntries: editingTrx.splitEntries,
               }}
               onClose={() => setEditingTrx(null)}
               customTrigger={<span className="hidden" />}

--- a/tests/e2e/split-edit-hydration.e2e.ts
+++ b/tests/e2e/split-edit-hydration.e2e.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-209 — editing a SPLIT transaction must hydrate its allocation.
+//
+// The edit modal is opened from transactions.tsx with an `editData` object that
+// (before the fix) was rebuilt field-by-field and OMITTED `isSplit` +
+// `splitEntries`. The modal already hydrates its split state from those two
+// fields in its useState initializers, so dropping them made an edited split
+// fall back to a blank [blank, blank] allocation with the toggle OFF — the
+// Category Allocation panel vanished and the categories/amounts were lost.
+//
+// This spec drives the real browser: it quick-creates two categories, records a
+// balanced 2-row split expense, submits it, then reopens that transaction for
+// EDIT and asserts the allocation is fully hydrated (toggle ON, both rows with
+// their categories selected and amounts populated, frame reports "balanced").
+
+test.describe("editing a split transaction hydrates its allocation", () => {
+  test("reopening a split for edit restores toggle, categories, and amounts", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    // PER-183: onboarding no longer seeds a starter account — create one so the
+    // transaction form's account dropdown has something to select.
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill("E2E Split Edit Fixture")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.goto("/transactions")
+    await waitForHydration(page)
+
+    const uniqueSuffix = Date.now().toString(36)
+    const description = `E2E split edit ${uniqueSuffix}`
+    const categoryA = `E2E Split Cat A ${uniqueSuffix}`
+    const categoryB = `E2E Split Cat B ${uniqueSuffix}`
+
+    // --- Record a balanced 2-row SPLIT expense ---
+    await page.getByRole("button", { name: "New Transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    await page.getByLabel("Description *").fill(description)
+    await page.getByLabel("Amount *").fill("100000")
+    await page.locator('select[name="accountId"]').selectOption({ index: 1 })
+
+    // Quick-create two categories via the parent Category field so the split
+    // rows have real categories to choose from (the ephemeral e2e DB seeds no
+    // system categories). Each "Create ..." persists the category family-wide,
+    // so both remain available to the split-row selects after toggling split on.
+    await page.getByLabel("Category *").click()
+    await page.getByPlaceholder("Search categories...").fill(categoryA)
+    await page
+      .getByRole("option", { name: `Create category "${categoryA}"` })
+      .click()
+    await expect(page.getByLabel("Category *")).toContainText(categoryA)
+
+    await page.getByLabel("Category *").click()
+    await page.getByPlaceholder("Search categories...").fill(categoryB)
+    await page
+      .getByRole("option", { name: `Create category "${categoryB}"` })
+      .click()
+    await expect(page.getByLabel("Category *")).toContainText(categoryB)
+
+    // Activate split mode; the Category Allocation panel appears with 2 rows.
+    await page.locator("#split-mode-toggle").click()
+    await expect(page.getByText("Category Allocation")).toBeVisible()
+
+    const splitCategories = page.getByLabel("Category for split entry")
+    const splitDescriptions = page.getByLabel("Description for split entry")
+    const splitAmounts = page.getByLabel("Amount for split entry")
+
+    await splitCategories.nth(0).selectOption({ label: categoryA })
+    await splitDescriptions.nth(0).fill("Groceries part")
+    await splitAmounts.nth(0).fill("60000")
+
+    await splitCategories.nth(1).selectOption({ label: categoryB })
+    await splitDescriptions.nth(1).fill("Household part")
+    await splitAmounts.nth(1).fill("40000")
+
+    // Balanced allocation → status line confirms all funds allocated.
+    await expect(page.getByText("Perfect! All funds allocated")).toBeVisible()
+
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(description)).toBeVisible()
+
+    // --- Reopen that transaction for EDIT ---
+    await page.getByRole("button", { name: "Edit Transaction" }).first().click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    // The split toggle must be ON and the allocation panel present (this is the
+    // exact regression PER-209 fixes — previously both were lost on edit).
+    await expect(page.locator("#split-mode-toggle")).toBeChecked()
+    await expect(page.getByText("Category Allocation")).toBeVisible()
+
+    // Both rows are hydrated: two category selects, both with a real (non-empty)
+    // category value selected, and their amounts populated.
+    const editCategories = page.getByLabel("Category for split entry")
+    const editDescriptions = page.getByLabel("Description for split entry")
+    const editAmounts = page.getByLabel("Amount for split entry")
+
+    await expect(editCategories).toHaveCount(2)
+    // A non-empty value proves a real categoryId is selected (the placeholder
+    // "-- Select --" option has value ""), which only round-trips if the
+    // allocation's categoryId was hydrated from editData.splitEntries.
+    await expect(editCategories.nth(0)).toHaveValue(/.+/)
+    await expect(editCategories.nth(1)).toHaveValue(/.+/)
+
+    await expect(editDescriptions.nth(0)).toHaveValue("Groceries part")
+    await expect(editDescriptions.nth(1)).toHaveValue("Household part")
+
+    await expect(editAmounts.nth(0)).toHaveValue("60000")
+    await expect(editAmounts.nth(1)).toHaveValue("40000")
+
+    // Bundled polish: a fully balanced allocation still reports success on edit.
+    await expect(page.getByText("Perfect! All funds allocated")).toBeVisible()
+  })
+})


### PR DESCRIPTION
## PER-209 — Editing a split transaction loses its allocation

### Root cause
The singleton edit modal in `src/routes/_protected/transactions.tsx` opened with an `editData={{...}}` object rebuilt field-by-field from `editingTrx` that **omitted `isSplit` and `splitEntries`**. The modal (`src/components/transaction-form-modal.tsx`) already hydrates its split state from `editData.splitEntries` + `editData.isSplit` in its `useState` initializers — but because those two fields were never passed, `editData.splitEntries` was `undefined`, so the form fell back to `[blank, blank]` with `isSplit=false`. Result: opening a split transaction for edit hid the Category Allocation panel and lost every category/amount, making splits un-editable.

### Fix
Pass `isSplit` and `splitEntries` from `editingTrx` into the `editData` literal. `editingTrx` is already typed as the modal's `editData` prop type (and `TransactionRow`'s `onEdit` already maps both fields onto it), so the types line up with no casts. Minimal and contained.

**Regression guard for PER-205:** the persistently-mounted "New Transaction" singleton renders with no `editData`, so it still resets split state on a fresh entry. Only edit mode hydrates from `editData`.

### Bundled UX polish (same panel)
When the allocation is fully balanced (`remaining === 0 && parentAmount > 0`), the **panel frame itself** now turns emerald (border + subtle bg, light + dark) instead of only the status line — implemented by subscribing to the parent `amount` at the panel level via `form.Subscribe` and applying emerald/amber classes with `cn()`. The now-redundant inner amount subscription is collapsed into the same one; the existing status text is preserved unchanged.

### Test evidence
New `tests/e2e/split-edit-hydration.e2e.ts`: onboard → quick-create two categories → record a balanced 2-row split expense → submit → reopen for edit → assert the toggle is ON, both category rows are present with non-empty selected categories, descriptions and amounts (`60000` / `40000`) are populated, and the balanced status still shows.

```
✓  1 tests/e2e/split-edit-hydration.e2e.ts:19:3 › editing a split transaction hydrates its allocation › reopening a split for edit restores toggle, categories, and amounts (22.5s)
  1 passed (47.6s)
```

Verified the spec fails **without** the fix (proof it's a real regression guard):

```
✘  1 tests/e2e/split-edit-hydration.e2e.ts:19:3 › ... (35.7s)
    Error: expect(locator).toBeChecked() failed
      - unexpected value "unchecked"
    > 96 |     await expect(page.locator("#split-mode-toggle")).toBeChecked()
  1 failed
```

`vp check` clean:

```
pass: All 312 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 231 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
