### PR TITLE
feat(accounts): PER-219 — accounts list tools (search/filter/pin/view-toggle)

### DIFF
--- a/src/lib/account-list-tools.test.ts
+++ b/src/lib/account-list-tools.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vite-plus/test"
+
+import {
+  accountMatchesQuery,
+  compareAccounts,
+  filterAccounts,
+  isPinned,
+  parsePinnedIds,
+  parseViewMode,
+  sortAccounts,
+  togglePinned,
+  type AccountFilterState,
+  type AccountListItem,
+} from "./account-list-tools"
+
+function account(overrides: Partial<AccountListItem> = {}): AccountListItem {
+  return {
+    id: "acc-1",
+    name: "Bank Jago",
+    accountType: "DEPOSITORY",
+    status: "active",
+    ...overrides,
+  }
+}
+
+const baseFilter: AccountFilterState = {
+  query: "",
+  type: "all",
+  showArchived: false,
+}
+
+describe("accountMatchesQuery", () => {
+  it("matches everything on an empty or whitespace query", () => {
+    expect(accountMatchesQuery("Bank Jago", "")).toBe(true)
+    expect(accountMatchesQuery("Bank Jago", "   ")).toBe(true)
+  })
+
+  it("matches case-insensitively on substrings", () => {
+    expect(accountMatchesQuery("Bank Jago", "jago")).toBe(true)
+    expect(accountMatchesQuery("Bank Jago", "BANK")).toBe(true)
+    expect(accountMatchesQuery("Bank Jago", "  ja  ")).toBe(true)
+  })
+
+  it("returns false when the name does not contain the query", () => {
+    expect(accountMatchesQuery("Bank Jago", "mandiri")).toBe(false)
+  })
+})
+
+describe("filterAccounts", () => {
+  const accounts: Array<AccountListItem> = [
+    account({ id: "a", name: "Bank Jago", accountType: "DEPOSITORY" }),
+    account({ id: "b", name: "Cash Wallet", accountType: "CASH" }),
+    account({
+      id: "c",
+      name: "Old Savings",
+      accountType: "DEPOSITORY",
+      status: "archived",
+    }),
+  ]
+
+  it("hides archived accounts unless showArchived is set", () => {
+    expect(filterAccounts(accounts, baseFilter).map((a) => a.id)).toEqual([
+      "a",
+      "b",
+    ])
+    expect(
+      filterAccounts(accounts, { ...baseFilter, showArchived: true }).map(
+        (a) => a.id
+      )
+    ).toEqual(["a", "b", "c"])
+  })
+
+  it("filters by account type", () => {
+    expect(
+      filterAccounts(accounts, { ...baseFilter, type: "CASH" }).map((a) => a.id)
+    ).toEqual(["b"])
+  })
+
+  it("filters by case-insensitive name query", () => {
+    expect(
+      filterAccounts(accounts, { ...baseFilter, query: "bank" }).map(
+        (a) => a.id
+      )
+    ).toEqual(["a"])
+  })
+
+  it("combines type, query, and archived filters", () => {
+    expect(
+      filterAccounts(accounts, {
+        query: "savings",
+        type: "DEPOSITORY",
+        showArchived: true,
+      }).map((a) => a.id)
+    ).toEqual(["c"])
+    // Same query but archived hidden → no results.
+    expect(
+      filterAccounts(accounts, {
+        query: "savings",
+        type: "DEPOSITORY",
+        showArchived: false,
+      })
+    ).toEqual([])
+  })
+
+  it("does not mutate the input array", () => {
+    const input = [...accounts]
+    filterAccounts(input, baseFilter)
+    expect(input).toHaveLength(3)
+  })
+})
+
+describe("isPinned / togglePinned", () => {
+  it("reports membership", () => {
+    expect(isPinned(["a", "b"], "b")).toBe(true)
+    expect(isPinned(["a", "b"], "c")).toBe(false)
+  })
+
+  it("adds an unpinned id and removes a pinned id without mutating", () => {
+    const pinned = ["a"]
+    expect(togglePinned(pinned, "b")).toEqual(["a", "b"])
+    expect(togglePinned(pinned, "a")).toEqual([])
+    expect(pinned).toEqual(["a"])
+  })
+})
+
+describe("compareAccounts / sortAccounts", () => {
+  const accounts: Array<AccountListItem> = [
+    account({ id: "z", name: "Zebra", status: "active" }),
+    account({ id: "a", name: "Apple", status: "active" }),
+    account({ id: "arch", name: "AAA Archived", status: "archived" }),
+    account({ id: "m", name: "Mango", status: "active" }),
+  ]
+
+  it("sorts pinned first, then active before archived, then A→Z", () => {
+    const sorted = sortAccounts(accounts, ["m"])
+    expect(sorted.map((a) => a.id)).toEqual(["m", "a", "z", "arch"])
+  })
+
+  it("keeps archived below active even when the archived one is pinned's peer", () => {
+    // No pins: active alphabetical first, archived last despite alphabetical name.
+    const sorted = sortAccounts(accounts, [])
+    expect(sorted.map((a) => a.id)).toEqual(["a", "m", "z", "arch"])
+  })
+
+  it("orders multiple pinned entries among themselves by the same rules", () => {
+    const sorted = sortAccounts(accounts, ["z", "a"])
+    // Both pinned → active/alpha within the pinned block, then the rest.
+    expect(sorted.map((a) => a.id)).toEqual(["a", "z", "m", "arch"])
+  })
+
+  it("does not mutate the input array", () => {
+    const input = [...accounts]
+    sortAccounts(input, ["m"])
+    expect(input.map((a) => a.id)).toEqual(["z", "a", "arch", "m"])
+  })
+
+  it("exposes a reusable comparator", () => {
+    const cmp = compareAccounts<AccountListItem>(["m"])
+    expect(cmp(account({ id: "m" }), account({ id: "a" }))).toBeLessThan(0)
+  })
+})
+
+describe("parsePinnedIds", () => {
+  it("returns an empty array for null or malformed input", () => {
+    expect(parsePinnedIds(null)).toEqual([])
+    expect(parsePinnedIds("not json")).toEqual([])
+    expect(parsePinnedIds('{"not":"an array"}')).toEqual([])
+  })
+
+  it("keeps only string entries", () => {
+    expect(parsePinnedIds('["a","b"]')).toEqual(["a", "b"])
+    expect(parsePinnedIds('["a",1,null,"b"]')).toEqual(["a", "b"])
+  })
+})
+
+describe("parseViewMode", () => {
+  it("returns compact only for the exact 'compact' token", () => {
+    expect(parseViewMode("compact")).toBe("compact")
+  })
+
+  it("falls back to grid for anything else", () => {
+    expect(parseViewMode(null)).toBe("grid")
+    expect(parseViewMode("grid")).toBe("grid")
+    expect(parseViewMode("garbage")).toBe("grid")
+  })
+})

