### PR TITLE
fix(debt): PER-213 — repayment guards, contact reuse, full person list, English UI

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -49,7 +49,7 @@ const data: {
       icon: IconDatabase,
     },
     {
-      title: "Utang-Piutang",
+      title: "Debts",
       url: "/debts",
       icon: IconHandStop,
     },

--- a/src/lib/debt-collections.ts
+++ b/src/lib/debt-collections.ts
@@ -4,10 +4,11 @@ import { getQueryClient } from "./query-client"
 import { getPersonDebtsFn } from "@/server/debts"
 
 // =============================================================================
-// PER-212 / ADR-0049 — reactive Utang-Piutang (person-debt) collection.
+// PER-212 / ADR-0049 — reactive People & Debts (person-debt) collection.
 //
-// `getPersonDebtsFn` returns one row per person who has at least one linked
-// RECEIVABLE/LOAN account, with signed net positions as digit-strings (BigInt
+// `getPersonDebtsFn` returns one row per person contact (PER-213: including
+// persons with no debt yet — empty accounts/positions render "No debts yet"),
+// with signed net positions as digit-strings (BigInt
 // is not JSON-serializable). Mutations (create person / lend / borrow / repay)
 // call their `createServerFn` handlers directly, then
 // `personDebtCollection.utils.refetch()` to resync with the Postgres source of

--- a/src/routes/_protected/debts.tsx
+++ b/src/routes/_protected/debts.tsx
@@ -5,7 +5,7 @@ import {
 } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
-import { HandCoins, Plus, Users } from "lucide-react"
+import { HandCoins, Plus, UserPlus, Users } from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
@@ -58,7 +58,7 @@ export const Route = createFileRoute("/_protected/debts")({
     ])
     return null
   },
-  staticData: { title: "Utang-Piutang" },
+  staticData: { title: "People & Debts" },
   pendingComponent: DebtsPendingComponent,
   errorComponent: DebtsErrorComponent,
   component: DebtsPage,
@@ -72,6 +72,24 @@ const ACTION_LABEL: Record<DebtAction, string> = {
   borrow: "Borrow (I will owe them)",
   repay_receivable: "Repayment received (they pay me back)",
   repay_loan: "Repayment made (I pay them back)",
+}
+
+// Lend/borrow are always valid; a repayment is only offered when the selected
+// person actually has an outstanding debt in that direction. Passing no debt
+// record (a brand-new person) yields lend/borrow only. This keeps the UI from
+// offering a repayment that the server would reject as "No outstanding …".
+function availableActionsFor(
+  debt: PersonDebtRecord | undefined
+): ReadonlyArray<DebtAction> {
+  const actions: DebtAction[] = ["lend", "borrow"]
+  if (!debt) return actions
+  const hasOutstanding = (accountType: "RECEIVABLE" | "LOAN") =>
+    debt.accounts.some(
+      (a) => a.accountType === accountType && BigInt(a.balance) !== 0n
+    )
+  if (hasOutstanding("RECEIVABLE")) actions.push("repay_receivable")
+  if (hasOutstanding("LOAN")) actions.push("repay_loan")
+  return actions
 }
 
 // After any debt mutation, resync both the person-debt list and the accounts
@@ -117,6 +135,7 @@ function DebtsPage() {
     q.from({ d: personDebtCollection })
   )
   const [recordOpen, setRecordOpen] = React.useState(false)
