### PR TITLE
feat(accounts): PER-224 — account intelligence slice 3: account health score

### DIFF
--- a/src/lib/account-health.test.ts
+++ b/src/lib/account-health.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vite-plus/test"
+import { computeAccountHealth } from "./account-health"
+
+describe("computeAccountHealth", () => {
+  test("excellent: healthy runway + covered reserve + clean integrity", () => {
+    const h = computeAccountHealth({
+      runwayStatus: "healthy",
+      reserveState: "healthy",
+      driftTone: "none",
+    })
+    expect(h.score).toBe(100)
+    expect(h.band).toBe("excellent")
+    expect(h.lowConfidence).toBe(false)
+    expect(h.factors.every((f) => f.tone === "good")).toBe(true)
+  })
+
+  test("attention: below reserve dominates the score", () => {
+    const h = computeAccountHealth({
+      runwayStatus: "below",
+      reserveState: "below",
+      driftTone: "none",
+    })
+    // runway 0*.5 + buffer .1*.3 + integrity 1*.2 = .23 → 23
+    expect(h.score).toBe(23)
+    expect(h.band).toBe("attention")
+    // bad factors sort first
+    expect(h.factors[0]?.tone).toBe("bad")
+  })
+
+  test("weights renormalize when no reserve is set", () => {
+    // buffer N/A → only runway(.5) + integrity(.2) apply, renormalized over .7.
+    const h = computeAccountHealth({
+      runwayStatus: "watch",
+      reserveState: "none",
+      driftTone: "none",
+    })
+    // (0.5*.5 + 1*.2) / .7 = .45/.7 = .642857 → 64
+    expect(h.score).toBe(64)
+    expect(h.band).toBe("good")
+    expect(h.factors.some((f) => f.key === "buffer")).toBe(false)
+  })
+
+  test("unknown: neither runway nor buffer applies (integrity alone is not enough)", () => {
+    const h = computeAccountHealth({
+      runwayStatus: "insufficient_data",
+      reserveState: "none",
+      driftTone: "none",
+    })
+    expect(h.score).toBeNull()
+    expect(h.band).toBe("unknown")
+    expect(h.lowConfidence).toBe(true)
+  })
+
+  test("lowConfidence when scored without runway history but a reserve exists", () => {
+    const h = computeAccountHealth({
+      runwayStatus: "insufficient_data",
+      reserveState: "healthy",
+      driftTone: "none",
+    })
+    // buffer(1*.3) + integrity(1*.2) over .5 = 100, but flagged low confidence.
+    expect(h.score).toBe(100)
+    expect(h.lowConfidence).toBe(true)
+    expect(h.band).toBe("excellent")
+  })
+
+  test("drift error pulls the score down and surfaces a bad factor", () => {
+    const clean = computeAccountHealth({
+      runwayStatus: "healthy",
+      reserveState: "healthy",
+      driftTone: "none",
+    })
+    const drifted = computeAccountHealth({
+      runwayStatus: "healthy",
+      reserveState: "healthy",
+      driftTone: "error",
+    })
+    expect(drifted.score).toBeLessThan(clean.score as number)
+    expect(
+      drifted.factors.some((f) => f.key === "integrity" && f.tone === "bad")
+    ).toBe(true)
+  })
+
+  test("informational drift (imported) is not surfaced as a factor line", () => {
+    const h = computeAccountHealth({
+      runwayStatus: "healthy",
+      reserveState: "healthy",
+      driftTone: "informational",
+    })
+    expect(h.factors.some((f) => f.key === "integrity")).toBe(false)
+  })
+
+  test("factor ordering: bad before caution before good", () => {
+    const h = computeAccountHealth({
+      runwayStatus: "watch", // caution
+      reserveState: "healthy", // good
+      driftTone: "error", // bad
+    })
+    const tones = h.factors.map((f) => f.tone)
+    expect(tones).toEqual(["bad", "caution", "good"])
+  })
+})

