### PR TITLE
feat(accounts): PER-223 — account intelligence slice 2: idle-cash opportunity

### DIFF
--- a/src/lib/account-idle-cash.test.ts
+++ b/src/lib/account-idle-cash.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vite-plus/test"
+import { computeIdleCash } from "./account-idle-cash"
+import { type AnalyticsTxn } from "./account-analytics"
+
+const NOW = new Date("2026-08-02T12:00:00.000Z")
+const DAY_MS = 86_400_000
+const ACC = "acc-1"
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * DAY_MS)
+}
+function expense(amount: bigint, n: number): AnalyticsTxn {
+  return { date: daysAgo(n), amount, type: "expense", accountId: ACC }
+}
+function income(amount: bigint, n: number): AnalyticsTxn {
+  return { date: daysAgo(n), amount, type: "income", accountId: ACC }
+}
+
+describe("computeIdleCash", () => {
+  test("flags a large surplus that stayed above the reserve all window", () => {
+    // Funded 90d ago (pre-window evidence), then tiny churn; the low-water mark
+    // stays high → most of the balance has provably sat idle.
+    const txns = [
+      income(10_000_000n, 90),
+      expense(100_000n, 40),
+      income(100_000n, 20),
+    ]
+    const r = computeIdleCash(txns, 10_000_000n, 500_000n, ACC, { now: NOW })
+    expect(r.hasSurplus).toBe(true)
+    expect(r.idleSurplusMinor > 8_000_000n).toBe(true)
+    expect(r.fractionIdle).toBeGreaterThan(0.8)
+  })
+
+  test("honesty guard: no pre-window history → not claimed (new vs idle is ambiguous)", () => {
+    // High stable balance but the only activity is inside the window, so we
+    // cannot prove the account is old enough to call it "idle 60+ days".
+    const txns = [expense(100_000n, 10)]
+    const r = computeIdleCash(txns, 5_000_000n, 0n, ACC, { now: NOW })
+    expect(r.minBalanceMinor > 0n).toBe(true) // surplus exists numerically…
+    expect(r.hasSurplus).toBe(false) // …but is not surfaced without coverage
+  })
+
+  test("zero-history balance (opening-only account) is not claimed", () => {
+    const r = computeIdleCash([], 3_000_000n, 500_000n, ACC, { now: NOW })
+    expect(r.hasSurplus).toBe(false)
+  })
+
+  test("no surplus when the balance dipped near the reserve during the window", () => {
+    // Funded 90d ago (coverage present), then swung down to ~reserve mid-window
+    // and back — so nothing actually sat idle.
+    const txns = [
+      income(5_000_000n, 90),
+      expense(4_600_000n, 30), // down to 400,000
+      income(4_600_000n, 10), // back to 5,000,000
+    ]
+    const r = computeIdleCash(txns, 5_000_000n, 500_000n, ACC, { now: NOW })
+    expect(r.minBalanceMinor).toBe(400_000n)
+    expect(r.hasSurplus).toBe(false)
+    expect(r.idleSurplusMinor).toBe(0n)
+  })
+
+  test("respects the minFraction gate (small surplus not surfaced)", () => {
+    // Coverage present (funded 90d ago); surplus is only ~10% of balance.
+    const txns = [income(1_000_000n, 90), expense(100_000n, 15)]
+    const r = computeIdleCash(txns, 1_000_000n, 900_000n, ACC, { now: NOW })
+    expect(r.fractionIdle).toBeLessThan(0.2)
+    expect(r.hasSurplus).toBe(false)
+  })
+
+  test("no reserve → all stably-held cash counts as idle (with coverage)", () => {
+    const txns = [income(2_000_000n, 90)]
+    const r = computeIdleCash(txns, 2_000_000n, 0n, ACC, { now: NOW })
+    expect(r.idleSurplusMinor).toBe(2_000_000n)
+    expect(r.hasSurplus).toBe(true)
+  })
+
+  test("a dip OUTSIDE the window does not lower the idle surplus", () => {
+    // Big dip 90/89 days ago (outside the 60d window) then stable high since.
+    const txns = [
+      income(10_000_000n, 120),
+      expense(9_000_000n, 90),
+      income(9_000_000n, 89),
+    ]
+    const r = computeIdleCash(txns, 10_000_000n, 500_000n, ACC, {
+      now: NOW,
+      windowDays: 60,
+    })
+    expect(r.minBalanceMinor).toBe(10_000_000n)
+    expect(r.hasSurplus).toBe(true)
+  })
+
+  test("current balance at/below reserve → no idle surplus", () => {
+    const txns = [income(500_000n, 90)]
+    const r = computeIdleCash(txns, 500_000n, 500_000n, ACC, { now: NOW })
+    expect(r.idleSurplusMinor).toBe(0n)
+    expect(r.hasSurplus).toBe(false)
+  })
+})