--- a/src/lib/account-list-tools.ts
+++ b/src/lib/account-list-tools.ts
@@ -1,0 +1,148 @@
+import type { AccountType } from "./accounts"
+
+// =============================================================================
+// PER-219 — Accounts list tools (search / filter / pin / view-toggle).
+//
+// This module is the single home for the PURE logic behind the accounts-list
+// toolbar: query/type/archived filtering, pin-aware sorting, and the parsing of
+// persisted preferences. Everything here is deterministic and free of DOM and
+// React so it can be unit-tested in isolation (see account-list-tools.test.ts).
+//
+// The only functions that touch `window.localStorage` are the thin read/write
+// wrappers at the bottom; they delegate all decoding to the pure `parse*`
+// helpers above them, which ARE tested. This keeps the correctness-bearing
+// logic verifiable while the storage plumbing stays trivial.
+// =============================================================================
+
+/** Grid = the existing card grid; compact = a dense row list. */
+export type AccountViewMode = "grid" | "compact"
+
+/** A concrete account type, or the "show every type" sentinel. */
+export type AccountTypeFilter = AccountType | "all"
+
+/**
+ * The minimal shape the list tools operate on. `AccountRecord` is a superset,
+ * so any `AccountRecord[]` is assignable to `AccountListItem[]` — the helpers
+ * stay decoupled from the wire type and cheap to construct in tests.
+ */
+export interface AccountListItem {
+  id: string
+  name: string
+  accountType: string
+  status: string
+}
+
+export interface AccountFilterState {
+  query: string
+  type: AccountTypeFilter
+  showArchived: boolean
+}
+
+/** Case-insensitive substring match; an empty/whitespace query matches all. */
+export function accountMatchesQuery(name: string, query: string): boolean {
+  const needle = query.trim().toLowerCase()
+  if (needle === "") return true
+  return name.toLowerCase().includes(needle)
+}
+
+/**
+ * Apply the three list filters. Order is deliberate — archived rows are dropped
+ * first (cheapest, most common exclusion), then type, then the text query.
+ */
+export function filterAccounts<T extends AccountListItem>(
+  accounts: ReadonlyArray<T>,
+  { query, type, showArchived }: AccountFilterState
+): Array<T> {
+  return accounts.filter((account) => {
+    if (!showArchived && account.status !== "active") return false
+    if (type !== "all" && account.accountType !== type) return false
+    return accountMatchesQuery(account.name, query)
+  })
+}
+
+export function isPinned(
+  pinnedIds: ReadonlyArray<string>,
+  id: string
+): boolean {
+  return pinnedIds.includes(id)
+}
+
+/** Pure toggle: returns a NEW array with `id` added or removed. */
+export function togglePinned(
+  pinnedIds: ReadonlyArray<string>,
+  id: string
+): Array<string> {
+  return pinnedIds.includes(id)
+    ? pinnedIds.filter((existing) => existing !== id)
+    : [...pinnedIds, id]
+}
+
+/**
+ * Comparator: pinned first, then active before archived, then name A→Z. The
+ * active/name tail mirrors the existing accounts.index grouping sort so the
+ * only behavioural change is pins floating to the top of their section.
+ */
+export function compareAccounts<T extends AccountListItem>(
+  pinnedIds: ReadonlyArray<string>
+): (left: T, right: T) => number {
+  const pinned = new Set(pinnedIds)
+  return (left, right) => {
+    const leftPinned = pinned.has(left.id)
+    const rightPinned = pinned.has(right.id)
+    if (leftPinned !== rightPinned) return leftPinned ? -1 : 1
+    if (left.status !== right.status) {
+      return left.status === "active" ? -1 : 1
+    }
+    return left.name.localeCompare(right.name)
+  }
+}
+
+/** Non-mutating sort using {@link compareAccounts}. */
+export function sortAccounts<T extends AccountListItem>(
+  accounts: ReadonlyArray<T>,
+  pinnedIds: ReadonlyArray<string>
+): Array<T> {
+  return [...accounts].sort(compareAccounts(pinnedIds))
+}
+
+// --- Persistence -------------------------------------------------------------
+
+const PINNED_STORAGE_KEY = "permoney.accounts.pinnedIds"
+const VIEW_STORAGE_KEY = "permoney.accounts.viewMode"
+
+/** Decode a persisted pinned-ids payload defensively; junk → `[]`. */
+export function parsePinnedIds(raw: string | null): Array<string> {
+  if (!raw) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((value): value is string => typeof value === "string")
+  } catch {
+    return []
+  }
+}
+
+/** Decode a persisted view mode; anything but "compact" falls back to grid. */
+export function parseViewMode(raw: string | null): AccountViewMode {
+  return raw === "compact" ? "compact" : "grid"
+}
+
+export function readPinnedIds(): Array<string> {
+  if (typeof window === "undefined") return []
+  return parsePinnedIds(window.localStorage.getItem(PINNED_STORAGE_KEY))
+}
+
+export function writePinnedIds(ids: ReadonlyArray<string>): void {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(ids))
+}
+
+export function readViewMode(): AccountViewMode {
+  if (typeof window === "undefined") return "grid"
+  return parseViewMode(window.localStorage.getItem(VIEW_STORAGE_KEY))
+}
+
+export function writeViewMode(mode: AccountViewMode): void {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(VIEW_STORAGE_KEY, mode)
+}

