### PR TITLE
feat(accounts): PER-218 — account-detail analytics (balance trend + range + category breakdown + search/filter)

### DIFF
--- a/src/lib/account-analytics.test.ts
+++ b/src/lib/account-analytics.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import {
+  buildBalanceSeries,
+  matchesQuery,
+  rangeCutoff,
+  signedDeltaForAccount,
+  summarizeCategories,
+  type AnalyticsTxn,
+} from "./account-analytics"
+
+const ID = "acc-1"
+
+function txn(partial: Partial<AnalyticsTxn>): AnalyticsTxn {
+  return {
+    date: "2026-01-01",
+    amount: 0n,
+    type: "expense",
+    accountId: ID,
+    ...partial,
+  }
+}
+
+describe("signedDeltaForAccount", () => {
+  it("income is positive, expense negative", () => {
+    expect(signedDeltaForAccount({ type: "income", amount: 100n }, ID)).toBe(
+      100n
+    )
+    expect(signedDeltaForAccount({ type: "expense", amount: 100n }, ID)).toBe(
+      -100n
+    )
+  })
+  it("transfer is + when this account is the destination, − when source", () => {
+    expect(
+      signedDeltaForAccount(
+        { type: "transfer", amount: 100n, toAccountId: ID },
+        ID
+      )
+    ).toBe(100n)
+    expect(
+      signedDeltaForAccount(
+        { type: "transfer", amount: 100n, toAccountId: "other" },
+        ID
+      )
+    ).toBe(-100n)
+  })
+})
+
+describe("rangeCutoff", () => {
+  it("returns null for ALL", () => {
+    expect(rangeCutoff("ALL")).toBeNull()
+  })
+  it("subtracts the right window", () => {
+    const now = new Date("2026-04-01T00:00:00")
+    const oneMonth = rangeCutoff("1M", now)!
+    // Local date math (tz-independent): April → March.
+    expect(oneMonth.getFullYear()).toBe(2026)
+    expect(oneMonth.getMonth()).toBe(2) // 0-indexed March
+    expect(rangeCutoff("1Y", now)?.getFullYear()).toBe(2025)
+  })
+})
+
+describe("buildBalanceSeries", () => {
+  const txns: AnalyticsTxn[] = [
+    txn({ date: "2026-01-10", type: "income", amount: 100_000n }),
+    txn({ date: "2026-02-15", type: "expense", amount: 30_000n }),
+    txn({
+      date: "2026-03-20",
+      type: "transfer",
+      amount: 50_000n,
+      toAccountId: ID,
+    }),
+  ]
+  const now = new Date("2026-04-01T00:00:00")
+
+  it("reconstructs balance-after per day, ending at the current balance", () => {
+    // Σ deltas = +100k −30k +50k = +120k. currentBalance 120k ⇒ opening 0.
+    const series = buildBalanceSeries(txns, 120_000n, ID, "IDR", "ALL", now)
+    // Major units: 120_000 minor / 100 = 1200.
+    const byDate = Object.fromEntries(series.map((p) => [p.date, p.balance]))
+    expect(byDate["2026-01-10"]).toBe(1000)
+    expect(byDate["2026-02-15"]).toBe(700)
+    expect(byDate["2026-03-20"]).toBe(1200)
+    // Final point is today = authoritative current balance.
+    expect(series[series.length - 1].balance).toBe(1200)
+  })
+
+  it("backs out a non-zero opening balance", () => {
+    // currentBalance 200k, Σ deltas 120k ⇒ opening 80k (800 major).
+    const series = buildBalanceSeries(txns, 200_000n, ID, "IDR", "ALL", now)
+    const byDate = Object.fromEntries(series.map((p) => [p.date, p.balance]))
+    expect(byDate["2026-01-10"]).toBe(1800) // 80k + 100k = 180k
+    expect(series[series.length - 1].balance).toBe(2000)
+  })
+
+  it("anchors the window at the cutoff carrying the pre-cutoff balance", () => {
+    const series = buildBalanceSeries(txns, 120_000n, ID, "IDR", "1M", now)
+    // cutoff = 2026-03-01; last balance before it is 700 (after the Feb expense).
+    expect(series[0].date).toBe("2026-03-01")
+    expect(series[0].balance).toBe(700)
+    // Jan/Feb daily points are collapsed away.
+    expect(series.some((p) => p.date === "2026-01-10")).toBe(false)
+  })
+
+  it("handles an empty ledger as a single current-balance point", () => {
+    const series = buildBalanceSeries([], 50_000n, ID, "IDR", "ALL", now)
+    expect(series).toHaveLength(1)
+    expect(series[0].balance).toBe(500)
+  })
+})
+
+describe("summarizeCategories", () => {
+  const txns: AnalyticsTxn[] = [
+    txn({ type: "expense", amount: 30_000n, category: { name: "Food" } }),
+    txn({ type: "expense", amount: 20_000n, category: { name: "Food" } }),
+    txn({ type: "expense", amount: 10_000n, category: { name: "Transport" } }),
+    txn({ type: "income", amount: 100_000n, category: { name: "Salary" } }),
+  ]
+
+  it("aggregates outflow by category, sorted by magnitude", () => {
+    const out = summarizeCategories(txns, ID, { direction: "out" })
+    expect(out.map((s) => [s.name, s.total])).toEqual([
+      ["Food", 50_000n],
+      ["Transport", 10_000n],
+    ])
+  })
+
+  it("respects the limit", () => {
+    const out = summarizeCategories(txns, ID, { direction: "out", limit: 1 })
+    expect(out).toHaveLength(1)
+    expect(out[0].name).toBe("Food")
+  })
+
+  it("aggregates inflow separately", () => {
+    const inn = summarizeCategories(txns, ID, { direction: "in" })
+    expect(inn).toEqual([{ name: "Salary", color: null, total: 100_000n }])
+  })
+})
+
+describe("matchesQuery", () => {
+  it("matches description, merchant, or category case-insensitively", () => {
+    const t = {
+      description: "Kopi Kenangan",
+      merchant: { name: "Kopi Kenangan" },
+      category: { name: "Food & Drink" },
+    }
+    expect(matchesQuery(t, "kopi")).toBe(true)
+    expect(matchesQuery(t, "FOOD")).toBe(true)
+    expect(matchesQuery(t, "xyz")).toBe(false)
+    expect(matchesQuery(t, "")).toBe(true)
+  })
+})