--- a/src/lib/account-health.ts
+++ b/src/lib/account-health.ts
@@ -1,0 +1,201 @@
+import { type RunwayStatus } from "./account-runway"
+import { type ReserveHealth } from "./account-reserve"
+
+// =============================================================================
+// PER-224 — Account health score: account intelligence layer, slice 3.
+//
+// A single 0–100 summary per cash-like account that NEVER hides its inputs — it
+// always ships the breakdown of contributing factors alongside the number. It is
+// composed only of signals we already compute reliably, and it measures SAFETY /
+// TRUST, not "efficiency":
+//
+//   - runway     (safe over time)      weight 0.5   — PER-222
+//   - buffer     (safe right now)      weight 0.3   — PER-217 reserve health
+//   - integrity  (data you can trust)  weight 0.2   — balance drift (ADR-0043)
+//
+// Weights are renormalized over the signals that actually APPLY, so an account
+// without a reserve or without enough history is never scored on a signal it
+// can't support. Idle cash (PER-223) is deliberately NOT a penalty — a large
+// buffer is healthy, it's an opportunity, handled by its own panel.
+//
+// Pure + deterministic. No money math here (inputs are already-classified
+// enums), so no bigint concerns.
+// =============================================================================
+
+export type HealthBand =
+  | "excellent" // >= 80
+  | "good" // 60–79
+  | "fair" // 40–59
+  | "attention" // < 40
+  | "unknown" // not enough applicable signal to score
+
+export type FactorTone = "good" | "caution" | "bad"
+
+export interface HealthFactor {
+  key: "runway" | "buffer" | "integrity"
+  label: string
+  tone: FactorTone
+}
+
+export interface AccountHealth {
+  /** 0–100, or null when there isn't enough applicable signal to be honest. */
+  score: number | null
+  band: HealthBand
+  /** Human-readable contributors, most-actionable first. Never empty when scored. */
+  factors: HealthFactor[]
+  /** True when the score rests only on present-state signals (no runway history). */
+  lowConfidence: boolean
+}
+
+export type DriftTone = "none" | "informational" | "warning" | "error"
+
+const WEIGHTS = { runway: 0.5, buffer: 0.3, integrity: 0.2 } as const
+
+// Each sub-score is 0..1, or null when the signal does not apply to this account.
+function runwaySubScore(status: RunwayStatus | null): number | null {
+  switch (status) {
+    case "growing":
+    case "healthy":
+      return 1
+    case "watch":
+      return 0.5
+    case "critical":
+      return 0.15
+    case "below":
+      return 0
+    default: // insufficient_data | null → no time-based signal yet
+      return null
+  }
+}
+
+function bufferSubScore(state: ReserveHealth): number | null {
+  switch (state) {
+    case "healthy":
+      return 1
+    case "near":
+      return 0.55
+    case "below":
+      return 0.1
+    default: // "none" → no reserve set, not scored
+      return null
+  }
+}
+
+function integritySubScore(tone: DriftTone): number {
+  switch (tone) {
+    case "none":
+      return 1
+    case "informational":
+      return 0.9
+    case "warning":
+      return 0.5
+    case "error":
+      return 0.15
+  }
+}
+
+function bandFor(score: number): HealthBand {
+  if (score >= 80) return "excellent"
+  if (score >= 60) return "good"
+  if (score >= 40) return "fair"
+  return "attention"
+}
+
+function runwayFactor(status: RunwayStatus): HealthFactor {
+  if (status === "below") {
+    return { key: "runway", label: "Below your reserve", tone: "bad" }
+  }
+  if (status === "critical") {
+    return { key: "runway", label: "Very low runway", tone: "bad" }
+  }
+  if (status === "watch") {
+    return { key: "runway", label: "Approaching your reserve", tone: "caution" }
+  }
+  return { key: "runway", label: "Comfortable runway", tone: "good" }
+}
+
+function bufferFactor(state: ReserveHealth): HealthFactor {
+  if (state === "below") {
+    return { key: "buffer", label: "Below your reserve", tone: "bad" }
+  }
+  if (state === "near") {
+    return { key: "buffer", label: "Close to your reserve", tone: "caution" }
+  }
+  return { key: "buffer", label: "Reserve comfortably covered", tone: "good" }
+}
+
+function integrityFactor(tone: DriftTone): HealthFactor | null {
+  if (tone === "error") {
+    return { key: "integrity", label: "Balance drift detected", tone: "bad" }
+  }
+  if (tone === "warning") {
+    return {
+      key: "integrity",
+      label: "Balance needs reconcile",
+      tone: "caution",
+    }
+  }
+  // "none" / "informational" are not worth surfacing as their own line.
+  return null
+}
+
+/**
+ * Compose an account's health from its already-classified signals. Returns a
+ * null score (band "unknown") when neither runway nor buffer applies — i.e. we
+ * have nothing but data-integrity to go on, which alone would be a misleading
+ * "perfect" score for a brand-new/empty account.
+ */
+export function computeAccountHealth(input: {
+  runwayStatus: RunwayStatus | null
+  reserveState: ReserveHealth
+  driftTone: DriftTone
+}): AccountHealth {
+  const runway = runwaySubScore(input.runwayStatus)
+  const buffer = bufferSubScore(input.reserveState)
+  const integrity = integritySubScore(input.driftTone)
+
+  // Need at least one forward/at-rest safety signal; integrity alone isn't enough.
+  if (runway === null && buffer === null) {
+    return {
+      score: null,
+      band: "unknown",
+      factors: integrityFactor(input.driftTone)
+        ? [integrityFactor(input.driftTone) as HealthFactor]
+        : [],
+      lowConfidence: true,
+    }
+  }
+
+  let weighted = 0
+  let totalWeight = 0
+  if (runway !== null) {
+    weighted += runway * WEIGHTS.runway
+    totalWeight += WEIGHTS.runway
+  }
+  if (buffer !== null) {
+    weighted += buffer * WEIGHTS.buffer
+    totalWeight += WEIGHTS.buffer
+  }
+  weighted += integrity * WEIGHTS.integrity
+  totalWeight += WEIGHTS.integrity
+
+  const score = Math.round((weighted / totalWeight) * 100)
+
+  // Factors, most-actionable first (bad → caution → good).
+  const factors: HealthFactor[] = []
+  if (input.runwayStatus !== null && runway !== null) {
+    factors.push(runwayFactor(input.runwayStatus))
+  }
+  if (buffer !== null) factors.push(bufferFactor(input.reserveState))
+  const integ = integrityFactor(input.driftTone)
+  if (integ) factors.push(integ)
+  const order: Record<FactorTone, number> = { bad: 0, caution: 1, good: 2 }
+  factors.sort((a, b) => order[a.tone] - order[b.tone])
+
+  return {
+    score,
+    band: bandFor(score),
+    factors,
+    lowConfidence: runway === null, // scored without any runway history
+  }
+}