+  const [addPersonOpen, setAddPersonOpen] = React.useState(false)
 
   const safeDebts = React.useMemo<ReadonlyArray<PersonDebtRecord>>(
     () => debts ?? [],
@@ -140,7 +159,7 @@ function DebtsPage() {
             <div className="flex items-center justify-between">
               <div>
                 <h1 className="text-2xl font-semibold tracking-tight">
-                  Utang-Piutang
+                  People &amp; Debts
                 </h1>
                 <p className="text-sm text-muted-foreground">
                   Money you have lent to or borrowed from people. Each person is
@@ -148,10 +167,19 @@ function DebtsPage() {
                   stay correct.
                 </p>
               </div>
-              <Button onClick={() => setRecordOpen(true)}>
-                <Plus className="size-4" />
-                Record debt
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setAddPersonOpen(true)}
+                >
+                  <UserPlus className="size-4" />
+                  Add person
+                </Button>
+                <Button onClick={() => setRecordOpen(true)}>
+                  <Plus className="size-4" />
+                  Record debt
+                </Button>
+              </div>
             </div>
 
             {safeDebts.length === 0 ? (
@@ -173,6 +201,16 @@ function DebtsPage() {
           onSaved={async () => {
             await refreshDebtsAfterMutation()
             setRecordOpen(false)
+          }}
+        />
+      ) : null}
+
+      {addPersonOpen ? (
+        <AddPersonDialog
+          onClose={() => setAddPersonOpen(false)}
+          onSaved={async () => {
+            await refreshDebtsAfterMutation()
+            setAddPersonOpen(false)
           }}
         />
       ) : null}
@@ -209,34 +247,120 @@ function PersonDebtCard({ debt }: Readonly<{ debt: PersonDebtRecord }>) {
           <CardTitle className="text-base">{debt.name}</CardTitle>
           {debt.settled ? (
             <Badge variant="outline" className="text-emerald-600">
-              Lunas
+              Settled
             </Badge>
           ) : null}
         </div>
       </CardHeader>
       <CardContent className="space-y-1.5">
-        {debt.positions.map((position) => {
-          const net = BigInt(position.net)
-          const direction = describeNetPosition(net)
-          const magnitude = net < 0n ? -net : net
-          return (
-            <div
-              key={position.currency}
-              className="flex items-center justify-between text-sm"
-            >
-              <span className="text-muted-foreground">{direction}</span>
-              <span className="font-medium tabular-nums">
-                {formatCurrency(magnitude.toString(), position.currency)}
-              </span>
+        {debt.positions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No debts yet</p>
+        ) : (
+          <>
+            {debt.positions.map((position) => {
+              const net = BigInt(position.net)
+              const direction = describeNetPosition(net)
+              const magnitude = net < 0n ? -net : net
+              return (
+                <div
+                  key={position.currency}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <span className="text-muted-foreground">{direction}</span>
+                  <span className="font-medium tabular-nums">
+                    {formatCurrency(magnitude.toString(), position.currency)}
+                  </span>
+                </div>
+              )
+            })}
+            <div className="pt-2 text-xs text-muted-foreground">
+              {debt.accounts.length} linked account
+              {debt.accounts.length === 1 ? "" : "s"}
             </div>
-          )
-        })}
-        <div className="pt-2 text-xs text-muted-foreground">
-          {debt.accounts.length} linked account
-          {debt.accounts.length === 1 ? "" : "s"}
-        </div>
+          </>
+        )}
       </CardContent>
     </Card>
+  )
+}
+
+// Create a contact WITHOUT recording any debt. PER-213: a person can exist with
+// no debt yet (and still appears in the list as "No debts yet"); this is the
+// only affordance that produces one.
+function AddPersonDialog({
+  onClose,
+  onSaved,
+}: Readonly<{
+  onClose: () => void
+  onSaved: () => Promise<void>
+}>) {
+  const [name, setName] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+    const trimmed = name.trim()
+    if (trimmed === "") {
+      setError("Enter the person's name.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      await createPersonFn({
+        data: { name: trimmed, idempotencyKey: createUuidV7() },
+      })
+      await onSaved()
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : String(error_))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>Add a person</DialogTitle>
+            <DialogDescription>
+              Add a contact now and record what you lent or borrowed later.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="add-person-name">Name</Label>
+            <Input
+              id="add-person-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Budi"
+            />
+          </div>
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Adding…" : "Add"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -256,6 +380,12 @@ function RecordDebtDialog({
   })
   const { data: accounts } = useLiveQuery((q) =>
     q.from({ a: accountCollection })
+  )
+  // Outstanding-per-person, used to constrain which repayment directions the
+  // dialog offers (a repayment with no matching outstanding debt is rejected
+  // server-side, so we never surface it).
+  const { data: debtRecords } = useLiveQuery((q) =>
+    q.from({ d: personDebtCollection })
   )
 
   // Only your own cash-like asset accounts are valid endpoints for a debt move.
