### PR TITLE
feat(debt): PER-214 — Debts polish (person-as-merchant, per-person detail, summary, delete, UI)

### DIFF
--- a/prisma/migrations/20260802120000_debt_transfer_merchant_backfill/migration.sql
+++ b/prisma/migrations/20260802120000_debt_transfer_merchant_backfill/migration.sql
@@ -1,0 +1,31 @@
+-- PER-214 — backfill the person as merchant on existing debt-transfer legs.
+--
+-- Since PER-214, lend/borrow/repay transfers stamp the person (a
+-- Merchant kind="person") as `merchantId` on BOTH legs, so the ledger Merchant
+-- column shows the person and the merchant filter surfaces them. Transfers
+-- posted BEFORE this change have `merchantId IS NULL`. This one-shot backfill
+-- attributes those historical legs to the same person the account already
+-- points at via `Account.counterpartyMerchantId`.
+--
+-- A "debt-transfer leg" is any non-deleted Transaction whose SOURCE
+-- (`accountId`) or DESTINATION (`toAccountId`) account is a person-debt account
+-- (an Account with a non-null `counterpartyMerchantId`). Both legs of a debt
+-- transfer qualify: one references the debt account via `accountId`, the other
+-- via `toAccountId`.
+--
+-- Tenant safety: the update is naturally scoped — a Transaction and the Account
+-- it references always share the same `familyId` (enforced by the tenant
+-- composite FKs), so setting `merchantId` from that account's
+-- `counterpartyMerchantId` can never cross a family boundary. The target
+-- merchant is likewise the account's own family merchant. We only touch rows
+-- that are still NULL, so re-running is a no-op and it never clobbers a
+-- merchant a user set by hand.
+
+UPDATE "Transaction" AS t
+SET "merchantId" = a."counterpartyMerchantId"
+FROM "Account" AS a
+WHERE t."merchantId" IS NULL
+  AND t."deletedAt" IS NULL
+  AND a."counterpartyMerchantId" IS NOT NULL
+  AND a."familyId" = t."familyId"
+  AND (t."accountId" = a.id OR t."toAccountId" = a.id);

--- a/src/routes/_protected/debts.tsx
+++ b/src/routes/_protected/debts.tsx
@@ -4,13 +4,31 @@ import {
   type ErrorComponentProps,
 } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