--- a/src/lib/account-idle-cash.ts
+++ b/src/lib/account-idle-cash.ts
@@ -1,0 +1,117 @@
+import { signedDeltaForAccount, type AnalyticsTxn } from "./account-analytics"
+
+// =============================================================================
+// PER-223 — "idle cash" opportunity: account intelligence layer, slice 2.
+//
+// The elegant inverse of runway (PER-222). Runway warns when cash is trending
+// DOWN toward the reserve; idle-cash spots cash that has stayed UP, untouched,
+// far above the reserve — money that was safe-to-spend the entire window but was
+// never used, so it could be moved somewhere it earns.
+//
+// Definition (honest + simple): over a trailing window, reconstruct the balance
+// trajectory and take its MINIMUM. Everything above the reserve at that low-water
+// mark has provably sat idle for the whole window:
+//
+//     idle surplus = max(0, minBalanceOverWindow − reserve)
+//
+// Client-side, pure, no server/DB — same pattern and money discipline as runway
+// (bigint minor units throughout; Number only for the final display fraction).
+// =============================================================================
+
+const DAY_MS = 86_400_000
+
+export interface IdleCashInsight {
+  /** True when the idle surplus is material enough to surface (see minFraction). */
+  hasSurplus: boolean
+  /** min-over-window balance − reserve, floored at 0, in minor units. */
+  idleSurplusMinor: bigint
+  /** The low-water mark of the balance over the window, in minor units. */
+  minBalanceMinor: bigint
+  /** idleSurplus / currentBalance (0..1) — how much of the balance sits idle. */
+  fractionIdle: number
+  windowDays: number
+}
+
+function toTime(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime()
+}
+
+function chronological(a: AnalyticsTxn, b: AnalyticsTxn): number {
+  const ta = toTime(a.date)
+  const tb = toTime(b.date)
+  if (ta !== tb) return ta - tb
+  const ca = a.createdAt ? toTime(a.createdAt) : 0
+  const cb = b.createdAt ? toTime(b.createdAt) : 0
+  return ca - cb
+}
+
+/**
+ * Detect cash that has sat idle above the reserve for the whole trailing window.
+ * `txns` should be the per-account ledger (via `applyFilters` — the PER-202
+ * lens). Pure and deterministic given `now`. The caller decides WHEN to surface
+ * it (e.g. cash-like ASSET, and not a `savings` account where idle is the point).
+ */
+export function computeIdleCash(
+  txns: ReadonlyArray<AnalyticsTxn>,
+  currentBalanceMinor: bigint,
+  reserveMinor: bigint,
+  accountId: string,
+  opts?: { windowDays?: number; now?: Date; minFraction?: number }
+): IdleCashInsight {
+  const windowDays = opts?.windowDays ?? 60
+  const now = opts?.now ?? new Date()
+  const minFraction = opts?.minFraction ?? 0.2
+  const cutoffMs = now.getTime() - windowDays * DAY_MS
+
+  const sorted = [...txns].sort(chronological)
+  const total = sorted.reduce(
+    (sum, t) => sum + signedDeltaForAccount(t, accountId),
+    0n
+  )
+  // Back out the opening balance, then walk forward tracking the lowest balance
+  // seen from the window's start (its opening level) onward.
+  const opening = currentBalanceMinor - total
+
+  let running = opening
+  let balanceAtCutoff = opening // running balance as of the window start
+  let windowMin: bigint | null = null
+  // Honesty guard: we may only claim "idle for the last N days" if we have
+  // evidence the account existed BEFORE the window — i.e. at least one
+  // transaction dated at/before the cutoff. Account has no createdAt to lean on,
+  // so a zero-history balance (e.g. a brand-new account funded only by its
+  // opening balance) is ambiguous — new vs long-idle — and must NOT be claimed.
+  let hasPreWindowTxn = false
+  for (const t of sorted) {
+    const ms = toTime(t.date)
+    running += signedDeltaForAccount(t, accountId)
+    if (ms <= cutoffMs) {
+      balanceAtCutoff = running
+      hasPreWindowTxn = true
+    } else {
+      windowMin =
+        windowMin === null || running < windowMin ? running : windowMin
+    }
+  }
+
+  // Low-water mark across the window: its opening level and every in-window point
+  // (the current balance is the last in-window point, so it's already covered).
+  let minBalance = balanceAtCutoff
+  if (windowMin !== null && windowMin < minBalance) minBalance = windowMin
+
+  const idleSurplus =
+    minBalance - reserveMinor > 0n ? minBalance - reserveMinor : 0n
+  const fractionIdle =
+    currentBalanceMinor > 0n
+      ? Number(idleSurplus) / Number(currentBalanceMinor)
+      : 0
+  const hasSurplus =
+    hasPreWindowTxn && idleSurplus > 0n && fractionIdle >= minFraction
+
+  return {
+    hasSurplus,
+    idleSurplusMinor: idleSurplus,
+    minBalanceMinor: minBalance,
+    fractionIdle,
+    windowDays,
+  }
+}

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -1,5 +1,6 @@
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
 import {
+  PiggyBank,
   ShieldCheck,
   TrendingDown,
   TrendingUp,
@@ -25,6 +26,7 @@ import {
   reserveLockedFraction,
 } from "@/lib/account-reserve"
 import { type AccountRunway } from "@/lib/account-runway"
+import { type IdleCashInsight } from "@/lib/account-idle-cash"
 import { formatCurrency } from "@/lib/currency"
 import { cn } from "@/lib/utils"
 
@@ -283,6 +285,34 @@ export function AccountRunwayNote({
           {detail}
         </p>
       ) : null}
+    </div>
+  )
+}
+
+// PER-223 — "idle cash" opportunity: cash that has sat above the reserve,
+// untouched, all window. Opportunity tone (emerald), not an alarm. Renders
+// nothing unless there is a material surplus, so the caller can mount it freely.
+export function IdleCashNote({
+  insight,
+  currency,
+}: Readonly<{ insight: IdleCashInsight; currency: string }>) {
+  if (!insight.hasSurplus) return null
+  const pct = Math.round(insight.fractionIdle * 100)
+  return (
+    <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-4">
+      <p className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        <PiggyBank className="size-3.5" aria-hidden />
+        Idle cash
+      </p>
+      <p className="mt-1 text-lg font-semibold tabular-nums">
+        {formatCurrency(insight.idleSurplusMinor.toString(), currency)} sitting
+        idle
+      </p>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        About {pct}% of this account has stayed untouched above your reserve for
+        the last {insight.windowDays}+ days — consider moving it somewhere it
+        earns.
+      </p>
     </div>
   )
 }

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -33,11 +33,13 @@ import {
   AccountRunwayNote,
   BalanceTrendChart,
   CategoryBreakdown,
+  IdleCashNote,
   RangeSelector,
   SafeToSpendPanel,
 } from "./-account-analytics"
 import { accountSupportsReserve, hasReserve } from "@/lib/account-reserve"
 import { computeAccountRunway } from "@/lib/account-runway"