--- a/src/routes/_protected/-account-card.tsx
+++ b/src/routes/_protected/-account-card.tsx
@@ -2,6 +2,7 @@ import {
   Archive,
   MoreVertical,
   Pencil,
+  Pin,
   RotateCcw,
   Scale,
   ShieldCheck,
@@ -41,6 +42,36 @@ import { cn } from "@/lib/utils"
 // detail route. Navigation is delegated via `onOpen` so this card stays
 // router-free and unit-testable without a RouterProvider.
 
+// PER-219 — a shared pin/favorite control, reused by both the grid card and the
+// compact list row so the two views stay pixel-consistent. Filled + primary when
+// pinned; outline otherwise. Pure presentational, navigation/state is a parent
+// concern.
+export function PinButton({
+  pinned,
+  onToggle,
+  disabled,
+}: {
+  pinned: boolean
+  onToggle: () => void
+  disabled?: boolean
+}) {
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      disabled={disabled}
+      onClick={onToggle}
+      aria-label={pinned ? "Unpin account" : "Pin account to top"}
+      aria-pressed={pinned}
+    >
+      <Pin
+        className={cn("size-4", pinned && "fill-current text-primary")}
+        aria-hidden
+      />
+    </Button>
+  )
+}
+
 export const ACCOUNT_TYPE_LABEL: Record<AccountType, string> = {
   CASH: "Cash",
   DEPOSITORY: "Bank / Depository",
@@ -62,6 +93,8 @@ export function AccountCard({
   onReactivate,
   onDelete,
   onOpen,
+  pinned = false,
+  onTogglePin,
 }: {
   account: AccountRecord
   drift: ReadonlyArray<DriftRecord>
@@ -74,6 +107,10 @@ export function AccountCard({
   // Opens the per-account detail route. Optional so a component test can mount
   // the card without a router (navigation is a parent concern).
   onOpen?: () => void
+  // PER-219 pin/favorite. Optional so existing mounts (and the unit test) work
+  // without wiring pin state; the pin button only renders when a handler exists.
+  pinned?: boolean
+  onTogglePin?: () => void
 }) {
   const archived = account.status !== "active"
   const cashLike = account.balanceSource === "transaction_flow"
@@ -133,7 +170,11 @@ export function AccountCard({
           ) : null}
         </div>
 
-        <div className="flex justify-end gap-1">
+        <div className="flex items-center justify-end gap-1">
+          {onTogglePin ? (
+            <PinButton pinned={pinned} onToggle={onTogglePin} disabled={busy} />
+          ) : null}
+          <div className="flex-1" />
           {!archived ? (
             <Button
               size="icon"

--- a/src/routes/_protected/accounts.index.tsx
+++ b/src/routes/_protected/accounts.index.tsx
@@ -7,15 +7,25 @@ import {
 } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
-import { Plus, TriangleAlert, Upload, Wallet } from "lucide-react"
+import {
+  Archive,
+  LayoutGrid,
+  Plus,
+  Rows3,
+  Search,
+  TriangleAlert,
+  Upload,
+  Wallet,
+} from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Badge } from "@/components/ui/badge"
-import { AccountCard, ACCOUNT_TYPE_LABEL } from "./-account-card"
+import { AccountCard, ACCOUNT_TYPE_LABEL, PinButton } from "./-account-card"
 import { Button } from "@/components/ui/button"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import {
   Card,
   CardContent,
@@ -64,11 +74,24 @@ import {
   type AccountClass,
   type AccountType,
 } from "@/lib/accounts"
+import {
+  filterAccounts,
+  isPinned,
+  readPinnedIds,
+  readViewMode,
+  sortAccounts,
+  togglePinned,
+  writePinnedIds,
+  writeViewMode,
+  type AccountTypeFilter,
+  type AccountViewMode,
+} from "@/lib/account-list-tools"
 import { CURRENCY_OPTIONS, formatCurrency } from "@/lib/currency"
 import { negateMoney, parseUserInput } from "@/lib/money"
 import { normalizeNetWorthAt, type PointBalance } from "@/lib/net-worth"
 import { getFxOverviewFn } from "@/server/fx"
 import type { CurrencyCode } from "@/lib/data/currencies"
+import { cn } from "@/lib/utils"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import {
   archiveAccountFn,
@@ -144,6 +167,19 @@ function AccountsPage() {
   )
   const [dialog, setDialog] = React.useState<DialogState>(null)
   const [busyId, setBusyId] = React.useState<string | null>(null)
+  // PER-219 list tools. Search/type/archived are ephemeral view state; pins and
+  // view mode are client-only preferences hydrated once from localStorage (the
+  // route is ssr:false, so these initializers run on the client). Persistence
+  // writes happen inside the event handlers below — no useEffect.
+  const [query, setQuery] = React.useState("")
+  const [typeFilter, setTypeFilter] = React.useState<AccountTypeFilter>("all")
+  const [showArchived, setShowArchived] = React.useState(false)
+  const [pinnedIds, setPinnedIds] = React.useState<ReadonlyArray<string>>(() =>
+    readPinnedIds()
+  )
+  const [viewMode, setViewMode] = React.useState<AccountViewMode>(() =>
+    readViewMode()
+  )
   const navigate = useNavigate()
 
   const safeAccounts = React.useMemo<ReadonlyArray<AccountRecord>>(
@@ -176,26 +212,46 @@ function AccountsPage() {
     return map
   }, [driftRows])
 
-  // Group by class, then sort active-before-archived and alphabetically. Memoized
-  // so the grouping is not recomputed on unrelated re-renders.
+  // Apply search / type / archived filters (pure — see account-list-tools).
+  const filteredAccounts = React.useMemo(
+    () =>
+      filterAccounts(listedAccounts, {
+        query,
+        type: typeFilter,
+        showArchived,
+      }),
+    [listedAccounts, query, typeFilter, showArchived]
+  )
+
+  // Group the filtered set by class, then sort each bucket pinned-first,
+  // active-before-archived, A→Z (sortAccounts). Memoized so grouping is not
+  // recomputed on unrelated re-renders.
   const grouped = React.useMemo(() => {
     const byClass = new Map<AccountClass, AccountRecord[]>()
-    for (const account of listedAccounts) {
+    for (const account of filteredAccounts) {
       const cls = account.accountClass as AccountClass
       const bucket = byClass.get(cls) ?? []
       bucket.push(account)
       byClass.set(cls, bucket)
     }
-    for (const bucket of byClass.values()) {
-      bucket.sort((left, right) => {
-        if (left.status !== right.status) {
-          return left.status === "active" ? -1 : 1
-        }
-        return left.name.localeCompare(right.name)
-      })
+    for (const [cls, bucket] of byClass) {
+      byClass.set(cls, sortAccounts(bucket, pinnedIds))
     }
     return byClass
-  }, [listedAccounts])
+  }, [filteredAccounts, pinnedIds])
+
+  function handleTogglePin(accountId: string) {
+    setPinnedIds((current) => {
+      const next = togglePinned(current, accountId)
+      writePinnedIds(next)
+      return next
+    })
+  }
+
+  function handleViewChange(mode: AccountViewMode) {
+    setViewMode(mode)
+    writeViewMode(mode)
+  }
 
   async function refreshAfterMutation() {
     await Promise.all([
@@ -269,42 +325,87 @@ function AccountsPage() {
               <EmptyState onCreate={() => setDialog({ mode: "create" })} />
             ) : (
               <div className="flex flex-col gap-6">
-                {CLASS_ORDER.map((cls) => {
-                  const bucket = grouped.get(cls)
-                  if (!bucket || bucket.length === 0) return null
-                  return (
-                    <section key={cls} className="flex flex-col gap-3">
-                      <h2 className="text-sm font-medium text-muted-foreground">
-                        {CLASS_LABEL[cls]}
-                      </h2>
-                      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                        {bucket.map((account) => (
-                          <AccountCard
-                            key={account.id}
-                            account={account}
-                            drift={driftByAccount.get(account.id) ?? []}
-                            busy={busyId === account.id}
-                            onEdit={() => setDialog({ mode: "edit", account })}
-                            onValuation={() =>
-                              setDialog({ mode: "valuation", account })
-                            }
-                            onArchive={() => handleArchive(account)}
-                            onReactivate={() => handleReactivate(account)}
-                            onDelete={() =>
-                              setDialog({ mode: "delete", account })
-                            }
-                            onOpen={() =>
-                              navigate({
-                                to: "/accounts/$accountId",
-                                params: { accountId: account.id },
-                              })
-                            }
-                          />
-                        ))}
-                      </div>
-                    </section>
-                  )
-                })}
+                <AccountsToolbar
+                  query={query}
+                  onQueryChange={setQuery}
+                  typeFilter={typeFilter}
+                  onTypeFilterChange={setTypeFilter}
+                  showArchived={showArchived}
+                  onShowArchivedChange={setShowArchived}
+                  viewMode={viewMode}
+                  onViewModeChange={handleViewChange}
+                />
+
+                {filteredAccounts.length === 0 ? (
+                  <NoResults
+                    onClear={() => {
+                      setQuery("")
+                      setTypeFilter("all")
+                      setShowArchived(false)
+                    }}
+                  />
+                ) : (
+                  CLASS_ORDER.map((cls) => {
+                    const bucket = grouped.get(cls)
+                    if (!bucket || bucket.length === 0) return null
+                    return (
+                      <section key={cls} className="flex flex-col gap-3">
+                        <h2 className="text-sm font-medium text-muted-foreground">
+                          {CLASS_LABEL[cls]}
+                        </h2>
+                        {viewMode === "grid" ? (
+                          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            {bucket.map((account) => (
+                              <AccountCard
+                                key={account.id}
+                                account={account}
+                                drift={driftByAccount.get(account.id) ?? []}
+                                busy={busyId === account.id}
+                                pinned={isPinned(pinnedIds, account.id)}
+                                onTogglePin={() => handleTogglePin(account.id)}
+                                onEdit={() =>
+                                  setDialog({ mode: "edit", account })
+                                }
+                                onValuation={() =>
+                                  setDialog({ mode: "valuation", account })
+                                }
+                                onArchive={() => handleArchive(account)}
+                                onReactivate={() => handleReactivate(account)}
+                                onDelete={() =>
+                                  setDialog({ mode: "delete", account })
+                                }
+                                onOpen={() =>
+                                  navigate({
+                                    to: "/accounts/$accountId",
+                                    params: { accountId: account.id },
+                                  })
+                                }
+                              />
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="flex flex-col gap-2">
+                            {bucket.map((account) => (
+                              <CompactAccountRow
+                                key={account.id}
+                                account={account}
+                                pinned={isPinned(pinnedIds, account.id)}
+                                busy={busyId === account.id}
+                                onTogglePin={() => handleTogglePin(account.id)}
+                                onOpen={() =>
+                                  navigate({
+                                    to: "/accounts/$accountId",
+                                    params: { accountId: account.id },
+                                  })
+                                }
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </section>
+                    )
+                  })
+                )}
               </div>
             )}
           </div>
@@ -375,6 +476,164 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+// PER-219 — the list toolbar: name search, type filter, archived toggle, and
+// the grid/compact view switch. Pure controlled component; all state lives in
+// the page so filtering/sorting stay one source of truth.
+function AccountsToolbar({
+  query,
+  onQueryChange,
+  typeFilter,
+  onTypeFilterChange,
+  showArchived,
+  onShowArchivedChange,
+  viewMode,
+  onViewModeChange,
+}: {
+  query: string
+  onQueryChange: (value: string) => void
+  typeFilter: AccountTypeFilter
+  onTypeFilterChange: (value: AccountTypeFilter) => void
+  showArchived: boolean
+  onShowArchivedChange: (value: boolean) => void
+  viewMode: AccountViewMode
+  onViewModeChange: (value: AccountViewMode) => void
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+      <div className="relative flex-1 sm:min-w-56">
+        <Search
+          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden
+        />
+        <Input
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder="Search accounts…"
+          aria-label="Search accounts by name"
+          className="pl-9"
+        />
+      </div>
+
+      <Select
+        value={typeFilter}
+        onValueChange={(value) =>
+          onTypeFilterChange(value as AccountTypeFilter)
+        }
+      >
+        <SelectTrigger className="sm:w-48" aria-label="Filter by account type">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All types</SelectItem>
+          {ACCOUNT_TYPE_VALUES.map((type) => (
+            <SelectItem key={type} value={type}>
+              {ACCOUNT_TYPE_LABEL[type]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Button
+        type="button"
+        variant={showArchived ? "secondary" : "outline"}
+        aria-pressed={showArchived}
+        onClick={() => onShowArchivedChange(!showArchived)}
+      >
+        <Archive className="size-4" />
+        Show archived
+      </Button>
+
+      <ToggleGroup
+        type="single"
+        value={viewMode}
+        onValueChange={(value) => {
+          // Radix emits "" when the active item is re-clicked; keep the current
+          // view rather than dropping into an undefined mode.
+          if (value === "grid" || value === "compact") onViewModeChange(value)
+        }}
+        variant="outline"
+        className="sm:ml-auto"
+      >
+        <ToggleGroupItem value="grid" aria-label="Grid view">
+          <LayoutGrid className="size-4" />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="compact" aria-label="Compact view">
+          <Rows3 className="size-4" />
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  )
+}
+
+function NoResults({ onClear }: { onClear: () => void }) {
+  return (
+    <Card className="border-dashed">
+      <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+        <Search className="size-8 text-muted-foreground" aria-hidden />
+        <div>
+          <p className="font-medium">No accounts match your filters</p>
+          <p className="text-sm text-muted-foreground">
+            Try a different search term or account type, or show archived
+            accounts.
+          </p>
+        </div>
+        <Button variant="outline" onClick={onClear}>
+          Clear filters
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+// PER-219 compact row — a dense alternative to the ATM-card grid. Shows name /
+// type / balance and opens the same per-account detail route. Reuses the shared
+// PinButton so pin affordance is identical across both views.
+function CompactAccountRow({
+  account,
+  pinned,
+  busy,
+  onTogglePin,
+  onOpen,
+}: {
+  account: AccountRecord
+  pinned: boolean
+  busy: boolean
+  onTogglePin: () => void
+  onOpen: () => void
+}) {
+  const archived = account.status !== "active"
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 transition-colors hover:bg-muted/40",
+        archived && "opacity-60"
+      )}
+    >
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`Open ${account.name}`}
+        className="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      >
+        <span className="truncate font-medium">{account.name}</span>
+        <Badge variant="secondary" className="shrink-0">
+          {ACCOUNT_TYPE_LABEL[account.accountType as AccountType] ??
+            account.accountType}
+        </Badge>
+        {archived ? (
+          <Badge variant="outline" className="shrink-0">
+            Archived
+          </Badge>
+        ) : null}
+      </button>
+      <span className="shrink-0 font-semibold tabular-nums">
+        {formatCurrency(account.balance, account.currency)}
+      </span>
+      <PinButton pinned={pinned} onToggle={onTogglePin} disabled={busy} />
+    </div>
   )
 }
 

--- a/src/routes/_protected/accounts.index.tsx
+++ b/src/routes/_protected/accounts.index.tsx
@@ -512,7 +512,7 @@ function AccountsToolbar({
           value={query}
           onChange={(event) => onQueryChange(event.target.value)}
           placeholder="Search accounts…"
-          aria-label="Search accounts by name"
+          aria-label="Search accounts"
           className="pl-9"
         />
       </div>


### PR DESCRIPTION
## PER-219 — Accounts list tools

Client-only, additive, ledger-neutral enhancements to the accounts list page (`src/routes/_protected/accounts.index.tsx`). No server / schema / prisma changes.

### What's new
- **Search** accounts by name — case-insensitive, over the already-loaded `accountCollection`.
- **Filter by account type** (`Select` seeded from `ACCOUNT_TYPE_LABEL`) + a **show/hide archived** button toggle. Integrated with the existing `CLASS_ORDER` / `grouped` class grouping.
- **Grid ↔ compact view toggle** — grid keeps the existing `AccountCard` grid; compact is a dense row list (name / type / balance) that navigates to `/accounts/$accountId` via the same `navigate(...)` the grid uses. View choice persists in `localStorage`.
- **Pin/favorite to top** — a pin button on both the grid card action area and the compact row. Pinned IDs persist in `localStorage` and sort first *within* their class section.

### Architecture
- All pure logic (query/type/archived filtering, pin-aware sort, `localStorage` parse) extracted into **`src/lib/account-list-tools.ts`** with unit tests in **`src/lib/account-list-tools.test.ts`** (`vite-plus/test`). Pure helpers take state in/out; only the thin `read*/write*` wrappers touch `window.localStorage`, delegating decoding to the tested `parse*` helpers.
- No `any`, no `useEffect` — preferences are hydrated once via lazy `useState` initializers (route is `ssr: false`) and written in event handlers.
- `AccountCard` gains optional `pinned` / `onTogglePin` props (kept optional so the existing `-account-card.test.tsx` passes unchanged). A shared `PinButton` is reused by the card and the compact row.

### Validation
- `vp check` — clean (format + lint + types).
- `vp test run src/lib/account-list-tools.test.ts` — 19 passed.
- `vp test run src/routes/_protected/-account-card.test.tsx` — 4 passed (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1