### PR TITLE
feat(accounts): PER-217 — reserve / minimum balance ("dana mengendap") + safe-to-spend

### DIFF
--- a/prisma/migrations/20260802130000_account_reserve_balance/migration.sql
+++ b/prisma/migrations/20260802130000_account_reserve_balance/migration.sql
@@ -1,0 +1,29 @@
+-- PER-217 — Account reserve / minimum balance ("dana mengendap").
+--
+-- A user-defined spending floor: money the owner keeps untouched inside a
+-- cash-like account (a real bank/e-wallet minimum balance, commonly Rp 20k–50k,
+-- or a self-imposed buffer). It is LEDGER-NEUTRAL by construction:
+--   * it NEVER changes Account.balance, net worth, transactions, or valuations;
+--   * it only feeds the computed "available" (safe-to-spend) view server-side
+--     (available = current − held − reserve) and the same figure on the client.
+--
+-- Because it is a spending earmark, it is meaningful ONLY for cash-like ASSET
+-- accounts (accountClass = 'ASSET' AND balanceSource = 'transaction_flow').
+-- Liabilities have no "reserve to keep", and tracked/valuation assets are not
+-- spent against. A CHECK enforces that invariant so it can never drift
+-- ("Database Is the Law", CLAUDE.md §5A): the column is NULL for every other
+-- account, and non-negative when present.
+
+ALTER TABLE "Account"
+  ADD COLUMN "reserveBalance" BIGINT;
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT "account_reserve_balance_valid"
+  CHECK (
+    "reserveBalance" IS NULL
+    OR (
+      "reserveBalance" >= 0
+      AND "accountClass" = 'ASSET'
+      AND "balanceSource" = 'transaction_flow'
+    )
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,16 @@ model Account {
   dueDay            Int?
   interestRateBps   Int?
 
+  // PER-217 — user-defined minimum balance floor ("dana mengendap" / reserve).
+  // Ledger-NEUTRAL: it NEVER mutates `balance`, net worth, transactions, or
+  // valuations. It is a spending earmark that only feeds the computed
+  // "available" (safe-to-spend) view: available = current − held − reserve.
+  // Stored NON-NEGATIVE in MINOR UNITS. Meaningful only for cash-like ASSET
+  // accounts (accountClass="ASSET", balanceSource="transaction_flow") — a real
+  // bank/e-wallet minimum balance. A DB CHECK keeps it NULL for every other
+  // account so the invariant can never drift ("Database Is the Law").
+  reserveBalance BigInt?
+
   // PER-212 / ADR-0049 — person-to-person debt (informal lending/borrowing).
   // When set, this RECEIVABLE/LOAN account IS the ledger for a debt with a
   // specific person contact (a Merchant with kind="person"). Its presence is

--- a/src/components/blocks/account-visual.test.tsx
+++ b/src/components/blocks/account-visual.test.tsx
@@ -69,4 +69,17 @@ describe("AccountVisual", () => {
     )
     expect(screen.getByText(/outstanding/i)).toBeTruthy()
   })
+
+  it("shows safe-to-spend (balance − reserve) when a reserve is set", () => {
+    // base balance 1,500,000 minor = 15,000 major; reserve 500,000 minor =
+    // 5,000 major → safe-to-spend 10,000.
+    render(<AccountVisual account={{ ...base, reserveBalance: "500000" }} />)
+    expect(screen.getByText(/safe to spend/i)).toBeTruthy()
+    expect(screen.getByText(/10,000/)).toBeTruthy()
+  })
+
+  it("omits the safe-to-spend line when no reserve is set", () => {
+    render(<AccountVisual account={{ ...base, reserveBalance: null }} />)
+    expect(screen.queryByText(/safe to spend/i)).toBeNull()
+  })
 })

--- a/src/components/blocks/account-visual.tsx
+++ b/src/components/blocks/account-visual.tsx
@@ -1,6 +1,14 @@
-import { CreditCard, Landmark, Smartphone, Wallet, Wifi } from "lucide-react"
+import {
+  CreditCard,
+  Landmark,
+  ShieldCheck,
+  Smartphone,
+  Wallet,
+  Wifi,
+} from "lucide-react"
 
 import { formatCurrency } from "@/lib/currency"
+import { availableAfterReserve, hasReserve } from "@/lib/account-reserve"
 import { cn } from "@/lib/utils"
 
 // =============================================================================
@@ -41,6 +49,16 @@ export interface AccountVisualData {
   balance: string
   currency: string
   color: string | null
+  // PER-217 — reserve/minimum balance in minor units (or null). When present,
+  // the card surfaces a "safe-to-spend" (balance − reserve) line.
+  reserveBalance?: string | null
+}
+
+/** Reserve as minor-unit bigint when it is meaningfully set, else null. */
+function reserveMinorOf(account: AccountVisualData): bigint | null {
+  if (!account.reserveBalance) return null
+  const minor = BigInt(account.reserveBalance)
+  return hasReserve(minor) ? minor : null
 }
 
 // Sensible brand default per card-like type when the account has no colour.
