### PR TITLE
feat(accounts): PER-222 — account intelligence slice 1: runway to reserve

### DIFF
--- a/src/lib/account-runway.test.ts
+++ b/src/lib/account-runway.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "vite-plus/test"
+import { computeAccountRunway, isRunwayAlerting } from "./account-runway"
+import { type AnalyticsTxn } from "./account-analytics"
+
+// Fixed "now" so every forecast is deterministic.
+const NOW = new Date("2026-08-02T12:00:00.000Z")
+const DAY_MS = 86_400_000
+const ACC = "acc-1"
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * DAY_MS)
+}
+
+/** An expense (money leaving the account) `n` days ago. */
+function expense(amount: bigint, n: number): AnalyticsTxn {
+  return { date: daysAgo(n), amount, type: "expense", accountId: ACC }
+}
+
+/** Income (money arriving) `n` days ago. */
+function income(amount: bigint, n: number): AnalyticsTxn {
+  return { date: daysAgo(n), amount, type: "income", accountId: ACC }
+}
+
+describe("computeAccountRunway", () => {
+  test("growing: net inflow over the window → no dip forecast", () => {
+    const txns = [
+      income(500_000n, 2),
+      income(600_000n, 10),
+      income(400_000n, 20),
+    ]
+    const r = computeAccountRunway(txns, 2_000_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    expect(r.status).toBe("growing")
+    expect(r.daysToReserve).toBeNull()
+    expect(r.dailyBurnMinor).toBeNull()
+    expect(r.netDailyFlowMinor > 0n).toBe(true)
+  })
+
+  test("critical: burns down to the reserve floor in < 7 days", () => {
+    // available = 1,000,000 − 500,000 = 500,000; burn 100,000/day → 5 days.
+    const txns = Array.from({ length: 8 }, (_, i) => expense(375_000n, i + 1))
+    const r = computeAccountRunway(txns, 1_000_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    expect(r.status).toBe("critical")
+    expect(r.daysToReserve).toBe(5)
+    expect(r.dailyBurnMinor).toBe(100_000n)
+    expect(r.reserveDate).not.toBeNull()
+    expect(isRunwayAlerting(r.status)).toBe(true)
+  })
+
+  test("watch: dips below the floor within 30 days", () => {
+    // available = 500,000; burn 25,000/day → 20 days.
+    const txns = Array.from({ length: 8 }, () => expense(93_750n, 15))
+    const r = computeAccountRunway(txns, 1_000_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    expect(r.status).toBe("watch")
+    expect(r.daysToReserve).toBe(20)
+    expect(isRunwayAlerting(r.status)).toBe(true)
+  })
+
+  test("healthy: burning, but more than 30 days of runway", () => {
+    // available = 10,000,000; burn 10,000/day → 1000 days.
+    const txns = Array.from({ length: 8 }, () => expense(37_500n, 12))
+    const r = computeAccountRunway(txns, 10_500_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    expect(r.status).toBe("healthy")
+    expect(r.daysToReserve).toBeGreaterThan(30)
+    expect(isRunwayAlerting(r.status)).toBe(false)
+  })
+
+  test("below: already at/under the reserve floor, regardless of activity", () => {
+    const txns = [expense(50_000n, 1)]
+    const r = computeAccountRunway(txns, 400_000n, 500_000n, ACC, { now: NOW })
+    expect(r.status).toBe("below")
+    expect(r.daysToReserve).toBe(0)
+    expect(isRunwayAlerting(r.status)).toBe(true)
+  })
+
+  test("insufficient_data: above the floor but too few recent transactions", () => {
+    const txns = [expense(100_000n, 3), expense(100_000n, 5)] // 2 < minSamples(3)
+    const r = computeAccountRunway(txns, 1_000_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    expect(r.status).toBe("insufficient_data")
+    expect(r.daysToReserve).toBeNull()
+    expect(r.lowConfidence).toBe(true)
+  })
+
+  test("thin sample (3–7 txns) forecasts but flags low confidence", () => {
+    const txns = Array.from({ length: 5 }, (_, i) => expense(200_000n, i + 1))
+    const r = computeAccountRunway(txns, 1_000_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    expect(r.sampleSize).toBe(5)
+    expect(r.lowConfidence).toBe(true)
+    expect(["critical", "watch", "healthy"]).toContain(r.status)
+  })
+
+  test("ignores transactions outside the trailing window", () => {
+    // A big spend 45 days ago must NOT count in a 30-day window.
+    const txns = [expense(9_000_000n, 45), expense(30_000n, 2)]
+    const r = computeAccountRunway(txns, 1_000_000n, 0n, ACC, {
+      now: NOW,
+      windowDays: 30,
+    })
+    expect(r.sampleSize).toBe(1)
+  })
+
+  test("no reserve → runway to empty (floor = 0)", () => {
+    // available = full balance 300,000; burn 30,000/day over 30d → 10 days.
+    const txns = Array.from({ length: 8 }, () => expense(112_500n, 10))
+    const r = computeAccountRunway(txns, 300_000n, 0n, ACC, { now: NOW })
+    expect(r.status).toBe("watch")
+    expect(r.daysToReserve).toBe(10)
+  })
+
+  test("transfers count from this account's perspective (out = burn)", () => {
+    // Transfers OUT of ACC are negative deltas → contribute to burn.
+    const txns = Array.from({ length: 8 }, () => ({
+      date: daysAgo(6),
+      amount: 62_500n,
+      type: "transfer" as const,
+      accountId: ACC,
+      toAccountId: "other",
+    }))
+    const r = computeAccountRunway(txns, 1_000_000n, 500_000n, ACC, {
+      now: NOW,
+    })
+    // 8 × 62,500 = 500,000 over 30d → burn ~16,667/day → available 500,000 → ~30d.
+    expect(r.dailyBurnMinor).not.toBeNull()
+    expect(["watch", "healthy"]).toContain(r.status)
+  })
+})

--- a/src/lib/account-runway.ts
+++ b/src/lib/account-runway.ts
@@ -1,0 +1,149 @@
+import { signedDeltaForAccount, type AnalyticsTxn } from "./account-analytics"
+
+// =============================================================================
+// PER-222 — "runway to reserve": the account intelligence layer, slice 1.
+//
+// Turns the static "safe to spend today" (PER-217 reserve) into a forward look:
+// at this account's real trailing net daily flow, WHEN does its balance dip
+// below its reserve floor ("dana mengendap")? When no reserve is set the floor
+// is 0, so it becomes "runway to empty".
+//
+// Client-side heuristic (locked grill 2026-08-02): pure math over the ledger the
+// account pages already load — no server model, no migration. The output shape
+// is deliberately UI-agnostic so a future server insights engine can produce the
+// same `AccountRunway` without changing any consumer. All money stays in bigint
+// minor units; only the final day-count / ratio uses Number (a bounded,
+// display-only quantity, never money math).
+// =============================================================================
+
+const DAY_MS = 86_400_000
+
+export type RunwayStatus =
+  | "below" // already at/under the reserve floor
+  | "critical" // will dip below the floor in < 7 days
+  | "watch" // will dip below the floor in < 30 days
+  | "healthy" // burning, but > 30 days of runway
+  | "growing" // net inflow over the window — no dip expected
+  | "insufficient_data" // too few recent transactions to forecast
+
+export interface AccountRunway {
+  status: RunwayStatus
+  /** Signed average net flow per day over the window, in minor units (rounded). */
+  netDailyFlowMinor: bigint
+  /** Positive average spend per day when burning; null when not burning. */
+  dailyBurnMinor: bigint | null
+  /** Whole days until the balance reaches the reserve floor; null when N/A. */
+  daysToReserve: number | null
+  /** Calendar date the floor is reached; null when N/A. */
+  reserveDate: Date | null
+  windowDays: number
+  /** Number of transactions in the trailing window (the forecast's evidence). */
+  sampleSize: number
+  /** True when the window has too little activity for a confident forecast. */
+  lowConfidence: boolean
+}
+
+function toTime(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime()
+}
+
+/**
+ * Forecast an account's runway to its reserve floor from its trailing net daily
+ * flow. `txns` should already be the per-account ledger (e.g. via `applyFilters`
+ * — the PER-202 lens), so `signedDeltaForAccount` never double-counts. Pure and
+ * deterministic given `now`.
+ */
+export function computeAccountRunway(
+  txns: ReadonlyArray<AnalyticsTxn>,
+  currentBalanceMinor: bigint,
+  reserveMinor: bigint,
+  accountId: string,
+  opts?: { windowDays?: number; now?: Date; minSamples?: number }
+): AccountRunway {
+  const windowDays = opts?.windowDays ?? 30
+  const now = opts?.now ?? new Date()
+  const minSamples = opts?.minSamples ?? 3
+  const nowMs = now.getTime()
+  const cutoffMs = nowMs - windowDays * DAY_MS
+
+  // Trailing window: transactions dated within (now − window, now].
+  let netFlow = 0n
+  let sampleSize = 0
+  for (const t of txns) {
+    const ms = toTime(t.date)
+    if (ms <= cutoffMs || ms > nowMs) continue
+    netFlow += signedDeltaForAccount(t, accountId)
+    sampleSize += 1
+  }
+
+  const netDailyFlowMinor = BigInt(Math.round(Number(netFlow) / windowDays))
+  const available = currentBalanceMinor - reserveMinor
+  // < 8 txns in the window is a thin sample; forecasts get a confidence hint.
+  const lowConfidence = sampleSize < 8
+
+  const base = {
+    netDailyFlowMinor,
+    windowDays,
+    sampleSize,
+  }
+
+  // Already at or under the floor — a present-state fact, reported regardless of
+  // how much recent activity there is (it needs no forecast).
+  if (available <= 0n) {
+    return {
+      ...base,
+      status: "below",
+      dailyBurnMinor: netFlow < 0n ? -netDailyFlowMinor : null,
+      daysToReserve: 0,
+      reserveDate: now,
+      lowConfidence,
+    }
+  }
+
+  // Above the floor but too little evidence to forecast a burn.
+  if (sampleSize < minSamples) {
+    return {
+      ...base,
+      status: "insufficient_data",
+      dailyBurnMinor: null,
+      daysToReserve: null,
+      reserveDate: null,
+      lowConfidence: true,
+    }
+  }
+
+  // Net inflow (or flat) over the window: the account is not trending toward its
+  // floor, so there is no dip to forecast.
+  if (netFlow >= 0n) {
+    return {
+      ...base,
+      status: "growing",
+      dailyBurnMinor: null,
+      daysToReserve: null,
+      reserveDate: null,
+      lowConfidence,
+    }
+  }
+
+  // Burning: project days to the floor from the average daily burn. Compute the
+  // day-count from the raw window totals (one division) to avoid double rounding.
+  const burnPerDay = Number(-netFlow) / windowDays
+  const daysToReserve = Math.floor(Number(available) / burnPerDay)
+  const reserveDate = new Date(nowMs + daysToReserve * DAY_MS)
+  const status: RunwayStatus =
+    daysToReserve < 7 ? "critical" : daysToReserve < 30 ? "watch" : "healthy"
+
+  return {
+    ...base,
+    status,
+    dailyBurnMinor: -netDailyFlowMinor,
+    daysToReserve,
+    reserveDate,
+    lowConfidence,
+  }
+}
+
+/** Whether a runway status warrants an ambient badge (card / dashboard). */
+export function isRunwayAlerting(status: RunwayStatus): boolean {
+  return status === "below" || status === "critical" || status === "watch"
+}

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -1,5 +1,10 @@
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
-import { ShieldCheck } from "lucide-react"
+import {
+  ShieldCheck,
+  TrendingDown,
+  TrendingUp,
+  TriangleAlert,
+} from "lucide-react"
 
 import {
   ChartContainer,
@@ -19,6 +24,7 @@ import {
   reserveHealth,
   reserveLockedFraction,
 } from "@/lib/account-reserve"
+import { type AccountRunway } from "@/lib/account-runway"
 import { formatCurrency } from "@/lib/currency"
 import { cn } from "@/lib/utils"
 
@@ -195,6 +201,88 @@ export function SafeToSpendPanel({
         />
         <div className="h-full flex-1 bg-primary/70" />
       </div>
+    </div>
+  )
+}
+
+// PER-222 — "runway to reserve" note: forecasts when the account dips below its
+// reserve floor from its trailing net daily flow. Pure props in; the math is the
+// unit-tested computeAccountRunway. Calm by default, urgent only when it matters.
+export function AccountRunwayNote({
+  runway,
+  currency,
+}: Readonly<{ runway: AccountRunway; currency: string }>) {
+  const { status } = runway
+  const dateLabel = runway.reserveDate
+    ? runway.reserveDate.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      })
+    : null
+  const burnLabel =
+    runway.dailyBurnMinor !== null
+      ? `${formatCurrency(runway.dailyBurnMinor.toString(), currency)}/day`
+      : null
+
+  const urgent = status === "below" || status === "critical"
+
+  let icon = <TrendingDown className="size-3.5" aria-hidden />
+  let headline: string
+  let detail: string | null = null
+
+  if (status === "insufficient_data") {
+    icon = <TriangleAlert className="size-3.5" aria-hidden />
+    headline = "Not enough recent activity to forecast runway"
+  } else if (status === "growing") {
+    icon = <TrendingUp className="size-3.5" aria-hidden />
+    headline = "Trending up — no dip below your reserve expected"
+  } else if (status === "below") {
+    icon = <TriangleAlert className="size-3.5" aria-hidden />
+    headline = "You're below your reserve now"
+    detail = burnLabel ? `Burning about ${burnLabel}.` : null
+  } else {
+    // critical / watch / healthy — a real runway forecast.
+    const days = runway.daysToReserve ?? 0
+    headline = `About ${days} ${days === 1 ? "day" : "days"} of runway`
+    detail = [
+      dateLabel ? `reaches your reserve around ${dateLabel}` : null,
+      burnLabel ? `at ~${burnLabel}` : null,
+    ]
+      .filter(Boolean)
+      .join(" ")
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-4",
+        urgent ? "border-destructive/40 bg-destructive/5" : undefined
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {icon}
+          Runway
+        </p>
+        {runway.lowConfidence && status !== "insufficient_data" ? (
+          <span className="text-[10px] font-medium text-muted-foreground">
+            Low confidence
+          </span>
+        ) : null}
+      </div>
+      <p
+        className={cn(
+          "mt-1 text-lg font-semibold",
+          urgent ? "text-destructive" : undefined
+        )}
+      >
+        {headline}
+      </p>
+      {detail ? (
+        <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
+          {detail}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/src/routes/_protected/-account-card.test.tsx
+++ b/src/routes/_protected/-account-card.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen } from "@testing-library/react"
 import { AccountCard } from "./-account-card"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import type { AccountRecord, DriftRecord } from "@/lib/account-collections"
+import type { AccountRunway } from "@/lib/account-runway"
 
 // PER-178 — the accounts-page badge must soften a migration-origin
 // ANCHOR_CHAIN warning to a neutral "Imported" affordance while a live-user
@@ -113,5 +114,60 @@ describe("AccountCard drift badge", () => {
     ])
     expect(screen.getByText(/balance drift/i)).toBeTruthy()
     expect(screen.queryByText(/imported/i)).toBeNull()
+  })
+})
+
+describe("AccountCard runway badge (PER-222)", () => {
+  function runway(over: Partial<AccountRunway>): AccountRunway {
+    return {
+      status: "healthy",
+      netDailyFlowMinor: 0n,
+      dailyBurnMinor: null,
+      daysToReserve: null,
+      reserveDate: null,
+      windowDays: 30,
+      sampleSize: 10,
+      lowConfidence: false,
+      ...over,
+    }
+  }
+
+  function renderWithRunway(r?: AccountRunway) {
+    render(
+      <TooltipProvider>
+        <AccountCard
+          account={account}
+          drift={[]}
+          busy={false}
+          onEdit={noop}
+          onValuation={noop}
+          onArchive={noop}
+          onReactivate={noop}
+          onDelete={noop}
+          runway={r}
+        />
+      </TooltipProvider>
+    )
+  }
+
+  it("shows a days-to-reserve badge when the runway is alerting (watch/critical)", () => {
+    renderWithRunway(runway({ status: "critical", daysToReserve: 4 }))
+    expect(screen.getByText("~4d to reserve")).toBeTruthy()
+  })
+
+  it("shows 'Below reserve' when already under the floor", () => {
+    renderWithRunway(runway({ status: "below", daysToReserve: 0 }))
+    expect(screen.getByText("Below reserve")).toBeTruthy()
+  })
+
+  it("shows no runway badge for a healthy/growing account", () => {
+    renderWithRunway(runway({ status: "healthy", daysToReserve: 120 }))
+    expect(screen.queryByText(/to reserve/i)).toBeNull()
+    expect(screen.queryByText(/below reserve/i)).toBeNull()
+  })
+
+  it("shows no runway badge when no runway is provided", () => {
+    renderWithRunway(undefined)
+    expect(screen.queryByText(/to reserve/i)).toBeNull()
   })
 })

--- a/src/routes/_protected/-account-card.tsx
+++ b/src/routes/_protected/-account-card.tsx
@@ -115,6 +115,10 @@ export function AccountCard({
   const archived = account.status !== "active"
   const cashLike = account.balanceSource === "transaction_flow"
   const runwayBadge = runway && isRunwayAlerting(runway.status) ? runway : null
+  // `daysToReserve` is non-null for watch/critical from computeAccountRunway, but
+  // the type allows null (a future server path could) — guard so we never render
+  // "~nulld to reserve".
+  const runwayDays = runwayBadge?.daysToReserve ?? null
   // Surface the single worst drift entry (ADR-0043 §6 classification lives in
   // src/lib/account-drift-presentation.ts, unit-tested there). Read-only — the
   // badge never mutates anything (ADR-0034 §7).
@@ -157,13 +161,17 @@ export function AccountCard({
                   <TrendingDown className="size-3" />
                   {runwayBadge.status === "below"
                     ? "Below reserve"
-                    : `~${runwayBadge.daysToReserve}d to reserve`}
+                    : runwayDays !== null
+                      ? `~${runwayDays}d to reserve`
+                      : "Reserve approaching"}
                 </Badge>
               </TooltipTrigger>
               <TooltipContent>
                 {runwayBadge.status === "below"
                   ? "This account is below the minimum balance you set to keep untouched."
-                  : `At its recent spending pace, this account reaches your reserve in about ${runwayBadge.daysToReserve} days.`}
+                  : runwayDays !== null
+                    ? `At its recent spending pace, this account reaches your reserve in about ${runwayDays} days.`
+                    : "At its recent spending pace, this account is approaching your reserve."}
               </TooltipContent>
             </Tooltip>
           ) : null}

--- a/src/routes/_protected/-account-card.tsx
+++ b/src/routes/_protected/-account-card.tsx
@@ -7,6 +7,7 @@ import {
   Scale,
   ShieldCheck,
   Trash2,
+  TrendingDown,
   TrendingUp,
   TriangleAlert,
 } from "lucide-react"
@@ -27,6 +28,7 @@ import {
 } from "@/components/ui/tooltip"
 import { AccountVisual } from "@/components/blocks/account-visual"
 import { ACCOUNT_TYPE_LABEL, type AccountType } from "@/lib/accounts"
+import { isRunwayAlerting, type AccountRunway } from "@/lib/account-runway"
 import type { AccountRecord, DriftRecord } from "@/lib/account-collections"
 import { selectDriftBadge } from "@/lib/account-drift-presentation"
 import { formatCurrency } from "@/lib/currency"
@@ -89,6 +91,7 @@ export function AccountCard({
   onOpen,
   pinned = false,
   onTogglePin,
+  runway,
 }: {
   account: AccountRecord
   drift: ReadonlyArray<DriftRecord>
@@ -105,9 +108,13 @@ export function AccountCard({
   // without wiring pin state; the pin button only renders when a handler exists.
   pinned?: boolean
   onTogglePin?: () => void
+  // PER-222 — runway forecast for this account (cash-like only). Optional so
+  // existing mounts/tests work; the ambient badge only shows when alerting.
+  runway?: AccountRunway
 }) {
   const archived = account.status !== "active"
   const cashLike = account.balanceSource === "transaction_flow"
+  const runwayBadge = runway && isRunwayAlerting(runway.status) ? runway : null
   // Surface the single worst drift entry (ADR-0043 §6 classification lives in
   // src/lib/account-drift-presentation.ts, unit-tested there). Read-only — the
   // badge never mutates anything (ADR-0034 §7).
@@ -135,6 +142,31 @@ export function AccountCard({
             {cashLike ? "Cash-like" : "Tracked asset"}
           </Badge>
           {archived ? <Badge variant="outline">Archived</Badge> : null}
+          {runwayBadge ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant={
+                    runwayBadge.status === "watch" ? "outline" : "destructive"
+                  }
+                  className={cn(
+                    runwayBadge.status === "watch" &&
+                      "border-amber-500/50 text-amber-600 dark:text-amber-400"
+                  )}
+                >
+                  <TrendingDown className="size-3" />
+                  {runwayBadge.status === "below"
+                    ? "Below reserve"
+                    : `~${runwayBadge.daysToReserve}d to reserve`}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                {runwayBadge.status === "below"
+                  ? "This account is below the minimum balance you set to keep untouched."
+                  : `At its recent spending pace, this account reaches your reserve in about ${runwayBadge.daysToReserve} days.`}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
           {driftBadge?.tone === "informational" ? (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -30,12 +30,14 @@ import {
 import { transactionCollection } from "@/lib/collections"
 import { applyFilters } from "@/lib/transaction-filters"
 import {
+  AccountRunwayNote,
   BalanceTrendChart,
   CategoryBreakdown,
   RangeSelector,
   SafeToSpendPanel,
 } from "./-account-analytics"
 import { accountSupportsReserve, hasReserve } from "@/lib/account-reserve"
+import { computeAccountRunway } from "@/lib/account-runway"
 import {
   buildBalanceSeries,
   buildStatementCsv,
@@ -136,6 +138,21 @@ function AccountDetailPage() {
         limit: 6,
       }),
     [rangedLedger, accountId]
+  )
+
+  // PER-222 — runway to reserve, from the full per-account ledger (trailing net
+  // daily flow). Only meaningful for cash-like accounts.
+  const runway = React.useMemo(
+    () =>
+      cashLike
+        ? computeAccountRunway(
+            ledger,
+            currentBalance,
+            account?.reserveBalance ? BigInt(account.reserveBalance) : 0n,
+            accountId
+          )
+        : null,
+    [cashLike, ledger, currentBalance, account?.reserveBalance, accountId]
   )
 
   const kpi = React.useMemo(() => {
@@ -271,6 +288,9 @@ function AccountDetailPage() {
               reserveMinor={BigInt(account.reserveBalance ?? "0")}
               currency={currency}
             />
+          ) : null}
+          {runway ? (
+            <AccountRunwayNote runway={runway} currency={currency} />
           ) : null}
           <div className="grid grid-cols-2 gap-3">
             <MiniStat

--- a/src/routes/_protected/accounts.index.tsx
+++ b/src/routes/_protected/accounts.index.tsx
@@ -58,6 +58,9 @@ import {
   type AccountRecord,
   type DriftRecord,
 } from "@/lib/account-collections"
+import { transactionCollection } from "@/lib/collections"
+import { applyFilters } from "@/lib/transaction-filters"
+import { computeAccountRunway, type AccountRunway } from "@/lib/account-runway"
 import {
   ACCOUNT_TYPE_VALUES,
   type AccountClass,
@@ -96,6 +99,8 @@ export const Route = createFileRoute("/_protected/accounts/")({
     await Promise.all([
       accountCollection.preload(),
       balanceDriftCollection.preload(),
+      // PER-222 — the runway badge needs each account's ledger.
+      transactionCollection.preload(),
     ])
     return null
   },
@@ -147,6 +152,9 @@ function AccountsPage() {
   const { data: driftRows } = useLiveQuery((q) =>
     q.from({ d: balanceDriftCollection })
   )
+  const { data: allTransactions } = useLiveQuery((q) =>
+    q.from({ t: transactionCollection })
+  )
   const [dialog, setDialog] = React.useState<DialogState>(null)
   const [busyId, setBusyId] = React.useState<string | null>(null)
   // PER-219 list tools. Search/type/archived are ephemeral view state; pins and
@@ -193,6 +201,32 @@ function AccountsPage() {
     }
     return map
   }, [driftRows])
+
+  // PER-222 — per-account runway forecast (cash-like ASSET only), using the SAME
+  // applyFilters lens as the detail page so the badge and the detail panel agree.
+  const runwayByAccount = React.useMemo(() => {
+    const map = new Map<string, AccountRunway>()
+    if (!allTransactions) return map
+    for (const a of listedAccounts) {
+      if (
+        a.accountClass !== "ASSET" ||
+        a.balanceSource !== "transaction_flow"
+      ) {
+        continue
+      }
+      const ledger = applyFilters(allTransactions, { accounts: [a.id] })
+      map.set(
+        a.id,
+        computeAccountRunway(
+          ledger,
+          BigInt(a.balance),
+          a.reserveBalance ? BigInt(a.reserveBalance) : 0n,
+          a.id
+        )
+      )
+    }
+    return map
+  }, [allTransactions, listedAccounts])
 
   // Apply search / type / archived filters (pure — see account-list-tools).
   const filteredAccounts = React.useMemo(
@@ -343,6 +377,7 @@ function AccountsPage() {
                                 account={account}
                                 drift={driftByAccount.get(account.id) ?? []}
                                 busy={busyId === account.id}
+                                runway={runwayByAccount.get(account.id)}
                                 pinned={isPinned(pinnedIds, account.id)}
                                 onTogglePin={() => handleTogglePin(account.id)}
                                 onEdit={() =>

--- a/tests/e2e/account-detail.e2e.ts
+++ b/tests/e2e/account-detail.e2e.ts
@@ -47,6 +47,14 @@ test.describe("account detail (PER-216)", () => {
     await expect(page.getByText(/reserved/i).first()).toBeVisible()
     await expect(page.getByText("Rp 1,500,000.00").first()).toBeVisible()
 
+    // PER-222 — the runway panel renders. A fresh account has no posted
+    // transactions (opening balance is an anchor, not a txn), so the honest
+    // state is "not enough activity to forecast" rather than a fabricated number.
+    await expect(page.getByText(/Runway/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/not enough recent activity to forecast/i)
+    ).toBeVisible()
+
     // --- Detail actions (PER-221): Edit + Reconcile reuse the shared dialogs ---
     // Edit opens the shared account form (prefilled) and closes cleanly.
     await page.getByRole("button", { name: "Edit", exact: true }).click()


### PR DESCRIPTION
## What & why

First slice of the **account intelligence layer**. It turns the static "safe to spend today" (PER-217) into a forward look: from each cash-like account's real **trailing net daily flow**, forecast **when its balance dips below its reserve floor** ("dana mengendap") — e.g. _"~14 days of runway (around Aug 16)"_. No reserve set ⇒ floor is 0 ⇒ "runway to empty".

**Locked grill (all recommended):** client-side heuristic now (server later), trailing net daily flow, ambient badges + panels.

## How

Pure, unit-tested math over the ledger the account pages already load — **no server model, no migration**. The `AccountRunway` output shape is deliberately UI-agnostic so a future server insights engine can produce it without changing any consumer.

- `src/lib/account-runway.ts` — `computeAccountRunway(txns, currentBalance, reserve, accountId, {windowDays, now, minSamples})` → `{ status, netDailyFlowMinor, dailyBurnMinor, daysToReserve, reserveDate, windowDays, sampleSize, lowConfidence }`. Status: `below / critical (<7d) / watch (<30d) / healthy / growing / insufficient_data`. Reuses `signedDeltaForAccount` (the PER-202 lens) so it never double-counts.
- **Detail hero** — `AccountRunwayNote` panel: calm by default, urgent (destructive tint) only for below/critical, low-confidence hint on thin data.
- **Accounts list** — computes a per-account runway map (same `applyFilters` lens as the detail page) and shows an ambient near-reserve / low-runway badge on the card.

## Tests

- **10** helper unit tests (each status, window filtering, transfers, no-reserve→empty, thin-sample confidence).
- **4** card-badge unit tests (watch/critical → `~Nd to reserve`, below → "Below reserve", healthy/none → no badge).
- `account-detail` e2e asserts the runway panel renders (honest "insufficient data" for a fresh account).
- Full list-route e2e (per-account-incoming-transfer, onboarding-empty) re-run green after the loader now also preloads the transaction collection.
- `vp check` clean (253 files).

Tracked in [PER-222](https://linear.app/permana/issue/PER-222/account-intelligence-slice-1-runway-to-reserve). Later slices: idle-cash opportunity, recurring/bill detection, account health score, server insights engine, push/email alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)