### PR TITLE
feat(debt): PER-212 — person-to-person debt (counterparty + Utang-Piutang view)

### DIFF
--- a/docs/adr/0049-counterparty-personal-debt.md
+++ b/docs/adr/0049-counterparty-personal-debt.md
@@ -1,0 +1,126 @@
+# ADR-0049 — Counterparty layer for person-to-person debt (Utang-Piutang)
+
+|                   |                |
+| ----------------- | -------------- |
+| **Status**        | Accepted       |
+| **Date**          | 2026-08-01     |
+| **Accepted**      | 2026-08-01     |
+| **Deciders**      | Hendri Permana |
+| **Supersedes**    | —              |
+| **Superseded by** | —              |
+| **Amends**        | —              |
+
+## Context
+
+PER-211 (epic) makes informal person-to-person lending and borrowing — the
+Indonesian _Utang-Piutang_ everyone actually does with friends and family
+("Budi still owes me Rp 200k", "I borrowed Rp 1.5jt from Abah") — a
+first-class part of Permoney. PER-212 is Slice 1: the ad-hoc core. Installment
+schedules, payment reminders, and interest accrual are later slices of the
+same epic and are explicitly out of scope here.
+
+The temptation is to build a dedicated "debt" sub-ledger: a `Debt` table, its
+own balance field, its own payment rows. That would be a second source of
+financial truth living beside the canonical `Transaction`/`Account` ledger,
+and every ledger invariant we already enforce (double-entry, signed amounts,
+atomic balance updates, idempotency, tenant-reference validation, RLS scoping,
+append-only audit, net-worth inclusion) would have to be re-implemented and
+re-tested for it — or, more likely, quietly skipped. That is exactly the
+"weakens future adaptability / ledger correctness" shortcut the project
+doctrine forbids (CLAUDE.md §5).
+
+## Decision
+
+**A person-debt is not a new ledger concept. It is an ordinary account,
+flagged.**
+
+1. **Person = `Merchant.kind = "person"`.** A friend/family contact is a
+   `Merchant` with the new `kind` discriminator (`"business"` — the classic
+   payee — vs `"person"`). This unifies "payee" and "debt party" into one
+   counterparty concept (the PER-189 extension point), so a person can later
+   double as a spend-analytics dimension without a parallel entity. `kind` is
+   domain-constrained by a DB CHECK (`Database Is the Law`).
+
+2. **A debt is a `RECEIVABLE`/`LOAN` account linked to that person.**
+   `Account.counterpartyMerchantId` is a nullable link to the person
+   `Merchant` this account represents. Its **presence is the only
+   discriminator** of an "informal person-debt account":
+
+   - `RECEIVABLE` (ASSET) — they owe you (_piutang_).
+   - `LOAN` (LIABILITY) — you owe them (_utang_).
+
+   These are existing account types with existing ledger behavior. Nothing
+   about balance math, sign rules, or valuation changes. The link is a
+   **tenant-safe composite FK** to `Merchant(id, familyId)` (Pattern A,
+   ADR-0010) with `MATCH SIMPLE`, so a NULL link is unchecked and a non-NULL
+   link can only reference a `Merchant` in the same family. Foreign keys alone
+   are not tenant isolation; the composite target is. A `kind = "person"` +
+   type ∈ {RECEIVABLE, LOAN} check is enforced in the account-create path,
+   with the composite FK as the durable backstop.
+
+3. **Lend / borrow / repay are ordinary transfers.** Every debt movement is
+   routed through the SAME `createTransactionForFamily` the rest of the app
+   uses. The module (`src/server/debts.ts`) only orchestrates — ensure the
+   right person-debt account exists (create-if-absent, idempotent by lookup),
+   then post a transfer in the correct direction. The `kind`
+   (`funds_movement` / `liability_draw` / `loan_payment`) is **derived by the
+   ledger core** from the two account types, never passed in:
+
+   | Flow             | Transfer          | Derived kind     | Effect                  |
+   | ---------------- | ----------------- | ---------------- | ----------------------- |
+   | Lend             | cash → RECEIVABLE | `funds_movement` | their debt to you grows |
+   | Borrow           | LOAN → cash       | `liability_draw` | your debt to them grows |
+   | Repay receivable | RECEIVABLE → cash | `funds_movement` | they pay you back       |
+   | Repay loan       | cash → LOAN       | `loan_payment`   | you pay them back       |
+
+   Because these are ordinary transfers, double-entry, idempotency replay,
+   audit, RLS, and atomic `{increment/decrement}` balance updates all hold
+   **for free**. There is no debt sub-ledger.
+
+4. **Presentation split, not a data split.** Person-debt accounts are hidden
+   from the main Accounts list (`getAccountsForFamily({ includeCounterparty:
+false })` filters them; the default stays `true` so every existing caller
+   and the net-worth math keep seeing them). They live in the new
+   Utang-Piutang view, which lists each person with a signed **net position**
+   (Σ balances of their linked accounts, per currency) and a **settled**
+   ("Lunas") flag when every position nets to zero.
+
+5. **Net-worth total is invariant; only the breakdown changes.** Because a
+   person-debt is a RECEIVABLE(ASSET)/LOAN(LIABILITY) account, it is already
+   inside the net-worth total by construction (`normalizeNetWorthAt`,
+   ADR-0038). This slice does **not** change the total. The only change is
+   presentation: the net-worth card renders one grouped **"Personal debts
+   (net)"** line (the base-currency net contribution of just the
+   counterparty-linked accounts) instead of listing each debt account. The
+   grand total is still computed over ALL accounts. This is proven by a
+   real-Postgres test asserting the total is byte-identical whether or not the
+   debt accounts are counterparty-linked.
+
+## Consequences
+
+- **Uniform ledger.** No second balance authority. A person-debt account is
+  reconcilable, auditable, importable, and net-worth-correct with zero extra
+  machinery. If the ledger core changes, debts inherit the change.
+- **Cheap future slices.** Installments/reminders/interest (later PER-211
+  slices) can attach schedule/rule metadata to the person and post the same
+  ordinary transfers; the money model does not need to move.
+- **Multi-currency honesty.** A person lent-to in two currencies gets two
+  linked accounts and two net positions; the view reports per-currency nets
+  rather than summing across currencies. Cross-currency debt transfers reuse
+  the ledger's existing same-currency constraint for now.
+- **Cost.** One nullable column, one discriminator column, one composite FK,
+  one index. The person-debt account currency is pinned to the cash account's
+  currency at first use to keep every debt transfer same-currency.
+- **Migration safety.** Additive only: `Merchant.kind` defaults to
+  `"business"` (every existing merchant keeps its meaning) and
+  `Account.counterpartyMerchantId` defaults to NULL (every existing account is
+  a normal account). No backfill, no data movement.
+
+## References
+
+- PER-211 (epic), PER-212 (this slice)
+- ADR-0008 — core domain model and ledger boundaries
+- ADR-0010 — tenant composite-FK invariants (Pattern A)
+- ADR-0038 — net-worth computed-on-read (the total this slice must not shift)
+- PER-189 — merchant quick-create (the `kind` extension point)
+- `docs/account-taxonomy.md` — RECEIVABLE / LOAN account types