@@ -90,6 +108,7 @@ function AtmCard({
   const base =
     account.color ?? DEFAULT_CARD_COLOR[account.accountType] ?? "#334155"
   const hero = size === "hero"
+  const reserveMinor = reserveMinorOf(account)
   return (
     <div
       className={cn(
@@ -154,6 +173,21 @@ function AtmCard({
           >
             {formatCurrency(account.balance, account.currency)}
           </p>
+          {reserveMinor !== null ? (
+            <p className="mt-0.5 flex items-center gap-1 text-[10px] text-white/70 tabular-nums">
+              <ShieldCheck className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">
+                {formatCurrency(
+                  availableAfterReserve(
+                    BigInt(account.balance),
+                    reserveMinor
+                  ).toString(),
+                  account.currency
+                )}{" "}
+                safe to spend
+              </span>
+            </p>
+          ) : null}
         </div>
         <TypeIcon
           accountType={account.accountType}
@@ -171,6 +205,7 @@ function PlainCard({
 }: Readonly<{ account: AccountVisualData; size: "grid" | "hero" }>) {
   const hero = size === "hero"
   const isLiability = account.accountClass === "LIABILITY"
+  const reserveMinor = reserveMinorOf(account)
   return (
     <div
       className={cn(
@@ -204,6 +239,21 @@ function PlainCard({
         >
           {formatCurrency(account.balance, account.currency)}
         </p>
+        {reserveMinor !== null ? (
+          <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground tabular-nums">
+            <ShieldCheck className="size-3 shrink-0" aria-hidden />
+            <span className="truncate">
+              {formatCurrency(
+                availableAfterReserve(
+                  BigInt(account.balance),
+                  reserveMinor
+                ).toString(),
+                account.currency
+              )}{" "}
+              safe to spend
+            </span>
+          </p>
+        ) : null}
       </div>
     </div>
   )

--- a/src/lib/account-reserve.test.ts
+++ b/src/lib/account-reserve.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vite-plus/test"
+import {
+  accountSupportsReserve,
+  availableAfterReserve,
+  hasReserve,
+  reserveHealth,
+  reserveLockedFraction,
+} from "./account-reserve"
+
+describe("availableAfterReserve", () => {
+  test("subtracts the reserve from the balance", () => {
+    expect(availableAfterReserve(1_000_000n, 200_000n)).toBe(800_000n)
+  })
+
+  test("is the full balance when no reserve", () => {
+    expect(availableAfterReserve(1_000_000n, 0n)).toBe(1_000_000n)
+  })
+
+  test("goes negative when below the reserve (deliberate signal)", () => {
+    expect(availableAfterReserve(50_000n, 200_000n)).toBe(-150_000n)
+  })
+})
+
+describe("reserveHealth", () => {
+  test("none when no reserve", () => {
+    expect(reserveHealth(1_000_000n, 0n)).toBe("none")
+  })
+
+  test("below when balance under the floor", () => {
+    expect(reserveHealth(199_999n, 200_000n)).toBe("below")
+  })
+
+  test("near within 20% above the floor", () => {
+    // 200k floor → near band is [200k, 240k)
+    expect(reserveHealth(200_000n, 200_000n)).toBe("near")
+    expect(reserveHealth(239_999n, 200_000n)).toBe("near")
+  })
+
+  test("healthy at/after the 20% ceiling", () => {
+    expect(reserveHealth(240_000n, 200_000n)).toBe("healthy")
+    expect(reserveHealth(10_000_000n, 200_000n)).toBe("healthy")
+  })
+})
+
+describe("reserveLockedFraction", () => {
+  test("0 when no reserve", () => {
+    expect(reserveLockedFraction(1_000_000n, 0n)).toBe(0)
+  })
+
+  test("proportional when balance exceeds reserve", () => {
+    expect(reserveLockedFraction(1_000_000n, 250_000n)).toBeCloseTo(0.25, 5)
+  })
+
+  test("fully locked when balance at/below reserve", () => {
+    expect(reserveLockedFraction(200_000n, 200_000n)).toBe(1)
+    expect(reserveLockedFraction(50_000n, 200_000n)).toBe(1)
+  })
+
+  test("fully locked when balance non-positive but reserve set", () => {
+    expect(reserveLockedFraction(0n, 200_000n)).toBe(1)
+    expect(reserveLockedFraction(-10n, 200_000n)).toBe(1)
+  })
+})
+
+describe("hasReserve", () => {
+  test("false for null / zero, true for positive", () => {
+    expect(hasReserve(null)).toBe(false)
+    expect(hasReserve(0n)).toBe(false)
+    expect(hasReserve(1n)).toBe(true)
+  })
+})
+
+describe("accountSupportsReserve", () => {
+  test("true only for cash-like ASSET", () => {
+    expect(
+      accountSupportsReserve({
+        accountClass: "ASSET",
+        balanceSource: "transaction_flow",
+      })
+    ).toBe(true)
+  })
+
+  test("false for tracked assets and liabilities", () => {
+    expect(
+      accountSupportsReserve({
+        accountClass: "ASSET",
+        balanceSource: "valuation",
+      })
+    ).toBe(false)
+    expect(
+      accountSupportsReserve({
+        accountClass: "LIABILITY",
+        balanceSource: "transaction_flow",
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/account-reserve.ts
+++ b/src/lib/account-reserve.ts
@@ -1,0 +1,88 @@
+// =============================================================================
+// PER-217 — reserve / minimum balance ("dana mengendap") — pure client helpers.
+//
+// The reserve is a user-defined spending FLOOR: money kept untouched inside a
+// cash-like account (a bank/e-wallet minimum balance, or a self-imposed buffer).
+// It is LEDGER-NEUTRAL — it never changes the stored balance, net worth, or any
+// transaction. It only reshapes what the user sees as "safe to spend":
+//
+//     available (safe-to-spend) = balance − reserve
+//
+// The server folds the reserve into its authoritative `available` (which also
+// subtracts uncleared holds — see valuations.ts computeAvailable). These helpers
+// give the client the same reserve-aware figure for the account card and detail
+// hero WITHOUT a round-trip, working purely on the minor-unit balance + reserve
+// already present on every account record. All math stays in bigint minor units.
+// =============================================================================
+
+/**
+ * Safe-to-spend after honoring the reserve floor. May be NEGATIVE when the
+ * balance has dipped below the reserve — that is a deliberate, useful signal
+ * ("you're into your dana mengendap"), never clamped away.
+ */
+export function availableAfterReserve(
+  balanceMinor: bigint,
+  reserveMinor: bigint
+): bigint {
+  return balanceMinor - reserveMinor
+}
+
+/**
+ * Health of the balance relative to its reserve floor:
+ *   - "none":    no reserve set (reserve <= 0)
+ *   - "below":   balance is under the floor (available is negative)
+ *   - "near":    balance is within 20% above the floor (getting close)
+ *   - "healthy": comfortably above the floor
+ */
+export type ReserveHealth = "none" | "below" | "near" | "healthy"
+
+export function reserveHealth(
+  balanceMinor: bigint,
+  reserveMinor: bigint
+): ReserveHealth {
+  if (reserveMinor <= 0n) return "none"
+  if (balanceMinor < reserveMinor) return "below"
+  // 20% headroom band above the floor, computed in integer minor units.
+  const nearCeiling = (reserveMinor * 12n) / 10n
+  if (balanceMinor < nearCeiling) return "near"
+  return "healthy"
+}
+
+/**
+ * Fraction (0..1) of the current balance that the reserve locks down — the size
+ * of the "reserved" segment in a balance gauge. Balance at/below the reserve is
+ * fully locked (1); no reserve or a non-positive balance leaves nothing to
+ * split. Uses Number only for the final ratio (safe: it is a bounded 0..1
+ * proportion for display, never money math).
+ */
+export function reserveLockedFraction(
+  balanceMinor: bigint,
+  reserveMinor: bigint
+): number {
+  if (reserveMinor <= 0n) return 0
+  if (balanceMinor <= 0n) return 1
+  if (reserveMinor >= balanceMinor) return 1
+  return Number(reserveMinor) / Number(balanceMinor)
+}
+
+/**
+ * Whether a reserve is meaningfully set (positive) for display purposes. A
+ * `null`/absent or "0" reserve reads as "no reserve".
+ */
+export function hasReserve(reserveMinor: bigint | null): boolean {
+  return reserveMinor !== null && reserveMinor > 0n
+}
+
+/**
+ * Reserve is only meaningful for cash-like ASSET accounts (the DB CHECK enforces
+ * this; the client mirrors it to decide whether to show the reserve input/UI).
+ */
+export function accountSupportsReserve(account: {
+  accountClass: string
+  balanceSource: string
+}): boolean {
+  return (
+    account.accountClass === "ASSET" &&
+    account.balanceSource === "transaction_flow"
+  )
+}

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -1,4 +1,5 @@
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import { ShieldCheck } from "lucide-react"
 
 import {
   ChartContainer,
@@ -13,7 +14,13 @@ import {
   type BalancePoint,
   type CategorySlice,
 } from "@/lib/account-analytics"
+import {
+  availableAfterReserve,
+  reserveHealth,
+  reserveLockedFraction,
+} from "@/lib/account-reserve"
 import { formatCurrency } from "@/lib/currency"
+import { cn } from "@/lib/utils"
 
 // PER-218 — presentational analytics for the account detail page. Pure props
 // in, chart out. All numbers are pre-derived by the unit-tested helpers in
@@ -123,6 +130,72 @@ export function BalanceTrendChart({
         />
       </AreaChart>
     </ChartContainer>
+  )
+}
+
+// PER-217 — "safe to spend" panel: available (balance − reserve) with a gauge
+// that splits the balance into its reserved floor and its free headroom. Shown
+// on the detail hero only when a reserve is set. Pure props in; the reserve math
+// is the unit-tested helpers in src/lib/account-reserve.ts.
+export function SafeToSpendPanel({
+  balanceMinor,
+  reserveMinor,
+  currency,
+}: Readonly<{ balanceMinor: bigint; reserveMinor: bigint; currency: string }>) {
+  const available = availableAfterReserve(balanceMinor, reserveMinor)
+  const health = reserveHealth(balanceMinor, reserveMinor)
+  const lockedPct = Math.round(
+    reserveLockedFraction(balanceMinor, reserveMinor) * 100
+  )
+  const belowFloor = health === "below"
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-4",
+        belowFloor ? "border-destructive/40 bg-destructive/5" : undefined
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          <ShieldCheck className="size-3.5" aria-hidden />
+          Safe to spend
+        </p>
+        {belowFloor ? (
+          <span className="text-[10px] font-medium text-destructive">
+            Below reserve
+          </span>
+        ) : health === "near" ? (
+          <span className="text-[10px] font-medium text-muted-foreground">
+            Near reserve
+          </span>
+        ) : null}
+      </div>
+      <p
+        className={cn(
+          "mt-1 text-2xl font-semibold tabular-nums",
+          belowFloor ? "text-destructive" : undefined
+        )}
+      >
+        {formatCurrency(available.toString(), currency)}
+      </p>
+      <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
+        of {formatCurrency(balanceMinor.toString(), currency)} ·{" "}
+        {formatCurrency(reserveMinor.toString(), currency)} reserved
+      </p>
+      <div
+        className="mt-3 flex h-2 overflow-hidden rounded-full bg-muted"
+        role="presentation"
+      >
+        <div
+          className={cn(
+            "h-full",
+            belowFloor ? "bg-destructive" : "bg-muted-foreground/40"
+          )}
+          style={{ width: `${lockedPct}%` }}
+        />
+        <div className="h-full flex-1 bg-primary/70" />
+      </div>
+    </div>
   )
 }
 

--- a/src/routes/_protected/-account-card.test.tsx
+++ b/src/routes/_protected/-account-card.test.tsx
@@ -38,6 +38,7 @@ const account: AccountRecord = {
   dueDay: null,
   interestRateBps: null,
   counterpartyMerchantId: null,
+  reserveBalance: null,
 }
 
 function renderCard(drift: ReadonlyArray<DriftRecord>) {

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -29,7 +29,9 @@ import {
   BalanceTrendChart,
   CategoryBreakdown,
   RangeSelector,
+  SafeToSpendPanel,
 } from "./-account-analytics"
+import { accountSupportsReserve, hasReserve } from "@/lib/account-reserve"
 import {
   buildBalanceSeries,
   buildStatementCsv,
@@ -235,6 +237,16 @@ function AccountDetailPage() {
               <Badge variant="outline">Archived</Badge>
             ) : null}
           </div>
+          {accountSupportsReserve(account) &&
+          hasReserve(
+            account.reserveBalance ? BigInt(account.reserveBalance) : null
+          ) ? (
+            <SafeToSpendPanel
+              balanceMinor={BigInt(account.balance)}
+              reserveMinor={BigInt(account.reserveBalance ?? "0")}
+              currency={currency}
+            />
+          ) : null}
           <div className="grid grid-cols-2 gap-3">
             <MiniStat
               label="Money in"

--- a/src/routes/_protected/accounts.index.tsx
+++ b/src/routes/_protected/accounts.index.tsx
@@ -87,7 +87,8 @@ import {
   type AccountViewMode,
 } from "@/lib/account-list-tools"
 import { CURRENCY_OPTIONS, formatCurrency } from "@/lib/currency"
-import { negateMoney, parseUserInput } from "@/lib/money"
+import { negateMoney, parseUserInput, toDisplayNumber } from "@/lib/money"
+import { accountSupportsReserve } from "@/lib/account-reserve"
 import { normalizeNetWorthAt, type PointBalance } from "@/lib/net-worth"
 import { getFxOverviewFn } from "@/server/fx"
 import type { CurrencyCode } from "@/lib/data/currencies"
@@ -795,12 +796,29 @@ function AccountFormDialog({
   const [isImportable, setIsImportable] = React.useState<boolean>(
     editing?.isImportable ?? false
   )
+  // PER-217 — reserve/minimum balance, as a user-facing MAJOR-unit string. On
+  // edit, seed from the stored minor-unit value (lazy init, no useEffect).
+  const [reserveInput, setReserveInput] = React.useState<string>(() =>
+    editing?.reserveBalance
+      ? String(
+          toDisplayNumber(
+            BigInt(editing.reserveBalance),
+            (editing.currency as CurrencyCode) ?? "IDR"
+          )
+        )
+      : ""
+  )
   const [error, setError] = React.useState<string | null>(null)
   const [submitting, setSubmitting] = React.useState(false)
 
   // Derived, pure: the class and balance source preview track the chosen type.
   const previewClass = getAccountClassForType(accountType)
   const previewCashLike = isCashLikeAccount(accountType)
+  // PER-217 — a reserve only makes sense on a cash-like ASSET account. On create
+  // this tracks the chosen type; on edit it reflects the (fixed) account.
+  const supportsReserve = editing
+    ? accountSupportsReserve(editing)
+    : previewClass === "ASSET" && previewCashLike
 
   // Subtypes are flexible; offer the known vocabulary as a convenience, led by
   // the "default for type" sentinel.
@@ -817,6 +835,25 @@ function AccountFormDialog({
     setError(null)
     setSubmitting(true)
     try {
+      // PER-217 — parse the reserve once for whichever branch runs. An empty
+      // input on edit CLEARS the reserve (null); on create it means "no reserve"
+      // (omit). A malformed non-empty value is rejected before any write.
+      let reserveMinor: string | null | undefined
+      if (supportsReserve) {
+        if (reserveInput.trim() === "") {
+          reserveMinor = editing ? null : undefined
+        } else {
+          const parsedReserve = parseUserInput(
+            reserveInput.trim(),
+            currency as CurrencyCode
+          )
+          if (parsedReserve === null || parsedReserve < 0n) {
+            throw new Error("Enter a valid reserve amount.")
+          }
+          reserveMinor = parsedReserve.toString()
+        }
+      }
+
       if (editing) {
         await updateAccountFn({
           data: {
@@ -825,6 +862,9 @@ function AccountFormDialog({
             accountSubtype: resolvedSubtype,
             institutionName: institutionName.trim() || null,
             isImportable,
+            ...(reserveMinor === undefined
+              ? {}
+              : { reserveBalance: reserveMinor }),
             idempotencyKey: createUuidV7(),
           },
         })
@@ -852,6 +892,7 @@ function AccountFormDialog({
             currency,
             openingBalance: openingMinor,
             institutionName: institutionName.trim() || null,
+            ...(reserveMinor ? { reserveBalance: reserveMinor } : {}),
             idempotencyKey: createUuidV7(),
           },
         })
@@ -985,6 +1026,27 @@ function AccountFormDialog({
               placeholder="e.g. Bank Central Asia"
             />
           </div>
+
+          {supportsReserve ? (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="reserve-balance">
+                Reserve / minimum balance ({currency})
+              </Label>
+              <Input
+                id="reserve-balance"
+                inputMode="decimal"
+                value={reserveInput}
+                onChange={(e) => setReserveInput(e.target.value)}
+                placeholder="0"
+              />
+              <p className="text-xs text-muted-foreground">
+                Money you keep untouched — your “dana mengendap”. It never
+                changes your balance or net worth; it only lowers your{" "}
+                <span className="font-medium">safe-to-spend</span> (available =
+                balance − reserve).{editing ? " Leave empty to remove." : ""}
+              </p>
+            </div>
+          ) : null}
 
           {editing ? (
             <div className="flex items-start gap-3 rounded-md border p-3">

--- a/src/server/accounts.ts
+++ b/src/server/accounts.ts
@@ -117,6 +117,17 @@ const institutionNameSchema = z.string().trim().min(1).max(120)
 const accountTypeSchema = z.enum(ACCOUNT_TYPE_VALUES)
 const subtypeSchema = z.string().trim().min(1).max(64)
 
+// PER-217 — reserve / minimum balance ("dana mengendap"). A NON-NEGATIVE
+// magnitude in MINOR UNITS as a digit-string (BigInt is not JSON-serializable),
+// or `null` to clear it. Ledger-neutral; validated cash-like-ASSET-only in the
+// create/update paths, with the DB CHECK as the durable backstop.
+const reserveBalanceSchema = z
+  .union([
+    z.string().regex(/^\d+$/, "reserveBalance must be a string of digits"),
+    z.number().int().nonnegative(),
+  ])
+  .nullable()
+
 export const createAccountInputSchema = z.object({
   // Optional client-generated id so the optimistic UI and the server agree.
   id: z.string().min(1).optional(),
@@ -132,6 +143,9 @@ export const createAccountInputSchema = z.object({
   // and validated tenant-owned + kind="person" in createAccountForFamily. The
   // main account-create dialog never sets it; the Utang-Piutang debt flows do.
   counterpartyMerchantId: z.string().min(1).nullable().optional(),
+  // PER-217 — optional reserve/minimum balance set at creation (cash-like ASSET
+  // only; validated in createAccountForFamily).
+  reserveBalance: reserveBalanceSchema.optional(),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -144,6 +158,9 @@ export const updateAccountInputSchema = z.object({
   // Whether this account may receive provider/import feed data (taxonomy
   // contract). Promotion of staged import rows requires this gate (ADR-0039 §6).
   isImportable: z.boolean().optional(),
+  // PER-217 — set/clear the reserve. `null` clears it; omitted leaves it
+  // unchanged. Cash-like ASSET only (validated in updateAccountForFamily).
+  reserveBalance: reserveBalanceSchema.optional(),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -155,6 +172,31 @@ export const accountIdActionInputSchema = z.object({
 type CreateAccountInput = z.infer<typeof createAccountInputSchema>
 type UpdateAccountInput = z.infer<typeof updateAccountInputSchema>
 type AccountIdActionInput = z.infer<typeof accountIdActionInputSchema>
+
+// PER-217 — normalize a reserve/minimum-balance input to the signed value we
+// store, or throw a validated error. Rules ("Database Is the Law" mirrors these
+// in the DB CHECK): non-negative; a 0 reserve is stored as NULL (no reserve);
+// and a positive reserve is only allowed on cash-like ASSET accounts. Call ONLY
+// when the caller actually supplied a value (never pass `undefined` for the
+// "leave unchanged" case — the update path guards that before calling).
+function resolveReserveBalance(
+  rawReserve: string | number | null,
+  accountClass: string,
+  balanceSource: string
+): bigint | null {
+  if (rawReserve === null) return null
+  const value = BigInt(rawReserve)
+  if (value < 0n) {
+    throw new AccountValidationError("reserveBalance cannot be negative")
+  }
+  if (value === 0n) return null
+  if (accountClass !== "ASSET" || balanceSource !== "transaction_flow") {
+    throw new AccountValidationError(
+      "reserveBalance is only valid for cash-like ASSET accounts (a minimum balance you keep untouched)"
+    )
+  }
+  return value
+}
 
 export interface SerializedAccount {
   id: string
@@ -183,6 +225,9 @@ export interface SerializedAccount {
   // exclusion + the net-worth "Personal debts (net)" grouping (presentation
   // only; the balance still counts toward net worth exactly as before).
   counterpartyMerchantId: string | null
+  // PER-217 — reserve/minimum balance in MINOR UNITS (digit-string), or null
+  // when unset. Ledger-neutral; only feeds the "available" (safe-to-spend) view.
+  reserveBalance: string | null
 }
 
 function serializeAccount(account: Account): SerializedAccount {
@@ -208,6 +253,7 @@ function serializeAccount(account: Account): SerializedAccount {
     dueDay: account.dueDay,
     interestRateBps: account.interestRateBps,
     counterpartyMerchantId: account.counterpartyMerchantId,
+    reserveBalance: account.reserveBalance?.toString() ?? null,
   }
 }
 
@@ -309,6 +355,14 @@ export async function createAccountForFamily({
       `counterpartyMerchantId is only valid for RECEIVABLE or LOAN accounts, not ${taxonomy.accountType}`
     )
   }
+  // PER-217 — resolve the reserve against the resolved taxonomy (cash-like ASSET
+  // only). Rejects a positive reserve on any non-cash-like account before write.
+  const reserveBalance = resolveReserveBalance(
+    data.reserveBalance ?? null,
+    taxonomy.accountClass,
+    taxonomy.balanceSource
+  )
+
   const requestHash = await hashCanonicalPayload({
     accountSubtype: taxonomy.accountSubtype,
     accountType: taxonomy.accountType,
@@ -318,6 +372,7 @@ export async function createAccountForFamily({
     institutionName: data.institutionName ?? null,
     name: data.name,
     openingBalance: openingRawValue.toString(),
+    reserveBalance: reserveBalance?.toString() ?? null,
   })
   const auditCtx = await createAuditContext(
     { user: { id: user.id, familyId } },
@@ -382,6 +437,7 @@ export async function createAccountForFamily({
           familyId,
           institutionName: data.institutionName ?? null,
           name: data.name,
+          reserveBalance,
           status: "active",
         },
       })
@@ -491,6 +547,15 @@ export async function updateAccountForFamily({
       data.institutionName === undefined ? undefined : data.institutionName,
     isImportable: data.isImportable ?? null,
     name: data.name ?? null,
+    // PER-217 — hash the RAW input (deterministic); undefined = leave unchanged,
+    // null = clear. The cash-like-ASSET validation runs inside the transaction
+    // against the existing account (type is fixed at creation).
+    reserveBalance:
+      data.reserveBalance === undefined
+        ? undefined
+        : data.reserveBalance === null
+          ? null
+          : data.reserveBalance.toString(),
   })
   const auditCtx = await createAuditContext(
     { user: { id: user.id, familyId } },
@@ -521,6 +586,7 @@ export async function updateAccountForFamily({
         institutionName?: string | null
         isImportable?: boolean
         name?: string
+        reserveBalance?: bigint | null
       } = {}
       if (data.name !== undefined) updateData.name = data.name
       if (data.color !== undefined) updateData.color = data.color
@@ -529,6 +595,16 @@ export async function updateAccountForFamily({
       }
       if (data.isImportable !== undefined) {
         updateData.isImportable = data.isImportable
+      }
+      // PER-217 — only touch the reserve when the caller supplied the field.
+      // Validated against the existing account's class/source (type is fixed at
+      // creation), so a reserve can never land on a non-cash-like account.
+      if (data.reserveBalance !== undefined) {
+        updateData.reserveBalance = resolveReserveBalance(
+          data.reserveBalance,
+          before.accountClass,
+          before.balanceSource
+        )
       }
       if (data.accountSubtype !== undefined) {
         // Re-normalize against the account's existing type so a subtype edit can

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -184,6 +184,9 @@ export interface AccountBalanceView {
   current: string
   held: string
   available: string | null
+  // PER-217 — reserve/minimum balance folded into `available` (safe-to-spend).
+  // Always non-negative; "0" when the account has no reserve set.
+  reserve: string
 }
 
 export interface BalanceRebuildResult {
@@ -231,6 +234,8 @@ export interface AccountBalanceFacts {
   version: number
   currency: string
   creditLimit: bigint | null
+  // PER-217 — user reserve/minimum balance (cash-like ASSET only, else NULL).
+  reserveBalance: bigint | null
 }
 
 const ACCOUNT_BALANCE_SELECT = {
@@ -242,6 +247,7 @@ const ACCOUNT_BALANCE_SELECT = {
   version: true,
   currency: true,
   creditLimit: true,
+  reserveBalance: true,
 } as const
 
 function normalBalanceForClass(accountClass: string): "POSITIVE" | "NEGATIVE" {
@@ -959,7 +965,14 @@ export async function getAccountBalanceForFamily({
       toMoney(0n)
     )
 
-    const available = computeAvailable(account, current, held)
+    // PER-217 — the reserve is a spending earmark; it only applies to cash-like
+    // assets (the DB CHECK already guarantees it is NULL otherwise). Fold it into
+    // `available` so "available" means true safe-to-spend: current − held − reserve.
+    const reserve =
+      account.reserveBalance !== null
+        ? toMoney(account.reserveBalance)
+        : toMoney(0n)
+    const available = computeAvailable(account, current, held, reserve)
 
     return {
       accountId,
@@ -967,6 +980,7 @@ export async function getAccountBalanceForFamily({
       current: current.toString(),
       held: held.toString(),
       available: available === null ? null : available.toString(),
+      reserve: reserve.toString(),
     }
   })
 }
@@ -974,13 +988,16 @@ export async function getAccountBalanceForFamily({
 function computeAvailable(
   account: AccountBalanceFacts,
   current: Money,
-  held: Money
+  held: Money,
+  // PER-217 — user reserve/minimum balance (already 0 for non-cash-like).
+  reserve: Money
 ): Money | null {
-  // Tracked assets: fully available net worth, nothing held.
+  // Tracked assets: fully available net worth, nothing held or reserved.
   if (account.balanceSource === "valuation") return current
 
   if (account.accountClass === "LIABILITY") {
-    // Revolving credit with a limit: remaining headroom.
+    // Revolving credit with a limit: remaining headroom. A reserve is never set
+    // on a liability (DB CHECK), so it does not participate here.
     if (account.creditLimit !== null) {
       return subMoney(
         subMoney(toMoney(account.creditLimit), absMoney(current)),
@@ -991,8 +1008,10 @@ function computeAvailable(
     return null
   }
 
-  // Cash-like asset: spendable balance, unclamped (overdraft shows negative).
-  return subMoney(current, held)
+  // Cash-like asset: safe-to-spend = balance − uncleared holds − reserve floor.
+  // Unclamped: dipping below your reserve shows a negative available, which is
+  // exactly the signal the user wants ("you're into your dana mengendap").
+  return subMoney(subMoney(current, held), reserve)
 }
 
 export const getAccountBalanceFn = createServerFn({ method: "GET" })

--- a/tests/e2e/account-detail.e2e.ts
+++ b/tests/e2e/account-detail.e2e.ts
@@ -23,6 +23,10 @@ test.describe("account detail (PER-216)", () => {
     await page.getByRole("button", { name: "New account" }).click()
     await page.getByLabel("Name").fill(accountName)
     await page.getByLabel("Opening balance").fill("2000000")
+    // PER-217 — set a reserve/minimum balance ("dana mengendap"). The reserve
+    // field only shows for cash-like ASSET accounts; DEPOSITORY (the default
+    // type) qualifies. 500,000 reserve → safe-to-spend 1,500,000.
+    await page.getByLabel(/Reserve . minimum balance/i).fill("500000")
     await page.getByRole("button", { name: "Create" }).click()
     await expect(page.getByRole("dialog")).toHaveCount(0)
 
@@ -36,6 +40,12 @@ test.describe("account detail (PER-216)", () => {
     // Hero shows the name + formatted balance.
     await expect(page.getByText(accountName).first()).toBeVisible()
     await expect(page.getByText("Rp 2,000,000.00").first()).toBeVisible()
+
+    // PER-217 — the safe-to-spend panel shows available = balance − reserve, and
+    // names the reserved portion. (Balance is unchanged — reserve is ledger-neutral.)
+    await expect(page.getByText(/safe to spend/i).first()).toBeVisible()
+    await expect(page.getByText(/reserved/i).first()).toBeVisible()
+    await expect(page.getByText("Rp 1,500,000.00").first()).toBeVisible()
 
     // The statement section renders. A fresh account's opening balance is an
     // opening VALUATION anchor, not a posted transaction, so the ledger is

--- a/tests/integration/accounts-manual-ux.integration.ts
+++ b/tests/integration/accounts-manual-ux.integration.ts
@@ -8,12 +8,14 @@ import {
 } from "vite-plus/test"
 import {
   AccountNotFoundError,
+  AccountValidationError,
   archiveAccountForFamily,
   createAccountForFamily,
   getAccountsForFamily,
   reactivateAccountForFamily,
   updateAccountForFamily,
 } from "@/server/accounts"
+import { getAccountBalanceForFamily } from "@/server/valuations"
 import {
   createIntegrationHarness,
   type IntegrationHarness,
@@ -256,6 +258,179 @@ describe("accounts manual UX vertical slice (PER-143)", () => {
       )
       // Only the first archive transitioned state and wrote an audit row.
       expect(softDeleteAudits).toHaveLength(1)
+    })
+  })
+
+  describe("reserve / minimum balance (PER-217)", () => {
+    test("stores a reserve on a cash-like ASSET and folds it into available (safe-to-spend)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+
+      const created = await createAccountForFamily({
+        data: {
+          name: "BCA with buffer",
+          accountType: "DEPOSITORY",
+          currency: "IDR",
+          openingBalance: "1000000",
+          reserveBalance: "200000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(created.balance).toBe("1000000")
+      expect(created.reserveBalance).toBe("200000")
+
+      // Ledger-neutral: the stored balance is untouched by the reserve.
+      const row = await harness.withFamily(owner.family.id, async (tx) =>
+        tx.account.findUniqueOrThrow({ where: { id: created.id } })
+      )
+      expect(row.balance).toBe(1000000n)
+      expect(row.reserveBalance).toBe(200000n)
+
+      // available = current − held − reserve; held is 0 with no pending txns.
+      const view = await getAccountBalanceForFamily({
+        accountId: created.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      expect(view.current).toBe("1000000")
+      expect(view.held).toBe("0")
+      expect(view.reserve).toBe("200000")
+      expect(view.available).toBe("800000")
+    })
+
+    test("a 0 reserve is normalized to null (no reserve)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const created = await createAccountForFamily({
+        data: {
+          name: "No buffer",
+          accountType: "DEPOSITORY",
+          openingBalance: "500000",
+          reserveBalance: "0",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(created.reserveBalance).toBeNull()
+    })
+
+    test("rejects a reserve on a liability account (validated, before any write)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      let captured: unknown
+      try {
+        await createAccountForFamily({
+          data: {
+            name: "Card with bogus reserve",
+            accountType: "CREDIT",
+            openingBalance: "0",
+            reserveBalance: "50000",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+        expect.fail("Expected AccountValidationError")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(AccountValidationError)
+    })
+
+    test("rejects a reserve on a tracked (valuation) asset", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      let captured: unknown
+      try {
+        await createAccountForFamily({
+          data: {
+            name: "Gold with bogus reserve",
+            accountType: "TRACKED_ASSET",
+            accountSubtype: "commodity",
+            openingBalance: "0",
+            reserveBalance: "50000",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+        expect.fail("Expected AccountValidationError")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(AccountValidationError)
+    })
+
+    test("update sets then clears the reserve (null clears; omit leaves unchanged)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await factories.createAccount({
+        familyId: owner.family.id,
+        name: "Editable buffer",
+      })
+
+      const set = await updateAccountForFamily({
+        data: {
+          id: account.id,
+          reserveBalance: "150000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(set.reserveBalance).toBe("150000")
+
+      // Omitting the field leaves the reserve unchanged.
+      const renamed = await updateAccountForFamily({
+        data: {
+          id: account.id,
+          name: "Renamed",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(renamed.reserveBalance).toBe("150000")
+
+      // Explicit null clears it.
+      const cleared = await updateAccountForFamily({
+        data: {
+          id: account.id,
+          reserveBalance: null,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(cleared.reserveBalance).toBeNull()
+    })
+
+    test("the DB CHECK is the backstop: a raw reserve on a liability is rejected", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const card = await createAccountForFamily({
+        data: {
+          name: "Visa",
+          accountType: "CREDIT",
+          openingBalance: "0",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      // Bypass the app-layer validation and write straight to the row: the DB
+      // CHECK (Database Is the Law) must still reject it.
+      let captured: unknown
+      try {
+        await harness.withFamily(owner.family.id, async (tx) =>
+          tx.account.update({
+            where: { id: card.id },
+            data: { reserveBalance: 50000n },
+          })
+        )
+        expect.fail("Expected the DB CHECK to reject the reserve")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
## What & why

Adds an account **reserve / minimum balance** — the "dana mengendap" the creator asked for: money you keep untouched inside a cash-like account (a real bank/e-wallet minimum balance, or a self-imposed buffer).

It is **ledger-neutral** by construction — it never changes the stored balance, net worth, transactions, or valuations. It only reshapes what the user sees as **safe to spend**:

```
available (safe-to-spend) = current − held − reserve
```

This deliberately *unifies* the reserve with Permoney's existing `available`/`held` balance view (which already subtracted uncleared holds), so "Available" now means true safe-to-spend — the Revolut/Monzo pattern, done coherently rather than bolted on.

## Layers (vertical slice)

- **DB** — `Account.reserveBalance BigInt?` + `CHECK (NULL, or >= 0 AND accountClass='ASSET' AND balanceSource='transaction_flow')`. The invariant can never drift ("Database Is the Law").
- **Server** — create/update validate + persist (`0` normalized to `NULL`; cash-like ASSET only; folded into `requestHash` + audit via `serializeAccount`); folded into the authoritative `computeAvailable` in `valuations.ts` with a new `reserve` field on `AccountBalanceView`.
- **Client** — pure, unit-tested helpers (`availableAfterReserve`, `reserveHealth`, `reserveLockedFraction`); a reserve input in the account form (create + edit, shown only for cash-like ASSET); a "safe to spend" line on the ATM/plain card; a `SafeToSpendPanel` gauge on the detail hero with below/near-reserve states.

## Tests

- **14** helper unit + **2** card-visual unit
- **5** real-Postgres integration: fold into available, `0→null`, liability + tracked-asset rejection, set/clear/omit update semantics, and the DB CHECK backstop (raw write on a liability rejected)
- **account-detail e2e** asserts the safe-to-spend panel (balance − reserve) on the hero

`vp check` clean (249 files); all suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)