-import { useQuery } from "@tanstack/react-query"
-import { HandCoins, Plus, UserPlus, Users } from "lucide-react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  ArrowLeft,
+  HandCoins,
+  Plus,
+  Trash2,
+  UserPlus,
+  Users,
+} from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -24,6 +42,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
 import {
   Select,
   SelectContent,
@@ -38,15 +57,20 @@ import {
 } from "@/lib/debt-collections"
 import { formatCurrency } from "@/lib/currency"
 import { parseUserInput } from "@/lib/money"
+import { cn } from "@/lib/utils"
 import type { CurrencyCode } from "@/lib/data/currencies"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import {
   createPersonFn,
+  getPersonDebtDetailFn,
+  getPersonDebtSummaryFn,
   getPersonsFn,
+  type PersonDebtMovement,
   recordBorrowFn,
   recordLendFn,
   recordRepaymentFn,
 } from "@/server/debts"
+import { deleteTransactionFn } from "@/server/transactions"
 
 export const Route = createFileRoute("/_protected/debts")({
   // TanStack DB collections are browser-only; SSR would hang on the pending sync.
@@ -74,6 +98,11 @@ const ACTION_LABEL: Record<DebtAction, string> = {
   repay_loan: "Repayment made (I pay them back)",
 }
 
+// React-query cache keys for the summary header and per-person detail. Kept as
+// constants so mutation handlers invalidate exactly what they wrote.
+const SUMMARY_KEY = ["person_debt_summary"] as const
+const DETAIL_KEY = "person_debt_detail" as const
+
 // Lend/borrow are always valid; a repayment is only offered when the selected
 // person actually has an outstanding debt in that direction. Passing no debt
 // record (a brand-new person) yields lend/borrow only. This keeps the UI from
@@ -92,21 +121,60 @@ function availableActionsFor(
   return actions
 }
 
-// After any debt mutation, resync both the person-debt list and the accounts
-// (balances moved) with the Postgres source of truth (CLAUDE.md §5B).
-async function refreshDebtsAfterMutation(): Promise<void> {
-  await Promise.all([
-    personDebtCollection.utils.refetch(),
-    accountCollection.utils.refetch(),
-  ])
-}
-
 /** Human-readable sign of a signed net position, extracted to avoid a nested
  * ternary at the call site (SonarCloud S3358). */
 function describeNetPosition(net: bigint): string {
   if (net > 0n) return "They owe you"
   if (net < 0n) return "You owe them"
   return "Settled"
+}
+
+// Deterministic avatar accent when the person has no explicit colour. Small,
+// readable palette; the hash keeps a given name stable across renders.
+const AVATAR_PALETTE = [
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+  "#f97316",
+  "#10b981",
+  "#14b8a6",
+  "#6366f1",
+] as const
+
+function avatarColor(name: string, color: string | null): string {
+  if (color) return color
+  let hash = 0
+  for (let index = 0; index < name.length; index += 1) {
+    hash = (hash * 31 + name.charCodeAt(index)) % 2_147_483_647
+  }
+  return AVATAR_PALETTE[hash % AVATAR_PALETTE.length]
+}
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return "?"
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+function PersonAvatar({
+  name,
+  color,
+  className,
+}: Readonly<{ name: string; color: string | null; className?: string }>) {
+  return (
+    <Avatar className={cn("size-9", className)}>
+      <AvatarFallback
+        className="font-medium text-white"
+        // Person colour is dynamic data, not a design token, so it cannot be a
+        // Tailwind utility. The CSS custom property keeps className styling for
+        // everything else while carrying the per-person accent.
+        style={{ backgroundColor: avatarColor(name, color) }}
+      >
+        {initialsOf(name)}
+      </AvatarFallback>
+    </Avatar>
+  )
 }
 
 function DebtsPendingComponent() {
@@ -131,16 +199,49 @@ function DebtsErrorComponent({ error }: ErrorComponentProps) {
 }
 
 function DebtsPage() {
+  const queryClient = useQueryClient()
   const { data: debts } = useLiveQuery((q) =>
     q.from({ d: personDebtCollection })
   )
   const [recordOpen, setRecordOpen] = React.useState(false)
   const [addPersonOpen, setAddPersonOpen] = React.useState(false)
+  // In-page drill-down: null = the grid, a person id = that person's detail.
+  const [selectedPersonId, setSelectedPersonId] = React.useState<string | null>(
+    null
+  )
+  // When "Record" is opened from a person's detail view, preselect them.
+  const [recordPersonId, setRecordPersonId] = React.useState<string | null>(
+    null
+  )
 
   const safeDebts = React.useMemo<ReadonlyArray<PersonDebtRecord>>(
     () => debts ?? [],
     [debts]
   )
+
+  // After any debt mutation, resync BOTH TanStack DB collections (person list +
+  // account balances) AND the react-query reads (summary header, per-person
+  // detail) with the Postgres source of truth (CLAUDE.md §5B).
+  //
+  // Only the two collections are awaited: they back the grid the caller is about
+  // to reveal (and gate closing the dialog). The summary/detail invalidations
+  // are fire-and-forget — those views update reactively when their refetch lands
+  // and must never delay closing the record dialog. The detail view separately
+  // awaits its own `refetch()` after a delete, so its freshness never relies on
+  // this invalidation.
+  const refresh = React.useCallback(async () => {
+    void queryClient.invalidateQueries({ queryKey: SUMMARY_KEY })
+    void queryClient.invalidateQueries({ queryKey: [DETAIL_KEY] })
+    await Promise.all([
+      personDebtCollection.utils.refetch(),
+      accountCollection.utils.refetch(),
+    ])
+  }, [queryClient])
+
+  function openRecord(personId: string | null) {
+    setRecordPersonId(personId)
+    setRecordOpen(true)
+  }
 
   return (
     <TooltipProvider>
@@ -156,40 +257,57 @@ function DebtsPage() {
         <SidebarInset>
           <SiteHeader />
           <div className="flex flex-1 flex-col gap-6 p-4 lg:p-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <h1 className="text-2xl font-semibold tracking-tight">
-                  People &amp; Debts
-                </h1>
-                <p className="text-sm text-muted-foreground">
-                  Money you have lent to or borrowed from people. Each person is
-                  backed by ordinary ledger accounts, so balances and net worth
-                  stay correct.
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  onClick={() => setAddPersonOpen(true)}
-                >
-                  <UserPlus className="size-4" />
-                  Add person
-                </Button>
-                <Button onClick={() => setRecordOpen(true)}>
-                  <Plus className="size-4" />
-                  Record debt
-                </Button>
-              </div>
-            </div>
-
-            {safeDebts.length === 0 ? (
-              <DebtsEmptyState onRecord={() => setRecordOpen(true)} />
+            {selectedPersonId ? (
+              <PersonDetailView
+                personId={selectedPersonId}
+                onBack={() => setSelectedPersonId(null)}
+                onRecord={() => openRecord(selectedPersonId)}
+                onRefresh={refresh}
+              />
             ) : (
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                {safeDebts.map((debt) => (
-                  <PersonDebtCard key={debt.personId} debt={debt} />
-                ))}
-              </div>
+              <>
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <h1 className="text-2xl font-semibold tracking-tight">
+                      People &amp; Debts
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                      Money you have lent to or borrowed from people. Each
+                      person is backed by ordinary ledger accounts, so balances
+                      and net worth stay correct.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() => setAddPersonOpen(true)}
+                    >
+                      <UserPlus className="size-4" />
+                      Add person
+                    </Button>
+                    <Button onClick={() => openRecord(null)}>
+                      <Plus className="size-4" />
+                      Record debt
+                    </Button>
+                  </div>
+                </div>
+
+                <DebtSummaryHeader />
+
+                {safeDebts.length === 0 ? (
+                  <DebtsEmptyState onRecord={() => openRecord(null)} />
+                ) : (
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {safeDebts.map((debt) => (
+                      <PersonDebtCard
+                        key={debt.personId}
+                        debt={debt}
+                        onSelect={() => setSelectedPersonId(debt.personId)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
             )}
           </div>
         </SidebarInset>
@@ -197,9 +315,10 @@ function DebtsPage() {
 
       {recordOpen ? (
         <RecordDebtDialog
+          initialPersonId={recordPersonId}
           onClose={() => setRecordOpen(false)}
           onSaved={async () => {
-            await refreshDebtsAfterMutation()
+            await refresh()
             setRecordOpen(false)
           }}
         />
@@ -209,12 +328,86 @@ function DebtsPage() {
         <AddPersonDialog
           onClose={() => setAddPersonOpen(false)}
           onSaved={async () => {
-            await refreshDebtsAfterMutation()
+            await refresh()
             setAddPersonOpen(false)
           }}
         />
       ) : null}
     </TooltipProvider>
+  )
+}
+
+// Σ "They owe you" vs Σ "You owe them" and the net, in the family base
+// currency. Reads the dedicated summary server fn (multi-currency conversion
+// happens server-side); invalidated by `refresh` after every mutation.
+function DebtSummaryHeader() {
+  const { data: summary } = useQuery({
+    queryKey: SUMMARY_KEY,
+    queryFn: async () => await getPersonDebtSummaryFn(),
+  })
+
+  if (!summary) return null
+  const receivable = BigInt(summary.receivable)
+  const loan = BigInt(summary.loan)
+  const net = BigInt(summary.net)
+  if (receivable === 0n && loan === 0n) return null
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      <SummaryTile
+        label="They owe you"
+        value={formatCurrency(summary.receivable, summary.baseCurrency)}
+        tone="positive"
+      />
+      <SummaryTile
+        label="You owe them"
+        value={formatCurrency(summary.loan, summary.baseCurrency)}
+        tone="negative"
+      />
+      <SummaryTile
+        label="Net position"
+        value={formatCurrency(
+          (net < 0n ? -net : net).toString(),
+          summary.baseCurrency
+        )}
+        tone={net > 0n ? "positive" : net < 0n ? "negative" : "neutral"}
+        hint={describeNetPosition(net)}
+      />
+    </div>
+  )
+}
+
+function SummaryTile({
+  label,
+  value,
+  tone,
+  hint,
+}: Readonly<{
+  label: string
+  value: string
+  tone: "positive" | "negative" | "neutral"
+  hint?: string
+}>) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-1 py-4">
+        <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "text-xl font-semibold tabular-nums",
+            tone === "positive" && "text-emerald-600 dark:text-emerald-400",
+            tone === "negative" && "text-amber-600 dark:text-amber-400"
+          )}
+        >
+          {value}
+        </span>
+        {hint ? (
+          <span className="text-xs text-muted-foreground">{hint}</span>
+        ) : null}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -239,12 +432,29 @@ function DebtsEmptyState({ onRecord }: Readonly<{ onRecord: () => void }>) {
   )
 }
 
-function PersonDebtCard({ debt }: Readonly<{ debt: PersonDebtRecord }>) {
+function PersonDebtCard({
+  debt,
+  onSelect,
+}: Readonly<{ debt: PersonDebtRecord; onSelect: () => void }>) {
   return (
-    <Card>
+    <Card
+      className="cursor-pointer transition-colors hover:border-primary/40 hover:bg-accent/40"
+      onClick={onSelect}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault()
+          onSelect()
+        }
+      }}
+    >
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base">{debt.name}</CardTitle>
+          <div className="flex items-center gap-3">
+            <PersonAvatar name={debt.name} color={debt.color} />
+            <CardTitle className="text-base">{debt.name}</CardTitle>
+          </div>
           {debt.settled ? (
             <Badge variant="outline" className="text-emerald-600">
               Settled
@@ -267,7 +477,13 @@ function PersonDebtCard({ debt }: Readonly<{ debt: PersonDebtRecord }>) {
                   className="flex items-center justify-between text-sm"
                 >
                   <span className="text-muted-foreground">{direction}</span>
-                  <span className="font-medium tabular-nums">
+                  <span
+                    className={cn(
+                      "font-medium tabular-nums",
+                      net > 0n && "text-emerald-600 dark:text-emerald-400",
+                      net < 0n && "text-amber-600 dark:text-amber-400"
+                    )}
+                  >
                     {formatCurrency(magnitude.toString(), position.currency)}
                   </span>
                 </div>
@@ -281,6 +497,285 @@ function PersonDebtCard({ debt }: Readonly<{ debt: PersonDebtRecord }>) {
         )}
       </CardContent>
     </Card>
+  )
+}
+
+// ============================================================================
+// PER-214 (B/D) — per-person detail drill-down: header, net position, movement
+// history, and per-movement delete (via the EXISTING transfer-symmetric core).
+// ============================================================================
+
+function PersonDetailView({
+  personId,
+  onBack,
+  onRecord,
+  onRefresh,
+}: Readonly<{
+  personId: string
+  onBack: () => void
+  onRecord: () => void
+  onRefresh: () => Promise<void>
+}>) {
+  const {
+    data: detail,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: [DETAIL_KEY, personId],
+    queryFn: async () =>
+      await getPersonDebtDetailFn({ data: { personMerchantId: personId } }),
+  })
+
+  const [pendingDelete, setPendingDelete] =
+    React.useState<PersonDebtMovement | null>(null)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <div className="size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    )
+  }
+
+  if (!detail) {
+    return (
+      <div className="flex flex-col gap-4">
+        <Button variant="ghost" className="w-fit" onClick={onBack}>
+          <ArrowLeft className="size-4" />
+          Back
+        </Button>
+        <p className="text-sm text-muted-foreground">Person not found.</p>
+      </div>
+    )
+  }
+
+  async function handleDeleteConfirmed() {
+    const movement = pendingDelete
+    if (!movement) return
+    await deleteTransactionFn({
+      data: { id: movement.id, idempotencyKey: createUuidV7() },
+    })
+    setPendingDelete(null)
+    // Resync everything, then refetch THIS detail view immediately so the
+    // movement list and position update without waiting for a navigation.
+    await onRefresh()
+    await refetch()
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onBack}
+            aria-label="Back"
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          <PersonAvatar
+            name={detail.name}
+            color={detail.color}
+            className="size-11"
+          />
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-semibold tracking-tight">
+                {detail.name}
+              </h1>
+              {detail.settled ? (
+                <Badge variant="outline" className="text-emerald-600">
+                  Settled
+                </Badge>
+              ) : null}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {detail.movements.length} movement
+              {detail.movements.length === 1 ? "" : "s"}
+            </p>
+          </div>
+        </div>
+        <Button onClick={onRecord}>
+          <Plus className="size-4" />
+          Record
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Net position
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1.5">
+          {detail.positions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No debts yet</p>
+          ) : (
+            detail.positions.map((position) => {
+              const net = BigInt(position.net)
+              const magnitude = net < 0n ? -net : net
+              return (
+                <div
+                  key={position.currency}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <span className="text-muted-foreground">
+                    {describeNetPosition(net)}
+                  </span>
+                  <span
+                    className={cn(
+                      "font-semibold tabular-nums",
+                      net > 0n && "text-emerald-600 dark:text-emerald-400",
+                      net < 0n && "text-amber-600 dark:text-amber-400"
+                    )}
+                  >
+                    {formatCurrency(magnitude.toString(), position.currency)}
+                  </span>
+                </div>
+              )
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Movement history
+        </h2>
+        {detail.movements.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No movements recorded yet.
+          </p>
+        ) : (
+          <Card>
+            <CardContent className="p-0">
+              {detail.movements.map((movement, index) => (
+                <MovementRow
+                  key={movement.id}
+                  movement={movement}
+                  showSeparator={index > 0}
+                  onDelete={() => setPendingDelete(movement)}
+                />
+              ))}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <DeleteMovementDialog
+        movement={pendingDelete}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={handleDeleteConfirmed}
+      />
+    </div>
+  )
+}
+
+function MovementRow({
+  movement,
+  showSeparator,
+  onDelete,
+}: Readonly<{
+  movement: PersonDebtMovement
+  showSeparator: boolean
+  onDelete: () => void
+}>) {
+  const amount = BigInt(movement.amount)
+  const magnitude = amount < 0n ? -amount : amount
+  const positive = amount > 0n
+  const date = new Date(movement.date)
+
+  return (
+    <div>
+      {showSeparator ? <Separator /> : null}
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{movement.description}</p>
+          <p className="text-xs text-muted-foreground">
+            {date.toLocaleDateString(undefined, {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+            })}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "text-sm font-semibold tabular-nums",
+              positive
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-amber-600 dark:text-amber-400"
+            )}
+          >
+            {positive ? "+" : "−"}
+            {formatCurrency(magnitude.toString(), movement.currency)}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Delete movement"
+            onClick={onDelete}
+          >
+            <Trash2 className="size-4 text-muted-foreground" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DeleteMovementDialog({
+  movement,
+  onCancel,
+  onConfirm,
+}: Readonly<{
+  movement: PersonDebtMovement | null
+  onCancel: () => void
+  onConfirm: () => Promise<void>
+}>) {
+  const [submitting, setSubmitting] = React.useState(false)
+
+  async function handleConfirm() {
+    setSubmitting(true)
+    try {
+      await onConfirm()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AlertDialog
+      open={movement !== null}
+      onOpenChange={(open) => (open ? null : onCancel())}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this movement?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This reverses both ledger legs of the transfer and restores the
+            balances. The person&apos;s net position updates immediately. This
+            cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(event) => {
+              // Keep the dialog controlled by `movement`; run the async delete
+              // ourselves instead of letting the action auto-close first.
+              event.preventDefault()
+              void handleConfirm()
+            }}
+            disabled={submitting}
+          >
+            {submitting ? "Deleting…" : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 
@@ -367,9 +862,11 @@ function AddPersonDialog({
 const NEW_PERSON_SENTINEL = "__new_person"
 
 function RecordDebtDialog({
+  initialPersonId,
   onClose,
   onSaved,
 }: Readonly<{
+  initialPersonId: string | null
   onClose: () => void
   onSaved: () => Promise<void>
 }>) {
@@ -401,7 +898,9 @@ function RecordDebtDialog({
     [accounts]
   )
 
-  const [personId, setPersonId] = React.useState<string>(NEW_PERSON_SENTINEL)
+  const [personId, setPersonId] = React.useState<string>(
+    initialPersonId ?? NEW_PERSON_SENTINEL
+  )
   const [newPersonName, setNewPersonName] = React.useState("")
   const [action, setAction] = React.useState<DebtAction>("lend")
   const [cashAccountId, setCashAccountId] = React.useState<string>("")

--- a/src/server/debts.ts
+++ b/src/server/debts.ts
@@ -11,6 +11,8 @@ import { uuidV7Schema, type RunInTenantTransaction } from "./mutation-kit"
 import { createAccountForFamily } from "./accounts"
 import { createMerchantForFamily, type SerializedMerchant } from "./merchants"
 import { createTransactionForFamily } from "./transactions"
+import { getFamilyBaseCurrency } from "./fx"
+import { normalizeNetWorthAt, type RateResolver } from "@/lib/net-worth"
 
 // =============================================================================
 // PER-212 / ADR-0049 — person-to-person debt (Utang-Piutang), Slice 1 of the
@@ -352,6 +354,12 @@ async function orchestrateDebtMovement({
       amount,
       description: description ?? describe(person.name),
       date: date ?? new Date(),
+      // PER-214: stamp the person (a Merchant kind="person") as the transfer's
+      // merchant so BOTH ledger legs attribute to them — the ledger Merchant
+      // column shows the person and the existing merchant filter surfaces every
+      // debt movement by person. Tenant validation passes because the person is
+      // a family merchant (validateTenantReferences.assertMerchantInFamily).
+      merchantId: person.id,
       idempotencyKey,
     },
     familyId,
@@ -473,6 +481,9 @@ export async function recordRepaymentForFamily({
             ? `Repayment from ${person.name}`
             : `Repayment to ${person.name}`),
         date: data.date ?? new Date(),
+        // PER-214: attribute the repayment legs to the person too (see
+        // orchestrateDebtMovement).
+        merchantId: person.id,
         idempotencyKey: data.idempotencyKey,
       },
       familyId,
@@ -733,6 +744,256 @@ export const getPersonsFn = createServerFn({ method: "GET" })
   .middleware([familyMiddleware])
   .handler(async ({ context }) => {
     return await getPersonsForFamily({
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+// ============================================================================
+// READ — Per-person debt detail (PER-214, scope B).
+//
+// Everything the detail drill-down needs in ONE tenant-scoped read: the person
+// header, their signed net position per currency, settled state, and the full
+// movement history. A "movement" is the ONE transfer leg posted on the person's
+// RECEIVABLE/LOAN account (never the cash leg). That leg's SIGNED amount is,
+// by construction, exactly the delta it applied to the net position:
+//   lend           : RECEIVABLE inflow  +amount  (they owe you more)
+//   repay received : RECEIVABLE outflow -amount  (they owe you less)
+//   borrow         : LOAN outflow       -amount  (you owe them more)
+//   repay made     : LOAN inflow        +amount  (you owe them less)
+// so the UI derives direction and colour from the sign alone. The leg `id` is
+// delete-safe: `deleteTransactionForFamily` redirects an inflow leg to its
+// outflow twin and reverses BOTH legs symmetrically (PER-20 / ADR-0012).
+// ============================================================================
+
+export interface PersonDebtMovement {
+  // The debt-account leg's transaction id — the handle passed to the EXISTING
+  // `deleteTransactionFn` (transfer-symmetric, balance-safe, idempotent).
+  id: string
+  // ISO string (BigInt/Date are not JSON-serializable across the RPC boundary).
+  date: string
+  description: string
+  currency: string
+  accountType: string
+  // Signed net-position delta as a digit-string (> 0 grows what they owe you or
+  // shrinks what you owe them; < 0 the reverse).
+  amount: string
+  kind: string
+}
+
+export interface PersonDebtDetailView {
+  personId: string
+  name: string
+  color: string | null
+  accounts: PersonDebtAccountView[]
+  positions: PersonDebtCurrencyPosition[]
+  settled: boolean
+  movements: PersonDebtMovement[]
+}
+
+export const getPersonDebtDetailInputSchema = z.object({
+  personMerchantId: z.string().min(1),
+})
+
+export async function getPersonDebtDetailForFamily({
+  familyId,
+  userId,
+  personMerchantId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  familyId: string
+  userId: string
+  personMerchantId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<PersonDebtDetailView | null> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    // Tenant scoping: the person lookup is filtered by familyId + kind, so a
+    // cross-tenant personMerchantId returns null (never leaks another family's
+    // movements).
+    const person = await tx.merchant.findFirst({
+      where: { id: personMerchantId, familyId, kind: "person" },
+      select: { id: true, name: true, color: true },
+    })
+    if (!person) return null
+
+    const accounts = await tx.account.findMany({
+      where: {
+        familyId,
+        deletedAt: null,
+        counterpartyMerchantId: person.id,
+      },
+      select: {
+        id: true,
+        name: true,
+        accountType: true,
+        currency: true,
+        balance: true,
+      },
+      orderBy: { name: "asc" },
+    })
+
+    const accountTypeById = new Map(
+      accounts.map((account) => [account.id, account.accountType])
+    )
+    const accountIds = accounts.map((account) => account.id)
+
+    // Exactly ONE leg per transfer sits on a debt account (the other is the
+    // cash leg), so this never double-counts a movement.
+    const legs =
+      accountIds.length > 0
+        ? await tx.transaction.findMany({
+            where: {
+              familyId,
+              deletedAt: null,
+              accountId: { in: accountIds },
+            },
+            orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+            select: {
+              id: true,
+              date: true,
+              description: true,
+              currency: true,
+              amount: true,
+              accountId: true,
+              kind: true,
+            },
+          })
+        : []
+
+    const netByCurrency = new Map<string, bigint>()
+    for (const account of accounts) {
+      netByCurrency.set(
+        account.currency,
+        (netByCurrency.get(account.currency) ?? 0n) + account.balance
+      )
+    }
+    const positions: PersonDebtCurrencyPosition[] = [...netByCurrency.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([currency, net]) => ({ currency, net: net.toString() }))
+
+    return {
+      personId: person.id,
+      name: person.name,
+      color: person.color,
+      accounts: accounts.map((account) => ({
+        id: account.id,
+        name: account.name,
+        accountType: account.accountType,
+        currency: account.currency,
+        balance: account.balance.toString(),
+      })),
+      positions,
+      settled:
+        positions.length > 0 &&
+        positions.every((position) => BigInt(position.net) === 0n),
+      movements: legs.map((leg) => ({
+        id: leg.id,
+        date: leg.date.toISOString(),
+        description: leg.description,
+        currency: leg.currency,
+        accountType: accountTypeById.get(leg.accountId) ?? "",
+        amount: leg.amount.toString(),
+        kind: leg.kind,
+      })),
+    }
+  })
+}
+
+export const getPersonDebtDetailFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: z.input<typeof getPersonDebtDetailInputSchema>) =>
+    getPersonDebtDetailInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await getPersonDebtDetailForFamily({
+      familyId: context.familyId,
+      userId: context.user.id,
+      personMerchantId: data.personMerchantId,
+    })
+  })
+
+// ============================================================================
+// READ — Debts summary header (PER-214, scope C).
+//
+// Σ "They owe you" (receivables) vs Σ "You owe them" (|loans|) and the net, in
+// the family base currency. Reuses the net-worth normalizer: a person-debt
+// account is an ordinary RECEIVABLE(ASSET)/LOAN(LIABILITY), so
+// `normalizeNetWorthAt` already yields assets = Σ receivable-base,
+// liabilities = Σ |loan|-base, netWorth = assets - liabilities — exactly the
+// three totals this header shows. Foreign balances convert at the latest
+// snapshot rate; a currency with no rate is surfaced in `unconvertedCurrencies`
+// rather than silently zeroed (ADR-0038 §3).
+// ============================================================================
+
+export interface PersonDebtSummary {
+  baseCurrency: string
+  // Base-currency minor units as digit-strings.
+  receivable: string
+  loan: string
+  net: string
+  unconvertedCurrencies: string[]
+}
+
+export async function getPersonDebtSummaryForFamily({
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<PersonDebtSummary> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+
+    const accounts = await tx.account.findMany({
+      where: {
+        familyId,
+        deletedAt: null,
+        counterpartyMerchantId: { not: null },
+      },
+      select: { accountClass: true, currency: true, balance: true },
+    })
+
+    // Latest foreign->base rate per currency (greatest asOfDate wins).
+    const snapshots = await tx.fxRateSnapshot.findMany({
+      where: { familyId, toCurrency: baseCurrency },
+      orderBy: { asOfDate: "desc" },
+      select: { fromCurrency: true, rateScaled: true },
+    })
+    const latestRate = new Map<string, bigint>()
+    for (const snapshot of snapshots) {
+      if (!latestRate.has(snapshot.fromCurrency)) {
+        latestRate.set(snapshot.fromCurrency, snapshot.rateScaled)
+      }
+    }
+    const resolveRate: RateResolver = (fromCurrency) =>
+      latestRate.get(fromCurrency) ?? null
+
+    const breakdown = normalizeNetWorthAt(
+      accounts.map((account) => ({
+        accountClass: account.accountClass,
+        currency: account.currency,
+        native: account.balance,
+      })),
+      resolveRate,
+      baseCurrency
+    )
+
+    return {
+      baseCurrency,
+      receivable: breakdown.assets.toString(),
+      loan: breakdown.liabilities.toString(),
+      net: breakdown.netWorth.toString(),
+      unconvertedCurrencies: breakdown.unconverted.map((u) => u.currency),
+    }
+  })
+}
+
+export const getPersonDebtSummaryFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .handler(async ({ context }) => {
+    return await getPersonDebtSummaryForFamily({
       familyId: context.familyId,
       userId: context.user.id,
     })

--- a/tests/e2e/person-debt.e2e.ts
+++ b/tests/e2e/person-debt.e2e.ts
@@ -147,4 +147,64 @@ test.describe("person-to-person debt (PER-212)", () => {
       page.getByRole("option", { name: "Repayment made (I pay them back)" })
     ).toHaveCount(0)
   })
+
+  // PER-214 (Debts polish) — drill into a person's detail, see the movement
+  // history + net position, and delete a movement. Also confirms the person is
+  // attributed as the ledger merchant of the debt transfer.
+  test("drill into a person, see history + position, then delete a movement", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const cashName = `E2E Cash ${suffix}`
+    const personName = `Budi ${suffix}`
+
+    // --- Cash account ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(cashName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Lend to a brand-new person ---
+    await page.goto("/debts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "Record debt" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await page.getByLabel("New person name").fill(personName)
+    await page.getByRole("combobox", { name: "Cash account" }).click()
+    await page.getByRole("option", { name: `${cashName} (IDR)` }).click()
+    await page.getByLabel(/^Amount/).fill("500000")
+    await page.getByRole("button", { name: "Save" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- The person now shows as the merchant on the ledger transfer ---
+    await page.goto("/transactions")
+    await waitForHydration(page)
+    await expect(page.getByText(personName).first()).toBeVisible()
+
+    // --- Drill into the person's detail from the Debts list ---
+    await page.goto("/debts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: new RegExp(personName) }).click()
+
+    // Detail header, net position, and the movement history are all present.
+    await expect(page.getByRole("heading", { name: personName })).toBeVisible()
+    await expect(page.getByText("They owe you")).toBeVisible()
+    await expect(page.getByText("Movement history")).toBeVisible()
+    await expect(page.getByText(`Lent to ${personName}`)).toBeVisible()
+
+    // --- Delete the movement (confirm in the dialog) ---
+    await page.getByRole("button", { name: "Delete movement" }).click()
+    await expect(page.getByRole("alertdialog")).toBeVisible()
+    await page.getByRole("button", { name: "Delete", exact: true }).click()
+    await expect(page.getByRole("alertdialog")).toHaveCount(0)
+
+    // --- Position updated: the movement is gone (reversed, balance-safe) ---
+    await expect(page.getByText("No movements recorded yet.")).toBeVisible()
+    await expect(page.getByText(`Lent to ${personName}`)).toHaveCount(0)
+  })
 })

--- a/tests/integration/person-debt.integration.ts
+++ b/tests/integration/person-debt.integration.ts
@@ -9,14 +9,18 @@ import {
 import { getAccountsForFamily } from "../../src/server/accounts"
 import {
   createPersonForFamily,
+  getPersonDebtDetailForFamily,
   getPersonDebtsForFamily,
+  getPersonDebtSummaryForFamily,
   getPersonsForFamily,
   PersonDebtValidationError,
   recordBorrowForFamily,
   recordLendForFamily,
   recordRepaymentForFamily,
 } from "../../src/server/debts"
+import { deleteTransactionForFamily } from "../../src/server/transactions"
 import { createMerchantForFamily } from "../../src/server/merchants"
+import { convertMinor, encodeRate } from "../../src/lib/fx"
 import { normalizeNetWorthAt, type PointBalance } from "../../src/lib/net-worth"
 import {
   createIntegrationHarness,
@@ -161,7 +165,44 @@ describe("PER-212 person-to-person debt", () => {
     })
 
   const debtsOf = (owner: Owner) => getPersonDebtsForFamily(readerCtx(owner))
+  const detailOf = (owner: Owner, personMerchantId: string) =>
+    getPersonDebtDetailForFamily({ ...readerCtx(owner), personMerchantId })
+  const summaryOf = (owner: Owner) =>
+    getPersonDebtSummaryForFamily(readerCtx(owner))
   const personsOf = (owner: Owner) => getPersonsForFamily(readerCtx(owner))
+
+  // Every non-deleted Transaction leg that sits ON a person's debt account
+  // (accountId), with its merchantId, signed amount, and id — the raw evidence
+  // the detail view and the merchant-attribution invariant rest on.
+  const debtLegsOf = (owner: Owner, personMerchantId: string) =>
+    harness.withMember(owner.family.id, owner.user.id, async (tx) => {
+      const accounts = await tx.account.findMany({
+        where: {
+          familyId: owner.family.id,
+          counterpartyMerchantId: personMerchantId,
+          deletedAt: null,
+        },
+        select: { id: true },
+      })
+      const ids = accounts.map((a) => a.id)
+      return ids.length === 0
+        ? []
+        : tx.transaction.findMany({
+            where: {
+              familyId: owner.family.id,
+              accountId: { in: ids },
+              deletedAt: null,
+            },
+            select: { id: true, merchantId: true, amount: true },
+          })
+    })
+
+  const countMerchantLegs = (owner: Owner, merchantId: string) =>
+    harness.withMember(owner.family.id, owner.user.id, (tx) =>
+      tx.transaction.count({
+        where: { familyId: owner.family.id, merchantId, deletedAt: null },
+      })
+    )
   const listAccounts = (owner: Owner, includeCounterparty?: boolean) =>
     getAccountsForFamily({
       ...readerCtx(owner),
@@ -504,5 +545,220 @@ describe("PER-212 person-to-person debt", () => {
     expect(record?.accounts).toEqual([])
     expect(record?.positions).toEqual([])
     expect(record?.settled).toBe(false)
+  })
+
+  // ========================================================================
+  // PER-214 (Debts polish)
+  // ========================================================================
+
+  // --- A. Person as merchant on debt movements --------------------------
+  test("PER-214: lend/borrow/repay legs carry the person as merchant", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+
+    await lend(owner, budi.id, cash.id, "40000")
+    // Both transfer legs (cash outflow + receivable inflow) attribute to Budi.
+    expect(await countMerchantLegs(owner, budi.id)).toBe(2)
+    // The debt-account leg specifically has merchantId set to the person.
+    let debtLegs = await debtLegsOf(owner, budi.id)
+    expect(debtLegs).toHaveLength(1)
+    expect(debtLegs[0].merchantId).toBe(budi.id)
+
+    await borrow(owner, budi.id, cash.id, "20000")
+    expect(await countMerchantLegs(owner, budi.id)).toBe(4)
+
+    await repay(owner, budi.id, "receivable", cash.id, "40000")
+    // Repayment legs also attribute to the person.
+    expect(await countMerchantLegs(owner, budi.id)).toBe(6)
+    debtLegs = await debtLegsOf(owner, budi.id)
+    expect(debtLegs.every((leg) => leg.merchantId === budi.id)).toBe(true)
+  })
+
+  test("PER-214: backfill sets merchantId on legacy null-merchant debt legs", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    await lend(owner, budi.id, cash.id, "40000")
+
+    // Simulate a pre-PER-214 transfer: strip merchantId from BOTH legs.
+    await harness.withMember(owner.family.id, owner.user.id, (tx) =>
+      tx.transaction.updateMany({
+        where: { familyId: owner.family.id },
+        data: { merchantId: null },
+      })
+    )
+    expect(await countMerchantLegs(owner, budi.id)).toBe(0)
+
+    // Run the EXACT backfill SQL from the migration
+    // (20260802120000_debt_transfer_merchant_backfill).
+    await harness.withMember(owner.family.id, owner.user.id, (tx) =>
+      tx.$executeRawUnsafe(`
+        UPDATE "Transaction" AS t
+        SET "merchantId" = a."counterpartyMerchantId"
+        FROM "Account" AS a
+        WHERE t."merchantId" IS NULL
+          AND t."deletedAt" IS NULL
+          AND a."counterpartyMerchantId" IS NOT NULL
+          AND a."familyId" = t."familyId"
+          AND (t."accountId" = a.id OR t."toAccountId" = a.id);
+      `)
+    )
+
+    // Both legs of the debt transfer are re-attributed to the person.
+    expect(await countMerchantLegs(owner, budi.id)).toBe(2)
+    const debtLegs = await debtLegsOf(owner, budi.id)
+    expect(debtLegs.every((leg) => leg.merchantId === budi.id)).toBe(true)
+  })
+
+  // --- D. Delete a debt movement (reuse the existing ledger core) --------
+  test("PER-214: deleting a lend reverses BOTH legs; double-delete is a no-op", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    await lend(owner, budi.id, cash.id, "40000")
+
+    // The movement shown in the detail view is the debt-account leg.
+    const [movement] = await debtLegsOf(owner, budi.id)
+    expect(movement).toBeDefined()
+
+    const key = factories.createIdempotencyKey()
+    await deleteTransactionForFamily({
+      id: movement.id,
+      idempotencyKey: key,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Cash restored, receivable back to zero (both legs reversed).
+    let accounts = await readAccounts(owner.family.id)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+    expect(
+      accounts.find((a) => a.counterpartyMerchantId === budi.id)?.balance
+    ).toBe(0n)
+    // No live debt legs remain.
+    expect(await debtLegsOf(owner, budi.id)).toHaveLength(0)
+
+    // Replay the SAME key: idempotent no-op, balances unchanged (no double
+    // reverse).
+    await deleteTransactionForFamily({
+      id: movement.id,
+      idempotencyKey: key,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    accounts = await readAccounts(owner.family.id)
+    expect(accounts.find((a) => a.id === cash.id)?.balance).toBe(100_000n)
+    expect(
+      accounts.find((a) => a.counterpartyMerchantId === budi.id)?.balance
+    ).toBe(0n)
+  })
+
+  // --- B. Per-person detail: running position + movement list -----------
+  test("PER-214: detail returns running position + movements (multi-currency)", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    const usdCash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      currency: "USD",
+      familyId: owner.family.id,
+      name: "USD Cash",
+    })
+
+    await lend(owner, budi.id, cash.id, "50000") // IDR receivable +50k
+    await borrow(owner, budi.id, cash.id, "20000") // IDR loan -20k
+    await lend(owner, budi.id, usdCash.id, "25000") // USD receivable +25k
+
+    const detail = await detailOf(owner, budi.id)
+    expect(detail).not.toBeNull()
+    expect(detail?.name).toBe("Budi")
+    // Net = IDR (50k - 20k = 30k) and USD (25k), sorted by currency.
+    expect(detail?.positions).toEqual([
+      { currency: "IDR", net: "30000" },
+      { currency: "USD", net: "25000" },
+    ])
+    expect(detail?.settled).toBe(false)
+
+    // Three movements, newest first. Each movement's signed amount is the delta
+    // it applied to the net position.
+    expect(detail?.movements).toHaveLength(3)
+    const byCurrencyAndAmount = (detail?.movements ?? []).map((m) => ({
+      currency: m.currency,
+      amount: m.amount,
+      accountType: m.accountType,
+    }))
+    expect(byCurrencyAndAmount).toContainEqual({
+      currency: "IDR",
+      amount: "50000",
+      accountType: "RECEIVABLE",
+    })
+    expect(byCurrencyAndAmount).toContainEqual({
+      currency: "IDR",
+      amount: "-20000",
+      accountType: "LOAN",
+    })
+    expect(byCurrencyAndAmount).toContainEqual({
+      currency: "USD",
+      amount: "25000",
+      accountType: "RECEIVABLE",
+    })
+  })
+
+  test("PER-214: detail tenant isolation — family B cannot read family A's person", async () => {
+    const { owner: ownerA, cash: cashA, person: budi } = await setup(100_000n)
+    const ownerB = await factories.createAuthenticatedOnboardedUser()
+    await lend(ownerA, budi.id, cashA.id, "40000")
+
+    // Family B asking for family A's person id gets null (never A's movements).
+    expect(await detailOf(ownerB, budi.id)).toBeNull()
+    // Family A still reads its own.
+    expect((await detailOf(ownerA, budi.id))?.movements).toHaveLength(1)
+  })
+
+  // --- C. Summary totals (base currency, multi-currency) ----------------
+  test("PER-214: summary sums receivables vs loans vs net (single currency)", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n)
+    await lend(owner, budi.id, cash.id, "40000") // receivable +40k
+    await borrow(owner, budi.id, cash.id, "30000") // loan -30k
+
+    const summary = await summaryOf(owner)
+    expect(summary.baseCurrency).toBe("IDR")
+    expect(summary.receivable).toBe("40000")
+    expect(summary.loan).toBe("30000")
+    expect(summary.net).toBe("10000")
+    expect(summary.unconvertedCurrencies).toEqual([])
+  })
+
+  test("PER-214: summary converts foreign balances at the latest rate", async () => {
+    const { owner, cash, person: budi } = await setup(100_000n) // IDR base
+    const usdCash = await factories.createAccount({
+      accountType: "DEPOSITORY",
+      balance: 100_000n,
+      currency: "USD",
+      familyId: owner.family.id,
+      name: "USD Cash",
+    })
+
+    // 1 USD = 15.5 IDR (contrived; keeps the math exact for the assertion).
+    const rate = encodeRate("15.5")
+    await harness.withMember(owner.family.id, owner.user.id, (tx) =>
+      tx.fxRateSnapshot.create({
+        data: {
+          familyId: owner.family.id,
+          fromCurrency: "USD",
+          toCurrency: "IDR",
+          rateScaled: rate,
+          asOfDate: new Date("2026-01-01T00:00:00.000Z"),
+          createdById: owner.user.id,
+        },
+      })
+    )
+
+    await lend(owner, budi.id, cash.id, "40000") // IDR receivable +40k
+    await lend(owner, budi.id, usdCash.id, "25000") // USD receivable +25k
+
+    const usdInBase = convertMinor(25_000n, "USD", "IDR", rate)
+    const expectedReceivable = 40_000n + usdInBase
+
+    const summary = await summaryOf(owner)
+    expect(summary.baseCurrency).toBe("IDR")
+    expect(summary.receivable).toBe(expectedReceivable.toString())
+    expect(summary.loan).toBe("0")
+    expect(summary.net).toBe(expectedReceivable.toString())
+    expect(summary.unconvertedCurrencies).toEqual([])
   })
 })


### PR DESCRIPTION
## PER-214 — Debts polish

Slice 1.5 makes the "Debts" feature feel complete. Everything reuses the existing ledger cores (`createTransactionForFamily` / `deleteTransactionForFamily`) — no new debt sub-ledger.

### What changed

- **A. Person as merchant on debt movements.** `orchestrateDebtMovement` and the repayment `postTransfer` now pass `merchantId: person.id`, so both transfer legs attribute to the person — the ledger Merchant column shows them and the existing merchant filter surfaces every debt movement. Migration `20260802120000_debt_transfer_merchant_backfill` attributes existing null-merchant debt-transfer legs from the account's `counterpartyMerchantId` (tenant-safe, idempotent, add-only).
- **B. Per-person detail view.** In-page drill-down: header, running net position per currency, settled state, and full movement history (newest first, with date / description / signed amount / direction). New `getPersonDebtDetailForFamily` / `getPersonDebtDetailFn`, tenant-scoped, reusing existing read patterns. Quick actions: "Record" (preselecting the person) and per-movement delete.
- **C. Summary header on /debts.** Σ "They owe you" vs Σ "You owe them" and the net, in the family base currency. New `getPersonDebtSummaryForFamily` reuses the net-worth normalizer + a latest-rate resolver for multi-currency conversion.
- **D. Delete a debt movement.** Uses the EXISTING `deleteTransactionFn` (transfer-symmetric, balance-safe, audited, idempotent) behind a confirm `AlertDialog`; refetches the debt collection(s) + summary/detail after.
- **E. Richer UI.** Person avatars (initial + colour), emerald(+ they owe you)/amber(− you owe them) coloring, movement rows, empty states, consistent spacing per DESIGN.md.

### Test evidence

`vp check` — clean (format + lint + types).

Integration (`tests/integration/person-debt.integration.ts`, real Postgres) — 21 passed (14 existing + 7 new): merchant attribution on lend/borrow/repay legs; backfill SQL sets merchantId on legacy null-merchant legs; transfer-symmetric delete reverses BOTH legs + idempotent double-delete; detail running position + multi-currency movement list; detail tenant isolation; single- and multi-currency summary totals.

e2e (`tests/e2e/person-debt.e2e.ts`) — new "drill into a person, see history + position, then delete a movement" passes at the default timeout, plus the two other PER-213 tests. (The pre-existing first test in the spec cold-compiles the onboard→accounts→debts route chain on the dev server; it passes with a longer timeout locally and is warm in the full CI suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