@@ -282,6 +412,24 @@ function RecordDebtDialog({
 
   const selectedCash = cashAccounts.find((a) => a.id === cashAccountId)
   const currency = (selectedCash?.currency ?? "IDR") as CurrencyCode
+
+  const selectedDebt = (debtRecords ?? []).find((d) => d.personId === personId)
+  const availableActions = React.useMemo(
+    () => availableActionsFor(selectedDebt),
+    [selectedDebt]
+  )
+
+  // Changing the person can invalidate the current action (e.g. switching to a
+  // person with no outstanding loan while "Repayment made" is selected). Reset
+  // to a valid action in the same handler — no effect needed.
+  function handlePersonChange(nextPersonId: string) {
+    setPersonId(nextPersonId)
+    const nextDebt = (debtRecords ?? []).find(
+      (d) => d.personId === nextPersonId
+    )
+    const next = availableActionsFor(nextDebt)
+    if (!next.includes(action)) setAction("lend")
+  }
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -367,7 +515,7 @@ function RecordDebtDialog({
 
           <div className="flex flex-col gap-2">
             <Label>Person</Label>
-            <Select value={personId} onValueChange={setPersonId}>
+            <Select value={personId} onValueChange={handlePersonChange}>
               <SelectTrigger aria-label="Person">
                 <SelectValue />
               </SelectTrigger>
@@ -402,7 +550,7 @@ function RecordDebtDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {(Object.keys(ACTION_LABEL) as DebtAction[]).map((key) => (
+                {availableActions.map((key) => (
                   <SelectItem key={key} value={key}>
                     {ACTION_LABEL[key]}
                   </SelectItem>

--- a/src/server/debts.ts
+++ b/src/server/debts.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { createUuidV7 } from "@/lib/uuid-v7"
+import { formatCurrency } from "@/lib/currency"
 import {
   familyMiddleware,
   requireCapability,
@@ -54,6 +55,19 @@ export class PersonDebtNotFoundError extends Error {
   readonly statusCode = 404
 }
 
+/**
+ * Raised when a repayment is not a valid ledger move: there is no outstanding
+ * debt in that direction, or the amount would overshoot the outstanding balance
+ * (which would drive a RECEIVABLE negative or a LOAN positive and trip the
+ * `account_normal_balance_sign` CHECK). The human-readable reason lives in
+ * `.message` because TanStack Start's ShallowErrorPlugin strips every Error
+ * property but `.message` across the server-fn RPC boundary (memory: PER-187).
+ */
+export class PersonDebtValidationError extends Error {
+  override readonly name = "PersonDebtValidationError"
+  readonly statusCode = 422
+}
+
 const nameSchema = z.string().trim().min(1).max(120)
 const hexColorSchema = z
   .string()
@@ -94,7 +108,11 @@ export async function createPersonForFamily({
 }): Promise<SerializedMerchant> {
   const data = createPersonInputSchema.parse(rawData)
   // A person is just a Merchant with kind="person": one counterparty concept,
-  // reusing the merchant create contract (idempotency + audit + name dedup).
+  // reusing the merchant create contract (idempotency + audit). PER-213 locked
+  // "one contact = payee + debt-party": on a case-insensitive name collision we
+  // REUSE the existing merchant (promoting a "business" payee to "person" if
+  // needed) rather than hard-failing, so a payee you already transact with can
+  // become a debt party without a duplicate-name error.
   return await createMerchantForFamily({
     data: {
       name: data.name,
@@ -105,6 +123,7 @@ export async function createPersonForFamily({
     familyId,
     user,
     runInTenantTransaction,
+    reuseExisting: true,
   })
 }
 
@@ -399,6 +418,19 @@ export async function recordBorrowForFamily({
   })
 }
 
+/**
+ * Repayment is DELIBERATELY not routed through the create-if-absent path
+ * (`ensurePersonDebtAccountId`): a repayment can only ever REDUCE an existing
+ * debt, never open a new one. Reusing the create path let "Repayment received"
+ * for a person with no receivable (or an overshoot) drive a RECEIVABLE negative
+ * / a LOAN positive and trip the `account_normal_balance_sign` CHECK (PER-213).
+ *
+ * Guards (in order): the person and cash account must belong to the family; an
+ * EXISTING debt account of the matching direction+currency must exist with a
+ * non-zero balance; and the amount must not exceed the outstanding magnitude.
+ * Exact settle-to-zero is allowed. Only then is the reversing transfer posted
+ * through the same ledger core as every other flow.
+ */
 export async function recordRepaymentForFamily({
   data: rawData,
   familyId,
@@ -415,21 +447,89 @@ export async function recordRepaymentForFamily({
   //   receivable repaid: RECEIVABLE → cash (they pay you back)
   //   loan repaid       : cash → LOAN       (you pay them back)
   const isReceivable = data.direction === "receivable"
-  return await orchestrateDebtMovement({
+  const person = await loadPersonOrThrow({
     familyId,
     user,
-    runInTenantTransaction,
     personMerchantId: data.personMerchantId,
-    cashAccountId: data.cashAccountId,
-    ensureDirection: data.direction,
-    cashIsSource: !isReceivable,
-    amount: data.amount,
-    date: data.date,
-    description: data.description,
-    describe: (name) =>
-      isReceivable ? `Repayment from ${name}` : `Repayment to ${name}`,
-    idempotencyKey: data.idempotencyKey,
+    runInTenantTransaction,
   })
+  const currency = await loadCashAccountCurrency({
+    familyId,
+    user,
+    accountId: data.cashAccountId,
+    runInTenantTransaction,
+  })
+
+  const postTransfer = async (debtAccountId: string) =>
+    await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        accountId: isReceivable ? debtAccountId : data.cashAccountId,
+        toAccountId: isReceivable ? data.cashAccountId : debtAccountId,
+        amount: data.amount,
+        description:
+          data.description ??
+          (isReceivable
+            ? `Repayment from ${person.name}`
+            : `Repayment to ${person.name}`),
+        date: data.date ?? new Date(),
+        idempotencyKey: data.idempotencyKey,
+      },
+      familyId,
+      user,
+      runInTenantTransaction,
+    })
+
+  const accountType = DIRECTION_ACCOUNT_TYPE[data.direction]
+  const debtAccount = await runInTenantTransaction(familyId, user.id, (tx) =>
+    tx.account.findFirst({
+      where: {
+        familyId,
+        counterpartyMerchantId: person.id,
+        accountType,
+        currency,
+        deletedAt: null,
+      },
+      select: { id: true, balance: true },
+    })
+  )
+
+  // Idempotency: a genuine retry re-sends the same key AFTER the balance was
+  // already reduced (possibly to zero), so the guards below would wrongly reject
+  // it. Detect the replay by the transaction row that already carries this key
+  // and delegate straight to the ledger core, which returns the stored result
+  // without touching balances again.
+  if (debtAccount) {
+    const alreadyPosted = await runInTenantTransaction(
+      familyId,
+      user.id,
+      (tx) =>
+        tx.transaction.findFirst({
+          where: { familyId, idempotencyKey: data.idempotencyKey },
+          select: { id: true },
+        })
+    )
+    if (alreadyPosted) return await postTransfer(debtAccount.id)
+  }
+
+  const outstanding =
+    debtAccount === null
+      ? 0n
+      : debtAccount.balance < 0n
+        ? -debtAccount.balance
+        : debtAccount.balance
+  if (debtAccount === null || outstanding === 0n) {
+    throw new PersonDebtValidationError(
+      `No outstanding ${data.direction} for ${person.name} to repay`
+    )
+  }
+  if (BigInt(data.amount) > outstanding) {
+    throw new PersonDebtValidationError(
+      `Repayment exceeds the ${formatCurrency(outstanding, currency)} outstanding`
+    )
+  }
+
+  return await postTransfer(debtAccount.id)
 }
 
 export const recordLendFn = createServerFn({ method: "POST" })
@@ -472,7 +572,7 @@ export const recordRepaymentFn = createServerFn({ method: "POST" })
   })
 
 // ============================================================================
-// READ — Utang-Piutang view (persons with linked debt accounts + net position)
+// READ — People & Debts view (ALL person contacts + net position; PER-213)
 // ============================================================================
 
 export interface PersonDebtAccountView {
@@ -547,8 +647,11 @@ export async function getPersonDebtsForFamily({
     const views: PersonDebtView[] = []
     for (const person of persons) {
       const linked = accountsByPerson.get(person.id) ?? []
-      // Only persons that actually have a debt relationship are listed.
-      if (linked.length === 0) continue
+      // PER-213: list EVERY person contact, including those with no debt yet
+      // (empty accounts/positions), so a freshly-added person never vanishes.
+      // The view renders "No debts yet" for them; `settled` stays false so they
+      // are not styled as "Settled" (that badge is reserved for people who HAD
+      // a debt that netted back to zero).
 
       const netByCurrency = new Map<string, bigint>()
       for (const account of linked) {
@@ -575,7 +678,11 @@ export async function getPersonDebtsForFamily({
           balance: account.balance.toString(),
         })),
         positions,
-        settled: positions.every((position) => BigInt(position.net) === 0n),
+        // Settled (Lunas) only when there IS a debt history that nets to zero;
+        // a person with no positions is "No debts yet", not settled.
+        settled:
+          positions.length > 0 &&
+          positions.every((position) => BigInt(position.net) === 0n),
       })
     }
     return views

--- a/src/server/merchants.ts
+++ b/src/server/merchants.ts
@@ -88,11 +88,19 @@ export async function createMerchantForFamily({
   familyId,
   user,
   runInTenantTransaction = scopedTenantTransaction,
+  // PER-213 / locked "one contact = payee + debt-party": when true, a
+  // case-insensitive name collision is REUSED instead of rejected, and the
+  // existing merchant is promoted to the requested `kind` (e.g. a "business"
+  // payee that already exists becomes a "person" debt-party) inside the same
+  // tenant transaction with an audit row. Person creation passes this; ordinary
+  // quick-create keeps the strict duplicate-name error.
+  reuseExisting = false,
 }: {
   data: z.input<typeof createMerchantInputSchema>
   familyId: string
   user: ServerUser
   runInTenantTransaction?: RunInTenantTransaction
+  reuseExisting?: boolean
 }): Promise<SerializedMerchant> {
   const data: CreateMerchantInput = createMerchantInputSchema.parse(rawData)
   const trimmedName = data.name.trim()
@@ -127,19 +135,43 @@ export async function createMerchantForFamily({
       const existing = await tx.merchant.findFirst({
         where: { familyId, name: { equals: trimmedName, mode: "insensitive" } },
       })
-      if (existing) throw new DuplicateNameError("Merchant", trimmedName)
 
-      const merchant = await tx.merchant.create({
-        data: { familyId, name: trimmedName, color, kind },
-      })
+      let merchant: Merchant
+      if (existing) {
+        if (!reuseExisting)
+          throw new DuplicateNameError("Merchant", trimmedName)
+        // Reuse the existing contact. Promote its kind if the caller asks for a
+        // different one (business payee → person debt-party), auditing the
+        // before/after inside this same transaction.
+        if (existing.kind !== kind) {
+          const before = serializeMerchant(existing)
+          merchant = await tx.merchant.update({
+            where: { id: existing.id },
+            data: { kind },
+          })
+          await auditLog(tx, auditCtx, {
+            action: "update",
+            entityType: "Merchant",
+            entityId: merchant.id,
+            before,
+            after: serializeMerchant(merchant),
+          })
+        } else {
+          merchant = existing
+        }
+      } else {
+        merchant = await tx.merchant.create({
+          data: { familyId, name: trimmedName, color, kind },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Merchant",
+          entityId: merchant.id,
+          after: serializeMerchant(merchant),
+        })
+      }
 
       const serialized = serializeMerchant(merchant)
-      await auditLog(tx, auditCtx, {
-        action: "create",
-        entityType: "Merchant",
-        entityId: merchant.id,
-        after: serialized,
-      })
       await persistIdempotentEndpointResponse(tx, {
         endpoint: CREATE_MERCHANT_ENDPOINT,
         familyId,
@@ -154,6 +186,10 @@ export async function createMerchantForFamily({
     return await runOnce()
   } catch (error) {
     if (isNameDedupConstraintError(error, MERCHANT_NAME_DEDUP_INDEX)) {
+      // A concurrent create won the name race. For reuse callers, retry once so
+      // the pre-check now finds and reuses (and promotes) the winning row
+      // instead of surfacing a duplicate-name error.
+      if (reuseExisting) return await runOnce()
       throw new DuplicateNameError("Merchant", trimmedName)
     }
     // A concurrent request with the same key may win the IdempotencyRecord

--- a/tests/e2e/person-debt.e2e.ts
+++ b/tests/e2e/person-debt.e2e.ts
@@ -73,8 +73,78 @@ test.describe("person-to-person debt (PER-212)", () => {
     await page.getByRole("button", { name: "Save" }).click()
     await expect(page.getByRole("dialog")).toHaveCount(0)
 
-    // --- The person is now settled: Lunas badge, net back to zero ---
-    await expect(page.getByText("Lunas")).toBeVisible()
-    await expect(page.getByText("Settled")).toBeVisible()
+    // --- The person is now settled: the "Settled" badge appears and the net is
+    //     back to zero. (Both the badge and the net-zero position read
+    //     "Settled", so scope to the first match.) ---
+    await expect(page.getByText("Settled").first()).toBeVisible()
+  })
+
+  test("a person added with no debt still appears in the list as 'No debts yet'", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const personName = `Nodebt ${Date.now().toString(36)}`
+
+    await page.goto("/debts")
+    await waitForHydration(page)
+
+    // Add a contact WITHOUT recording any debt.
+    await page.getByRole("button", { name: "Add person" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await page.getByLabel("Name").fill(personName)
+    await page.getByRole("button", { name: "Add" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // The person still shows, flagged as having no debts (PER-213).
+    await expect(page.getByText(personName)).toBeVisible()
+    await expect(page.getByText("No debts yet")).toBeVisible()
+  })
+
+  test("the repayment dialog only offers directions the person actually owes", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const cashName = `E2E Cash ${suffix}`
+    const personName = `Budi ${suffix}`
+
+    // Cash account.
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(cashName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Lend to a brand-new person → they owe you (a receivable, no loan).
+    await page.goto("/debts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "Record debt" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await page.getByLabel("New person name").fill(personName)
+    await page.getByRole("combobox", { name: "Cash account" }).click()
+    await page.getByRole("option", { name: `${cashName} (IDR)` }).click()
+    await page.getByLabel(/^Amount/).fill("500000")
+    await page.getByRole("button", { name: "Save" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Re-open, select that person, and inspect the Action options: only the
+    // receivable repayment is offered (they owe you, you don't owe them).
+    await page.getByRole("button", { name: "Record debt" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await page.getByRole("combobox", { name: "Person" }).click()
+    await page.getByRole("option", { name: personName }).click()
+    await page.getByRole("combobox", { name: "Action" }).click()
+    await expect(
+      page.getByRole("option", {
+        name: "Repayment received (they pay me back)",
+      })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("option", { name: "Repayment made (I pay them back)" })
+    ).toHaveCount(0)
   })
 })

--- a/tests/integration/person-debt.integration.ts
+++ b/tests/integration/person-debt.integration.ts
@@ -11,10 +11,12 @@ import {
   createPersonForFamily,
   getPersonDebtsForFamily,
   getPersonsForFamily,
+  PersonDebtValidationError,
   recordBorrowForFamily,
   recordLendForFamily,
   recordRepaymentForFamily,
 } from "../../src/server/debts"
+import { createMerchantForFamily } from "../../src/server/merchants"
 import { normalizeNetWorthAt, type PointBalance } from "../../src/lib/net-worth"
 import {
   createIntegrationHarness,
@@ -322,5 +324,185 @@ describe("PER-212 person-to-person debt", () => {
       (tx) => tx.transaction.count({ where: { familyId: owner.family.id } })
     )
     expect(txCount).toBe(2)
+  })
+
+  // --- PER-213 repayment guards -------------------------------------------
+  // Repayment must NEVER open a debt or overshoot it (that drove a RECEIVABLE
+  // negative / a LOAN positive and tripped `account_normal_balance_sign`).
+
+  const countMerchants = (owner: Owner) =>
+    harness.withMember(owner.family.id, owner.user.id, (tx) =>
+      tx.merchant.count({ where: { familyId: owner.family.id } })
+    )
+
+  test("(a) repayment received with no receivable throws, creates no account, no crash", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+
+    const err = await repay(
+      owner,
+      budi.id,
+      "receivable",
+      cash.id,
+      "10000"
+    ).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(PersonDebtValidationError)
+    expect((err as Error).message).toMatch(/No outstanding receivable for Budi/)
+
+    const accounts = await readAccounts(owner.family.id)
+    // No RECEIVABLE was created for this person, and cash is untouched.
+    expect(
+      accounts.filter((a) => a.counterpartyMerchantId === budi.id)
+    ).toHaveLength(0)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+  })
+
+  test("(b) repayment made with no loan throws, creates no account", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+
+    const err = await repay(owner, budi.id, "loan", cash.id, "10000").catch(
+      (e: unknown) => e
+    )
+    expect(err).toBeInstanceOf(PersonDebtValidationError)
+    expect((err as Error).message).toMatch(/No outstanding loan for Budi/)
+
+    const accounts = await readAccounts(owner.family.id)
+    expect(
+      accounts.filter((a) => a.counterpartyMerchantId === budi.id)
+    ).toHaveLength(0)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+  })
+
+  test("(c) repayment overshoot is rejected; balances unchanged", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    await lend(owner, budi.id, cash.id, "40000")
+
+    const err = await repay(
+      owner,
+      budi.id,
+      "receivable",
+      cash.id,
+      "50000"
+    ).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(PersonDebtValidationError)
+    expect((err as Error).message).toMatch(/exceeds/)
+
+    // The failed overshoot left the receivable and cash exactly as the lend did.
+    const accounts = await readAccounts(owner.family.id)
+    expect(
+      accounts.find((a) => a.counterpartyMerchantId === budi.id)?.balance
+    ).toBe(40_000n)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(60_000n)
+  })
+
+  test("(d) exact settle-to-zero repayment still works", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    await lend(owner, budi.id, cash.id, "40000")
+
+    await repay(owner, budi.id, "receivable", cash.id, "40000") // exact
+
+    const accounts = await readAccounts(owner.family.id)
+    expect(
+      accounts.find((a) => a.counterpartyMerchantId === budi.id)?.balance
+    ).toBe(0n)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+
+    const debts = await debtsOf(owner)
+    expect(debts.find((d) => d.personId === budi.id)?.settled).toBe(true)
+  })
+
+  test("idempotency replay of a repayment is a no-op (balance stays settled)", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    await lend(owner, budi.id, cash.id, "40000")
+
+    const key = factories.createIdempotencyKey()
+    const date = new Date("2026-06-05T00:00:00.000Z")
+    const repayOnce = () =>
+      recordRepaymentForFamily({
+        data: {
+          personMerchantId: budi.id,
+          direction: "receivable",
+          cashAccountId: cash.id,
+          amount: "40000",
+          idempotencyKey: key,
+          date,
+        },
+        ...memberCtx(owner),
+      })
+
+    await repayOnce()
+    await repayOnce() // replay AFTER the balance was already reduced to zero
+
+    const accounts = await readAccounts(owner.family.id)
+    expect(
+      accounts.find((a) => a.counterpartyMerchantId === budi.id)?.balance
+    ).toBe(0n)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+  })
+
+  // --- PER-213 contact reuse on name collision ----------------------------
+
+  test("(e) creating a person whose name equals an existing merchant reuses the SAME row (promoted to person)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+
+    const before = await countMerchants(owner)
+    const business = await createMerchantForFamily({
+      data: {
+        name: "Toko Budi",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      ...memberCtx(owner),
+    })
+    expect(business.kind).toBe("business")
+    expect(await countMerchants(owner)).toBe(before + 1)
+
+    // Same name, different case → reuse + promote, NOT a duplicate-name error.
+    const person = await createPersonForFamily({
+      data: {
+        name: "toko budi",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      ...memberCtx(owner),
+    })
+    expect(person.id).toBe(business.id) // same underlying merchant row
+    expect(person.kind).toBe("person") // promoted business → person
+    expect(await countMerchants(owner)).toBe(before + 1) // no new row created
+  })
+
+  // --- PER-213 multi-currency person --------------------------------------
+
+  test("(f) lending to one person in two currencies yields two positions", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n) // IDR cash
+    const usdCash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      currency: "USD",
+      familyId: owner.family.id,
+      name: "USD Cash",
+    })
+
+    await lend(owner, budi.id, cash.id, "40000") // IDR receivable
+    await lend(owner, budi.id, usdCash.id, "25000") // USD receivable
+
+    const debts = await debtsOf(owner)
+    const record = debts.find((d) => d.personId === budi.id)
+    expect(record?.accounts).toHaveLength(2)
+    // Positions are sorted by currency (IDR before USD).
+    expect(record?.positions).toEqual([
+      { currency: "IDR", net: "40000" },
+      { currency: "USD", net: "25000" },
+    ])
+  })
+
+  // --- PER-213 full person list -------------------------------------------
+
+  test("a person with no debt still appears in the list (empty positions, not settled)", async () => {
+    const { owner, person: budi } = await setup(100_000n)
+
+    const debts = await debtsOf(owner)
+    const record = debts.find((d) => d.personId === budi.id)
+    expect(record).toBeDefined()
+    expect(record?.accounts).toEqual([])
+    expect(record?.positions).toEqual([])
+    expect(record?.settled).toBe(false)
   })
 })


### PR DESCRIPTION
Real bugs found by dogfooding the just-shipped person-debt feature (PER-212). All fixes live in `src/server/debts.ts`, `src/server/merchants.ts`, `src/routes/_protected/debts.tsx`, and `src/components/app-sidebar.tsx`.

## Fixes

**1. CRITICAL — repayment can no longer drive a debt account past zero (`account_normal_balance_sign` crash).**
`recordRepaymentForFamily` no longer reuses the create-if-absent path. It now:
- Looks up the EXISTING person-debt account for `(personMerchantId, direction→accountType, cash-account currency)`. If none (or a zero balance) → throws a friendly `PersonDebtValidationError` (`No outstanding {receivable|loan} for {name} to repay`). It never creates an account.
- Reads the current balance; `outstanding = abs(balance)`. If `amount > outstanding` → `Repayment exceeds the {formatted outstanding} outstanding`. Exact settle-to-zero is allowed.
- Only then posts the reversing transfer through the same `createTransactionForFamily` core.
- A replay short-circuit (a transaction row already carries the idempotency key) keeps repayment idempotent even after the balance has been reduced.
- Human-readable text lives in `.message` (ShallowErrorPlugin strips everything else across the RPC boundary — PER-187).
- The dialog now constrains repayment options to the directions the selected person actually owes.

**2. Contact reuse on name collision** (locked "one contact = payee + debt-party"). `createMerchantForFamily` gains a `reuseExisting` flag: a case-insensitive name match is reused, promoting a `business` payee to `person` with an audit row inside the same tenant transaction; idempotency + audit preserved. `createPersonForFamily` passes it. The transaction-form merchant picker already lists all kinds, so a promoted contact stays selectable as a payee (no filter to remove).

**3. Person list shows ALL persons.** `getPersonDebtsForFamily` no longer skips persons with no linked accounts; they render "No debts yet" with `settled=false` (the Settled badge stays reserved for debts that netted back to zero). Added a minimal "Add person" affordance so a debtless contact can actually be created via the UI.

**4. English-only UI.** Sidebar "Utang-Piutang" → "Debts"; page title/heading → "People & Debts"; "Lunas" badge → "Settled".

## Test evidence

`vp check`: `Found no warnings, lint errors, or type errors in 238 files`

Integration (real Postgres) — `tests/integration/person-debt.integration.ts`, **14 passed**, incl. the required cases:
- (a) repayment received with no receivable → friendly error, no account created, no crash
- (b) repayment made with no loan → same
- (c) overshoot rejected, balances unchanged
- (d) exact settle-to-zero still works
- (e) create-person whose name equals an existing business merchant → same row reused, count unchanged, `kind` becomes `person`
- (f) multi-currency person (IDR + USD) → two positions
- plus repayment idempotency-replay no-op and debtless-person listing

e2e — `tests/e2e/person-debt.e2e.ts`, **3 passed**: original lend→settle flow, debtless person shows "No debts yet", repayment dialog only offers valid directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)