### PR TITLE
feat(accounts): PER-229 — investment & gold performance (cost basis, gain/loss, return %)

### DIFF
--- a/src/components/blocks/account-form-dialog.tsx
+++ b/src/components/blocks/account-form-dialog.tsx
@@ -221,7 +221,7 @@ export function AccountFormDialog({
                     setAccountType(value as AccountType)
                   }
                 >
-                  <SelectTrigger>
+                  <SelectTrigger aria-label="Account type">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -236,7 +236,7 @@ export function AccountFormDialog({
               <div className="flex flex-col gap-2">
                 <Label>Currency</Label>
                 <Select value={currency} onValueChange={setCurrency}>
-                  <SelectTrigger>
+                  <SelectTrigger aria-label="Currency">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>

--- a/src/lib/account-performance.test.ts
+++ b/src/lib/account-performance.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vite-plus/test"
+import { computeAccountPerformance } from "./account-performance"
+import { type AnalyticsTxn } from "./account-analytics"
+
+const ACC = "inv-1"
+
+/** A transfer INTO the account (a buy / contribution). */
+function buy(amount: bigint): AnalyticsTxn {
+  return {
+    date: "2026-01-01",
+    amount,
+    type: "transfer",
+    accountId: "bank",
+    toAccountId: ACC,
+  }
+}
+/** A transfer OUT of the account (a sell / withdrawal). */
+function sell(amount: bigint): AnalyticsTxn {
+  return {
+    date: "2026-02-01",
+    amount,
+    type: "transfer",
+    accountId: ACC,
+    toAccountId: "bank",
+  }
+}
+
+describe("computeAccountPerformance", () => {
+  test("opening-only account that gained: cost = opening, gain = value − opening", () => {
+    // Gold bought at 20,000,000 (opening), now worth 25,000,000, no transfers.
+    const p = computeAccountPerformance([], 20_000_000n, 25_000_000n, ACC)
+    expect(p.costBasisMinor).toBe(20_000_000n)
+    expect(p.marketValueMinor).toBe(25_000_000n)
+    expect(p.gainMinor).toBe(5_000_000n)
+    expect(p.returnPct).toBeCloseTo(0.25, 5)
+    expect(p.isGain).toBe(true)
+    expect(p.hasBasis).toBe(true)
+  })
+
+  test("opening + later contributions add to the cost basis", () => {
+    // opening 10,000,000 + buy 5,000,000 = 15,000,000 invested; now worth 18,000,000.
+    const p = computeAccountPerformance(
+      [buy(5_000_000n)],
+      10_000_000n,
+      18_000_000n,
+      ACC
+    )
+    expect(p.contributionsMinor).toBe(5_000_000n)
+    expect(p.costBasisMinor).toBe(15_000_000n)
+    expect(p.gainMinor).toBe(3_000_000n)
+    expect(p.isGain).toBe(true)
+  })
+
+  test("contribution-only account (opening 0)", () => {
+    const p = computeAccountPerformance([buy(8_000_000n)], 0n, 9_000_000n, ACC)
+    expect(p.costBasisMinor).toBe(8_000_000n)
+    expect(p.gainMinor).toBe(1_000_000n)
+    expect(p.hasBasis).toBe(true)
+  })
+
+  test("a loss shows negative gain", () => {
+    const p = computeAccountPerformance([], 20_000_000n, 17_000_000n, ACC)
+    expect(p.gainMinor).toBe(-3_000_000n)
+    expect(p.isGain).toBe(false)
+    expect(p.returnPct).toBeCloseTo(-0.15, 5)
+  })
+
+  test("flat: value equals cost basis", () => {
+    const p = computeAccountPerformance([], 5_000_000n, 5_000_000n, ACC)
+    expect(p.gainMinor).toBe(0n)
+    expect(p.isFlat).toBe(true)
+    expect(p.isGain).toBe(false)
+    expect(p.returnPct).toBe(0)
+  })
+
+  test("withdrawal reduces cost basis dollar-for-dollar", () => {
+    // opening 10,000,000, then sell 4,000,000 out → basis 6,000,000; now worth 9,000,000.
+    const p = computeAccountPerformance(
+      [sell(4_000_000n)],
+      10_000_000n,
+      9_000_000n,
+      ACC
+    )
+    expect(p.contributionsMinor).toBe(-4_000_000n)
+    expect(p.costBasisMinor).toBe(6_000_000n)
+    expect(p.gainMinor).toBe(3_000_000n)
+  })
+
+  test("no positive basis → hasBasis false, no fabricated return", () => {
+    // Withdrew more than invested (after gains): basis goes non-positive.
+    const p = computeAccountPerformance(
+      [sell(12_000_000n)],
+      10_000_000n,
+      2_000_000n,
+      ACC
+    )
+    expect(p.costBasisMinor).toBe(-2_000_000n)
+    expect(p.hasBasis).toBe(false)
+    expect(p.returnPct).toBeNull()
+  })
+})

--- a/src/lib/account-performance.ts
+++ b/src/lib/account-performance.ts
@@ -1,0 +1,66 @@
+import { signedDeltaForAccount, type AnalyticsTxn } from "./account-analytics"
+
+// =============================================================================
+// PER-229 — Investment & Gold performance (Slice 1), ledger-derived.
+//
+// For a valuation-tracked account (INVESTMENT / TRACKED_ASSET), performance is:
+//
+//   cost basis   = opening valuation value + Σ(net cash contributions)
+//   market value = current value (the account's latest valuation = its balance)
+//   gain/loss    = market value − cost basis          (unrealized)
+//   return %     = gain / cost basis                  (only when basis > 0)
+//
+// Net contributions come from the ledger with the SAME proven lens the rest of
+// the app uses (`signedDeltaForAccount`, PER-202/222/223): money transferred IN
+// is +, OUT is −. The opening valuation (the initial cost recorded at creation)
+// is the one piece the client can't derive, so it's fetched as a scalar
+// (`getAccountOpeningValueFn`) and passed in here.
+//
+// v1 is UNREALIZED only. A withdrawal reduces cost basis dollar-for-dollar (an
+// honest approximation, documented); precise lot accounting (FIFO/average) and
+// realized gains are PER-232. If cost basis isn't positive (no opening + no net
+// contributions, or more withdrawn than invested after gains), `hasBasis` is
+// false and callers show the market value WITHOUT a fabricated return.
+//
+// Pure; all money stays in bigint minor units, Number only for the display ratio.
+// =============================================================================
+
+export interface AccountPerformance {
+  costBasisMinor: bigint
+  marketValueMinor: bigint
+  gainMinor: bigint
+  /** Net cash moved in/out via the ledger (excludes the opening). Informational. */
+  contributionsMinor: bigint
+  /** gain / cost basis, or null when there is no positive basis to measure against. */
+  returnPct: number | null
+  isGain: boolean
+  isFlat: boolean
+  hasBasis: boolean
+}
+
+export function computeAccountPerformance(
+  txns: ReadonlyArray<AnalyticsTxn>,
+  openingValueMinor: bigint,
+  currentValueMinor: bigint,
+  accountId: string
+): AccountPerformance {
+  const contributions = txns.reduce(
+    (sum, t) => sum + signedDeltaForAccount(t, accountId),
+    0n
+  )
+  const costBasis = openingValueMinor + contributions
+  const gain = currentValueMinor - costBasis
+  const hasBasis = costBasis > 0n
+  const returnPct = hasBasis ? Number(gain) / Number(costBasis) : null
+
+  return {
+    costBasisMinor: costBasis,
+    marketValueMinor: currentValueMinor,
+    gainMinor: gain,
+    contributionsMinor: contributions,
+    returnPct,
+    isGain: gain > 0n,
+    isFlat: gain === 0n,
+    hasBasis,
+  }
+}

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/account-reserve"
 import { type AccountRunway } from "@/lib/account-runway"
 import { type IdleCashInsight } from "@/lib/account-idle-cash"
+import { type AccountPerformance } from "@/lib/account-performance"
 import {
   type AccountHealth,
   type FactorTone,
@@ -145,6 +146,70 @@ export function BalanceTrendChart({
         />
       </AreaChart>
     </ChartContainer>
+  )
+}
+
+// PER-229 — investment/gold performance: market value vs cost basis → unrealized
+// gain/loss + return %. Shown for valuation-tracked accounts. Green up / red down.
+export function PerformancePanel({
+  performance,
+  currency,
+}: Readonly<{ performance: AccountPerformance; currency: string }>) {
+  const {
+    marketValueMinor,
+    costBasisMinor,
+    gainMinor,
+    isGain,
+    isFlat,
+    hasBasis,
+  } = performance
+  const toneText = isFlat
+    ? "text-muted-foreground"
+    : isGain
+      ? "text-emerald-600 dark:text-emerald-400"
+      : "text-destructive"
+  const pctStr =
+    performance.returnPct === null
+      ? null
+      : `${performance.returnPct >= 0 ? "+" : ""}${(performance.returnPct * 100).toFixed(2)}%`
+  const gainStr = `${isGain && !isFlat ? "+" : ""}${formatCurrency(gainMinor.toString(), currency)}`
+
+  return (
+    <div className="rounded-2xl border p-4">
+      <p className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        <TrendingUp className="size-3.5" aria-hidden />
+        Performance
+      </p>
+      <p className="mt-1 text-2xl font-semibold tabular-nums">
+        {formatCurrency(marketValueMinor.toString(), currency)}
+      </p>
+      <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
+        Cost {formatCurrency(costBasisMinor.toString(), currency)}
+      </p>
+      {hasBasis ? (
+        <p
+          className={cn(
+            "mt-2 flex items-center gap-1 text-sm font-medium tabular-nums",
+            toneText
+          )}
+        >
+          {isFlat ? null : isGain ? (
+            <TrendingUp className="size-4 shrink-0" aria-hidden />
+          ) : (
+            <TrendingDown className="size-4 shrink-0" aria-hidden />
+          )}
+          <span>
+            {gainStr}
+            {pctStr ? ` (${pctStr})` : ""}
+          </span>
+        </p>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Record your cost — set the opening value at creation, or transfer
+          money in as you buy — to see gain/loss and return.
+        </p>
+      )}
+    </div>
   )
 }
 

--- a/src/routes/_protected/-account-analytics.tsx
+++ b/src/routes/_protected/-account-analytics.tsx
@@ -183,9 +183,11 @@ export function PerformancePanel({
       <p className="mt-1 text-2xl font-semibold tabular-nums">
         {formatCurrency(marketValueMinor.toString(), currency)}
       </p>
-      <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
-        Cost {formatCurrency(costBasisMinor.toString(), currency)}
-      </p>
+      {hasBasis ? (
+        <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
+          Cost {formatCurrency(costBasisMinor.toString(), currency)}
+        </p>
+      ) : null}
       {hasBasis ? (
         <p
           className={cn(

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -143,6 +143,9 @@ function AccountDetailPage() {
     queryFn: async () =>
       await getAccountOpeningValueFn({ data: { accountId } }),
     enabled: tracked,
+    // The opening valuation is written once at account creation and never
+    // edited, so it never needs refetching within a session.
+    staleTime: Infinity,
   })
 
   // PER-229 — performance: cost basis (opening + net contributions) vs market

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useLiveQuery } from "@tanstack/react-db"
+import { useQuery } from "@tanstack/react-query"
 import {
   ArrowLeft,
   Download,
@@ -36,6 +37,7 @@ import {
   BalanceTrendChart,
   CategoryBreakdown,
   IdleCashNote,
+  PerformancePanel,
   RangeSelector,
   SafeToSpendPanel,
 } from "./-account-analytics"
@@ -46,6 +48,8 @@ import {
 } from "@/lib/account-reserve"
 import { computeAccountRunway } from "@/lib/account-runway"
 import { computeIdleCash } from "@/lib/account-idle-cash"
+import { computeAccountPerformance } from "@/lib/account-performance"
+import { getAccountOpeningValueFn } from "@/server/valuations"
 import { computeAccountHealth } from "@/lib/account-health"
 import { selectDriftBadge } from "@/lib/account-drift-presentation"
 import {
@@ -128,7 +132,30 @@ function AccountDetailPage() {
 
   const currency = account?.currency ?? "IDR"
   const cashLike = account?.balanceSource === "transaction_flow"
+  const tracked = account?.balanceSource === "valuation"
   const currentBalance = account ? BigInt(account.balance) : 0n
+
+  // PER-229 — the opening valuation scalar (the one piece the client can't
+  // derive) for investment/gold cost basis. Fetched declaratively; only for
+  // valuation-tracked accounts. No useEffect (no-use-effect rule).
+  const { data: openingData } = useQuery({
+    queryKey: ["account_opening_value", accountId],
+    queryFn: async () =>
+      await getAccountOpeningValueFn({ data: { accountId } }),
+    enabled: tracked,
+  })
+
+  // PER-229 — performance: cost basis (opening + net contributions) vs market
+  // value → unrealized gain/loss + return %. Reuses the proven ledger lens.
+  const performance = React.useMemo(() => {
+    if (!tracked || !openingData) return null
+    return computeAccountPerformance(
+      ledger,
+      openingData.openingValue ? BigInt(openingData.openingValue) : 0n,
+      currentBalance,
+      accountId
+    )
+  }, [tracked, openingData, ledger, currentBalance, accountId])
 
   // Time-scoped subset (range drives KPI + breakdown + statement).
   const rangedLedger = React.useMemo(() => {
@@ -335,6 +362,9 @@ function AccountDetailPage() {
               <Badge variant="outline">Archived</Badge>
             ) : null}
           </div>
+          {performance ? (
+            <PerformancePanel performance={performance} currency={currency} />
+          ) : null}
           {health ? <AccountHealthPanel health={health} /> : null}
           {accountSupportsReserve(account) &&
           hasReserve(

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -1026,3 +1026,64 @@ export const getAccountBalanceFn = createServerFn({ method: "GET" })
       userId: context.user.id,
     })
   })
+
+// =============================================================================
+// PER-229 — Investment/Gold performance: the OPENING valuation scalar.
+//
+// Cost basis = opening value + Σ(net cash contributions). The client already
+// derives the net contributions from its loaded ledger with the proven
+// `signedDeltaForAccount` lens (PER-202/222/223) — the ONE thing it cannot see
+// is the account's opening valuation (valuations are not a client collection).
+// This fn returns exactly that scalar, tenant-scoped; all the money math stays
+// in the pure, unit-tested `computeAccountPerformance` on the client.
+// =============================================================================
+
+export interface AccountOpeningValueView {
+  accountId: string
+  currency: string
+  /** Signed opening valuation in minor units (positive for an ASSET), or null
+   * when the account has no opening valuation on record. */
+  openingValue: string | null
+}
+
+export async function getAccountOpeningValueForFamily({
+  accountId,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  accountId: string
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<AccountOpeningValueView> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const account = await fetchAccountFacts(tx, familyId, accountId)
+    if (!account) {
+      throw new ValuationError(`Account ${accountId} not found`)
+    }
+    const opening = await tx.valuation.findFirst({
+      where: { accountId, familyId, type: "opening" },
+      orderBy: { valuationDate: "asc" },
+      select: { value: true },
+    })
+    return {
+      accountId,
+      currency: account.currency,
+      openingValue: opening ? opening.value.toString() : null,
+    }
+  })
+}
+
+export const getAccountOpeningValueFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: z.infer<typeof accountBalanceQuerySchema>) =>
+    accountBalanceQuerySchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await getAccountOpeningValueForFamily({
+      accountId: data.accountId,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })

--- a/tests/e2e/investment-performance.e2e.ts
+++ b/tests/e2e/investment-performance.e2e.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-229 — Investment & Gold performance (Slice 1).
+// Create a TRACKED_ASSET (gold) account with an opening cost, open its detail,
+// and prove the Performance panel shows cost basis; then "Update value" to a
+// higher market value and prove the unrealized gain + return % appear.
+
+test.describe("investment performance (PER-229)", () => {
+  test("tracked-asset account shows cost basis, then gain after an update", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const name = `Gold ${suffix}`
+
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(name)
+    // Pick the Tracked Asset type (valuation-tracked) via the labeled select.
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByLabel("Opening balance").fill("20000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${name}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // Performance panel renders; a fresh account's cost == its opening value.
+    await expect(page.getByText("Performance")).toBeVisible()
+    // \s (not a literal space) so it matches formatCurrency's non-breaking space.
+    await expect(page.getByText(/Cost\s+Rp\s+20,000,000\.00/)).toBeVisible()
+
+    // Record a higher market value → unrealized gain of 5,000,000 (+25%).
+    await page
+      .getByRole("button", { name: "Update value", exact: true })
+      .click()
+    const dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByRole("heading", { name: "Update value" })
+    ).toBeVisible()
+    await dialog.getByLabel(/New value/i).fill("25000000")
+    await dialog.getByRole("button", { name: "Update value" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await expect(page.getByText(/\+Rp\s+5,000,000\.00/).first()).toBeVisible()
+    await expect(page.getByText(/\+25\.00%/).first()).toBeVisible()
+  })
+})

--- a/tests/integration/accounts-manual-ux.integration.ts
+++ b/tests/integration/accounts-manual-ux.integration.ts
@@ -15,7 +15,10 @@ import {
   reactivateAccountForFamily,
   updateAccountForFamily,
 } from "@/server/accounts"
-import { getAccountBalanceForFamily } from "@/server/valuations"
+import {
+  getAccountBalanceForFamily,
+  getAccountOpeningValueForFamily,
+} from "@/server/valuations"
 import {
   createIntegrationHarness,
   type IntegrationHarness,
@@ -427,6 +430,52 @@ describe("accounts manual UX vertical slice (PER-143)", () => {
           })
         )
         expect.fail("Expected the DB CHECK to reject the reserve")
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeTruthy()
+    })
+  })
+
+  describe("account opening value (PER-229 performance)", () => {
+    test("returns the signed opening valuation for a tracked asset", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const gold = await createAccountForFamily({
+        data: {
+          name: "Gold ANTAM",
+          accountType: "TRACKED_ASSET",
+          accountSubtype: "gold",
+          openingBalance: "20000000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const view = await getAccountOpeningValueForFamily({
+        accountId: gold.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      expect(view.openingValue).toBe("20000000")
+      expect(view.currency).toBe("IDR")
+    })
+
+    test("cannot read the opening value of another family's account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await factories.createAccount({
+        familyId: owner.family.id,
+      })
+
+      let captured: unknown
+      try {
+        await getAccountOpeningValueForFamily({
+          accountId: account.id,
+          familyId: intruder.family.id,
+          userId: intruder.user.id,
+        })
+        expect.fail("Expected a not-found error for a cross-tenant read")
       } catch (error) {
         captured = error
       }


### PR DESCRIPTION
## Apa & kenapa

Akun **INVESTMENT + TRACKED_ASSET** (emas/perak/…) kini menampilkan **performa** di halaman detail: nilai pasar vs modal → **untung/rugi belum-terealisasi + return %**. Ini yang selama ini kurang — dulu cuma bisa set "nilai sekarang" tanpa tahu modal & untungnya.

## Model (jujur, sesuai keputusan Anda)
- **cost basis** = nilai pembukaan + Σ(kontribusi kas bersih). Client sudah menurunkan kontribusi dari ledger dengan lens `signedDeltaForAccount` yang terbukti (PER-202/222/223); satu-satunya yang tak bisa dilihat client = **nilai pembukaan**, jadi ada server fn kecil (tenant-scoped) yang mengembalikan skalar itu saja. Semua matematika uang tetap di helper murni yang teruji.
- **untung/rugi** = nilai pasar − cost basis (unrealized); **return %** = untung / cost basis.
- v1 = unrealized saja; penarikan mengurangi modal dolar-per-dolar (aproksimasi terdokumentasi; lot presisi/realized = PER-232). Tanpa modal → tampil nilai saja, tanpa return palsu (`hasBasis=false`).

## Bentuk
- `getAccountOpeningValueFn` (family-scoped) + integration test real-Postgres (opening tracked-asset + baca lintas-tenant ditolak).
- `src/lib/account-performance.ts` (+ 7 unit test): `computeAccountPerformance`.
- `PerformancePanel` di hero detail untuk akun valuation-tracked (nilai, modal, ▲/▼ untung, return %, hijau/merah), di-fetch via `useQuery` (tanpa useEffect).
- `account-form-dialog`: `aria-label` pada select type/currency (a11y + testable).
- e2e: buat akun emas → cost basis; Update value → untung +25%.

`vp check` bersih (260 files); 7 unit + 18 integration + e2e hijau; 7 spec pemakai dialog-create lokal juga hijau (tak ada regresi aria-label).

Tracked: [PER-229](https://linear.app/permana/issue/PER-229/investment-and-gold-slice-1-ledger-derived-performance-cost-basis). Berikutnya: portfolio (230) → dashboard (231). Nilai pasar otomatis dari ADR-0050 (market data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)