--- a/src/lib/account-analytics.ts
+++ b/src/lib/account-analytics.ts
@@ -1,0 +1,224 @@
+import { toDisplayNumber } from "./money"
+import { type CurrencyCode } from "@/lib/data/currencies"
+
+// =============================================================================
+// PER-218 — pure, unit-tested analytics for the per-account detail page.
+//
+// Everything here is derived from the ONE canonical ledger (the already-loaded
+// transaction collection) plus the account's current balance. No server calls,
+// no mutations, no second source of truth — these are read-only lenses, exactly
+// like applyFilters. Money math stays in bigint minor units until the very last
+// step (chart data needs `number`), where we convert to major units for the
+// axis/tooltip.
+// =============================================================================
+
+export type AccountRange = "1M" | "3M" | "6M" | "1Y" | "ALL"
+
+export const ACCOUNT_RANGES: ReadonlyArray<{
+  value: AccountRange
+  label: string
+}> = [
+  { value: "1M", label: "1M" },
+  { value: "3M", label: "3M" },
+  { value: "6M", label: "6M" },
+  { value: "1Y", label: "1Y" },
+  { value: "ALL", label: "All" },
+]
+
+export interface AnalyticsTxn {
+  date: Date | string
+  createdAt?: Date | string
+  amount: bigint // absolute magnitude (sign lives in `type`)
+  type: string // "income" | "expense" | "transfer"
+  accountId: string
+  toAccountId?: string | null
+  category?: { name: string; color?: string | null } | null
+  merchant?: { name: string } | null
+  isSplit?: boolean
+}
+
+/**
+ * Signed movement of a transaction FROM this account's perspective.
+ * income → +, expense → −, transfer → + when this account is the destination
+ * leg, − when it is the source. Exactly one leg touches the account, so summing
+ * this over the ledger never double-counts (mirrors PER-202).
+ */
+export function signedDeltaForAccount(
+  trx: Pick<AnalyticsTxn, "type" | "amount" | "toAccountId">,
+  accountId: string
+): bigint {
+  if (trx.type === "income") return trx.amount
+  if (trx.type === "expense") return -trx.amount
+  return trx.toAccountId === accountId ? trx.amount : -trx.amount
+}
+
+/** Start-of-window cutoff for a range, or null for "ALL". */
+export function rangeCutoff(
+  range: AccountRange,
+  now: Date = new Date()
+): Date | null {
+  if (range === "ALL") return null
+  const d = new Date(now)
+  switch (range) {
+    case "1M":
+      d.setMonth(d.getMonth() - 1)
+      break
+    case "3M":
+      d.setMonth(d.getMonth() - 3)
+      break
+    case "6M":
+      d.setMonth(d.getMonth() - 6)
+      break
+    case "1Y":
+      d.setFullYear(d.getFullYear() - 1)
+      break
+  }
+  return d
+}
+
+function localIsoDay(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, "0")
+  const d = String(date.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
+}
+
+function chronological(a: AnalyticsTxn, b: AnalyticsTxn): number {
+  const ta = new Date(a.date).getTime()
+  const tb = new Date(b.date).getTime()
+  if (ta !== tb) return ta - tb
+  const ca = a.createdAt ? new Date(a.createdAt).getTime() : 0
+  const cb = b.createdAt ? new Date(b.createdAt).getTime() : 0
+  return ca - cb
+}
+
+export interface BalancePoint {
+  /** Local ISO day, e.g. "2026-07-31". */
+  date: string
+  /** Balance in MAJOR units (for the chart axis/tooltip). */
+  balance: number
+}
+
+/**
+ * Reconstruct the account balance after each day, chronologically, ending at
+ * `currentBalance` today. Correct for `balanceSource="transaction_flow"`
+ * (cash-like) accounts, where balance = opening + Σ(deltas): we back out the
+ * opening balance as `currentBalance − Σ(all deltas)` and walk forward.
+ *
+ * When a range is given, points before the cutoff collapse into a single anchor
+ * point AT the cutoff (carrying the balance as of then), so the line starts at
+ * the right level instead of zero. One point per day (last balance wins).
+ */
+export function buildBalanceSeries(
+  txns: ReadonlyArray<AnalyticsTxn>,
+  currentBalance: bigint,
+  accountId: string,
+  currency: string,
+  range: AccountRange = "ALL",
+  now: Date = new Date()
+): BalancePoint[] {
+  const sorted = [...txns].sort(chronological)
+  const total = sorted.reduce(
+    (sum, t) => sum + signedDeltaForAccount(t, accountId),
+    0n
+  )
+  const opening = currentBalance - total
+
+  let running = opening
+  const walked: Array<{ ms: number; iso: string; bal: bigint }> = []
+  for (const t of sorted) {
+    running += signedDeltaForAccount(t, accountId)
+    const dt = new Date(t.date)
+    walked.push({ ms: dt.getTime(), iso: localIsoDay(dt), bal: running })
+  }
+
+  const cutoff = rangeCutoff(range, now)
+  let windowed = walked
+  if (cutoff) {
+    const cutMs = cutoff.getTime()
+    const before = walked.filter((p) => p.ms < cutMs)
+    const inRange = walked.filter((p) => p.ms >= cutMs)
+    const anchorBal = before.length ? before[before.length - 1].bal : opening
+    windowed = [
+      { ms: cutMs, iso: localIsoDay(cutoff), bal: anchorBal },
+      ...inRange,
+    ]
+  }
+
+  // Collapse to one point per day (last balance of the day), then force a
+  // final "today" point equal to the authoritative current balance.
+  const byDay = new Map<string, bigint>()
+  for (const p of windowed) byDay.set(p.iso, p.bal)
+  byDay.set(localIsoDay(now), currentBalance)
+
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, bal]) => ({
+      date,
+      balance: toDisplayNumber(bal, currency as CurrencyCode),
+    }))
+}
+
+export interface CategorySlice {
+  name: string
+  color: string | null
+  /** Absolute total in minor units. */
+  total: bigint
+}
+
+/**
+ * Aggregate the account's movements by category (or merchant/label fallback),
+ * for one direction: "out" (money leaving the account) or "in" (arriving).
+ * Returns slices sorted by magnitude, optionally capped to `limit`.
+ */
+export function summarizeCategories(
+  txns: ReadonlyArray<AnalyticsTxn>,
+  accountId: string,
+  opts?: { direction?: "out" | "in"; limit?: number }
+): CategorySlice[] {
+  const direction = opts?.direction ?? "out"
+  const map = new Map<string, { color: string | null; total: bigint }>()
+  for (const t of txns) {
+    const delta = signedDeltaForAccount(t, accountId)
+    if (delta === 0n) continue
+    const isOut = delta < 0n
+    if (direction === "out" && !isOut) continue
+    if (direction === "in" && isOut) continue
+    const name =
+      t.type === "transfer"
+        ? "Transfer"
+        : (t.category?.name ??
+          t.merchant?.name ??
+          (t.isSplit ? "Split" : "Uncategorized"))
+    const color = t.category?.color ?? null
+    const abs = isOut ? -delta : delta
+    const existing = map.get(name)
+    if (existing) existing.total += abs
+    else map.set(name, { color, total: abs })
+  }
+  const slices = [...map.entries()].map(([name, v]) => ({
+    name,
+    color: v.color,
+    total: v.total,
+  }))
+  slices.sort((a, b) => (a.total < b.total ? 1 : a.total > b.total ? -1 : 0))
+  return typeof opts?.limit === "number" ? slices.slice(0, opts.limit) : slices
+}
+
+/** Free-text match over description / merchant / category (case-insensitive). */
+export function matchesQuery(
+  trx: {
+    description?: string | null
+    merchant?: { name: string } | null
+    category?: { name: string } | null
+  },
+  query: string
+): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  return (
+    (trx.description ?? "").toLowerCase().includes(q) ||
+    (trx.merchant?.name ?? "").toLowerCase().includes(q) ||
+    (trx.category?.name ?? "").toLowerCase().includes(q)
+  )
+}

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -1,0 +1,175 @@
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Button } from "@/components/ui/button"
+import {
+  ACCOUNT_RANGES,
+  type AccountRange,
+  type BalancePoint,
+  type CategorySlice,
+} from "@/lib/account-analytics"
+import { formatCurrency } from "@/lib/currency"
+
+// PER-218 — presentational analytics for the account detail page. Pure props
+// in, chart out. All numbers are pre-derived by the unit-tested helpers in
+// src/lib/account-analytics.ts; this file only draws them.
+
+export function RangeSelector({
+  value,
+  onChange,
+}: Readonly<{ value: AccountRange; onChange: (r: AccountRange) => void }>) {
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg border p-0.5">
+      {ACCOUNT_RANGES.map((r) => (
+        <Button
+          key={r.value}
+          type="button"
+          size="sm"
+          variant={r.value === value ? "secondary" : "ghost"}
+          className="h-7 px-2.5 text-xs"
+          aria-pressed={r.value === value}
+          onClick={() => onChange(r.value)}
+        >
+          {r.label}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+const balanceChartConfig = {
+  balance: { label: "Balance", color: "var(--chart-2)" },
+} satisfies ChartConfig
+
+function compactAxisNumber(value: number): string {
+  const abs = Math.abs(value)
+  if (abs >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (abs >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(value)
+}
+
+function formatChartDay(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}
+
+export function BalanceTrendChart({
+  series,
+  currency,
+}: Readonly<{ series: ReadonlyArray<BalancePoint>; currency: string }>) {
+  if (series.length < 2) {
+    return (
+      <div className="flex h-[200px] items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground">
+        Not enough history yet to draw a trend.
+      </div>
+    )
+  }
+  return (
+    <ChartContainer
+      config={balanceChartConfig}
+      className="aspect-auto h-[200px] w-full"
+    >
+      <AreaChart data={series as Array<BalancePoint>}>
+        <defs>
+          <linearGradient id="fillAccountBalance" x1="0" y1="0" x2="0" y2="1">
+            <stop
+              offset="5%"
+              stopColor="var(--color-balance)"
+              stopOpacity={0.8}
+            />
+            <stop
+              offset="95%"
+              stopColor="var(--color-balance)"
+              stopOpacity={0.1}
+            />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={40}
+          tickFormatter={formatChartDay}
+        />
+        <YAxis
+          width={44}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={compactAxisNumber}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(value) => formatChartDay(String(value))}
+              formatter={(value) => formatCurrency(Number(value), currency)}
+              indicator="dot"
+            />
+          }
+        />
+        <Area
+          dataKey="balance"
+          type="natural"
+          fill="url(#fillAccountBalance)"
+          stroke="var(--color-balance)"
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}
+
+export function CategoryBreakdown({
+  slices,
+  currency,
+}: Readonly<{ slices: ReadonlyArray<CategorySlice>; currency: string }>) {
+  if (slices.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No spending to break down in this range.
+      </p>
+    )
+  }
+  const max = slices.reduce((m, s) => (s.total > m ? s.total : m), 1n)
+  return (
+    <ul className="flex flex-col gap-2.5">
+      {slices.map((slice) => {
+        const pct = Number((slice.total * 100n) / max)
+        return (
+          <li key={slice.name} className="flex flex-col gap-1">
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="flex min-w-0 items-center gap-2">
+                <span
+                  aria-hidden
+                  className="size-2.5 shrink-0 rounded-full"
+                  // Category colour is dynamic data, not a design token (same
+                  // exception used across the app for category dots).
+                  style={{
+                    backgroundColor: slice.color ?? "var(--muted-foreground)",
+                  }}
+                />
+                <span className="truncate">{slice.name}</span>
+              </span>
+              <span className="shrink-0 text-muted-foreground tabular-nums">
+                {formatCurrency(slice.total, currency)}
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary/70"
+                style={{ width: `${Math.max(pct, 2)}%` }}
+              />
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
-import { ArrowLeft, ExternalLink, Receipt } from "lucide-react"
+import { ArrowLeft, ExternalLink, Receipt, Search } from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
@@ -9,6 +9,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
 import { AccountVisual } from "@/components/blocks/account-visual"
 import {
   accountCollection,
@@ -16,6 +17,19 @@ import {
 } from "@/lib/account-collections"
 import { transactionCollection } from "@/lib/collections"
 import { applyFilters } from "@/lib/transaction-filters"
+import {
+  BalanceTrendChart,
+  CategoryBreakdown,
+  RangeSelector,
+} from "./-account-analytics"
+import {
+  buildBalanceSeries,
+  matchesQuery,
+  rangeCutoff,
+  signedDeltaForAccount,
+  summarizeCategories,
+  type AccountRange,
+} from "@/lib/account-analytics"
 import { ACCOUNT_TYPE_LABEL } from "./-account-card"
 import { formatCurrency } from "@/lib/currency"
 import { toMoney, ZERO_MONEY, type Money } from "@/lib/money"
@@ -36,31 +50,22 @@ export const Route = createFileRoute("/_protected/accounts/$accountId")({
   component: AccountDetailPage,
 })
 
-/**
- * Which way does a transaction move money FROM this account's perspective?
- * `amount` is stored as an absolute magnitude (sign lives in `type`), so the
- * sign is decided here. A transfer is a single outflow leg: source = outflow,
- * destination = inflow — mirroring the per-account lens in transactions.tsx
- * (PER-202). This never double-counts: exactly one leg touches this account.
- */
-function directionForAccount(
-  trx: { type: string; toAccountId?: string | null },
-  accountId: string
-): 1 | -1 {
-  if (trx.type === "income") return 1
-  if (trx.type === "expense") return -1
-  return trx.toAccountId === accountId ? 1 : -1
-}
+const TYPE_FILTERS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "income", label: "Income" },
+  { value: "expense", label: "Expense" },
+  { value: "transfer", label: "Transfer" },
+]
 
-function isSameMonth(date: Date | string, ref: Date): boolean {
-  const d = new Date(date)
-  return (
-    d.getFullYear() === ref.getFullYear() && d.getMonth() === ref.getMonth()
-  )
+function isSameOrAfter(date: Date | string, cutoff: Date | null): boolean {
+  if (!cutoff) return true
+  return new Date(date).getTime() >= cutoff.getTime()
 }
 
 function AccountDetailPage() {
   const { accountId } = Route.useParams()
+  const [range, setRange] = React.useState<AccountRange>("3M")
+  const [query, setQuery] = React.useState("")
+  const [types, setTypes] = React.useState<ReadonlyArray<string>>([])
 
   const { data: accounts } = useLiveQuery((q) =>
     q.from({ a: accountCollection })
@@ -84,29 +89,61 @@ function AccountDetailPage() {
     [allTransactions, accountId]
   )
 
+  const currency = account?.currency ?? "IDR"
+  const cashLike = account?.balanceSource === "transaction_flow"
+  const currentBalance = account ? BigInt(account.balance) : 0n
+
+  // Time-scoped subset (range drives KPI + breakdown + statement).
+  const rangedLedger = React.useMemo(() => {
+    const cutoff = rangeCutoff(range)
+    return ledger.filter((t) => isSameOrAfter(t.date, cutoff))
+  }, [ledger, range])
+
+  // Full-history series (range windowing happens inside the helper so the line
+  // anchors correctly). Only meaningful for cash-like accounts.
+  const series = React.useMemo(
+    () =>
+      cashLike
+        ? buildBalanceSeries(ledger, currentBalance, accountId, currency, range)
+        : [],
+    [cashLike, ledger, currentBalance, accountId, currency, range]
+  )
+
+  const categories = React.useMemo(
+    () =>
+      summarizeCategories(rangedLedger, accountId, {
+        direction: "out",
+        limit: 6,
+      }),
+    [rangedLedger, accountId]
+  )
+
   const kpi = React.useMemo(() => {
-    const now = new Date()
     let inflow: Money = ZERO_MONEY
     let outflow: Money = ZERO_MONEY
-    for (const trx of ledger) {
-      if (!isSameMonth(trx.date, now)) continue
-      if (directionForAccount(trx, accountId) === 1)
-        inflow = toMoney(inflow + trx.amount)
-      else outflow = toMoney(outflow + trx.amount)
+    for (const trx of rangedLedger) {
+      const delta = signedDeltaForAccount(trx, accountId)
+      if (delta > 0n) inflow = toMoney(inflow + delta)
+      else outflow = toMoney(outflow - delta)
     }
     return { inflow, outflow }
-  }, [ledger, accountId])
+  }, [rangedLedger, accountId])
+
+  const statement = React.useMemo(
+    () =>
+      rangedLedger.filter(
+        (t) =>
+          matchesQuery(t, query) &&
+          (types.length === 0 || types.includes(t.type))
+      ),
+    [rangedLedger, query, types]
+  )
 
   if (accounts && !account) {
     return (
       <AppShell>
         <div className="flex flex-col items-start gap-4">
-          <Button asChild variant="ghost" size="sm">
-            <Link to="/accounts">
-              <ArrowLeft className="size-4" />
-              Back to accounts
-            </Link>
-          </Button>
+          <BackLink />
           <p className="text-muted-foreground">
             This account no longer exists, or you don&apos;t have access to it.
           </p>
@@ -123,17 +160,16 @@ function AccountDetailPage() {
     )
   }
 
-  const currency = account.currency
+  function toggleType(value: string) {
+    setTypes((prev) =>
+      prev.includes(value) ? prev.filter((t) => t !== value) : [...prev, value]
+    )
+  }
 
   return (
     <AppShell>
       <div className="flex items-center justify-between gap-2">
-        <Button asChild variant="ghost" size="sm">
-          <Link to="/accounts">
-            <ArrowLeft className="size-4" />
-            Back to accounts
-          </Link>
-        </Button>
+        <BackLink />
         <Button asChild variant="outline" size="sm">
           <Link to="/transactions" search={{ accounts: [accountId] }}>
             Open in ledger
@@ -142,8 +178,8 @@ function AccountDetailPage() {
         </Button>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,26rem)_1fr]">
-        {/* Hero card */}
+      <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,24rem)_1fr]">
+        {/* Left: hero + KPI + category breakdown */}
         <div className="flex flex-col gap-4">
           <AccountVisual account={account} size="hero" />
           <div className="flex flex-wrap gap-1.5">
@@ -159,76 +195,142 @@ function AccountDetailPage() {
           </div>
           <div className="grid grid-cols-2 gap-3">
             <MiniStat
-              label="In this month"
+              label="Money in"
               value={formatCurrency(kpi.inflow, currency)}
               tone="positive"
             />
             <MiniStat
-              label="Out this month"
+              label="Money out"
               value={formatCurrency(kpi.outflow, currency)}
               tone="negative"
             />
           </div>
+          <div className="rounded-2xl border p-4">
+            <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+              Spending by category
+            </h2>
+            <CategoryBreakdown slices={categories} currency={currency} />
+          </div>
         </div>
 
-        {/* Statement */}
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground">
-              Transactions ({ledger.length})
-            </h2>
-          </div>
-          {ledger.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed py-12 text-center">
-              <Receipt className="size-6 text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">
-                No transactions for this account yet.
-              </p>
+        {/* Right: balance trend + statement */}
+        <div className="flex flex-col gap-6">
+          <div className="rounded-2xl border p-4">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-sm font-medium text-muted-foreground">
+                Balance trend
+              </h2>
+              <RangeSelector value={range} onChange={setRange} />
             </div>
-          ) : (
-            <ul className="divide-y rounded-2xl border">
-              {ledger.map((trx) => {
-                const dir = directionForAccount(trx, accountId)
-                const secondary =
-                  trx.type === "transfer"
-                    ? dir === 1
-                      ? `Transfer from ${trx.account?.name ?? "account"}`
-                      : `Transfer to ${trx.toAccount?.name ?? "account"}`
-                    : (trx.category?.name ??
-                      trx.merchant?.name ??
-                      (trx.isSplit ? "Split" : "Uncategorized"))
-                return (
-                  <li
-                    key={trx.id}
-                    className="flex items-center justify-between gap-3 px-4 py-3"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">
-                        {trx.description}
-                      </p>
-                      <p className="truncate text-xs text-muted-foreground">
-                        {new Date(trx.date).toLocaleDateString()} · {secondary}
-                      </p>
-                    </div>
-                    <p
-                      className={cn(
-                        "shrink-0 text-sm font-semibold tabular-nums",
-                        dir === 1
-                          ? "text-emerald-600 dark:text-emerald-400"
-                          : "text-foreground"
-                      )}
+            {cashLike ? (
+              <BalanceTrendChart series={series} currency={currency} />
+            ) : (
+              <div className="flex h-[200px] items-center justify-center rounded-xl border border-dashed px-4 text-center text-sm text-muted-foreground">
+                Balance trend is available for cash-like accounts. This
+                account&apos;s value is tracked by valuations.
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-sm font-medium text-muted-foreground">
+                Transactions ({statement.length})
+              </h2>
+              <div className="relative">
+                <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search this account…"
+                  className="h-9 w-56 pl-8"
+                  aria-label="Search transactions"
+                />
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {TYPE_FILTERS.map((f) => (
+                <Button
+                  key={f.value}
+                  type="button"
+                  size="sm"
+                  variant={types.includes(f.value) ? "secondary" : "outline"}
+                  className="h-7 px-2.5 text-xs"
+                  aria-pressed={types.includes(f.value)}
+                  onClick={() => toggleType(f.value)}
+                >
+                  {f.label}
+                </Button>
+              ))}
+            </div>
+
+            {statement.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed py-12 text-center">
+                <Receipt className="size-6 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">
+                  {ledger.length === 0
+                    ? "No transactions for this account yet."
+                    : "No transactions match your filters."}
+                </p>
+              </div>
+            ) : (
+              <ul className="divide-y rounded-2xl border">
+                {statement.map((trx) => {
+                  const dir =
+                    signedDeltaForAccount(trx, accountId) >= 0n ? 1 : -1
+                  const secondary =
+                    trx.type === "transfer"
+                      ? dir === 1
+                        ? `Transfer from ${trx.account?.name ?? "account"}`
+                        : `Transfer to ${trx.toAccount?.name ?? "account"}`
+                      : (trx.category?.name ??
+                        trx.merchant?.name ??
+                        (trx.isSplit ? "Split" : "Uncategorized"))
+                  return (
+                    <li
+                      key={trx.id}
+                      className="flex items-center justify-between gap-3 px-4 py-3"
                     >
-                      {dir === 1 ? "+" : "−"}
-                      {formatCurrency(trx.amount, trx.currency)}
-                    </p>
-                  </li>
-                )
-              })}
-            </ul>
-          )}
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {trx.description}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {new Date(trx.date).toLocaleDateString()} ·{" "}
+                          {secondary}
+                        </p>
+                      </div>
+                      <p
+                        className={cn(
+                          "shrink-0 text-sm font-semibold tabular-nums",
+                          dir === 1
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-foreground"
+                        )}
+                      >
+                        {dir === 1 ? "+" : "−"}
+                        {formatCurrency(trx.amount, trx.currency)}
+                      </p>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
     </AppShell>
+  )
+}
+
+function BackLink() {
+  return (
+    <Button asChild variant="ghost" size="sm">
+      <Link to="/accounts">
+        <ArrowLeft className="size-4" />
+        Back to accounts
+      </Link>
+    </Button>
   )
 }
 

--- a/tests/e2e/account-detail.e2e.ts
+++ b/tests/e2e/account-detail.e2e.ts
@@ -37,11 +37,32 @@ test.describe("account detail (PER-216)", () => {
     await expect(page.getByText(accountName).first()).toBeVisible()
     await expect(page.getByText("Rp 2,000,000.00").first()).toBeVisible()
 
-    // The statement section renders (count reflects whatever the ledger holds
-    // for this account — opening balance may or may not post a row).
+    // The statement section renders. A fresh account's opening balance is an
+    // opening VALUATION anchor, not a posted transaction, so the ledger is
+    // genuinely empty here.
     await expect(
       page.getByRole("heading", { name: /Transactions \(/ })
     ).toBeVisible()
+    await expect(
+      page.getByText("No transactions for this account yet.")
+    ).toBeVisible()
+
+    // --- Analytics tools (PER-218) render and are interactive ---
+    await expect(
+      page.getByRole("heading", { name: "Balance trend" })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: "Spending by category" })
+    ).toBeVisible()
+    // Range selector toggles the active window.
+    const oneMonth = page.getByRole("button", { name: "1M", exact: true })
+    await oneMonth.click()
+    await expect(oneMonth).toHaveAttribute("aria-pressed", "true")
+    // The in-account search box accepts input without crashing the page.
+    const search = page.getByRole("textbox", { name: "Search transactions" })
+    await search.fill("coffee")
+    await expect(search).toHaveValue("coffee")
+    await search.clear()
 
     // --- Open in ledger carries the account filter ---
     await page.getByRole("link", { name: "Open in ledger" }).click()


### PR DESCRIPTION
## What & why
Closes PER-218. Builds on PER-216 to make the per-account page a world-class analytics surface (Revolut/Monzo/Copilot-grade) — **all read-only lenses over the one canonical ledger**, no new mutation paths, no second source of truth.

## Changes
- **`src/lib/account-analytics.ts`** — pure, unit-tested (money-shaped, so correctness is mandatory):
  - `signedDeltaForAccount` — per-account signed movement (transfer legs handled, no double-count).
  - `buildBalanceSeries` — reconstructs balance-after-per-day from `Account.balance` + ledger deltas (`opening = currentBalance − Σ deltas`), range-windowed with a cutoff anchor. Correct for `balanceSource="transaction_flow"` accounts.
  - `summarizeCategories`, `matchesQuery`, `rangeCutoff`.
- **`-account-analytics.tsx`** — `RangeSelector`, `BalanceTrendChart` (recharts via the existing `ChartContainer`, **no new dep**), `CategoryBreakdown`. Presentational only.
- **Detail route** — one range control (1M/3M/6M/1Y/All) drives the KPI + balance-trend chart + category breakdown; the statement gains free-text search + income/expense/transfer type chips. Valuation-tracked accounts honestly skip the trend (their balance is not a transaction sum).

## Correctness note
The balance trend is an honest reconstruction of the transaction-driven balance: for `transaction_flow` accounts the canonical balance is `opening + Σ transactions` (ADR-0034), so `opening = currentBalance − Σ deltas` and walking forward reproduces the exact stored balance at each point. Reconciliation anchors remain read-only for the balance (they drive drift, not the sum), so the reconstruction stays consistent with the canonical model.

## Tests
- 12 unit tests for the pure helpers (opening back-out incl. non-zero opening, range anchoring, empty ledger, category aggregation + limit + direction, query match).
- `account-detail.e2e.ts` extended: analytics tools render, range toggle flips `aria-pressed`, in-account search accepts input.
- `vp check` clean.

## Out of scope (→ PER-219)
- Quick-action toolbar (Add txn / Reconcile / Edit) + CSV export, and accounts LIST-page tools (search/filter/pin/view-toggle). Valuation-history chart for tracked assets is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1