--- a/src/lib/account-health.ts
+++ b/src/lib/account-health.ts
@@ -156,12 +156,11 @@ export function computeAccountHealth(input: {
 
   // Need at least one forward/at-rest safety signal; integrity alone isn't enough.
   if (runway === null && buffer === null) {
+    const integ = integrityFactor(input.driftTone)
     return {
       score: null,
       band: "unknown",
-      factors: integrityFactor(input.driftTone)
-        ? [integrityFactor(input.driftTone) as HealthFactor]
-        : [],
+      factors: integ ? [integ] : [],
       lowConfidence: true,
     }
   }

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -1,5 +1,7 @@
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
 import {
+  Activity,
+  Check,
   PiggyBank,
   ShieldCheck,
   TrendingDown,
@@ -27,6 +29,11 @@ import {
 } from "@/lib/account-reserve"
 import { type AccountRunway } from "@/lib/account-runway"
 import { type IdleCashInsight } from "@/lib/account-idle-cash"
+import {
+  type AccountHealth,
+  type FactorTone,
+  type HealthBand,
+} from "@/lib/account-health"
 import { formatCurrency } from "@/lib/currency"
 import { cn } from "@/lib/utils"
 
@@ -138,6 +145,114 @@ export function BalanceTrendChart({
         />
       </AreaChart>
     </ChartContainer>
+  )
+}
+
+// PER-224 — account health: one 0–100 score that ALWAYS shows its breakdown.
+// Summary of the safety signals (runway + buffer + integrity); never a black box.
+const HEALTH_BAND_LABEL: Record<HealthBand, string> = {
+  excellent: "Excellent",
+  good: "Good",
+  fair: "Fair",
+  attention: "Needs attention",
+  unknown: "Not enough data",
+}
+
+const HEALTH_BAND_TEXT: Record<HealthBand, string> = {
+  excellent: "text-emerald-600 dark:text-emerald-400",
+  good: "text-emerald-600 dark:text-emerald-400",
+  fair: "text-amber-600 dark:text-amber-400",
+  attention: "text-destructive",
+  unknown: "text-muted-foreground",
+}
+
+const HEALTH_BAND_METER: Record<HealthBand, string> = {
+  excellent: "bg-emerald-500",
+  good: "bg-emerald-500/80",
+  fair: "bg-amber-500",
+  attention: "bg-destructive",
+  unknown: "bg-muted-foreground/40",
+}
+
+const FACTOR_TEXT: Record<FactorTone, string> = {
+  good: "text-emerald-600 dark:text-emerald-400",
+  caution: "text-amber-600 dark:text-amber-400",
+  bad: "text-destructive",
+}
+
+export function AccountHealthPanel({
+  health,
+}: Readonly<{ health: AccountHealth }>) {
+  return (
+    <div className="rounded-2xl border p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          <Activity className="size-3.5" aria-hidden />
+          Account health
+        </p>
+        {health.lowConfidence && health.score !== null ? (
+          <span className="text-[10px] font-medium text-muted-foreground">
+            Limited history
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-1 flex items-baseline gap-2">
+        <span
+          className={cn(
+            "text-2xl font-semibold tabular-nums",
+            HEALTH_BAND_TEXT[health.band]
+          )}
+        >
+          {health.score === null ? "—" : health.score}
+        </span>
+        <span
+          className={cn("text-sm font-medium", HEALTH_BAND_TEXT[health.band])}
+        >
+          {HEALTH_BAND_LABEL[health.band]}
+        </span>
+      </div>
+
+      {health.score !== null ? (
+        <div
+          className="mt-2 h-2 overflow-hidden rounded-full bg-muted"
+          role="presentation"
+        >
+          <div
+            className={cn(
+              "h-full rounded-full",
+              HEALTH_BAND_METER[health.band]
+            )}
+            style={{ width: `${Math.max(health.score, 3)}%` }}
+          />
+        </div>
+      ) : (
+        <p className="mt-1 text-xs text-muted-foreground">
+          Add a reserve or a little transaction history to score this account.
+        </p>
+      )}
+
+      {health.factors.length > 0 ? (
+        <ul className="mt-3 flex flex-col gap-1.5">
+          {health.factors.map((f) => (
+            <li key={f.key} className="flex items-center gap-2 text-xs">
+              {f.tone === "good" ? (
+                <Check
+                  className={cn("size-3.5 shrink-0", FACTOR_TEXT.good)}
+                  aria-hidden
+                />
+              ) : (
+                <TriangleAlert
+                  className={cn("size-3.5 shrink-0", FACTOR_TEXT[f.tone])}
+                  aria-hidden
+                />
+              )}
+              <span className="text-foreground">{f.label}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
   )
 }
 

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -25,11 +25,13 @@ import { ValuationActionDialog } from "@/components/blocks/valuation-action-dial
 import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
+  balanceDriftCollection,
   type AccountRecord,
 } from "@/lib/account-collections"
 import { transactionCollection } from "@/lib/collections"
 import { applyFilters } from "@/lib/transaction-filters"
 import {
+  AccountHealthPanel,
   AccountRunwayNote,
   BalanceTrendChart,
   CategoryBreakdown,
@@ -37,9 +39,15 @@ import {
   RangeSelector,
   SafeToSpendPanel,
 } from "./-account-analytics"
-import { accountSupportsReserve, hasReserve } from "@/lib/account-reserve"
+import {
+  accountSupportsReserve,
+  hasReserve,
+  reserveHealth,
+} from "@/lib/account-reserve"
 import { computeAccountRunway } from "@/lib/account-runway"
 import { computeIdleCash } from "@/lib/account-idle-cash"
+import { computeAccountHealth } from "@/lib/account-health"
+import { selectDriftBadge } from "@/lib/account-drift-presentation"
 import {
   buildBalanceSeries,
   buildStatementCsv,
@@ -63,6 +71,8 @@ export const Route = createFileRoute("/_protected/accounts/$accountId")({
     await Promise.all([
       accountCollection.preload(),
       transactionCollection.preload(),
+      // PER-224 — health score folds in balance-drift (data integrity).
+      balanceDriftCollection.preload(),
     ])
     return null
   },
@@ -96,6 +106,9 @@ function AccountDetailPage() {
   )
   const { data: allTransactions } = useLiveQuery((q) =>
     q.from({ t: transactionCollection })
+  )
+  const { data: driftRows } = useLiveQuery((q) =>
+    q.from({ d: balanceDriftCollection })
   )
 
   const account = React.useMemo<AccountRecord | undefined>(
@@ -192,6 +205,32 @@ function AccountDetailPage() {
       ),
     [rangedLedger, query, types]
   )
+
+  // PER-224 — account health: fold runway + reserve buffer + balance-drift into
+  // one transparent score. Cash-like only (the signals don't apply to tracked
+  // assets / term liabilities).
+  const health = React.useMemo(() => {
+    if (!cashLike) return null
+    const accountDrift = (driftRows ?? []).filter(
+      (d) => d.accountId === accountId
+    )
+    const driftTone = selectDriftBadge(accountDrift)?.tone ?? "none"
+    const reserveMinor = account?.reserveBalance
+      ? BigInt(account.reserveBalance)
+      : 0n
+    return computeAccountHealth({
+      runwayStatus: runway?.status ?? null,
+      reserveState: reserveHealth(currentBalance, reserveMinor),
+      driftTone,
+    })
+  }, [
+    cashLike,
+    driftRows,
+    accountId,
+    account?.reserveBalance,
+    currentBalance,
+    runway,
+  ])
 
   if (accounts && !account) {
     return (
@@ -296,6 +335,7 @@ function AccountDetailPage() {
               <Badge variant="outline">Archived</Badge>
             ) : null}
           </div>
+          {health ? <AccountHealthPanel health={health} /> : null}
           {accountSupportsReserve(account) &&
           hasReserve(
             account.reserveBalance ? BigInt(account.reserveBalance) : null

--- a/tests/e2e/account-detail.e2e.ts
+++ b/tests/e2e/account-detail.e2e.ts
@@ -41,6 +41,11 @@ test.describe("account detail (PER-216)", () => {
     await expect(page.getByText(accountName).first()).toBeVisible()
     await expect(page.getByText("Rp 2,000,000.00").first()).toBeVisible()
 
+    // PER-224 — the account-health panel summarizes the safety signals with a
+    // transparent breakdown (here: a comfortably-covered reserve).
+    await expect(page.getByText("Account health")).toBeVisible()
+    await expect(page.getByText(/Reserve comfortably covered/i)).toBeVisible()
+
     // PER-217 — the safe-to-spend panel shows available = balance − reserve, and
     // names the reserved portion. (Balance is unchanged — reserve is ledger-neutral.)
     await expect(page.getByText(/safe to spend/i).first()).toBeVisible()


### PR DESCRIPTION
## Apa & kenapa

Slice 3 dari **account intelligence layer**. Satu skor **0–100** per akun cash-like yang **selalu menampilkan rinciannya** (bukan angka ajaib). Mengukur **keamanan/kepercayaan** dari sinyal yang sudah kita hitung andal:

- **Runway** (aman lintas waktu) — bobot 0.5 (PER-222)
- **Buffer/reserve** (aman sekarang) — bobot 0.3 (PER-217)
- **Integritas/drift saldo** (data terpercaya) — bobot 0.2 (ADR-0043)

Bobot dinormalisasi hanya atas sinyal yang **berlaku**, jadi akun tanpa reserve atau tanpa histori runway tidak dinilai dari sinyal yang tak didukungnya. Kalau runway & buffer sama-sama belum berlaku (akun baru/kosong) → tampil **"Not enough data"** (bukan skor sempurna yang menyesatkan); kalau hanya bertumpu sinyal saat ini → ditandai **"Limited history"**. Idle-cash (PER-223) sengaja **bukan** penalti — buffer besar itu sehat.

## Bentuk
- `src/lib/account-health.ts` (+ 8 unit test): `computeAccountHealth({runwayStatus, reserveState, driftTone})` → `{ score|null, band, factors[], lowConfidence }`. Band: excellent ≥80 / good ≥60 / fair ≥40 / attention <40 / unknown.
- `AccountHealthPanel` di puncak hero detail — skor + band + meter + daftar faktor "yang membantu / perlu perhatian" (bad → caution → good).
- Route detail kini preload `balanceDriftCollection` untuk melipat integritas.
- Client-side, tanpa server/DB, tanpa migrasi.

`vp check` bersih (257 files); 8/8 unit test hijau; e2e detail hijau (panel + faktor terlihat).

Tracked: [PER-224](https://linear.app/permana/issue/PER-224/account-intelligence-slice-3-account-health-score).

🤖 Generated with [Claude Code](https://claude.com/claude-code)