### PR TITLE
feat(accounts): PER-216 — per-account detail route + ATM-card hybrid visual

### DIFF
--- a/src/components/blocks/account-visual.test.tsx
+++ b/src/components/blocks/account-visual.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vite-plus/test"
+import { cleanup, render, screen } from "@testing-library/react"
+
+import {
+  AccountVisual,
+  isCardLikeAccountType,
+  type AccountVisualData,
+} from "./account-visual"
+
+// PER-216 — the account "ATM card" hero. Hybrid rendering + the hard rule that
+// we NEVER fabricate a card number (we don't store one; inventing digits would
+// falsify data).
+
+afterEach(cleanup)
+
+const base: AccountVisualData = {
+  name: "Bank Jago",
+  accountType: "DEPOSITORY",
+  accountClass: "ASSET",
+  balance: "1500000",
+  currency: "IDR",
+  color: null,
+}
+
+describe("isCardLikeAccountType", () => {
+  it("treats DEPOSITORY / E_WALLET / CREDIT as card-like", () => {
+    expect(isCardLikeAccountType("DEPOSITORY")).toBe(true)
+    expect(isCardLikeAccountType("E_WALLET")).toBe(true)
+    expect(isCardLikeAccountType("CREDIT")).toBe(true)
+  })
+  it("treats assets/liabilities that aren't cards as plain", () => {
+    for (const t of [
+      "CASH",
+      "LOAN",
+      "RECEIVABLE",
+      "INVESTMENT",
+      "TRACKED_ASSET",
+    ])
+      expect(isCardLikeAccountType(t)).toBe(false)
+  })
+})
+
+describe("AccountVisual", () => {
+  it("renders the account name and formatted balance", () => {
+    render(<AccountVisual account={base} />)
+    expect(screen.getByText("Bank Jago")).toBeTruthy()
+    // formatCurrency(1_500_000 minor, IDR) → grouped rupiah string
+    expect(screen.getByText(/15,000/)).toBeTruthy()
+  })
+
+  it("never renders a fabricated masked card number", () => {
+    const { container } = render(<AccountVisual account={base} />)
+    // No "•••• 1234" / "···· 1234" style masked PAN anywhere.
+    expect(container.textContent ?? "").not.toMatch(/[•·]{2,}\s*\d{2,}/)
+  })
+
+  it("labels a liability balance as Outstanding", () => {
+    render(
+      <AccountVisual
+        account={{
+          ...base,
+          name: "Credit Card",
+          accountType: "CREDIT",
+          accountClass: "LIABILITY",
+          balance: "-2000000",
+        }}
+      />
+    )
+    expect(screen.getByText(/outstanding/i)).toBeTruthy()
+  })
+})