+import { computeIdleCash } from "@/lib/account-idle-cash"
 import {
   buildBalanceSeries,
   buildStatementCsv,
@@ -146,6 +148,21 @@ function AccountDetailPage() {
     () =>
       cashLike
         ? computeAccountRunway(
+            ledger,
+            currentBalance,
+            account?.reserveBalance ? BigInt(account.reserveBalance) : 0n,
+            accountId
+          )
+        : null,
+    [cashLike, ledger, currentBalance, account?.reserveBalance, accountId]
+  )
+
+  // PER-223 — idle-cash opportunity (cash-like only; a "savings" account is
+  // meant to hold idle cash, so it's excluded from the nudge at render time).
+  const idleCash = React.useMemo(
+    () =>
+      cashLike
+        ? computeIdleCash(
             ledger,
             currentBalance,
             account?.reserveBalance ? BigInt(account.reserveBalance) : 0n,
@@ -291,6 +308,9 @@ function AccountDetailPage() {
           ) : null}
           {runway ? (
             <AccountRunwayNote runway={runway} currency={currency} />
+          ) : null}
+          {idleCash && account.accountSubtype !== "savings" ? (
+            <IdleCashNote insight={idleCash} currency={currency} />
           ) : null}
           <div className="grid grid-cols-2 gap-3">
             <MiniStat


### PR DESCRIPTION
## Apa & kenapa

Slice 2 dari **account intelligence layer** — kebalikan elegan dari runway (PER-222). Runway memperingatkan saat kas menuju TURUN ke reserve; idle-cash menemukan kas yang justru DIAM di atas reserve — uang yang sebenarnya aman dibelanjakan sepanjang window tapi tak pernah dipakai, jadi bisa dipindah ke tempat yang menghasilkan.

```
idle surplus = max(0, minBalanceOverWindow − reserve)
```

Dimunculkan hanya jika material (≥ 20% dari saldo).

## Honesty guard (penting)

`Account` tidak punya `createdAt`, jadi umur akun tak bisa diketahui dari row. Agar tidak mengklaim "idle 60+ hari" pada akun baru, idle-cash **hanya** dimunculkan bila ada transaksi bertanggal **sebelum** cutoff window (bukti akun sudah ada sepanjang window). Saldo tanpa histori (akun yang hanya diisi opening balance) itu ambigu (baru vs lama-nganggur) → tidak pernah diklaim. Prinsip: **jangan pernah memalsukan data.**

## Bentuk

- `src/lib/account-idle-cash.ts` (+ 8 unit test): `computeIdleCash` murni atas ledger, bigint minor units, pakai `signedDeltaForAccount` (lens PER-202).
- `IdleCashNote` — panel peluang (nuansa emerald) di hero detail. Cash-like ASSET saja; dilewati untuk subtype `savings` (di situ idle memang tujuannya).
- Client-side, tanpa server/DB, tanpa migrasi.

`vp check` bersih (255 files); 8/8 unit test hijau.

Tracked: [PER-223](https://linear.app/permana/issue/PER-223/account-intelligence-slice-2-idle-cash-opportunity). Slice berikutnya: recurring/bill detection, account health score, server insights engine, alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)