--- a/prisma/migrations/20260801130000_person_debt_counterparty/migration.sql
+++ b/prisma/migrations/20260801130000_person_debt_counterparty/migration.sql
@@ -1,0 +1,45 @@
+-- PER-212 / ADR-0049 — person-to-person debt (counterparty layer).
+--
+-- A person-debt is an ordinary RECEIVABLE(ASSET)/LOAN(LIABILITY) account
+-- flagged by a link to a "person" contact. This migration adds:
+--   1. Merchant.kind — "business" (classic payee) | "person" (debt party),
+--      domain-constrained by a CHECK ("Database Is the Law", CLAUDE.md §5A).
+--   2. Account.counterpartyMerchantId — nullable link to the person Merchant
+--      this informal-debt account represents. Its presence is the ONLY
+--      discriminator for a person-debt account.
+--
+-- The link is a TENANT-SAFE composite FK to Merchant(id, familyId)
+-- (Pattern A, ADR-0010 / migration 20260527160000_harden_tenant_composite_fk):
+-- MATCH SIMPLE means a NULL counterpartyMerchantId is never checked, and a
+-- non-NULL value can only reference a Merchant in the SAME family. Foreign keys
+-- alone are not tenant isolation; the composite (id, familyId) target is.
+--
+-- Merchant already carries UNIQUE (id, familyId) ("Merchant_id_familyId_key"),
+-- created by the PER-104 hardening migration, so the composite FK target exists.
+
+-- ============================================================================
+-- 1. Merchant.kind — business | person
+-- ============================================================================
+
+ALTER TABLE "Merchant"
+  ADD COLUMN "kind" TEXT NOT NULL DEFAULT 'business';
+
+ALTER TABLE "Merchant"
+  ADD CONSTRAINT "merchant_kind_domain"
+  CHECK ("kind" IN ('business', 'person'));
+
+-- ============================================================================
+-- 2. Account.counterpartyMerchantId — tenant-safe composite FK to Merchant
+-- ============================================================================
+
+ALTER TABLE "Account"
+  ADD COLUMN "counterpartyMerchantId" TEXT;
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT "account_counterparty_merchant_fkey"
+  FOREIGN KEY ("counterpartyMerchantId", "familyId")
+  REFERENCES "Merchant" (id, "familyId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "Account_counterpartyMerchantId_idx"
+  ON "Account" ("counterpartyMerchantId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,18 @@ model Account {
   dueDay            Int?
   interestRateBps   Int?
 
+  // PER-212 / ADR-0049 — person-to-person debt (informal lending/borrowing).
+  // When set, this RECEIVABLE/LOAN account IS the ledger for a debt with a
+  // specific person contact (a Merchant with kind="person"). Its presence is
+  // the ONLY discriminator: such accounts are hidden from the main Accounts
+  // list and grouped as "Personal debts (net)" on the net-worth card; they
+  // live in the Utang-Piutang view instead. The ledger stays uniform — a
+  // person-debt is an ordinary RECEIVABLE(ASSET)/LOAN(LIABILITY) account, so
+  // every balance / net-worth / audit / RLS invariant holds for free.
+  // Tenant-safe composite FK to Merchant(id, familyId) (Pattern A, ADR-0010).
+  counterpartyMerchantId String?
+  counterpartyMerchant   Merchant? @relation("AccountCounterparty", fields: [counterpartyMerchantId, familyId], references: [id, familyId], onDelete: Restrict, onUpdate: Cascade, map: "account_counterparty_merchant_fkey")
+
   familyId String
   family   Family @relation(fields: [familyId], references: [id])
 
@@ -203,6 +215,7 @@ model Account {
   @@index([familyId, status])
   @@index([familyId, deletedAt])
   @@index([familyId, externalProvider, externalAccountId])
+  @@index([counterpartyMerchantId])
 }
 
 model Merchant {
@@ -212,6 +225,14 @@ model Merchant {
   // Fitur Enterprise: Logo/Website
   color   String?
   logoUrl String?
+
+  // PER-212 / ADR-0049 — merchant discriminator. "business" is the classic
+  // payee (a shop, a biller); "person" is a friend/family contact used for
+  // informal person-to-person debt (Utang-Piutang). One counterparty concept
+  // unifies payee + debt-party (the PER-189 extension point). A person contact
+  // is linked to its RECEIVABLE/LOAN ledger account via
+  // Account.counterpartyMerchantId. Domain-constrained by a DB CHECK.
+  kind String @default("business")
 
   // Durable external-provider binding (ADR-0041 §3, mirrors Account). NULL for
   // manually-created merchants. A PARTIAL UNIQUE (familyId, externalProvider,
@@ -225,6 +246,9 @@ model Merchant {
   transactions Transaction[]
   splitEntries SplitEntry[]
   smartRules   SmartRule[]
+
+  // PER-212 — RECEIVABLE/LOAN accounts representing debts with THIS person.
+  counterpartyAccounts Account[] @relation("AccountCounterparty")
 
   // Tenant scoping (see ADR-0003).
   // PER-189: case/whitespace-insensitive per-family name uniqueness for

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   IconSettings,
   IconUsers,
   IconReceipt2,
+  IconHandStop,
 } from "@tabler/icons-react"
 
 import { NavMain, type NavItem } from "@/components/nav-main"
@@ -46,6 +47,11 @@ const data: {
       title: "Accounts & Wallets",
       url: "/accounts",
       icon: IconDatabase,
+    },
+    {
+      title: "Utang-Piutang",
+      url: "/debts",
+      icon: IconHandStop,
     },
     {
       title: "Budgets",

--- a/src/lib/debt-collections.ts
+++ b/src/lib/debt-collections.ts
@@ -1,0 +1,29 @@
+import { createCollection } from "@tanstack/react-db"
+import { queryCollectionOptions } from "@tanstack/query-db-collection"
+import { getQueryClient } from "./query-client"
+import { getPersonDebtsFn } from "@/server/debts"
+
+// =============================================================================
+// PER-212 / ADR-0049 — reactive Utang-Piutang (person-debt) collection.
+//
+// `getPersonDebtsFn` returns one row per person who has at least one linked
+// RECEIVABLE/LOAN account, with signed net positions as digit-strings (BigInt
+// is not JSON-serializable). Mutations (create person / lend / borrow / repay)
+// call their `createServerFn` handlers directly, then
+// `personDebtCollection.utils.refetch()` to resync with the Postgres source of
+// truth (CLAUDE.md §5B). Person counts are small, so eager sync is instant.
+// =============================================================================
+
+export type PersonDebtRecord = Awaited<
+  ReturnType<typeof getPersonDebtsFn>
+>[number]
+
+export const personDebtCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ["person_debts_live"],
+    queryClient: getQueryClient(),
+    queryFn: async () => await getPersonDebtsFn(),
+    getKey: (item: PersonDebtRecord) => item.personId,
+    syncMode: "eager",
+  })
+)

--- a/src/routes/_protected/-account-card.test.tsx
+++ b/src/routes/_protected/-account-card.test.tsx
@@ -37,6 +37,7 @@ const account: AccountRecord = {
   statementDay: null,
   dueDay: null,
   interestRateBps: null,
+  counterpartyMerchantId: null,
 }
 
 function renderCard(drift: ReadonlyArray<DriftRecord>) {

--- a/src/routes/_protected/accounts.tsx
+++ b/src/routes/_protected/accounts.tsx
@@ -149,6 +149,19 @@ function AccountsPage() {
     [accounts]
   )
 
+  // PER-212 / ADR-0049: person-debt accounts (counterpartyMerchantId != null)
+  // are ordinary RECEIVABLE/LOAN accounts that STAY in the net-worth total, but
+  // are hidden from the main list — they live in Utang-Piutang and are shown on
+  // the net-worth card only as one grouped "Personal debts (net)" line.
+  const listedAccounts = React.useMemo<ReadonlyArray<AccountRecord>>(
+    () => safeAccounts.filter((a) => a.counterpartyMerchantId === null),
+    [safeAccounts]
+  )
+  const personDebtAccounts = React.useMemo<ReadonlyArray<AccountRecord>>(
+    () => safeAccounts.filter((a) => a.counterpartyMerchantId !== null),
+    [safeAccounts]
+  )
+
   // accountId → its drift entries, so each card can show a badge without an
   // N+1 query. Memoized off the live drift collection.
   const driftByAccount = React.useMemo(() => {
@@ -165,7 +178,7 @@ function AccountsPage() {
   // so the grouping is not recomputed on unrelated re-renders.
   const grouped = React.useMemo(() => {
     const byClass = new Map<AccountClass, AccountRecord[]>()
-    for (const account of safeAccounts) {
+    for (const account of listedAccounts) {
       const cls = account.accountClass as AccountClass
       const bucket = byClass.get(cls) ?? []
       bucket.push(account)
@@ -180,7 +193,7 @@ function AccountsPage() {
       })
     }
     return byClass
-  }, [safeAccounts])
+  }, [listedAccounts])
 
   async function refreshAfterMutation() {
     await Promise.all([
@@ -244,10 +257,13 @@ function AccountsPage() {
             </div>
 
             {safeAccounts.length > 0 ? (
-              <NetWorthInBaseCard accounts={safeAccounts} />
+              <NetWorthInBaseCard
+                accounts={safeAccounts}
+                personDebtAccounts={personDebtAccounts}
+              />
             ) : null}
 
-            {safeAccounts.length === 0 ? (
+            {listedAccounts.length === 0 ? (
               <EmptyState onCreate={() => setDialog({ mode: "create" })} />
             ) : (
               <div className="flex flex-col gap-6">
@@ -914,8 +930,16 @@ function ValuationActionDialog({
 // silently dropped, so the figure is never quietly wrong.
 function NetWorthInBaseCard({
   accounts,
+  personDebtAccounts,
 }: {
   accounts: ReadonlyArray<AccountRecord>
+  // PER-212 / ADR-0049: the subset of `accounts` that are person-debt accounts.
+  // Their balances are ALREADY inside `accounts` (and therefore the grand
+  // total); they are passed separately ONLY to render one grouped "Personal
+  // debts (net)" breakdown line. The total is NEVER recomputed without them —
+  // the net-worth-total invariant (presentation-only grouping) holds by
+  // construction.
+  personDebtAccounts: ReadonlyArray<AccountRecord>
 }) {
   const { data: fxOverview } = useQuery({
     queryKey: ["fx-overview"],
@@ -924,11 +948,12 @@ function NetWorthInBaseCard({
 
   const base = fxOverview?.baseCurrency
   const rates = fxOverview?.rates
-  const { total, unconverted } = React.useMemo(() => {
+  const { total, unconverted, personDebtNet } = React.useMemo(() => {
     if (!base)
       return {
         total: 0n,
         unconverted: [] as Array<{ currency: string; native: bigint }>,
+        personDebtNet: null as bigint | null,
       }
     // rates are sorted asOfDate DESC, so the first per `fromCurrency` is latest.
     const latest = new Map<string, bigint>()
@@ -938,22 +963,33 @@ function NetWorthInBaseCard({
         latest.set(rate.fromCurrency, BigInt(rate.rateScaled))
       }
     }
+    const resolveRate = (currency: string) => latest.get(currency) ?? null
+    const toBalances = (rows: ReadonlyArray<AccountRecord>): PointBalance[] =>
+      rows.map((account) => ({
+        accountClass: account.accountClass,
+        currency: account.currency,
+        native: BigInt(account.balance),
+      }))
     // Status-agnostic, same shared `normalizeNetWorthAt` as the net-worth series
     // (ADR-0038 §5): this card equals the series' last point by construction.
-    const balances: PointBalance[] = accounts.map((account) => ({
-      accountClass: account.accountClass,
-      currency: account.currency,
-      native: BigInt(account.balance),
-    }))
-    const result = normalizeNetWorthAt(
-      balances,
-      (currency) => latest.get(currency) ?? null,
-      base
-    )
-    return { total: result.netWorth, unconverted: result.unconverted }
-  }, [accounts, base, rates])
+    // The grand total is over ALL accounts (person-debt included), so the
+    // grouping below is presentation only and never shifts the number.
+    const result = normalizeNetWorthAt(toBalances(accounts), resolveRate, base)
+    // The net base-currency contribution of just the person-debt accounts
+    // (RECEIVABLE assets minus LOAN liabilities), for the grouped line.
+    const debtResult =
+      personDebtAccounts.length > 0
+        ? normalizeNetWorthAt(toBalances(personDebtAccounts), resolveRate, base)
+        : null
+    return {
+      total: result.netWorth,
+      unconverted: result.unconverted,
+      personDebtNet: debtResult ? debtResult.netWorth : null,
+    }
+  }, [accounts, personDebtAccounts, base, rates])
 
   const hasUnconverted = unconverted.length > 0
+  const hasPersonDebts = personDebtAccounts.length > 0
 
   return (
     <Card>
@@ -967,19 +1003,38 @@ function NetWorthInBaseCard({
           {base ? formatCurrency(total.toString(), base) : "—"}
         </CardTitle>
       </CardHeader>
-      {hasUnconverted ? (
+      {hasPersonDebts || hasUnconverted ? (
         <CardContent className="space-y-2 pt-0">
-          <Badge variant="outline" className="gap-1 text-muted-foreground">
-            <TriangleAlert className="size-3" aria-hidden />
-            Not yet converted — add a rate in Currencies &amp; FX
-          </Badge>
-          <ul className="space-y-0.5 text-sm text-muted-foreground">
-            {unconverted.map(({ currency, native }) => (
-              <li key={currency} className="tabular-nums">
-                + {formatCurrency(native.toString(), currency)}
-              </li>
-            ))}
-          </ul>
+          {hasPersonDebts && base ? (
+            <Link
+              to="/debts"
+              className="flex items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-muted/50"
+            >
+              <span className="text-muted-foreground">
+                Personal debts (net)
+              </span>
+              <span className="font-medium tabular-nums">
+                {personDebtNet === null
+                  ? "—"
+                  : formatCurrency(personDebtNet.toString(), base)}
+              </span>
+            </Link>
+          ) : null}
+          {hasUnconverted ? (
+            <>
+              <Badge variant="outline" className="gap-1 text-muted-foreground">
+                <TriangleAlert className="size-3" aria-hidden />
+                Not yet converted — add a rate in Currencies &amp; FX
+              </Badge>
+              <ul className="space-y-0.5 text-sm text-muted-foreground">
+                {unconverted.map(({ currency, native }) => (
+                  <li key={currency} className="tabular-nums">
+                    + {formatCurrency(native.toString(), currency)}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
         </CardContent>
       ) : null}
     </Card>

--- a/src/routes/_protected/debts.tsx
+++ b/src/routes/_protected/debts.tsx
@@ -1,0 +1,476 @@
+import * as React from "react"
+import {
+  createFileRoute,
+  type ErrorComponentProps,
+} from "@tanstack/react-router"
+import { useLiveQuery } from "@tanstack/react-db"
+import { useQuery } from "@tanstack/react-query"
+import { HandCoins, Plus, Users } from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { accountCollection } from "@/lib/account-collections"
+import {
+  personDebtCollection,
+  type PersonDebtRecord,
+} from "@/lib/debt-collections"
+import { formatCurrency } from "@/lib/currency"
+import { parseUserInput } from "@/lib/money"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import {
+  createPersonFn,
+  getPersonsFn,
+  recordBorrowFn,
+  recordLendFn,
+  recordRepaymentFn,
+} from "@/server/debts"
+
+export const Route = createFileRoute("/_protected/debts")({
+  // TanStack DB collections are browser-only; SSR would hang on the pending sync.
+  ssr: false,
+  loader: async () => {
+    await Promise.all([
+      personDebtCollection.preload(),
+      accountCollection.preload(),
+    ])
+    return null
+  },
+  staticData: { title: "Utang-Piutang" },
+  pendingComponent: DebtsPendingComponent,
+  errorComponent: DebtsErrorComponent,
+  component: DebtsPage,
+})
+
+// The four ad-hoc debt actions (no schedules — that's a later PER-211 slice).
+type DebtAction = "lend" | "borrow" | "repay_receivable" | "repay_loan"
+
+const ACTION_LABEL: Record<DebtAction, string> = {
+  lend: "Lend (they will owe me)",
+  borrow: "Borrow (I will owe them)",
+  repay_receivable: "Repayment received (they pay me back)",
+  repay_loan: "Repayment made (I pay them back)",
+}
+
+function DebtsPendingComponent() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 p-6 text-center">
+      <div className="size-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      <p className="text-sm text-muted-foreground">Loading personal debts…</p>
+    </div>
+  )
+}
+
+function DebtsErrorComponent({ error }: ErrorComponentProps) {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
+      <h2 className="text-xl font-semibold">Failed to load personal debts</h2>
+      <pre className="max-w-prose rounded-md bg-muted p-3 text-left text-xs whitespace-pre-wrap">
+        {message}
+      </pre>
+    </div>
+  )
+}
+
+function DebtsPage() {
+  const { data: debts } = useLiveQuery((q) =>
+    q.from({ d: personDebtCollection })
+  )
+  const [recordOpen, setRecordOpen] = React.useState(false)
+
+  const safeDebts = React.useMemo<ReadonlyArray<PersonDebtRecord>>(
+    () => debts ?? [],
+    [debts]
+  )
+
+  async function refreshAfterMutation() {
+    await Promise.all([
+      personDebtCollection.utils.refetch(),
+      accountCollection.utils.refetch(),
+    ])
+  }
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider
+        style={
+          {
+            "--sidebar-width": "calc(var(--spacing) * 64)",
+            "--header-height": "calc(var(--spacing) * 14)",
+          } as React.CSSProperties
+        }
+      >
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-6 p-4 lg:p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Utang-Piutang
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Money you have lent to or borrowed from people. Each person is
+                  backed by ordinary ledger accounts, so balances and net worth
+                  stay correct.
+                </p>
+              </div>
+              <Button onClick={() => setRecordOpen(true)}>
+                <Plus className="size-4" />
+                Record debt
+              </Button>
+            </div>
+
+            {safeDebts.length === 0 ? (
+              <DebtsEmptyState onRecord={() => setRecordOpen(true)} />
+            ) : (
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {safeDebts.map((debt) => (
+                  <PersonDebtCard key={debt.personId} debt={debt} />
+                ))}
+              </div>
+            )}
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+
+      {recordOpen ? (
+        <RecordDebtDialog
+          onClose={() => setRecordOpen(false)}
+          onSaved={async () => {
+            await refreshAfterMutation()
+            setRecordOpen(false)
+          }}
+        />
+      ) : null}
+    </TooltipProvider>
+  )
+}
+
+function DebtsEmptyState({ onRecord }: { onRecord: () => void }) {
+  return (
+    <Card className="border-dashed">
+      <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+        <Users className="size-8 text-muted-foreground" />
+        <div>
+          <p className="font-medium">No personal debts yet</p>
+          <p className="text-sm text-muted-foreground">
+            Lent some cash to a friend, or borrowed from family? Record it here
+            and Permoney tracks who owes whom.
+          </p>
+        </div>
+        <Button onClick={onRecord}>
+          <HandCoins className="size-4" />
+          Record your first debt
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+function PersonDebtCard({ debt }: { debt: PersonDebtRecord }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{debt.name}</CardTitle>
+          {debt.settled ? (
+            <Badge variant="outline" className="text-emerald-600">
+              Lunas
+            </Badge>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1.5">
+        {debt.positions.map((position) => {
+          const net = BigInt(position.net)
+          const direction =
+            net > 0n ? "They owe you" : net < 0n ? "You owe them" : "Settled"
+          const magnitude = net < 0n ? -net : net
+          return (
+            <div
+              key={position.currency}
+              className="flex items-center justify-between text-sm"
+            >
+              <span className="text-muted-foreground">{direction}</span>
+              <span className="font-medium tabular-nums">
+                {formatCurrency(magnitude.toString(), position.currency)}
+              </span>
+            </div>
+          )
+        })}
+        <div className="pt-2 text-xs text-muted-foreground">
+          {debt.accounts.length} linked account
+          {debt.accounts.length === 1 ? "" : "s"}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+const NEW_PERSON_SENTINEL = "__new_person"
+
+function RecordDebtDialog({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  // All person contacts (incl. those with no debt yet) power the picker.
+  const { data: persons, refetch: refetchPersons } = useQuery({
+    queryKey: ["persons_all"],
+    queryFn: async () => await getPersonsFn(),
+  })
+  const { data: accounts } = useLiveQuery((q) =>
+    q.from({ a: accountCollection })
+  )
+
+  // Only your own cash-like asset accounts are valid endpoints for a debt move.
+  const cashAccounts = React.useMemo(
+    () =>
+      (accounts ?? []).filter(
+        (a) =>
+          a.counterpartyMerchantId === null &&
+          a.accountClass === "ASSET" &&
+          a.balanceSource === "transaction_flow" &&
+          a.status === "active"
+      ),
+    [accounts]
+  )
+
+  const [personId, setPersonId] = React.useState<string>(NEW_PERSON_SENTINEL)
+  const [newPersonName, setNewPersonName] = React.useState("")
+  const [action, setAction] = React.useState<DebtAction>("lend")
+  const [cashAccountId, setCashAccountId] = React.useState<string>("")
+  const [amount, setAmount] = React.useState("")
+  const [note, setNote] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const selectedCash = cashAccounts.find((a) => a.id === cashAccountId)
+  const currency = (selectedCash?.currency ?? "IDR") as CurrencyCode
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+
+    if (!cashAccountId) {
+      setError("Choose a cash account.")
+      return
+    }
+    const parsed = parseUserInput(amount.trim(), currency)
+    if (parsed === null || parsed <= 0n) {
+      setError("Enter a valid amount.")
+      return
+    }
+    const minor = parsed.toString()
+    const trimmedNote = note.trim()
+    const description = trimmedNote === "" ? undefined : trimmedNote
+
+    setSubmitting(true)
+    try {
+      // Resolve the person: create a new contact inline, or use the selected one.
+      let resolvedPersonId = personId
+      if (personId === NEW_PERSON_SENTINEL) {
+        const name = newPersonName.trim()
+        if (name === "") {
+          setError("Enter the person's name.")
+          setSubmitting(false)
+          return
+        }
+        const person = await createPersonFn({
+          data: { name, idempotencyKey: createUuidV7() },
+        })
+        resolvedPersonId = person.id
+        await refetchPersons()
+      }
+
+      const idempotencyKey = createUuidV7()
+      // Stamp the date client-side (once per submit) so a network retry re-sends
+      // the identical payload and the server idempotency replay is a true no-op.
+      const date = new Date()
+      if (action === "lend") {
+        await recordLendFn({
+          data: {
+            personMerchantId: resolvedPersonId,
+            fromAccountId: cashAccountId,
+            amount: minor,
+            description,
+            date,
+            idempotencyKey,
+          },
+        })
+      } else if (action === "borrow") {
+        await recordBorrowFn({
+          data: {
+            personMerchantId: resolvedPersonId,
+            toAccountId: cashAccountId,
+            amount: minor,
+            description,
+            date,
+            idempotencyKey,
+          },
+        })
+      } else {
+        await recordRepaymentFn({
+          data: {
+            personMerchantId: resolvedPersonId,
+            direction: action === "repay_receivable" ? "receivable" : "loan",
+            cashAccountId,
+            amount: minor,
+            description,
+            date,
+            idempotencyKey,
+          },
+        })
+      }
+      await onSaved()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>Record a debt</DialogTitle>
+            <DialogDescription>
+              Lend, borrow, or record a repayment. This posts an ordinary
+              transfer through your ledger.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            <Label>Person</Label>
+            <Select value={personId} onValueChange={setPersonId}>
+              <SelectTrigger aria-label="Person">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NEW_PERSON_SENTINEL}>
+                  + New person
+                </SelectItem>
+                {(persons ?? []).map((person) => (
+                  <SelectItem key={person.id} value={person.id}>
+                    {person.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {personId === NEW_PERSON_SENTINEL ? (
+              <Input
+                aria-label="New person name"
+                value={newPersonName}
+                onChange={(e) => setNewPersonName(e.target.value)}
+                placeholder="e.g. Budi"
+              />
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Action</Label>
+            <Select
+              value={action}
+              onValueChange={(value) => setAction(value as DebtAction)}
+            >
+              <SelectTrigger aria-label="Action">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.keys(ACTION_LABEL) as DebtAction[]).map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {ACTION_LABEL[key]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Cash account</Label>
+            <Select value={cashAccountId} onValueChange={setCashAccountId}>
+              <SelectTrigger aria-label="Cash account">
+                <SelectValue placeholder="Choose an account" />
+              </SelectTrigger>
+              <SelectContent>
+                {cashAccounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {account.name} ({account.currency})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="debt-amount">Amount ({currency})</Label>
+            <Input
+              id="debt-amount"
+              inputMode="decimal"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="0"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="debt-note">Note (optional)</Label>
+            <Input
+              id="debt-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="e.g. lunch money"
+            />
+          </div>
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/_protected/debts.tsx
+++ b/src/routes/_protected/debts.tsx
@@ -74,6 +74,23 @@ const ACTION_LABEL: Record<DebtAction, string> = {
   repay_loan: "Repayment made (I pay them back)",
 }
 
+// After any debt mutation, resync both the person-debt list and the accounts
+// (balances moved) with the Postgres source of truth (CLAUDE.md §5B).
+async function refreshDebtsAfterMutation(): Promise<void> {
+  await Promise.all([
+    personDebtCollection.utils.refetch(),
+    accountCollection.utils.refetch(),
+  ])
+}
+
+/** Human-readable sign of a signed net position, extracted to avoid a nested
+ * ternary at the call site (SonarCloud S3358). */
+function describeNetPosition(net: bigint): string {
+  if (net > 0n) return "They owe you"
+  if (net < 0n) return "You owe them"
+  return "Settled"
+}
+
 function DebtsPendingComponent() {
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 p-6 text-center">
@@ -105,13 +122,6 @@ function DebtsPage() {
     () => debts ?? [],
     [debts]
   )
-
-  async function refreshAfterMutation() {
-    await Promise.all([
-      personDebtCollection.utils.refetch(),
-      accountCollection.utils.refetch(),
-    ])
-  }
 
   return (
     <TooltipProvider>
@@ -161,7 +171,7 @@ function DebtsPage() {
         <RecordDebtDialog
           onClose={() => setRecordOpen(false)}
           onSaved={async () => {
-            await refreshAfterMutation()
+            await refreshDebtsAfterMutation()
             setRecordOpen(false)
           }}
         />
@@ -170,7 +180,7 @@ function DebtsPage() {
   )
 }
 
-function DebtsEmptyState({ onRecord }: { onRecord: () => void }) {
+function DebtsEmptyState({ onRecord }: Readonly<{ onRecord: () => void }>) {
   return (
     <Card className="border-dashed">
       <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
@@ -191,7 +201,7 @@ function DebtsEmptyState({ onRecord }: { onRecord: () => void }) {
   )
 }
 
-function PersonDebtCard({ debt }: { debt: PersonDebtRecord }) {
+function PersonDebtCard({ debt }: Readonly<{ debt: PersonDebtRecord }>) {
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -207,8 +217,7 @@ function PersonDebtCard({ debt }: { debt: PersonDebtRecord }) {
       <CardContent className="space-y-1.5">
         {debt.positions.map((position) => {
           const net = BigInt(position.net)
-          const direction =
-            net > 0n ? "They owe you" : net < 0n ? "You owe them" : "Settled"
+          const direction = describeNetPosition(net)
           const magnitude = net < 0n ? -net : net
           return (
             <div
@@ -236,10 +245,10 @@ const NEW_PERSON_SENTINEL = "__new_person"
 function RecordDebtDialog({
   onClose,
   onSaved,
-}: {
+}: Readonly<{
   onClose: () => void
   onSaved: () => Promise<void>
-}) {
+}>) {
   // All person contacts (incl. those with no debt yet) power the picker.
   const { data: persons, refetch: refetchPersons } = useQuery({
     queryKey: ["persons_all"],
@@ -309,48 +318,37 @@ function RecordDebtDialog({
         await refetchPersons()
       }
 
-      const idempotencyKey = createUuidV7()
-      // Stamp the date client-side (once per submit) so a network retry re-sends
-      // the identical payload and the server idempotency replay is a true no-op.
-      const date = new Date()
+      // Fields shared by all four flows. `date` is stamped client-side once so a
+      // network retry re-sends the identical payload and the server idempotency
+      // replay is a true no-op; the cash account + direction are the only things
+      // that vary per action.
+      const shared = {
+        personMerchantId: resolvedPersonId,
+        amount: minor,
+        description,
+        date: new Date(),
+        idempotencyKey: createUuidV7(),
+      }
       if (action === "lend") {
         await recordLendFn({
-          data: {
-            personMerchantId: resolvedPersonId,
-            fromAccountId: cashAccountId,
-            amount: minor,
-            description,
-            date,
-            idempotencyKey,
-          },
+          data: { ...shared, fromAccountId: cashAccountId },
         })
       } else if (action === "borrow") {
         await recordBorrowFn({
-          data: {
-            personMerchantId: resolvedPersonId,
-            toAccountId: cashAccountId,
-            amount: minor,
-            description,
-            date,
-            idempotencyKey,
-          },
+          data: { ...shared, toAccountId: cashAccountId },
         })
       } else {
         await recordRepaymentFn({
           data: {
-            personMerchantId: resolvedPersonId,
+            ...shared,
             direction: action === "repay_receivable" ? "receivable" : "loan",
             cashAccountId,
-            amount: minor,
-            description,
-            date,
-            idempotencyKey,
           },
         })
       }
       await onSaved()
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught))
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : String(error_))
       setSubmitting(false)
     }
   }

--- a/src/server/accounts.ts
+++ b/src/server/accounts.ts
@@ -127,6 +127,11 @@ export const createAccountInputSchema = z.object({
   color: hexColorSchema.nullable().optional(),
   openingBalance: openingBalanceSchema.optional(),
   institutionName: institutionNameSchema.nullable().optional(),
+  // PER-212 / ADR-0049: link this account to a "person" Merchant, turning it
+  // into an informal person-debt account. Only valid for RECEIVABLE/LOAN types
+  // and validated tenant-owned + kind="person" in createAccountForFamily. The
+  // main account-create dialog never sets it; the Utang-Piutang debt flows do.
+  counterpartyMerchantId: z.string().min(1).nullable().optional(),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -173,6 +178,11 @@ export interface SerializedAccount {
   statementDay: number | null
   dueDay: number | null
   interestRateBps: number | null
+  // PER-212 / ADR-0049: non-null ⇒ this is an informal person-debt account
+  // (RECEIVABLE/LOAN) linked to a "person" Merchant. Drives the main-list
+  // exclusion + the net-worth "Personal debts (net)" grouping (presentation
+  // only; the balance still counts toward net worth exactly as before).
+  counterpartyMerchantId: string | null
 }
 
 function serializeAccount(account: Account): SerializedAccount {
@@ -197,6 +207,7 @@ function serializeAccount(account: Account): SerializedAccount {
     statementDay: account.statementDay,
     dueDay: account.dueDay,
     interestRateBps: account.interestRateBps,
+    counterpartyMerchantId: account.counterpartyMerchantId,
   }
 }
 
@@ -211,15 +222,26 @@ interface ServerUser {
 export async function getAccountsForFamily({
   familyId,
   userId,
+  includeCounterparty = true,
   runInTenantTransaction = scopedTenantTransaction,
 }: {
   familyId: string
   userId: string
+  // PER-212 / ADR-0049: person-debt accounts (counterpartyMerchantId != null)
+  // are ordinary RECEIVABLE/LOAN accounts and MUST stay in the net-worth math,
+  // so the default is `true` — every existing caller (and the net-worth card)
+  // keeps seeing them. Pass `false` to fetch only the "real" accounts shown on
+  // the main Accounts page; the person-debt accounts live in Utang-Piutang.
+  includeCounterparty?: boolean
   runInTenantTransaction?: RunInTenantTransaction
 }): Promise<SerializedAccount[]> {
   return await runInTenantTransaction(familyId, userId, async (tx) => {
     const accounts = await tx.account.findMany({
-      where: { familyId, deletedAt: null },
+      where: {
+        familyId,
+        deletedAt: null,
+        ...(includeCounterparty ? {} : { counterpartyMerchantId: null }),
+      },
       orderBy: [{ status: "asc" }, { accountClass: "asc" }, { name: "asc" }],
     })
     return accounts.map(serializeAccount)
@@ -271,10 +293,27 @@ export async function createAccountForFamily({
   }
   const openingMagnitude =
     openingRawValue < 0n ? -openingRawValue : openingRawValue
+
+  // PER-212 / ADR-0049: a counterparty link only makes sense on a RECEIVABLE
+  // (they owe you) or LOAN (you owe them) account — the two debt-bearing types.
+  // Reject the shape here before any write; the tenant-owned + kind="person"
+  // check runs inside the transaction (RLS-scoped), with the composite FK as
+  // the durable backstop.
+  const counterpartyMerchantId = data.counterpartyMerchantId ?? null
+  if (
+    counterpartyMerchantId !== null &&
+    taxonomy.accountType !== "RECEIVABLE" &&
+    taxonomy.accountType !== "LOAN"
+  ) {
+    throw new AccountValidationError(
+      `counterpartyMerchantId is only valid for RECEIVABLE or LOAN accounts, not ${taxonomy.accountType}`
+    )
+  }
   const requestHash = await hashCanonicalPayload({
     accountSubtype: taxonomy.accountSubtype,
     accountType: taxonomy.accountType,
     color: data.color ?? null,
+    counterpartyMerchantId,
     currency,
     institutionName: data.institutionName ?? null,
     name: data.name,
@@ -309,6 +348,26 @@ export async function createAccountForFamily({
       )
       if (replay) return replay
 
+      // Tenant-owned reference validation (CLAUDE.md §5A): a person-debt link
+      // must point at a Merchant in THIS family with kind="person". FKs alone
+      // are not tenant isolation; the composite FK is the DB backstop.
+      if (counterpartyMerchantId !== null) {
+        const merchant = await tx.merchant.findFirst({
+          where: { id: counterpartyMerchantId, familyId },
+          select: { kind: true },
+        })
+        if (!merchant) {
+          throw new AccountValidationError(
+            `counterpartyMerchantId ${counterpartyMerchantId} not found for this family`
+          )
+        }
+        if (merchant.kind !== "person") {
+          throw new AccountValidationError(
+            `counterpartyMerchantId ${counterpartyMerchantId} must reference a person merchant, not a ${merchant.kind}`
+          )
+        }
+      }
+
       const account = await tx.account.create({
         data: {
           ...(data.id ? { id: data.id } : {}),
@@ -318,6 +377,7 @@ export async function createAccountForFamily({
           balance: signedOpeningBalance,
           balanceSource: taxonomy.balanceSource,
           color: data.color ?? null,
+          counterpartyMerchantId,
           currency,
           familyId,
           institutionName: data.institutionName ?? null,

--- a/src/server/debts.ts
+++ b/src/server/debts.ts
@@ -52,9 +52,6 @@ const DIRECTION_ACCOUNT_TYPE: Record<
 export class PersonDebtNotFoundError extends Error {
   override readonly name = "PersonDebtNotFoundError"
   readonly statusCode = 404
-  constructor(message: string) {
-    super(message)
-  }
 }
 
 const nameSchema = z.string().trim().min(1).max(120)
@@ -268,37 +265,74 @@ export const recordRepaymentInputSchema = z.object({
   idempotencyKey: uuidV7Schema,
 })
 
-async function postDebtTransfer({
+/**
+ * The single flow behind lend / borrow / repay: resolve the person, pin the
+ * currency to the chosen cash account, ensure that person's RECEIVABLE/LOAN
+ * account exists (create-if-absent, idempotent by lookup), then post ONE
+ * ordinary transfer between the cash account and the debt account. The transfer
+ * `kind` (funds_movement / liability_draw / loan_payment) is DERIVED from the
+ * two account types by the ledger core — never passed by this module. Every
+ * public debt mutation is a thin wrapper that only picks `ensureDirection`,
+ * whether cash is the source, and the default description.
+ */
+async function orchestrateDebtMovement({
   familyId,
   user,
-  fromAccountId,
-  toAccountId,
-  amount,
-  description,
-  date,
-  idempotencyKey,
   runInTenantTransaction,
+  personMerchantId,
+  cashAccountId,
+  ensureDirection,
+  cashIsSource,
+  amount,
+  date,
+  description,
+  describe,
+  idempotencyKey,
 }: {
   familyId: string
   user: ServerUser
-  fromAccountId: string
-  toAccountId: string
-  amount: string
-  description: string
-  date: Date
-  idempotencyKey: string
   runInTenantTransaction: RunInTenantTransaction
+  personMerchantId: string
+  cashAccountId: string
+  ensureDirection: PersonDebtDirection
+  // true ⇒ cash → debt account (lend, repay-loan); false ⇒ debt account → cash
+  // (borrow, repay-receivable).
+  cashIsSource: boolean
+  amount: string
+  date: Date | undefined
+  description: string | undefined
+  describe: (personName: string) => string
+  idempotencyKey: string
 }) {
-  // The kind (funds_movement / liability_draw / loan_payment) is DERIVED from
-  // the two account types by the ledger core — never passed by this module.
+  const person = await loadPersonOrThrow({
+    familyId,
+    user,
+    personMerchantId,
+    runInTenantTransaction,
+  })
+  const currency = await loadCashAccountCurrency({
+    familyId,
+    user,
+    accountId: cashAccountId,
+    runInTenantTransaction,
+  })
+  const debtAccountId = await ensurePersonDebtAccountId({
+    familyId,
+    user,
+    personName: person.name,
+    personMerchantId: person.id,
+    direction: ensureDirection,
+    currency,
+    runInTenantTransaction,
+  })
   return await createTransactionForFamily({
     data: {
       type: "transfer",
-      accountId: fromAccountId,
-      toAccountId,
+      accountId: cashIsSource ? cashAccountId : debtAccountId,
+      toAccountId: cashIsSource ? debtAccountId : cashAccountId,
       amount,
-      description,
-      date,
+      description: description ?? describe(person.name),
+      date: date ?? new Date(),
       idempotencyKey,
     },
     familyId,
@@ -319,37 +353,20 @@ export async function recordLendForFamily({
   runInTenantTransaction?: RunInTenantTransaction
 }) {
   const data = recordLendInputSchema.parse(rawData)
-  const person = await loadPersonOrThrow({
+  // Lend: cash → RECEIVABLE (their debt to you grows).
+  return await orchestrateDebtMovement({
     familyId,
     user,
+    runInTenantTransaction,
     personMerchantId: data.personMerchantId,
-    runInTenantTransaction,
-  })
-  const currency = await loadCashAccountCurrency({
-    familyId,
-    user,
-    accountId: data.fromAccountId,
-    runInTenantTransaction,
-  })
-  const receivableId = await ensurePersonDebtAccountId({
-    familyId,
-    user,
-    personName: person.name,
-    personMerchantId: person.id,
-    direction: "receivable",
-    currency,
-    runInTenantTransaction,
-  })
-  return await postDebtTransfer({
-    familyId,
-    user,
-    fromAccountId: data.fromAccountId,
-    toAccountId: receivableId,
+    cashAccountId: data.fromAccountId,
+    ensureDirection: "receivable",
+    cashIsSource: true,
     amount: data.amount,
-    description: data.description ?? `Lent to ${person.name}`,
-    date: data.date ?? new Date(),
+    date: data.date,
+    description: data.description,
+    describe: (name) => `Lent to ${name}`,
     idempotencyKey: data.idempotencyKey,
-    runInTenantTransaction,
   })
 }
 
@@ -365,37 +382,20 @@ export async function recordBorrowForFamily({
   runInTenantTransaction?: RunInTenantTransaction
 }) {
   const data = recordBorrowInputSchema.parse(rawData)
-  const person = await loadPersonOrThrow({
+  // Borrow: LOAN → cash (your debt to them grows; liability_draw is derived).
+  return await orchestrateDebtMovement({
     familyId,
     user,
+    runInTenantTransaction,
     personMerchantId: data.personMerchantId,
-    runInTenantTransaction,
-  })
-  const currency = await loadCashAccountCurrency({
-    familyId,
-    user,
-    accountId: data.toAccountId,
-    runInTenantTransaction,
-  })
-  const loanId = await ensurePersonDebtAccountId({
-    familyId,
-    user,
-    personName: person.name,
-    personMerchantId: person.id,
-    direction: "loan",
-    currency,
-    runInTenantTransaction,
-  })
-  return await postDebtTransfer({
-    familyId,
-    user,
-    fromAccountId: loanId,
-    toAccountId: data.toAccountId,
+    cashAccountId: data.toAccountId,
+    ensureDirection: "loan",
+    cashIsSource: false,
     amount: data.amount,
-    description: data.description ?? `Borrowed from ${person.name}`,
-    date: data.date ?? new Date(),
+    date: data.date,
+    description: data.description,
+    describe: (name) => `Borrowed from ${name}`,
     idempotencyKey: data.idempotencyKey,
-    runInTenantTransaction,
   })
 }
 
@@ -411,48 +411,24 @@ export async function recordRepaymentForFamily({
   runInTenantTransaction?: RunInTenantTransaction
 }) {
   const data = recordRepaymentInputSchema.parse(rawData)
-  const person = await loadPersonOrThrow({
+  // Repay is the transfer OPPOSITE to the original debt:
+  //   receivable repaid: RECEIVABLE → cash (they pay you back)
+  //   loan repaid       : cash → LOAN       (you pay them back)
+  const isReceivable = data.direction === "receivable"
+  return await orchestrateDebtMovement({
     familyId,
     user,
+    runInTenantTransaction,
     personMerchantId: data.personMerchantId,
-    runInTenantTransaction,
-  })
-  const currency = await loadCashAccountCurrency({
-    familyId,
-    user,
-    accountId: data.cashAccountId,
-    runInTenantTransaction,
-  })
-  const debtAccountId = await ensurePersonDebtAccountId({
-    familyId,
-    user,
-    personName: person.name,
-    personMerchantId: person.id,
-    direction: data.direction,
-    currency,
-    runInTenantTransaction,
-  })
-  // Repay is the transfer in the OPPOSITE direction to the original debt:
-  //   receivable repaid: RECEIVABLE -> cash  (they pay you back)
-  //   loan repaid       : cash -> LOAN        (you pay them back)
-  const fromAccountId =
-    data.direction === "receivable" ? debtAccountId : data.cashAccountId
-  const toAccountId =
-    data.direction === "receivable" ? data.cashAccountId : debtAccountId
-  return await postDebtTransfer({
-    familyId,
-    user,
-    fromAccountId,
-    toAccountId,
+    cashAccountId: data.cashAccountId,
+    ensureDirection: data.direction,
+    cashIsSource: !isReceivable,
     amount: data.amount,
-    description:
-      data.description ??
-      (data.direction === "receivable"
-        ? `Repayment from ${person.name}`
-        : `Repayment to ${person.name}`),
-    date: data.date ?? new Date(),
+    date: data.date,
+    description: data.description,
+    describe: (name) =>
+      isReceivable ? `Repayment from ${name}` : `Repayment to ${name}`,
     idempotencyKey: data.idempotencyKey,
-    runInTenantTransaction,
   })
 }
 
@@ -584,7 +560,7 @@ export async function getPersonDebtsForFamily({
       const positions: PersonDebtCurrencyPosition[] = [
         ...netByCurrency.entries(),
       ]
-        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .sort(([a], [b]) => a.localeCompare(b))
         .map(([currency, net]) => ({ currency, net: net.toString() }))
 
       views.push({

--- a/src/server/debts.ts
+++ b/src/server/debts.ts
@@ -1,0 +1,656 @@
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import {
+  familyMiddleware,
+  requireCapability,
+  scopedTenantTransaction,
+} from "./middleware/with-family"
+import { uuidV7Schema, type RunInTenantTransaction } from "./mutation-kit"
+import { createAccountForFamily } from "./accounts"
+import { createMerchantForFamily, type SerializedMerchant } from "./merchants"
+import { createTransactionForFamily } from "./transactions"
+
+// =============================================================================
+// PER-212 / ADR-0049 — person-to-person debt (Utang-Piutang), Slice 1 of the
+// PER-211 epic.
+//
+// A person-debt is NOT a new ledger concept. It is an ordinary
+// RECEIVABLE(ASSET) or LOAN(LIABILITY) account flagged by a link to a "person"
+// contact (`Account.counterpartyMerchantId` -> a `Merchant` with kind="person").
+// Lend / borrow / repay are ORDINARY TRANSFERS routed through the SAME
+// `createTransactionForFamily` the rest of the app uses, so double-entry,
+// signed amounts, atomic balance updates, idempotency, tenant-reference
+// validation, RLS scoping, and append-only audit all hold FOR FREE. This module
+// only orchestrates: ensure the right person-debt account exists, then post the
+// transfer in the correct direction. There is NO debt sub-ledger.
+//
+// Direction / kind derivation is delegated entirely to the ledger core
+// (`deriveTransferKindForAccounts`):
+//   - Lend  : cash -> RECEIVABLE  => funds_movement (their debt to you grows).
+//   - Borrow: LOAN -> cash        => liability_draw (your debt to them grows).
+//   - Repay receivable: RECEIVABLE -> cash => funds_movement.
+//   - Repay loan       : cash -> LOAN      => loan_payment.
+//
+// Installment schedules, reminders, and interest accrual are LATER slices
+// (PER-211); this slice is strictly ad-hoc amounts.
+// =============================================================================
+
+// Direction of a debt relative to the family: they owe you (receivable) or you
+// owe them (loan). Maps 1:1 to the account type that holds the debt.
+export type PersonDebtDirection = "receivable" | "loan"
+
+const DIRECTION_ACCOUNT_TYPE: Record<
+  PersonDebtDirection,
+  "RECEIVABLE" | "LOAN"
+> = {
+  receivable: "RECEIVABLE",
+  loan: "LOAN",
+}
+
+/** Raised when a debt flow references a person/account not owned by the family. */
+export class PersonDebtNotFoundError extends Error {
+  override readonly name = "PersonDebtNotFoundError"
+  readonly statusCode = 404
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+const nameSchema = z.string().trim().min(1).max(120)
+const hexColorSchema = z
+  .string()
+  .trim()
+  .regex(/^#[0-9a-fA-F]{6}$/, "color must be a #RRGGBB hex value")
+// Minor-unit magnitude as a positive digit-string (the wire form the account
+// dialogs already use). `createTransactionForFamily` re-validates it as
+// `positiveMoneyInputSchema`; this is the outer gate.
+const amountSchema = z
+  .string()
+  .regex(/^\d+$/, "amount must be a string of minor-unit digits")
+  .refine((value) => BigInt(value) > 0n, "amount must be positive")
+
+interface ServerUser {
+  id: string
+}
+
+// ============================================================================
+// PERSON (Merchant kind="person")
+// ============================================================================
+
+export const createPersonInputSchema = z.object({
+  name: nameSchema,
+  color: hexColorSchema.nullable().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+export async function createPersonForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof createPersonInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedMerchant> {
+  const data = createPersonInputSchema.parse(rawData)
+  // A person is just a Merchant with kind="person": one counterparty concept,
+  // reusing the merchant create contract (idempotency + audit + name dedup).
+  return await createMerchantForFamily({
+    data: {
+      name: data.name,
+      color: data.color ?? null,
+      kind: "person",
+      idempotencyKey: data.idempotencyKey,
+    },
+    familyId,
+    user,
+    runInTenantTransaction,
+  })
+}
+
+export const createPersonFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof createPersonInputSchema>) =>
+    createPersonInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await createPersonForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// ============================================================================
+// ENSURE PERSON-DEBT ACCOUNT (create-if-absent, idempotent by lookup)
+// ============================================================================
+
+async function loadPersonOrThrow({
+  familyId,
+  user,
+  personMerchantId,
+  runInTenantTransaction,
+}: {
+  familyId: string
+  user: ServerUser
+  personMerchantId: string
+  runInTenantTransaction: RunInTenantTransaction
+}): Promise<{ id: string; name: string }> {
+  const person = await runInTenantTransaction(familyId, user.id, (tx) =>
+    tx.merchant.findFirst({
+      where: { id: personMerchantId, familyId, kind: "person" },
+      select: { id: true, name: true },
+    })
+  )
+  if (!person) {
+    throw new PersonDebtNotFoundError(
+      `Person ${personMerchantId} not found for this family`
+    )
+  }
+  return person
+}
+
+/**
+ * Returns the id of THIS person's RECEIVABLE/LOAN account in `currency`,
+ * creating it (opening balance 0, via the canonical account-create contract)
+ * on first use. Idempotent by lookup: a replay finds the existing account and
+ * never creates a second one, so a re-tried lend/borrow never forks the ledger.
+ */
+async function ensurePersonDebtAccountId({
+  familyId,
+  user,
+  personName,
+  personMerchantId,
+  direction,
+  currency,
+  runInTenantTransaction,
+}: {
+  familyId: string
+  user: ServerUser
+  personName: string
+  personMerchantId: string
+  direction: PersonDebtDirection
+  currency: string
+  runInTenantTransaction: RunInTenantTransaction
+}): Promise<string> {
+  const accountType = DIRECTION_ACCOUNT_TYPE[direction]
+  const existing = await runInTenantTransaction(familyId, user.id, (tx) =>
+    tx.account.findFirst({
+      where: {
+        familyId,
+        counterpartyMerchantId: personMerchantId,
+        accountType,
+        currency,
+        deletedAt: null,
+      },
+      select: { id: true },
+    })
+  )
+  if (existing) return existing.id
+
+  const label =
+    direction === "receivable"
+      ? `Owed by ${personName}`
+      : `Owed to ${personName}`
+  const created = await createAccountForFamily({
+    data: {
+      accountType,
+      counterpartyMerchantId: personMerchantId,
+      currency,
+      name: label,
+      openingBalance: "0",
+      idempotencyKey: createUuidV7(),
+    },
+    familyId,
+    user,
+    runInTenantTransaction,
+  })
+  return created.id
+}
+
+async function loadCashAccountCurrency({
+  familyId,
+  user,
+  accountId,
+  runInTenantTransaction,
+}: {
+  familyId: string
+  user: ServerUser
+  accountId: string
+  runInTenantTransaction: RunInTenantTransaction
+}): Promise<string> {
+  const account = await runInTenantTransaction(familyId, user.id, (tx) =>
+    tx.account.findFirst({
+      where: { id: accountId, familyId, deletedAt: null },
+      select: { currency: true },
+    })
+  )
+  if (!account) {
+    throw new PersonDebtNotFoundError(
+      `Account ${accountId} not found for this family`
+    )
+  }
+  return account.currency
+}
+
+// ============================================================================
+// LEND / BORROW / REPAY (ordinary transfers via the ledger core)
+// ============================================================================
+
+export const recordLendInputSchema = z.object({
+  personMerchantId: z.string().min(1),
+  fromAccountId: z.string().min(1),
+  amount: amountSchema,
+  description: z.string().trim().min(1).max(200).optional(),
+  date: z.coerce.date().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+export const recordBorrowInputSchema = z.object({
+  personMerchantId: z.string().min(1),
+  toAccountId: z.string().min(1),
+  amount: amountSchema,
+  description: z.string().trim().min(1).max(200).optional(),
+  date: z.coerce.date().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+export const recordRepaymentInputSchema = z.object({
+  personMerchantId: z.string().min(1),
+  direction: z.enum(["receivable", "loan"]),
+  cashAccountId: z.string().min(1),
+  amount: amountSchema,
+  description: z.string().trim().min(1).max(200).optional(),
+  date: z.coerce.date().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+async function postDebtTransfer({
+  familyId,
+  user,
+  fromAccountId,
+  toAccountId,
+  amount,
+  description,
+  date,
+  idempotencyKey,
+  runInTenantTransaction,
+}: {
+  familyId: string
+  user: ServerUser
+  fromAccountId: string
+  toAccountId: string
+  amount: string
+  description: string
+  date: Date
+  idempotencyKey: string
+  runInTenantTransaction: RunInTenantTransaction
+}) {
+  // The kind (funds_movement / liability_draw / loan_payment) is DERIVED from
+  // the two account types by the ledger core — never passed by this module.
+  return await createTransactionForFamily({
+    data: {
+      type: "transfer",
+      accountId: fromAccountId,
+      toAccountId,
+      amount,
+      description,
+      date,
+      idempotencyKey,
+    },
+    familyId,
+    user,
+    runInTenantTransaction,
+  })
+}
+
+export async function recordLendForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordLendInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}) {
+  const data = recordLendInputSchema.parse(rawData)
+  const person = await loadPersonOrThrow({
+    familyId,
+    user,
+    personMerchantId: data.personMerchantId,
+    runInTenantTransaction,
+  })
+  const currency = await loadCashAccountCurrency({
+    familyId,
+    user,
+    accountId: data.fromAccountId,
+    runInTenantTransaction,
+  })
+  const receivableId = await ensurePersonDebtAccountId({
+    familyId,
+    user,
+    personName: person.name,
+    personMerchantId: person.id,
+    direction: "receivable",
+    currency,
+    runInTenantTransaction,
+  })
+  return await postDebtTransfer({
+    familyId,
+    user,
+    fromAccountId: data.fromAccountId,
+    toAccountId: receivableId,
+    amount: data.amount,
+    description: data.description ?? `Lent to ${person.name}`,
+    date: data.date ?? new Date(),
+    idempotencyKey: data.idempotencyKey,
+    runInTenantTransaction,
+  })
+}
+
+export async function recordBorrowForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordBorrowInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}) {
+  const data = recordBorrowInputSchema.parse(rawData)
+  const person = await loadPersonOrThrow({
+    familyId,
+    user,
+    personMerchantId: data.personMerchantId,
+    runInTenantTransaction,
+  })
+  const currency = await loadCashAccountCurrency({
+    familyId,
+    user,
+    accountId: data.toAccountId,
+    runInTenantTransaction,
+  })
+  const loanId = await ensurePersonDebtAccountId({
+    familyId,
+    user,
+    personName: person.name,
+    personMerchantId: person.id,
+    direction: "loan",
+    currency,
+    runInTenantTransaction,
+  })
+  return await postDebtTransfer({
+    familyId,
+    user,
+    fromAccountId: loanId,
+    toAccountId: data.toAccountId,
+    amount: data.amount,
+    description: data.description ?? `Borrowed from ${person.name}`,
+    date: data.date ?? new Date(),
+    idempotencyKey: data.idempotencyKey,
+    runInTenantTransaction,
+  })
+}
+
+export async function recordRepaymentForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordRepaymentInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}) {
+  const data = recordRepaymentInputSchema.parse(rawData)
+  const person = await loadPersonOrThrow({
+    familyId,
+    user,
+    personMerchantId: data.personMerchantId,
+    runInTenantTransaction,
+  })
+  const currency = await loadCashAccountCurrency({
+    familyId,
+    user,
+    accountId: data.cashAccountId,
+    runInTenantTransaction,
+  })
+  const debtAccountId = await ensurePersonDebtAccountId({
+    familyId,
+    user,
+    personName: person.name,
+    personMerchantId: person.id,
+    direction: data.direction,
+    currency,
+    runInTenantTransaction,
+  })
+  // Repay is the transfer in the OPPOSITE direction to the original debt:
+  //   receivable repaid: RECEIVABLE -> cash  (they pay you back)
+  //   loan repaid       : cash -> LOAN        (you pay them back)
+  const fromAccountId =
+    data.direction === "receivable" ? debtAccountId : data.cashAccountId
+  const toAccountId =
+    data.direction === "receivable" ? data.cashAccountId : debtAccountId
+  return await postDebtTransfer({
+    familyId,
+    user,
+    fromAccountId,
+    toAccountId,
+    amount: data.amount,
+    description:
+      data.description ??
+      (data.direction === "receivable"
+        ? `Repayment from ${person.name}`
+        : `Repayment to ${person.name}`),
+    date: data.date ?? new Date(),
+    idempotencyKey: data.idempotencyKey,
+    runInTenantTransaction,
+  })
+}
+
+export const recordLendFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordLendInputSchema>) =>
+    recordLendInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordLendForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+export const recordBorrowFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordBorrowInputSchema>) =>
+    recordBorrowInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordBorrowForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+export const recordRepaymentFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordRepaymentInputSchema>) =>
+    recordRepaymentInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordRepaymentForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// ============================================================================
+// READ — Utang-Piutang view (persons with linked debt accounts + net position)
+// ============================================================================
+
+export interface PersonDebtAccountView {
+  id: string
+  name: string
+  accountType: string
+  currency: string
+  // Signed minor units as a digit-string (RECEIVABLE >= 0, LOAN <= 0).
+  balance: string
+}
+
+export interface PersonDebtCurrencyPosition {
+  currency: string
+  // Signed net across this person's accounts in `currency`. > 0 they owe you;
+  // < 0 you owe them; 0 settled.
+  net: string
+}
+
+export interface PersonDebtView {
+  personId: string
+  name: string
+  color: string | null
+  accounts: PersonDebtAccountView[]
+  positions: PersonDebtCurrencyPosition[]
+  // True iff EVERY currency position nets to zero (fully "Lunas").
+  settled: boolean
+}
+
+export async function getPersonDebtsForFamily({
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<PersonDebtView[]> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const [persons, accounts] = await Promise.all([
+      tx.merchant.findMany({
+        where: { familyId, kind: "person" },
+        select: { id: true, name: true, color: true },
+        orderBy: { name: "asc" },
+      }),
+      tx.account.findMany({
+        where: {
+          familyId,
+          deletedAt: null,
+          counterpartyMerchantId: { not: null },
+        },
+        select: {
+          id: true,
+          name: true,
+          accountType: true,
+          currency: true,
+          balance: true,
+          counterpartyMerchantId: true,
+        },
+        orderBy: { name: "asc" },
+      }),
+    ])
+
+    const accountsByPerson = new Map<string, typeof accounts>()
+    for (const account of accounts) {
+      const key = account.counterpartyMerchantId
+      if (key === null) continue
+      const bucket = accountsByPerson.get(key) ?? []
+      bucket.push(account)
+      accountsByPerson.set(key, bucket)
+    }
+
+    const views: PersonDebtView[] = []
+    for (const person of persons) {
+      const linked = accountsByPerson.get(person.id) ?? []
+      // Only persons that actually have a debt relationship are listed.
+      if (linked.length === 0) continue
+
+      const netByCurrency = new Map<string, bigint>()
+      for (const account of linked) {
+        netByCurrency.set(
+          account.currency,
+          (netByCurrency.get(account.currency) ?? 0n) + account.balance
+        )
+      }
+      const positions: PersonDebtCurrencyPosition[] = [
+        ...netByCurrency.entries(),
+      ]
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([currency, net]) => ({ currency, net: net.toString() }))
+
+      views.push({
+        personId: person.id,
+        name: person.name,
+        color: person.color,
+        accounts: linked.map((account) => ({
+          id: account.id,
+          name: account.name,
+          accountType: account.accountType,
+          currency: account.currency,
+          balance: account.balance.toString(),
+        })),
+        positions,
+        settled: positions.every((position) => BigInt(position.net) === 0n),
+      })
+    }
+    return views
+  })
+}
+
+export const getPersonDebtsFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .handler(async ({ context }) => {
+    return await getPersonDebtsForFamily({
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+// ============================================================================
+// READ — all persons (for the "record debt" picker, incl. those with no debt
+// account yet). `getPersonDebtsFn` intentionally lists only persons WITH
+// linked accounts; this one lists every person contact.
+// ============================================================================
+
+export interface PersonView {
+  id: string
+  name: string
+  color: string | null
+}
+
+export async function getPersonsForFamily({
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<PersonView[]> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const persons = await tx.merchant.findMany({
+      where: { familyId, kind: "person" },
+      select: { id: true, name: true, color: true },
+      orderBy: { name: "asc" },
+    })
+    return persons
+  })
+}
+
+export const getPersonsFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .handler(async ({ context }) => {
+    return await getPersonsForFamily({
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })

--- a/src/server/merchants.ts
+++ b/src/server/merchants.ts
@@ -48,9 +48,16 @@ const hexColorSchema = z
   .trim()
   .regex(/^#[0-9a-fA-F]{6}$/, "color must be a #RRGGBB hex value")
 
+// PER-212 / ADR-0049: "business" (classic payee) | "person" (informal-debt
+// party). Defaults to "business" so every existing quick-create keeps its
+// meaning; a person contact is created by passing kind="person".
+export const MERCHANT_KIND_VALUES = ["business", "person"] as const
+export type MerchantKind = (typeof MERCHANT_KIND_VALUES)[number]
+
 export const createMerchantInputSchema = z.object({
   name: nameSchema,
   color: hexColorSchema.nullable().optional(),
+  kind: z.enum(MERCHANT_KIND_VALUES).optional().default("business"),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -60,6 +67,7 @@ export interface SerializedMerchant {
   id: string
   name: string
   color: string | null
+  kind: MerchantKind
 }
 
 function serializeMerchant(merchant: Merchant): SerializedMerchant {
@@ -67,6 +75,7 @@ function serializeMerchant(merchant: Merchant): SerializedMerchant {
     id: merchant.id,
     name: merchant.name,
     color: merchant.color,
+    kind: merchant.kind as MerchantKind,
   }
 }
 
@@ -88,7 +97,12 @@ export async function createMerchantForFamily({
   const data: CreateMerchantInput = createMerchantInputSchema.parse(rawData)
   const trimmedName = data.name.trim()
   const color = data.color ?? null
-  const requestHash = await hashCanonicalPayload({ color, name: trimmedName })
+  const kind = data.kind
+  const requestHash = await hashCanonicalPayload({
+    color,
+    kind,
+    name: trimmedName,
+  })
   const auditCtx = await createAuditContext(
     { user: { id: user.id, familyId } },
     data.idempotencyKey
@@ -116,7 +130,7 @@ export async function createMerchantForFamily({
       if (existing) throw new DuplicateNameError("Merchant", trimmedName)
 
       const merchant = await tx.merchant.create({
-        data: { familyId, name: trimmedName, color },
+        data: { familyId, name: trimmedName, color, kind },
       })
 
       const serialized = serializeMerchant(merchant)

--- a/tests/e2e/person-debt.e2e.ts
+++ b/tests/e2e/person-debt.e2e.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-212 / ADR-0049 — person-to-person debt (Utang-Piutang) end-to-end.
+// Onboard → create a cash account → record a LEND to a brand-new person →
+// assert it shows in Utang-Piutang with the right net position AND on the
+// net-worth card as the grouped "Personal debts (net)" line (never in the main
+// Accounts list) → record the repayment → assert the person is settled (Lunas).
+
+test.describe("person-to-person debt (PER-212)", () => {
+  test("lend to a new person, see it in Utang-Piutang + net-worth aggregate, then settle", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const cashName = `E2E Cash ${suffix}`
+    const personName = `Budi ${suffix}`
+
+    // --- Create the cash account (default cash-like type) ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(cashName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Record a lend to a brand-new person ---
+    await page.goto("/debts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "Record debt" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    // Person defaults to "+ New person"; just name them.
+    await page.getByLabel("New person name").fill(personName)
+    // Action defaults to "Lend (they will owe me)".
+    await page.getByRole("combobox", { name: "Cash account" }).click()
+    await page.getByRole("option", { name: `${cashName} (IDR)` }).click()
+    await page.getByLabel(/^Amount/).fill("500000")
+    await page.getByRole("button", { name: "Save" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Utang-Piutang shows the person with the right net position ---
+    await expect(page.getByText(personName)).toBeVisible()
+    await expect(page.getByText("They owe you")).toBeVisible()
+    await expect(page.getByText("Rp 500,000.00")).toBeVisible()
+
+    // --- Net-worth card: the grouped "Personal debts (net)" line appears, the
+    //     receivable stays OUT of the main Accounts list, and the TOTAL is
+    //     unchanged (2,000,000: 1,500,000 cash + 500,000 receivable). ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText("Personal debts (net)")).toBeVisible()
+    await expect(page.getByText("Rp 2,000,000.00")).toBeVisible()
+    await expect(page.getByText(`Owed by ${personName}`)).toHaveCount(0)
+
+    // --- Record the repayment (they pay you back in full) ---
+    await page.goto("/debts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "Record debt" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+
+    await page.getByRole("combobox", { name: "Person" }).click()
+    await page.getByRole("option", { name: personName }).click()
+    await page.getByRole("combobox", { name: "Action" }).click()
+    await page
+      .getByRole("option", { name: "Repayment received (they pay me back)" })
+      .click()
+    await page.getByRole("combobox", { name: "Cash account" }).click()
+    await page.getByRole("option", { name: `${cashName} (IDR)` }).click()
+    await page.getByLabel(/^Amount/).fill("500000")
+    await page.getByRole("button", { name: "Save" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- The person is now settled: Lunas badge, net back to zero ---
+    await expect(page.getByText("Lunas")).toBeVisible()
+    await expect(page.getByText("Settled")).toBeVisible()
+  })
+})

--- a/tests/integration/person-debt.integration.ts
+++ b/tests/integration/person-debt.integration.ts
@@ -1,0 +1,442 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import { getAccountsForFamily } from "../../src/server/accounts"
+import {
+  createPersonForFamily,
+  getPersonDebtsForFamily,
+  getPersonsForFamily,
+  recordBorrowForFamily,
+  recordLendForFamily,
+  recordRepaymentForFamily,
+} from "../../src/server/debts"
+import { normalizeNetWorthAt, type PointBalance } from "../../src/lib/net-worth"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import { createTestFactories, type TestFactories } from "./support/factories"
+
+// PER-212 / ADR-0049 — person-to-person debt (Utang-Piutang). A person-debt is
+// an ordinary RECEIVABLE/LOAN account flagged by a person Merchant, and every
+// flow is a plain transfer through `createTransactionForFamily`. These tests
+// prove the real boundary: balances, net position aggregation, the net-worth
+// TOTAL invariant (grouping is presentation-only), tenant isolation, and
+// idempotency replay — all against real Postgres.
+
+describe("PER-212 person-to-person debt", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  test("lend creates a RECEIVABLE that grows while cash drops", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      familyId: owner.family.id,
+      name: "Cash",
+    })
+    const budi = await createPersonForFamily({
+      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    await recordLendForFamily({
+      data: {
+        personMerchantId: budi.id,
+        fromAccountId: cash.id,
+        amount: "40000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    const accounts = await readAccounts(owner.family.id)
+    const cashRow = accounts.find((a) => a.id === cash.id)
+    const receivable = accounts.find(
+      (a) => a.counterpartyMerchantId === budi.id
+    )
+    expect(cashRow?.balance).toBe(60_000n)
+    expect(receivable?.accountType).toBe("RECEIVABLE")
+    expect(receivable?.balance).toBe(40_000n)
+
+    const debts = await getPersonDebtsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(debts).toHaveLength(1)
+    expect(debts[0].personId).toBe(budi.id)
+    expect(debts[0].settled).toBe(false)
+    expect(debts[0].positions).toEqual([{ currency: "IDR", net: "40000" }])
+  })
+
+  test("borrow creates a LOAN + cash grows (liability_draw)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 0n,
+      familyId: owner.family.id,
+      name: "Cash",
+    })
+    const abah = await createPersonForFamily({
+      data: { name: "Abah", idempotencyKey: factories.createIdempotencyKey() },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    const draw = await recordBorrowForFamily({
+      data: {
+        personMerchantId: abah.id,
+        toAccountId: cash.id,
+        amount: "30000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    expect(draw.kind).toBe("liability_draw")
+
+    const accounts = await readAccounts(owner.family.id)
+    const cashRow = accounts.find((a) => a.id === cash.id)
+    const loan = accounts.find((a) => a.counterpartyMerchantId === abah.id)
+    expect(cashRow?.balance).toBe(30_000n)
+    expect(loan?.accountType).toBe("LOAN")
+    expect(loan?.balance).toBe(-30_000n)
+
+    const debts = await getPersonDebtsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(debts[0].positions).toEqual([{ currency: "IDR", net: "-30000" }])
+    expect(debts[0].settled).toBe(false)
+  })
+
+  test("net position aggregates a person's accounts; repay to zero settles", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      familyId: owner.family.id,
+      name: "Cash",
+    })
+    const budi = await createPersonForFamily({
+      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    // Lend 50k (receivable +50k) AND borrow 20k from the same person
+    // (loan -20k). Net across the two linked accounts = +30k.
+    await recordLendForFamily({
+      data: {
+        personMerchantId: budi.id,
+        fromAccountId: cash.id,
+        amount: "50000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+    await recordBorrowForFamily({
+      data: {
+        personMerchantId: budi.id,
+        toAccountId: cash.id,
+        amount: "20000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    let debts = await getPersonDebtsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(debts[0].accounts).toHaveLength(2)
+    expect(debts[0].positions).toEqual([{ currency: "IDR", net: "30000" }])
+    expect(debts[0].settled).toBe(false)
+
+    // Repay both sides fully → net 0 → settled (Lunas).
+    await recordRepaymentForFamily({
+      data: {
+        personMerchantId: budi.id,
+        direction: "receivable",
+        cashAccountId: cash.id,
+        amount: "50000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+    await recordRepaymentForFamily({
+      data: {
+        personMerchantId: budi.id,
+        direction: "loan",
+        cashAccountId: cash.id,
+        amount: "20000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    debts = await getPersonDebtsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(debts[0].positions).toEqual([{ currency: "IDR", net: "0" }])
+    expect(debts[0].settled).toBe(true)
+
+    // Cash is back where it started: -50k lend +20k borrow +50k repaid -20k repaid.
+    const accounts = await readAccounts(owner.family.id)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+  })
+
+  test("net-worth TOTAL is identical whether or not debts are counterparty-linked", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      familyId: owner.family.id,
+      name: "Cash",
+    })
+    const budi = await createPersonForFamily({
+      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    await recordLendForFamily({
+      data: {
+        personMerchantId: budi.id,
+        fromAccountId: cash.id,
+        amount: "40000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+    await recordBorrowForFamily({
+      data: {
+        personMerchantId: budi.id,
+        toAccountId: cash.id,
+        amount: "30000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    // While linked: the main list (includeCounterparty:false) excludes the two
+    // debt accounts, but the net-worth math (includeCounterparty:true) keeps them.
+    const listedOnly = await getAccountsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      includeCounterparty: false,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(listedOnly).toHaveLength(1)
+    expect(listedOnly[0].id).toBe(cash.id)
+
+    const withDebtsLinked = await getAccountsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(withDebtsLinked).toHaveLength(3)
+    const totalLinked = netWorthOf(withDebtsLinked)
+
+    // Unlink the debt accounts: now plain RECEIVABLE/LOAN accounts, no flag.
+    await harness.withMember(owner.family.id, owner.user.id, async (tx) => {
+      await tx.account.updateMany({
+        where: { familyId: owner.family.id, counterpartyMerchantId: budi.id },
+        data: { counterpartyMerchantId: null },
+      })
+    })
+    const afterUnlink = await getAccountsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(afterUnlink).toHaveLength(3)
+    const totalUnlinked = netWorthOf(afterUnlink)
+
+    // The flag is presentation only: the grand total NEVER moves.
+    expect(totalLinked).toBe(totalUnlinked)
+    // Sanity: net worth = 100k (lending/borrowing nets to a wash on net worth).
+    expect(totalLinked).toBe(100_000n)
+  })
+
+  test("tenant isolation: family B cannot see family A's persons or debts", async () => {
+    const ownerA = await factories.createAuthenticatedOnboardedUser()
+    const ownerB = await factories.createAuthenticatedOnboardedUser()
+    const cashA = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      familyId: ownerA.family.id,
+      name: "A Cash",
+    })
+    const budi = await createPersonForFamily({
+      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
+      familyId: ownerA.family.id,
+      user: ownerA.user,
+      runInTenantTransaction: harness.withMember,
+    })
+    await recordLendForFamily({
+      data: {
+        personMerchantId: budi.id,
+        fromAccountId: cashA.id,
+        amount: "40000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: ownerA.family.id,
+      user: ownerA.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    const debtsB = await getPersonDebtsForFamily({
+      familyId: ownerB.family.id,
+      userId: ownerB.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    const personsB = await getPersonsForFamily({
+      familyId: ownerB.family.id,
+      userId: ownerB.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(debtsB).toEqual([])
+    expect(personsB).toEqual([])
+
+    // And family A still sees its own.
+    const debtsA = await getPersonDebtsForFamily({
+      familyId: ownerA.family.id,
+      userId: ownerA.user.id,
+      runInTenantTransaction: harness.withMember,
+    })
+    expect(debtsA).toHaveLength(1)
+  })
+
+  test("idempotency replay of a lend is a no-op", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      familyId: owner.family.id,
+      name: "Cash",
+    })
+    const budi = await createPersonForFamily({
+      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
+      familyId: owner.family.id,
+      user: owner.user,
+      runInTenantTransaction: harness.withMember,
+    })
+
+    const key = factories.createIdempotencyKey()
+    // A genuine replay re-sends the IDENTICAL request, date included (the client
+    // stamps the date once, so a network retry carries the same bytes).
+    const date = new Date("2026-06-05T00:00:00.000Z")
+    const lendOnce = () =>
+      recordLendForFamily({
+        data: {
+          personMerchantId: budi.id,
+          fromAccountId: cash.id,
+          amount: "40000",
+          date,
+          idempotencyKey: key,
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+        runInTenantTransaction: harness.withMember,
+      })
+
+    await lendOnce()
+    await lendOnce() // replay: same key, same payload
+
+    const accounts = await readAccounts(owner.family.id)
+    const receivables = accounts.filter(
+      (a) => a.counterpartyMerchantId === budi.id
+    )
+    // Exactly one receivable account, balance applied exactly once.
+    expect(receivables).toHaveLength(1)
+    expect(receivables[0].balance).toBe(40_000n)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(60_000n)
+
+    // Exactly two transaction legs total (one transfer, replayed = no new rows).
+    const txCount = await harness.withMember(
+      owner.family.id,
+      owner.user.id,
+      (tx) => tx.transaction.count({ where: { familyId: owner.family.id } })
+    )
+    expect(txCount).toBe(2)
+  })
+
+  async function readAccounts(familyId: string) {
+    return await harness.withFamily(familyId, (tx) =>
+      tx.account.findMany({
+        select: {
+          id: true,
+          accountType: true,
+          accountClass: true,
+          balance: true,
+          currency: true,
+          counterpartyMerchantId: true,
+        },
+        where: { familyId, deletedAt: null },
+      })
+    )
+  }
+
+  function netWorthOf(
+    accounts: ReadonlyArray<{
+      accountClass: string
+      currency: string
+      balance: string
+    }>
+  ): bigint {
+    const balances: PointBalance[] = accounts.map((a) => ({
+      accountClass: a.accountClass,
+      currency: a.currency,
+      native: BigInt(a.balance),
+    }))
+    // Single-currency (IDR) fixture, base = IDR: the rate resolver is never
+    // consulted (identity path), so it can safely return null.
+    return normalizeNetWorthAt(balances, () => null, "IDR").netWorth
+  }
+})

--- a/tests/integration/person-debt.integration.ts
+++ b/tests/integration/person-debt.integration.ts
@@ -29,6 +29,28 @@ import { createTestFactories, type TestFactories } from "./support/factories"
 // TOTAL invariant (grouping is presentation-only), tenant isolation, and
 // idempotency replay — all against real Postgres.
 
+type Owner = Awaited<
+  ReturnType<TestFactories["createAuthenticatedOnboardedUser"]>
+>
+
+// Pure net-worth reducer (module scope: no harness dependency). Single-currency
+// (IDR) fixtures, base = IDR: the rate resolver is never consulted (identity
+// path), so it can safely return null.
+function netWorthOf(
+  accounts: ReadonlyArray<{
+    accountClass: string
+    currency: string
+    balance: string
+  }>
+): bigint {
+  const balances: PointBalance[] = accounts.map((a) => ({
+    accountClass: a.accountClass,
+    currency: a.currency,
+    native: BigInt(a.balance),
+  }))
+  return normalizeNetWorthAt(balances, () => null, "IDR").netWorth
+}
+
 describe("PER-212 person-to-person debt", () => {
   let harness: IntegrationHarness
   let factories: TestFactories
@@ -46,32 +68,124 @@ describe("PER-212 person-to-person debt", () => {
     await harness.teardown()
   })
 
-  test("lend creates a RECEIVABLE that grows while cash drops", async () => {
+  // --- Arrange/act helpers: collapse the repeated
+  // `{ data, familyId, user, runInTenantTransaction }` ceremony so each test
+  // reads as intent, not boilerplate. ---
+
+  const memberCtx = (owner: Owner) => ({
+    familyId: owner.family.id,
+    user: owner.user,
+    runInTenantTransaction: harness.withMember,
+  })
+
+  const readerCtx = (owner: Owner) => ({
+    familyId: owner.family.id,
+    userId: owner.user.id,
+    runInTenantTransaction: harness.withMember,
+  })
+
+  async function setup(
+    cashBalance: bigint,
+    personName = "Budi"
+  ): Promise<{ owner: Owner; cash: { id: string }; person: { id: string } }> {
     const owner = await factories.createAuthenticatedOnboardedUser()
     const cash = await factories.createAccount({
       accountType: "DEPOSITORY",
-      balance: 100_000n,
+      balance: cashBalance,
       familyId: owner.family.id,
       name: "Cash",
     })
-    const budi = await createPersonForFamily({
-      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
-
-    await recordLendForFamily({
+    const person = await createPersonForFamily({
       data: {
-        personMerchantId: budi.id,
-        fromAccountId: cash.id,
-        amount: "40000",
+        name: personName,
         idempotencyKey: factories.createIdempotencyKey(),
       },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
+      ...memberCtx(owner),
     })
+    return { owner, cash, person }
+  }
+
+  const lend = (
+    owner: Owner,
+    personMerchantId: string,
+    fromAccountId: string,
+    amount: string,
+    opts?: { date?: Date; idempotencyKey?: string }
+  ) =>
+    recordLendForFamily({
+      data: {
+        personMerchantId,
+        fromAccountId,
+        amount,
+        idempotencyKey:
+          opts?.idempotencyKey ?? factories.createIdempotencyKey(),
+        ...(opts?.date ? { date: opts.date } : {}),
+      },
+      ...memberCtx(owner),
+    })
+
+  const borrow = (
+    owner: Owner,
+    personMerchantId: string,
+    toAccountId: string,
+    amount: string
+  ) =>
+    recordBorrowForFamily({
+      data: {
+        personMerchantId,
+        toAccountId,
+        amount,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      ...memberCtx(owner),
+    })
+
+  const repay = (
+    owner: Owner,
+    personMerchantId: string,
+    direction: "receivable" | "loan",
+    cashAccountId: string,
+    amount: string
+  ) =>
+    recordRepaymentForFamily({
+      data: {
+        personMerchantId,
+        direction,
+        cashAccountId,
+        amount,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      ...memberCtx(owner),
+    })
+
+  const debtsOf = (owner: Owner) => getPersonDebtsForFamily(readerCtx(owner))
+  const personsOf = (owner: Owner) => getPersonsForFamily(readerCtx(owner))
+  const listAccounts = (owner: Owner, includeCounterparty?: boolean) =>
+    getAccountsForFamily({
+      ...readerCtx(owner),
+      ...(includeCounterparty === undefined ? {} : { includeCounterparty }),
+    })
+
+  async function readAccounts(familyId: string) {
+    return await harness.withFamily(familyId, (tx) =>
+      tx.account.findMany({
+        select: {
+          id: true,
+          accountType: true,
+          accountClass: true,
+          balance: true,
+          currency: true,
+          counterpartyMerchantId: true,
+        },
+        where: { familyId, deletedAt: null },
+      })
+    )
+  }
+
+  test("lend creates a RECEIVABLE that grows while cash drops", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+
+    await lend(owner, budi.id, cash.id, "40000")
 
     const accounts = await readAccounts(owner.family.id)
     const cashRow = accounts.find((a) => a.id === cash.id)
@@ -82,11 +196,7 @@ describe("PER-212 person-to-person debt", () => {
     expect(receivable?.accountType).toBe("RECEIVABLE")
     expect(receivable?.balance).toBe(40_000n)
 
-    const debts = await getPersonDebtsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
+    const debts = await debtsOf(owner)
     expect(debts).toHaveLength(1)
     expect(debts[0].personId).toBe(budi.id)
     expect(debts[0].settled).toBe(false)
@@ -94,32 +204,9 @@ describe("PER-212 person-to-person debt", () => {
   })
 
   test("borrow creates a LOAN + cash grows (liability_draw)", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const cash = await factories.createAccount({
-      accountType: "DEPOSITORY",
-      balance: 0n,
-      familyId: owner.family.id,
-      name: "Cash",
-    })
-    const abah = await createPersonForFamily({
-      data: { name: "Abah", idempotencyKey: factories.createIdempotencyKey() },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    const { owner, cash, person: abah } = await setup(0n, "Abah")
 
-    const draw = await recordBorrowForFamily({
-      data: {
-        personMerchantId: abah.id,
-        toAccountId: cash.id,
-        amount: "30000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
-
+    const draw = await borrow(owner, abah.id, cash.id, "30000")
     expect(draw.kind).toBe("liability_draw")
 
     const accounts = await readAccounts(owner.family.id)
@@ -129,95 +216,29 @@ describe("PER-212 person-to-person debt", () => {
     expect(loan?.accountType).toBe("LOAN")
     expect(loan?.balance).toBe(-30_000n)
 
-    const debts = await getPersonDebtsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
+    const debts = await debtsOf(owner)
     expect(debts[0].positions).toEqual([{ currency: "IDR", net: "-30000" }])
     expect(debts[0].settled).toBe(false)
   })
 
   test("net position aggregates a person's accounts; repay to zero settles", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const cash = await factories.createAccount({
-      accountType: "DEPOSITORY",
-      balance: 100_000n,
-      familyId: owner.family.id,
-      name: "Cash",
-    })
-    const budi = await createPersonForFamily({
-      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    const { owner, cash, person: budi } = await setup(100_000n)
 
     // Lend 50k (receivable +50k) AND borrow 20k from the same person
     // (loan -20k). Net across the two linked accounts = +30k.
-    await recordLendForFamily({
-      data: {
-        personMerchantId: budi.id,
-        fromAccountId: cash.id,
-        amount: "50000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
-    await recordBorrowForFamily({
-      data: {
-        personMerchantId: budi.id,
-        toAccountId: cash.id,
-        amount: "20000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    await lend(owner, budi.id, cash.id, "50000")
+    await borrow(owner, budi.id, cash.id, "20000")
 
-    let debts = await getPersonDebtsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
+    let debts = await debtsOf(owner)
     expect(debts[0].accounts).toHaveLength(2)
     expect(debts[0].positions).toEqual([{ currency: "IDR", net: "30000" }])
     expect(debts[0].settled).toBe(false)
 
     // Repay both sides fully → net 0 → settled (Lunas).
-    await recordRepaymentForFamily({
-      data: {
-        personMerchantId: budi.id,
-        direction: "receivable",
-        cashAccountId: cash.id,
-        amount: "50000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
-    await recordRepaymentForFamily({
-      data: {
-        personMerchantId: budi.id,
-        direction: "loan",
-        cashAccountId: cash.id,
-        amount: "20000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    await repay(owner, budi.id, "receivable", cash.id, "50000")
+    await repay(owner, budi.id, "loan", cash.id, "20000")
 
-    debts = await getPersonDebtsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
+    debts = await debtsOf(owner)
     expect(debts[0].positions).toEqual([{ currency: "IDR", net: "0" }])
     expect(debts[0].settled).toBe(true)
 
@@ -227,59 +248,18 @@ describe("PER-212 person-to-person debt", () => {
   })
 
   test("net-worth TOTAL is identical whether or not debts are counterparty-linked", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const cash = await factories.createAccount({
-      accountType: "DEPOSITORY",
-      balance: 100_000n,
-      familyId: owner.family.id,
-      name: "Cash",
-    })
-    const budi = await createPersonForFamily({
-      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    const { owner, cash, person: budi } = await setup(100_000n)
 
-    await recordLendForFamily({
-      data: {
-        personMerchantId: budi.id,
-        fromAccountId: cash.id,
-        amount: "40000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
-    await recordBorrowForFamily({
-      data: {
-        personMerchantId: budi.id,
-        toAccountId: cash.id,
-        amount: "30000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    await lend(owner, budi.id, cash.id, "40000")
+    await borrow(owner, budi.id, cash.id, "30000")
 
     // While linked: the main list (includeCounterparty:false) excludes the two
     // debt accounts, but the net-worth math (includeCounterparty:true) keeps them.
-    const listedOnly = await getAccountsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      includeCounterparty: false,
-      runInTenantTransaction: harness.withMember,
-    })
+    const listedOnly = await listAccounts(owner, false)
     expect(listedOnly).toHaveLength(1)
     expect(listedOnly[0].id).toBe(cash.id)
 
-    const withDebtsLinked = await getAccountsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
+    const withDebtsLinked = await listAccounts(owner)
     expect(withDebtsLinked).toHaveLength(3)
     const totalLinked = netWorthOf(withDebtsLinked)
 
@@ -290,11 +270,7 @@ describe("PER-212 person-to-person debt", () => {
         data: { counterpartyMerchantId: null },
       })
     })
-    const afterUnlink = await getAccountsForFamily({
-      familyId: owner.family.id,
-      userId: owner.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
+    const afterUnlink = await listAccounts(owner)
     expect(afterUnlink).toHaveLength(3)
     const totalUnlinked = netWorthOf(afterUnlink)
 
@@ -305,86 +281,27 @@ describe("PER-212 person-to-person debt", () => {
   })
 
   test("tenant isolation: family B cannot see family A's persons or debts", async () => {
-    const ownerA = await factories.createAuthenticatedOnboardedUser()
+    const { owner: ownerA, cash: cashA, person: budi } = await setup(100_000n)
     const ownerB = await factories.createAuthenticatedOnboardedUser()
-    const cashA = await factories.createAccount({
-      accountType: "DEPOSITORY",
-      balance: 100_000n,
-      familyId: ownerA.family.id,
-      name: "A Cash",
-    })
-    const budi = await createPersonForFamily({
-      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
-      familyId: ownerA.family.id,
-      user: ownerA.user,
-      runInTenantTransaction: harness.withMember,
-    })
-    await recordLendForFamily({
-      data: {
-        personMerchantId: budi.id,
-        fromAccountId: cashA.id,
-        amount: "40000",
-        idempotencyKey: factories.createIdempotencyKey(),
-      },
-      familyId: ownerA.family.id,
-      user: ownerA.user,
-      runInTenantTransaction: harness.withMember,
-    })
 
-    const debtsB = await getPersonDebtsForFamily({
-      familyId: ownerB.family.id,
-      userId: ownerB.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
-    const personsB = await getPersonsForFamily({
-      familyId: ownerB.family.id,
-      userId: ownerB.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
-    expect(debtsB).toEqual([])
-    expect(personsB).toEqual([])
+    await lend(ownerA, budi.id, cashA.id, "40000")
+
+    expect(await debtsOf(ownerB)).toEqual([])
+    expect(await personsOf(ownerB)).toEqual([])
 
     // And family A still sees its own.
-    const debtsA = await getPersonDebtsForFamily({
-      familyId: ownerA.family.id,
-      userId: ownerA.user.id,
-      runInTenantTransaction: harness.withMember,
-    })
-    expect(debtsA).toHaveLength(1)
+    expect(await debtsOf(ownerA)).toHaveLength(1)
   })
 
   test("idempotency replay of a lend is a no-op", async () => {
-    const owner = await factories.createAuthenticatedOnboardedUser()
-    const cash = await factories.createAccount({
-      accountType: "DEPOSITORY",
-      balance: 100_000n,
-      familyId: owner.family.id,
-      name: "Cash",
-    })
-    const budi = await createPersonForFamily({
-      data: { name: "Budi", idempotencyKey: factories.createIdempotencyKey() },
-      familyId: owner.family.id,
-      user: owner.user,
-      runInTenantTransaction: harness.withMember,
-    })
+    const { owner, cash, person: budi } = await setup(100_000n)
 
     const key = factories.createIdempotencyKey()
     // A genuine replay re-sends the IDENTICAL request, date included (the client
     // stamps the date once, so a network retry carries the same bytes).
     const date = new Date("2026-06-05T00:00:00.000Z")
     const lendOnce = () =>
-      recordLendForFamily({
-        data: {
-          personMerchantId: budi.id,
-          fromAccountId: cash.id,
-          amount: "40000",
-          date,
-          idempotencyKey: key,
-        },
-        familyId: owner.family.id,
-        user: owner.user,
-        runInTenantTransaction: harness.withMember,
-      })
+      lend(owner, budi.id, cash.id, "40000", { date, idempotencyKey: key })
 
     await lendOnce()
     await lendOnce() // replay: same key, same payload
@@ -406,37 +323,4 @@ describe("PER-212 person-to-person debt", () => {
     )
     expect(txCount).toBe(2)
   })
-
-  async function readAccounts(familyId: string) {
-    return await harness.withFamily(familyId, (tx) =>
-      tx.account.findMany({
-        select: {
-          id: true,
-          accountType: true,
-          accountClass: true,
-          balance: true,
-          currency: true,
-          counterpartyMerchantId: true,
-        },
-        where: { familyId, deletedAt: null },
-      })
-    )
-  }
-
-  function netWorthOf(
-    accounts: ReadonlyArray<{
-      accountClass: string
-      currency: string
-      balance: string
-    }>
-  ): bigint {
-    const balances: PointBalance[] = accounts.map((a) => ({
-      accountClass: a.accountClass,
-      currency: a.currency,
-      native: BigInt(a.balance),
-    }))
-    // Single-currency (IDR) fixture, base = IDR: the rate resolver is never
-    // consulted (identity path), so it can safely return null.
-    return normalizeNetWorthAt(balances, () => null, "IDR").netWorth
-  }
 })


### PR DESCRIPTION
## PER-212 — Person-to-person debt (Utang-Piutang), Slice 1 of PER-211

Makes informal person-to-person lending/borrowing first-class by **reusing the
existing ledger**, not inventing a debt sub-ledger. Design was locked by grill;
implemented exactly.

### Locked design

A person-debt is **not** a new ledger concept — it's an ordinary
`RECEIVABLE`(ASSET) / `LOAN`(LIABILITY) account **flagged** by a link to a
"person" contact. Lend/borrow/repay are **ordinary transfers** through the
existing `createTransactionForFamily`, so double-entry, signed amounts, atomic
`{increment/decrement}` balance updates, idempotency, tenant-reference
validation, RLS scoping, and append-only audit all hold **for free**.

| Flow             | Transfer          | Derived kind     | Effect                  |
| ---------------- | ----------------- | ---------------- | ----------------------- |
| Lend             | cash → RECEIVABLE | `funds_movement` | their debt to you grows |
| Borrow           | LOAN → cash       | `liability_draw` | your debt to them grows |
| Repay receivable | RECEIVABLE → cash | `funds_movement` | they pay you back       |
| Repay loan       | cash → LOAN       | `loan_payment`   | you pay them back       |

The `kind` is derived by the ledger core from the two account types — never
passed in.

### Schema (migration `20260801130000_person_debt_counterparty`)

- `Merchant.kind` — `"business"` | `"person"` (default `"business"`,
  CHECK-constrained). A person = a Merchant with `kind="person"` (the PER-189
  extension point: one counterparty concept unifies payee + debt-party).
- `Account.counterpartyMerchantId` — nullable **tenant-safe composite FK** to
  `Merchant(id, familyId)` (Pattern A / ADR-0010, `MATCH SIMPLE`), indexed. Its
  presence is the only discriminator of a person-debt account.
- Additive only: no backfill, no data movement.

### Reuse-the-ledger approach (backend)

- `src/server/debts.ts`: `createPerson`, `recordLend`/`recordBorrow`/
  `recordRepayment`, `getPersonDebts` (Utang-Piutang net positions),
  `getPersons`. Each mutation ensures the right person-debt account exists
  (create-if-absent, **idempotent by lookup**) then posts a transfer via
  `createTransactionForFamily`. No new balance authority.
- `getAccountsForFamily` gains `includeCounterparty` (default **true**, so
  net-worth math and every existing caller keep seeing debt accounts); the main
  Accounts page passes the full set to the net-worth card and hides
  counterparty-linked accounts from the list.

### Net-worth TOTAL invariant

Person-debt accounts stay RECEIVABLE(ASSET)/LOAN(LIABILITY), so they are already
in the total by construction (`normalizeNetWorthAt`, ADR-0038). **The total does
not change.** The only change is presentation: one grouped **"Personal debts
(net)"** line on the net-worth card. Proven by a real-Postgres test asserting
the total is identical whether or not the debt accounts are counterparty-linked.

### Frontend

- New `/debts` (Utang-Piutang) route — `ssr:false` + loader awaiting
  `collection.preload()`; per-person net position + settled ("Lunas") state; a
  record-debt flow (create person inline + lend/borrow/repay, ad-hoc); refetch
  after every mutation.
- Net-worth card renders the grouped "Personal debts (net)" line; sidebar entry.

### Scope

Ad-hoc amounts only. Installment schedules, reminders, and interest are later
PER-211 slices (documented in the ADR).

### ADR

`docs/adr/0049-counterparty-personal-debt.md`.

### Test evidence

- `vp check` — clean (formatting + lint + types, 238 files).
- Integration (real Postgres) — new `tests/integration/person-debt.integration.ts`
  (6 tests): lend grows RECEIVABLE + drops cash; borrow creates LOAN
  (`liability_draw`) + grows cash; net-position aggregation across a person's
  accounts; repay-to-zero ⇒ settled; **net-worth total identical linked vs.
  unlinked**; tenant isolation; idempotency replay is a no-op. Shared-surface
  subset (person-debt + accounts-manual-ux + account-delete +
  merchant-category-quick-create + tenant-reference-validation + cross-tenant-fk
  + db-constraints) = **7 files, 83 tests passed**. Full suite run attached in
  the final report.
- e2e — new `tests/e2e/person-debt.e2e.ts`: onboard → lend to a new person →
  assert Utang-Piutang net position + net-worth aggregate line (not the
  Accounts list) → repay → settled. **1 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