--- a/src/components/blocks/account-visual.tsx
+++ b/src/components/blocks/account-visual.tsx
@@ -1,0 +1,221 @@
+import { CreditCard, Landmark, Smartphone, Wallet, Wifi } from "lucide-react"
+
+import { formatCurrency } from "@/lib/currency"
+import { cn } from "@/lib/utils"
+
+// =============================================================================
+// PER-216 — Account visual card (the "ATM card" hero).
+//
+// Hybrid rendering (locked design grill 2026-08-02):
+//   - DEPOSITORY / E_WALLET / CREDIT  → skeuomorphic gradient "card" (chip,
+//     contactless glyph, brand colour). These are the account types a human
+//     actually carries as a physical/virtual card, so the metaphor is honest.
+//   - everything else (CASH / LOAN / RECEIVABLE / INVESTMENT / TRACKED_ASSET)
+//     → a clean, flat panel. Chip-and-number styling on a mortgage or a gold
+//     holding would be dishonest skeuomorphism.
+//
+// We deliberately render NO card number. We do not store one, and inventing
+// "•••• 4821" would be falsifying data. The aesthetic stands on gradient +
+// chip + name + balance alone.
+//
+// Presentational only: no route/collection imports, so a component test can
+// mount it directly. The one data-driven style is the gradient, derived from
+// `account.color` — same documented exception used by PersonAvatar in
+// debts.tsx (dynamic data colour cannot be a Tailwind token).
+// =============================================================================
+
+const CARD_LIKE_TYPES: ReadonlySet<string> = new Set([
+  "DEPOSITORY",
+  "E_WALLET",
+  "CREDIT",
+])
+
+export function isCardLikeAccountType(accountType: string): boolean {
+  return CARD_LIKE_TYPES.has(accountType)
+}
+
+export interface AccountVisualData {
+  name: string
+  accountType: string
+  accountClass: string
+  balance: string
+  currency: string
+  color: string | null
+}
+
+// Sensible brand default per card-like type when the account has no colour.
+const DEFAULT_CARD_COLOR: Record<string, string> = {
+  DEPOSITORY: "#2563eb", // bank → blue
+  E_WALLET: "#7c3aed", // e-wallet → violet
+  CREDIT: "#0f766e", // credit card → teal
+}
+
+function clampByte(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)))
+}
+
+/** Shift a #RRGGBB hex toward black (factor<1) or white (factor>1). */
+function shadeHex(hex: string, factor: number): string {
+  const match = /^#?([0-9a-fA-F]{6})$/.exec(hex)
+  if (!match) return hex
+  const int = Number.parseInt(match[1], 16)
+  const r = clampByte(((int >> 16) & 0xff) * factor)
+  const g = clampByte(((int >> 8) & 0xff) * factor)
+  const b = clampByte((int & 0xff) * factor)
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`
+}
+
+function cardGradient(baseColor: string): string {
+  return `linear-gradient(135deg, ${shadeHex(baseColor, 1.12)} 0%, ${baseColor} 45%, ${shadeHex(baseColor, 0.7)} 100%)`
+}
+
+function TypeIcon({
+  accountType,
+  className,
+}: Readonly<{ accountType: string; className?: string }>) {
+  if (accountType === "CREDIT")
+    return <CreditCard className={className} aria-hidden />
+  if (accountType === "E_WALLET")
+    return <Smartphone className={className} aria-hidden />
+  if (accountType === "DEPOSITORY")
+    return <Landmark className={className} aria-hidden />
+  return <Wallet className={className} aria-hidden />
+}
+
+/** The gradient "ATM card". */
+function AtmCard({
+  account,
+  size,
+}: Readonly<{ account: AccountVisualData; size: "grid" | "hero" }>) {
+  const base =
+    account.color ?? DEFAULT_CARD_COLOR[account.accountType] ?? "#334155"
+  const hero = size === "hero"
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col justify-between overflow-hidden rounded-2xl text-white shadow-sm",
+        hero ? "aspect-[16/10] max-w-md p-6" : "aspect-[16/10] p-4"
+      )}
+      // Dynamic per-account brand colour — data, not a design token. Same
+      // documented exception as PersonAvatar (debts.tsx).
+      style={{ backgroundImage: cardGradient(base) }}
+    >
+      {/* Decorative sheen */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-1/3 -right-1/4 size-2/3 rounded-full bg-white/10 blur-2xl"
+      />
+      <div className="relative flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p
+            className={cn(
+              "truncate font-semibold",
+              hero ? "text-lg" : "text-sm"
+            )}
+          >
+            {account.name}
+          </p>
+          <p className="text-xs text-white/70">
+            {account.accountType === "CREDIT"
+              ? "Credit Card"
+              : account.accountType === "E_WALLET"
+                ? "E-Wallet"
+                : "Bank / Depository"}
+          </p>
+        </div>
+        <Wifi
+          aria-hidden
+          className={cn(
+            "shrink-0 rotate-90 text-white/80",
+            hero ? "size-5" : "size-4"
+          )}
+        />
+      </div>
+
+      {/* Chip */}
+      <div
+        aria-hidden
+        className={cn(
+          "relative rounded-md bg-gradient-to-br from-yellow-200 to-yellow-400/80 ring-1 ring-black/10",
+          hero ? "h-8 w-11" : "h-6 w-8"
+        )}
+      />
+
+      <div className="relative flex items-end justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[10px] tracking-wide text-white/60 uppercase">
+            {account.accountClass === "LIABILITY" ? "Outstanding" : "Balance"}
+          </p>
+          <p
+            className={cn(
+              "truncate font-semibold tabular-nums",
+              hero ? "text-2xl" : "text-lg"
+            )}
+          >
+            {formatCurrency(account.balance, account.currency)}
+          </p>
+        </div>
+        <TypeIcon
+          accountType={account.accountType}
+          className={cn("shrink-0 text-white/80", hero ? "size-7" : "size-5")}
+        />
+      </div>
+    </div>
+  )
+}
+
+/** The clean, flat panel for non-card account types. */
+function PlainCard({
+  account,
+  size,
+}: Readonly<{ account: AccountVisualData; size: "grid" | "hero" }>) {
+  const hero = size === "hero"
+  const isLiability = account.accountClass === "LIABILITY"
+  return (
+    <div
+      className={cn(
+        "flex flex-col justify-between rounded-2xl border bg-card",
+        hero ? "aspect-[16/10] max-w-md p-6" : "p-4"
+      )}
+    >
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <TypeIcon
+          accountType={account.accountType}
+          className={hero ? "size-5" : "size-4"}
+        />
+        <p
+          className={cn(
+            "truncate font-medium text-foreground",
+            hero ? "text-lg" : "text-sm"
+          )}
+        >
+          {account.name}
+        </p>
+      </div>
+      <div className={cn(hero ? "mt-6" : "mt-3")}>
+        <p className="text-[10px] tracking-wide text-muted-foreground uppercase">
+          {isLiability ? "Outstanding" : "Balance"}
+        </p>
+        <p
+          className={cn(
+            "font-semibold tabular-nums",
+            hero ? "text-2xl" : "text-lg"
+          )}
+        >
+          {formatCurrency(account.balance, account.currency)}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function AccountVisual({
+  account,
+  size = "grid",
+}: Readonly<{ account: AccountVisualData; size?: "grid" | "hero" }>) {
+  return isCardLikeAccountType(account.accountType) ? (
+    <AtmCard account={account} size={size} />
+  ) : (
+    <PlainCard account={account} size={size} />
+  )
+}

--- a/src/routes/_protected/-account-card.tsx
+++ b/src/routes/_protected/-account-card.tsx
@@ -1,6 +1,5 @@
 import {
   Archive,
-  Landmark,
   MoreVertical,
   Pencil,
   RotateCcw,
@@ -9,18 +8,11 @@ import {
   Trash2,
   TrendingUp,
   TriangleAlert,
-  Wallet,
 } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { Card } from "@/components/ui/card"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,6 +24,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { AccountVisual } from "@/components/blocks/account-visual"
 import type { AccountType } from "@/lib/accounts"
 import type { AccountRecord, DriftRecord } from "@/lib/account-collections"
 import { selectDriftBadge } from "@/lib/account-drift-presentation"
@@ -42,6 +35,11 @@ import { cn } from "@/lib/utils"
 // itself, mirrors -sure-import-ui.tsx) so this presentational card can be
 // imported directly by a component test without pulling in the route's
 // createFileRoute/collection-preload module graph.
+//
+// PER-216: the balance/name/type now live inside the shared <AccountVisual>
+// ("ATM card") which doubles as the clickable target that opens the per-account
+// detail route. Navigation is delegated via `onOpen` so this card stays
+// router-free and unit-testable without a RouterProvider.
 
 export const ACCOUNT_TYPE_LABEL: Record<AccountType, string> = {
   CASH: "Cash",
@@ -63,6 +61,7 @@ export function AccountCard({
   onArchive,
   onReactivate,
   onDelete,
+  onOpen,
 }: {
   account: AccountRecord
   drift: ReadonlyArray<DriftRecord>
@@ -72,25 +71,30 @@ export function AccountCard({
   onArchive: () => void
   onReactivate: () => void
   onDelete: () => void
+  // Opens the per-account detail route. Optional so a component test can mount
+  // the card without a router (navigation is a parent concern).
+  onOpen?: () => void
 }) {
   const archived = account.status !== "active"
   const cashLike = account.balanceSource === "transaction_flow"
-  const Icon = account.accountClass === "LIABILITY" ? Landmark : Wallet
   // Surface the single worst drift entry (ADR-0043 §6 classification lives in
   // src/lib/account-drift-presentation.ts, unit-tested there). Read-only — the
   // badge never mutates anything (ADR-0034 §7).
   const driftBadge = selectDriftBadge(drift)
   return (
-    <Card className={cn(archived && "opacity-60")}>
-      <CardHeader>
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <Icon className="size-4 text-muted-foreground" />
-            <CardTitle className="text-base">{account.name}</CardTitle>
-          </div>
-          {archived ? <Badge variant="outline">Archived</Badge> : null}
-        </div>
-        <CardDescription className="flex flex-wrap gap-1.5 pt-1">
+    <Card className={cn("overflow-hidden", archived && "opacity-60")}>
+      <button
+        type="button"
+        onClick={onOpen}
+        disabled={!onOpen}
+        aria-label={`Open ${account.name}`}
+        className="block w-full cursor-pointer rounded-b-none text-left transition-transform focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none enabled:hover:-translate-y-0.5 disabled:cursor-default"
+      >
+        <AccountVisual account={account} size="grid" />
+      </button>
+
+      <div className="flex flex-col gap-2 p-3">
+        <div className="flex flex-wrap items-center gap-1.5">
           <Badge variant="secondary">
             {ACCOUNT_TYPE_LABEL[account.accountType as AccountType] ??
               account.accountType}
@@ -99,6 +103,7 @@ export function AccountCard({
           <Badge variant={cashLike ? "default" : "outline"}>
             {cashLike ? "Cash-like" : "Tracked asset"}
           </Badge>
+          {archived ? <Badge variant="outline">Archived</Badge> : null}
           {driftBadge?.tone === "informational" ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -108,8 +113,8 @@ export function AccountCard({
                 </Badge>
               </TooltipTrigger>
               <TooltipContent>
-                Sure's own history already absorbed some drift before it was
-                exported, so this gap is expected — your balance is correct.
+                Sure&apos;s own history already absorbed some drift before it
+                was exported, so this gap is expected — your balance is correct.
               </TooltipContent>
             </Tooltip>
           ) : driftBadge ? (
@@ -126,16 +131,9 @@ export function AccountCard({
                 : `Needs reconcile (${formatCurrency(driftBadge.entry.drift, account.currency)})`}
             </Badge>
           ) : null}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex items-end justify-between gap-2">
-        <div>
-          <p className="text-xs text-muted-foreground">Balance</p>
-          <p className="text-lg font-semibold tabular-nums">
-            {formatCurrency(account.balance, account.currency)}
-          </p>
         </div>
-        <div className="flex gap-1">
+
+        <div className="flex justify-end gap-1">
           {!archived ? (
             <Button
               size="icon"
@@ -203,7 +201,7 @@ export function AccountCard({
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-      </CardContent>
+      </div>
     </Card>
   )
 }

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -1,0 +1,278 @@
+import * as React from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useLiveQuery } from "@tanstack/react-db"
+import { ArrowLeft, ExternalLink, Receipt } from "lucide-react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { AccountVisual } from "@/components/blocks/account-visual"
+import {
+  accountCollection,
+  type AccountRecord,
+} from "@/lib/account-collections"
+import { transactionCollection } from "@/lib/collections"
+import { applyFilters } from "@/lib/transaction-filters"
+import { ACCOUNT_TYPE_LABEL } from "./-account-card"
+import { formatCurrency } from "@/lib/currency"
+import { toMoney, ZERO_MONEY, type Money } from "@/lib/money"
+import { cn } from "@/lib/utils"
+
+export const Route = createFileRoute("/_protected/accounts/$accountId")({
+  // TanStack DB collections are client-only; SSR would hang (CLAUDE.md §5B).
+  ssr: false,
+  // Preload both lenses BEFORE render so useLiveQuery never starts a sync in
+  // the render phase (CLAUDE.md §5B — mandatory route-loader preload).
+  loader: async () => {
+    await Promise.all([
+      accountCollection.preload(),
+      transactionCollection.preload(),
+    ])
+    return null
+  },
+  component: AccountDetailPage,
+})
+
+/**
+ * Which way does a transaction move money FROM this account's perspective?
+ * `amount` is stored as an absolute magnitude (sign lives in `type`), so the
+ * sign is decided here. A transfer is a single outflow leg: source = outflow,
+ * destination = inflow — mirroring the per-account lens in transactions.tsx
+ * (PER-202). This never double-counts: exactly one leg touches this account.
+ */
+function directionForAccount(
+  trx: { type: string; toAccountId?: string | null },
+  accountId: string
+): 1 | -1 {
+  if (trx.type === "income") return 1
+  if (trx.type === "expense") return -1
+  return trx.toAccountId === accountId ? 1 : -1
+}
+
+function isSameMonth(date: Date | string, ref: Date): boolean {
+  const d = new Date(date)
+  return (
+    d.getFullYear() === ref.getFullYear() && d.getMonth() === ref.getMonth()
+  )
+}
+
+function AccountDetailPage() {
+  const { accountId } = Route.useParams()
+
+  const { data: accounts } = useLiveQuery((q) =>
+    q.from({ a: accountCollection })
+  )
+  const { data: allTransactions } = useLiveQuery((q) =>
+    q.from({ t: transactionCollection })
+  )
+
+  const account = React.useMemo<AccountRecord | undefined>(
+    () => accounts?.find((a) => a.id === accountId),
+    [accounts, accountId]
+  )
+
+  // Reuse the SAME ledger filter the /transactions page uses — this list is a
+  // filtered lens over the one canonical collection, never a second source.
+  const ledger = React.useMemo(
+    () =>
+      allTransactions
+        ? applyFilters(allTransactions, { accounts: [accountId] })
+        : [],
+    [allTransactions, accountId]
+  )
+
+  const kpi = React.useMemo(() => {
+    const now = new Date()
+    let inflow: Money = ZERO_MONEY
+    let outflow: Money = ZERO_MONEY
+    for (const trx of ledger) {
+      if (!isSameMonth(trx.date, now)) continue
+      if (directionForAccount(trx, accountId) === 1)
+        inflow = toMoney(inflow + trx.amount)
+      else outflow = toMoney(outflow + trx.amount)
+    }
+    return { inflow, outflow }
+  }, [ledger, accountId])
+
+  if (accounts && !account) {
+    return (
+      <AppShell>
+        <div className="flex flex-col items-start gap-4">
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/accounts">
+              <ArrowLeft className="size-4" />
+              Back to accounts
+            </Link>
+          </Button>
+          <p className="text-muted-foreground">
+            This account no longer exists, or you don&apos;t have access to it.
+          </p>
+        </div>
+      </AppShell>
+    )
+  }
+
+  if (!account) {
+    return (
+      <AppShell>
+        <div className="h-48 animate-pulse rounded-2xl bg-muted" />
+      </AppShell>
+    )
+  }
+
+  const currency = account.currency
+
+  return (
+    <AppShell>
+      <div className="flex items-center justify-between gap-2">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/accounts">
+            <ArrowLeft className="size-4" />
+            Back to accounts
+          </Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/transactions" search={{ accounts: [accountId] }}>
+            Open in ledger
+            <ExternalLink className="size-4" />
+          </Link>
+        </Button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,26rem)_1fr]">
+        {/* Hero card */}
+        <div className="flex flex-col gap-4">
+          <AccountVisual account={account} size="hero" />
+          <div className="flex flex-wrap gap-1.5">
+            <Badge variant="secondary">
+              {ACCOUNT_TYPE_LABEL[
+                account.accountType as keyof typeof ACCOUNT_TYPE_LABEL
+              ] ?? account.accountType}
+            </Badge>
+            <Badge variant="outline">{account.accountSubtype}</Badge>
+            {account.status !== "active" ? (
+              <Badge variant="outline">Archived</Badge>
+            ) : null}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <MiniStat
+              label="In this month"
+              value={formatCurrency(kpi.inflow, currency)}
+              tone="positive"
+            />
+            <MiniStat
+              label="Out this month"
+              value={formatCurrency(kpi.outflow, currency)}
+              tone="negative"
+            />
+          </div>
+        </div>
+
+        {/* Statement */}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-medium text-muted-foreground">
+              Transactions ({ledger.length})
+            </h2>
+          </div>
+          {ledger.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed py-12 text-center">
+              <Receipt className="size-6 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                No transactions for this account yet.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y rounded-2xl border">
+              {ledger.map((trx) => {
+                const dir = directionForAccount(trx, accountId)
+                const secondary =
+                  trx.type === "transfer"
+                    ? dir === 1
+                      ? `Transfer from ${trx.account?.name ?? "account"}`
+                      : `Transfer to ${trx.toAccount?.name ?? "account"}`
+                    : (trx.category?.name ??
+                      trx.merchant?.name ??
+                      (trx.isSplit ? "Split" : "Uncategorized"))
+                return (
+                  <li
+                    key={trx.id}
+                    className="flex items-center justify-between gap-3 px-4 py-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {trx.description}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {new Date(trx.date).toLocaleDateString()} · {secondary}
+                      </p>
+                    </div>
+                    <p
+                      className={cn(
+                        "shrink-0 text-sm font-semibold tabular-nums",
+                        dir === 1
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : "text-foreground"
+                      )}
+                    >
+                      {dir === 1 ? "+" : "−"}
+                      {formatCurrency(trx.amount, trx.currency)}
+                    </p>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </AppShell>
+  )
+}
+
+function MiniStat({
+  label,
+  value,
+  tone,
+}: Readonly<{ label: string; value: string; tone: "positive" | "negative" }>) {
+  return (
+    <div className="rounded-xl border p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          "mt-0.5 text-base font-semibold tabular-nums",
+          tone === "positive"
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-foreground"
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  )
+}
+
+function AppShell({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <TooltipProvider>
+      <SidebarProvider
+        style={
+          {
+            "--sidebar-width": "calc(var(--spacing) * 64)",
+            "--header-height": "calc(var(--spacing) * 14)",
+          } as React.CSSProperties
+        }
+      >
+        <AppSidebar variant="inset" />
+        <SidebarInset>
+          <SiteHeader />
+          <div className="flex flex-1 flex-col gap-6 p-4 lg:p-6">
+            {children}
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  )
+}

--- a/src/routes/_protected/accounts.index.tsx
+++ b/src/routes/_protected/accounts.index.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import {
   createFileRoute,
   Link,
+  useNavigate,
   type ErrorComponentProps,
 } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
@@ -79,7 +80,7 @@ import {
 } from "@/server/accounts"
 import { createValuationFn, getAccountBalanceFn } from "@/server/valuations"
 
-export const Route = createFileRoute("/_protected/accounts")({
+export const Route = createFileRoute("/_protected/accounts/")({
   // TanStack DB collections are browser-only; SSR would hang on the pending sync.
   ssr: false,
   // Preload the collection during navigation so `useLiveQuery` never kicks off
@@ -143,6 +144,7 @@ function AccountsPage() {
   )
   const [dialog, setDialog] = React.useState<DialogState>(null)
   const [busyId, setBusyId] = React.useState<string | null>(null)
+  const navigate = useNavigate()
 
   const safeAccounts = React.useMemo<ReadonlyArray<AccountRecord>>(
     () => accounts ?? [],
@@ -290,6 +292,12 @@ function AccountsPage() {
                             onReactivate={() => handleReactivate(account)}
                             onDelete={() =>
                               setDialog({ mode: "delete", account })
+                            }
+                            onOpen={() =>
+                              navigate({
+                                to: "/accounts/$accountId",
+                                params: { accountId: account.id },
+                              })
                             }
                           />
                         ))}

--- a/tests/e2e/account-detail.e2e.ts
+++ b/tests/e2e/account-detail.e2e.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-216 — per-account detail route + ATM-card hero.
+// Onboard → create an account → open it from the grid card → assert the detail
+// hero (name + balance), the empty statement state for a fresh account, that
+// "Open in ledger" carries the account filter, and that "Back to accounts"
+// returns. The per-account transaction LENS itself (transfer legs) is covered
+// by per-account-incoming-transfer.e2e + applyFilters unit tests; this spec
+// proves the route, navigation, and wiring.
+
+test.describe("account detail (PER-216)", () => {
+  test("open an account card → detail hero + statement + open-in-ledger + back", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const accountName = `E2E Detail ${suffix}`
+
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(accountName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Open the account from its grid card ---
+    await page.getByRole("button", { name: `Open ${accountName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+    await expect(
+      page.getByRole("link", { name: "Back to accounts" })
+    ).toBeVisible()
+
+    // Hero shows the name + formatted balance.
+    await expect(page.getByText(accountName).first()).toBeVisible()
+    await expect(page.getByText("Rp 2,000,000.00").first()).toBeVisible()
+
+    // The statement section renders (count reflects whatever the ledger holds
+    // for this account — opening balance may or may not post a row).
+    await expect(
+      page.getByRole("heading", { name: /Transactions \(/ })
+    ).toBeVisible()
+
+    // --- Open in ledger carries the account filter ---
+    await page.getByRole("link", { name: "Open in ledger" }).click()
+    await expect(page).toHaveURL(/\/transactions\?.*accounts/)
+
+    // --- Back to accounts ---
+    await page.goBack()
+    await expect(page).toHaveURL(/\/accounts\/[^/]+$/)
+    await page.getByRole("link", { name: "Back to accounts" }).click()
+    await expect(page).toHaveURL(/\/accounts$/)
+    // "New account" button is unique to the list route (the SiteHeader also
+    // renders an <h1> page title, so the heading text is not unique).
+    await expect(
+      page.getByRole("button", { name: "New account" })
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
## What & why
Closes PER-216. Creator-approved via design grill (2026-08-02). Two things creators asked for on the Accounts page: (1) see a single account's transactions **on the account page** (not only by filtering `/transactions`), and (2) make account cards look like real bank/ATM cards. Built on the **current** stack — the Radix→Base UI migration (PER-193) stays deferred until after prod go-live; the ATM look does not need it.

## Changes
- **`AccountVisual`** (`src/components/blocks/account-visual.tsx`) — shared hybrid card:
  - `DEPOSITORY` / `E_WALLET` / `CREDIT` → skeuomorphic gradient "ATM card" (chip, contactless glyph, brand colour derived from `account.color`).
  - everything else → clean flat panel (chip-and-number on a mortgage/gold would be dishonest).
  - **No fabricated card numbers** — we don't store them and must never falsify data. Aesthetic = gradient + chip + name + balance.
- **`/accounts/$accountId`** detail route — `ssr:false` + loader preloads `accountCollection` + `transactionCollection` (mandatory route-loader preload). Hero = the card; below = that account's transactions as a **filtered lens over the same canonical ledger** (`applyFilters({accounts:[id]})`, never a second source), signed from the account's perspective (transfer legs handled, no double-count). Plus this-month in/out KPI and an "Open in ledger" deep link.
- **Grid cards** now render the visual and navigate to the detail route via an `onOpen` callback (card stays router-free + unit-testable).
- **Route rename** `accounts.tsx` → `accounts.index.tsx` so `/accounts` (list) and `/accounts/$accountId` (detail) are siblings under an outlet parent — the list had no `<Outlet/>`, so the detail child never mounted otherwise.

## Data-integrity note
The per-account list does **not** duplicate ledger data — it is a filtered view over the one `transactionCollection`, exactly like the `/transactions` account filter (PER-202). One leg per transfer touches the account, so no double-count.

## Tests
- `account-visual.test.tsx` — hybrid classification, formatted balance, **no-fake-number guard**, liability "Outstanding" label.
- existing `-account-card.test.tsx` — still green with the new layout.
- `account-detail.e2e.ts` — open a card → detail hero + statement + "Open in ledger" (carries account filter) + back.
- `vp check` clean.

## Out of scope
- Reserve / minimum "Available balance" → PER-217.
- No ledger changes. No Base UI migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1