### PR TITLE
feat(accounts): PER-220 — account-detail quick actions (Add transaction prefilled + CSV export)

### DIFF
--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -146,6 +146,10 @@ interface TransactionFormModalProps {
     | null
   customTrigger?: React.ReactNode
   onClose?: () => void
+  // Seeds the source account when opening the CREATE form (e.g. "Add
+  // transaction" launched from a specific account's detail page). Ignored in
+  // edit mode, where the account comes from `editData`.
+  defaultAccountId?: string
 }
 
 type TransactionType = TransactionFormValues["type"]
@@ -1423,7 +1427,11 @@ function TransactionActionBar({
 function useTransactionFormModalController({
   editData,
   onClose,
-}: Pick<TransactionFormModalProps, "editData" | "onClose">) {
+  defaultAccountId,
+}: Pick<
+  TransactionFormModalProps,
+  "editData" | "onClose" | "defaultAccountId"
+>) {
   const isEditMode = !!editData
 
   // THE TOP-LEVEL FIX:
@@ -1555,7 +1563,7 @@ function useTransactionFormModalController({
         type: "expense" as const,
         amount: 0,
         description: "",
-        accountId: "",
+        accountId: defaultAccountId ?? "",
         categoryId: "",
         toAccountId: "",
         merchantId: "",
@@ -1950,6 +1958,7 @@ export function TransactionFormModal({
   editData,
   customTrigger,
   onClose,
+  defaultAccountId,
 }: TransactionFormModalProps) {
   const {
     activeTab,
@@ -1969,7 +1978,7 @@ export function TransactionFormModal({
     setIsSplit,
     setSplitEntries,
     splitEntries,
-  } = useTransactionFormModalController({ editData, onClose })
+  } = useTransactionFormModalController({ editData, onClose, defaultAccountId })
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>

--- a/src/lib/account-analytics.test.ts
+++ b/src/lib/account-analytics.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vite-plus/test"
 
 import {
   buildBalanceSeries,
+  buildStatementCsv,
   matchesQuery,
   rangeCutoff,
   signedDeltaForAccount,
   summarizeCategories,
   type AnalyticsTxn,
+  type StatementCsvRow,
 } from "./account-analytics"
 
 const ID = "acc-1"
@@ -134,6 +136,55 @@ describe("summarizeCategories", () => {
   it("aggregates inflow separately", () => {
     const inn = summarizeCategories(txns, ID, { direction: "in" })
     expect(inn).toEqual([{ name: "Salary", color: null, total: 100_000n }])
+  })
+})
+
+describe("buildStatementCsv", () => {
+  const rows: StatementCsvRow[] = [
+    {
+      date: "2026-03-10",
+      description: "Kopi, Kenangan",
+      type: "expense",
+      amount: 35_000n,
+      currency: "IDR",
+      accountId: ID,
+      category: { name: "Food" },
+    },
+    {
+      date: "2026-03-11",
+      description: "Salary",
+      type: "income",
+      amount: 100_000n,
+      currency: "IDR",
+      accountId: ID,
+      category: { name: "Salary" },
+    },
+    {
+      date: "2026-03-12",
+      type: "transfer",
+      amount: 50_000n,
+      currency: "IDR",
+      accountId: ID,
+      toAccountId: "other",
+      toAccount: { name: "GoPay" },
+    },
+  ]
+
+  it("emits a header and one signed, major-unit row per transaction", () => {
+    const lines = buildStatementCsv(rows, ID).split("\r\n")
+    expect(lines[0]).toBe("Date,Description,Category,Type,Amount,Currency")
+    // Expense → negative; description with a comma is quoted (RFC-4180).
+    expect(lines[1]).toBe('2026-03-10,"Kopi, Kenangan",Food,expense,-350,IDR')
+    // Income → positive.
+    expect(lines[2]).toBe("2026-03-11,Salary,Salary,income,1000,IDR")
+    // Transfer out → negative, labelled with the destination account.
+    expect(lines[3]).toBe("2026-03-12,,Transfer to GoPay,transfer,-500,IDR")
+  })
+
+  it("returns just the header for an empty statement", () => {
+    expect(buildStatementCsv([], ID)).toBe(
+      "Date,Description,Category,Type,Amount,Currency"
+    )
   })
 })
 

--- a/src/lib/account-analytics.ts
+++ b/src/lib/account-analytics.ts
@@ -222,3 +222,77 @@ export function matchesQuery(
     (trx.category?.name ?? "").toLowerCase().includes(q)
   )
 }
+
+export interface StatementCsvRow {
+  date: Date | string
+  description?: string | null
+  type: string
+  amount: bigint
+  currency: string
+  accountId: string
+  toAccountId?: string | null
+  account?: { name: string } | null
+  toAccount?: { name: string } | null
+  category?: { name: string } | null
+  merchant?: { name: string } | null
+  isSplit?: boolean
+}
+
+/** RFC-4180 field quoting: wrap in quotes and double internal quotes when the
+ * value contains a comma, quote, or newline. */
+function csvField(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+}
+
+function labelFor(row: StatementCsvRow, direction: 1 | -1): string {
+  if (row.type === "transfer") {
+    return direction === 1
+      ? `Transfer from ${row.account?.name ?? "account"}`
+      : `Transfer to ${row.toAccount?.name ?? "account"}`
+  }
+  return (
+    row.category?.name ??
+    row.merchant?.name ??
+    (row.isSplit ? "Split" : "Uncategorized")
+  )
+}
+
+/**
+ * Serialize an account's statement (as the user currently sees it — pass the
+ * already-filtered rows) to CSV. Amount is signed FROM this account's
+ * perspective, in MAJOR units. Pure + unit-tested; the browser download wrapper
+ * lives in the route.
+ */
+export function buildStatementCsv(
+  rows: ReadonlyArray<StatementCsvRow>,
+  accountId: string
+): string {
+  const header = [
+    "Date",
+    "Description",
+    "Category",
+    "Type",
+    "Amount",
+    "Currency",
+  ]
+  const lines = [header.join(",")]
+  for (const row of rows) {
+    const delta = signedDeltaForAccount(row, accountId)
+    const direction: 1 | -1 = delta >= 0n ? 1 : -1
+    const magnitude = delta < 0n ? -delta : delta
+    const major = toDisplayNumber(magnitude, row.currency as CurrencyCode)
+    const signed = direction === 1 ? major : -major
+    const isoDate = new Date(row.date).toISOString().slice(0, 10)
+    lines.push(
+      [
+        csvField(isoDate),
+        csvField(row.description ?? ""),
+        csvField(labelFor(row, direction)),
+        csvField(row.type),
+        csvField(String(signed)),
+        csvField(row.currency),
+      ].join(",")
+    )
+  }
+  return lines.join("\r\n")
+}

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -1,7 +1,14 @@
 import * as React from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
-import { ArrowLeft, ExternalLink, Receipt, Search } from "lucide-react"
+import {
+  ArrowLeft,
+  Download,
+  ExternalLink,
+  Plus,
+  Receipt,
+  Search,
+} from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
@@ -11,6 +18,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { AccountVisual } from "@/components/blocks/account-visual"
+import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
   type AccountRecord,
@@ -24,6 +32,7 @@ import {
 } from "./-account-analytics"
 import {
   buildBalanceSeries,
+  buildStatementCsv,
   matchesQuery,
   rangeCutoff,
   signedDeltaForAccount,
@@ -166,16 +175,49 @@ function AccountDetailPage() {
     )
   }
 
+  // The detail route is client-only (ssr:false), so `document`/`URL` are safe.
+  function exportCsv() {
+    const csv = buildStatementCsv(statement, accountId)
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    const url = URL.createObjectURL(blob)
+    const safeName = account!.name.replace(/[^\w.-]+/g, "_")
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `${safeName || "account"}-statement.csv`
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <AppShell>
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <BackLink />
-        <Button asChild variant="outline" size="sm">
-          <Link to="/transactions" search={{ accounts: [accountId] }}>
-            Open in ledger
-            <ExternalLink className="size-4" />
-          </Link>
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <TransactionFormModal
+            defaultAccountId={accountId}
+            customTrigger={
+              <Button size="sm">
+                <Plus className="size-4" />
+                Add transaction
+              </Button>
+            }
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={exportCsv}
+            disabled={statement.length === 0}
+          >
+            <Download className="size-4" />
+            Export CSV
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/transactions" search={{ accounts: [accountId] }}>
+              Open in ledger
+              <ExternalLink className="size-4" />
+            </Link>
+          </Button>
+        </div>
       </div>
 
       <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,24rem)_1fr]">

--- a/tests/e2e/account-detail.e2e.ts
+++ b/tests/e2e/account-detail.e2e.ts
@@ -64,6 +64,23 @@ test.describe("account detail (PER-216)", () => {
     await expect(search).toHaveValue("coffee")
     await search.clear()
 
+    // --- Quick actions (PER-220) ---
+    // Export CSV is disabled while the statement is empty.
+    await expect(
+      page.getByRole("button", { name: "Export CSV" })
+    ).toBeDisabled()
+    // Add transaction opens the create modal with THIS account prefilled
+    // (the source account <select> has our account as its selected option).
+    await page.getByRole("button", { name: "Add transaction" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog).toBeVisible()
+    const accountSelect = dialog.getByRole("combobox", { name: "Account *" })
+    await expect(accountSelect.locator("option:checked")).toHaveText(
+      new RegExp(accountName)
+    )
+    await page.keyboard.press("Escape")
+    await expect(dialog).toHaveCount(0)
+
     // --- Open in ledger carries the account filter ---
     await page.getByRole("link", { name: "Open in ledger" }).click()
     await expect(page).toHaveURL(/\/transactions\?.*accounts/)


### PR DESCRIPTION
## What & why
Closes PER-220 (split from PER-219). Two self-contained actions on the per-account detail page.

## Changes
- **Add transaction (prefilled).** `TransactionFormModal` gains an optional `defaultAccountId` prop, threaded into the CREATE form's default `accountId`. The detail toolbar launches the modal (`customTrigger`) with this account preselected. Create already does an optimistic `transactionCollection.insert`, so the detail statement + balance trend update live. Edit mode is unaffected (account still comes from `editData`).
- **CSV export.** Pure `buildStatementCsv` helper in `account-analytics.ts` — RFC-4180 field quoting, amount signed from the account's perspective in major units — plus a browser Blob download on the toolbar. Exports the **currently filtered** statement (search/type/range); button disabled when empty.

## Tests
- +2 unit tests for `buildStatementCsv` (signed rows, comma-quoting, empty → header-only). Total analytics suite now 14 → 16 assertions of pure logic.
- `account-detail.e2e.ts` extended: Export CSV disabled on an empty statement; **Add transaction opens the modal with this account as the selected source account** (verified via the selected `<option>`).
- `vp check` clean.

## Out of scope (→ PER-221)
- Edit account + Reconcile/Update value from the detail page (needs extracting `ValuationActionDialog` + the edit dialog out of `accounts.index.tsx` into shared components).

## Note
Accounts LIST-page tools (search/filter/pin/view-toggle) are PER-219, in a separate parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1