### PR TITLE
feat(investments): PER-232 — holdings core (Instrument + Holding + value=Σ holdings)

### DIFF
--- a/prisma/migrations/20260804120000_holdings_core/migration.sql
+++ b/prisma/migrations/20260804120000_holdings_core/migration.sql
@@ -1,0 +1,131 @@
+-- PER-232 / ADR-0051 — Investments & Holdings domain (Slice 1: market-priced).
+--
+-- Adds two tenant-scoped tables:
+--   * Instrument — the tradeable thing (fund / metal / stock / crypto / bond /
+--     deposit product), v1 manual, tenant-scoped, quoted in a currency.
+--   * Holding    — a position of an Instrument inside a valuation-tracked
+--     investment Account. Account value = Σ its holdings' current value, written
+--     back as a valuation ANCHOR (see src/server/holdings.ts) so the account
+--     balance materializes from holdings and every net-worth / balance / audit /
+--     RLS invariant holds unchanged (ADR-0008 asset-tracking contract).
+--
+-- Both carry TENANT-SAFE composite FKs (Pattern A, ADR-0010 / migration
+-- 20260527160000_harden_tenant_composite_fk): the (id, familyId) target pair,
+-- not the bare id, is what enforces tenant isolation. Account already has
+-- UNIQUE (id, familyId); this migration adds the matching key on Instrument so
+-- Holding(instrumentId, familyId) can reference it. "Database Is the Law"
+-- (CLAUDE.md §5A): domain values and non-negativity are DB CHECK constraints,
+-- not app conventions.
+--
+-- ADDITIVE ONLY — creates new tables + RLS; touches no existing row.
+
+-- ============================================================================
+-- 1. Instrument
+-- ============================================================================
+
+CREATE TABLE "Instrument" (
+    "id" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "symbol" TEXT,
+    "quoteCurrency" TEXT NOT NULL DEFAULT 'IDR',
+    "priceModel" TEXT NOT NULL DEFAULT 'market',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "familyId" TEXT NOT NULL,
+
+    CONSTRAINT "Instrument_pkey" PRIMARY KEY ("id")
+);
+
+-- Composite-FK target (tenant-safe reference from Holding).
+CREATE UNIQUE INDEX "Instrument_id_familyId_key" ON "Instrument"("id", "familyId");
+
+CREATE INDEX "Instrument_familyId_idx" ON "Instrument"("familyId");
+
+ALTER TABLE "Instrument" ADD CONSTRAINT "Instrument_familyId_fkey"
+  FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Instrument" ADD CONSTRAINT "instrument_quote_currency_is_iso_4217"
+  FOREIGN KEY ("quoteCurrency") REFERENCES "iso_4217_currency"("code") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Domain CHECKs.
+ALTER TABLE "Instrument"
+  ADD CONSTRAINT instrument_kind_domain CHECK (
+    "kind" IN ('mutual_fund', 'metal', 'stock', 'crypto', 'bond', 'deposit')
+  );
+
+ALTER TABLE "Instrument"
+  ADD CONSTRAINT instrument_price_model_domain CHECK (
+    "priceModel" IN ('market', 'yield')
+  );
+
+-- Currency shape, matching iso_4217_currency_code_shape on the registry so the
+-- CHECK can never contradict the foreign key (mirrors valuation_currency_shape).
+ALTER TABLE "Instrument"
+  ADD CONSTRAINT instrument_quote_currency_shape CHECK ("quoteCurrency" ~ '^[A-Z]{3,5}$');
+
+-- ============================================================================
+-- 2. Holding
+-- ============================================================================
+
+CREATE TABLE "Holding" (
+    "id" TEXT NOT NULL,
+    "quantity" DECIMAL(38,8) NOT NULL,
+    "avgUnitCostMinor" BIGINT NOT NULL,
+    "lastPriceMinor" BIGINT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "familyId" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "instrumentId" TEXT NOT NULL,
+
+    CONSTRAINT "Holding_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Holding_id_familyId_key" ON "Holding"("id", "familyId");
+
+CREATE INDEX "Holding_familyId_accountId_idx" ON "Holding"("familyId", "accountId");
+
+ALTER TABLE "Holding" ADD CONSTRAINT "Holding_familyId_fkey"
+  FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Tenant-safe composite FKs (MATCH SIMPLE is the Postgres default): a Holding can
+-- only reference an Account / Instrument in the SAME family.
+ALTER TABLE "Holding" ADD CONSTRAINT "Holding_accountId_familyId_fkey"
+  FOREIGN KEY ("accountId", "familyId") REFERENCES "Account"("id", "familyId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Holding" ADD CONSTRAINT "Holding_instrumentId_familyId_fkey"
+  FOREIGN KEY ("instrumentId", "familyId") REFERENCES "Instrument"("id", "familyId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Non-negativity (Database Is the Law): quantity and unit cost are never
+-- negative; a manual last price is either unset (NULL) or non-negative.
+ALTER TABLE "Holding"
+  ADD CONSTRAINT holding_quantity_non_negative CHECK ("quantity" >= 0);
+
+ALTER TABLE "Holding"
+  ADD CONSTRAINT holding_avg_unit_cost_non_negative CHECK ("avgUnitCostMinor" >= 0);
+
+ALTER TABLE "Holding"
+  ADD CONSTRAINT holding_last_price_non_negative CHECK ("lastPriceMinor" IS NULL OR "lastPriceMinor" >= 0);
+
+-- ============================================================================
+-- 3. Row-Level Security — tenant isolation, mirroring Account/Valuation.
+-- ============================================================================
+
+ALTER TABLE "Instrument" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY instrument_tenant_isolation ON "Instrument"
+  FOR ALL
+  USING ("familyId" = current_setting('app.family_id', true)::text)
+  WITH CHECK ("familyId" = current_setting('app.family_id', true)::text);
+
+ALTER TABLE "Instrument" FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE "Holding" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY holding_tenant_isolation ON "Holding"
+  FOR ALL
+  USING ("familyId" = current_setting('app.family_id', true)::text)
+  WITH CHECK ("familyId" = current_setting('app.family_id', true)::text);
+
+ALTER TABLE "Holding" FORCE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Iso4217Currency {
   fxFromCurrencies                 FxRateSnapshot[] @relation("FxRateFromCurrency")
   fxToCurrencies                   FxRateSnapshot[] @relation("FxRateToCurrency")
   budgetCurrencies                 Budget[]      @relation("BudgetCurrency")
+  instrumentQuoteCurrencies        Instrument[]  @relation("InstrumentQuoteCurrency")
 
   @@map("iso_4217_currency")
 }
@@ -53,6 +54,8 @@ model Family {
   importBatches ImportBatch[]
   rawImportedTransactions RawImportedTransaction[]
   importBatchArtifacts ImportBatchArtifact[]
+  instruments  Instrument[]
+  holdings     Holding[]
 }
 
 // ADR-0036: first-class family membership + role authorization.
@@ -216,6 +219,7 @@ model Account {
   transactionsTo   Transaction[] @relation("ToAccount")
   valuations       Valuation[]
   rawImportedTransactions RawImportedTransaction[]
+  holdings         Holding[]
 
   // Tenant-scoped fetch (every Account read is filtered by familyId once
   // ADR-0004 lands; cheap to add now). See ADR-0003.
@@ -927,4 +931,85 @@ model ImportBatchArtifact {
 
   @@unique([importBatchId, contentHash], name: "import_artifact_batch_content", map: "import_artifact_batch_content")
   @@index([familyId])
+}
+
+// =============================================================================
+// PER-232 / ADR-0051 — Investments & Holdings domain (Slice 1: market-priced).
+//
+// An `Instrument` is the tradeable thing (a named reksadana fund, a gram of
+// gold, a share). It is tenant-scoped (v1 manual instruments — no market-data
+// feed yet). A `Holding` is a position of an Instrument inside an investment
+// `Account` (balanceSource="valuation"). Account value = Σ its holdings' current
+// value, written back as a valuation ANCHOR (ADR-0034/0043) so every net-worth /
+// balance / audit / RLS invariant holds for free — holdings are the ASSET
+// valuation layer, never a second cash ledger (ADR-0008). See src/lib/holdings.ts
+// for the pure valuation math and src/server/holdings.ts for the mutation contract.
+// =============================================================================
+
+model Instrument {
+  id String @id @default(cuid())
+
+  // Instrument taxonomy (CHECK domain in migration). Slice 1 uses market-priced
+  // kinds; yield-bearing (deposit/bond accrual) math arrives in a later slice.
+  kind String
+
+  name   String
+  symbol String?
+
+  // The currency the instrument is quoted in (NAV/unit, price/gram, last price).
+  // FK to the ISO-4217 registry, mirroring Account.currency. Holdings on an
+  // account must share the account's currency (single-currency Σ this slice);
+  // multi-currency normalization (ADR-0035) is a later slice.
+  quoteCurrency         String          @default("IDR")
+  quoteCurrencyRegistry Iso4217Currency @relation("InstrumentQuoteCurrency", fields: [quoteCurrency], references: [code], onDelete: Restrict, onUpdate: Cascade, map: "instrument_quote_currency_is_iso_4217")
+
+  // Valuation method selector (CHECK domain). "market" = quantity × price/unit
+  // (this slice). "yield" (principal + accrued interest) is a later slice.
+  priceModel String @default("market")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  familyId String
+  family   Family @relation(fields: [familyId], references: [id])
+
+  holdings Holding[]
+
+  // Composite-FK target for Holding(instrumentId, familyId) — tenant isolation
+  // lives in the (id, familyId) pair, not the bare id (ADR-0010 Pattern A).
+  @@unique([id, familyId], map: "Instrument_id_familyId_key")
+  @@index([familyId])
+}
+
+model Holding {
+  id String @id @default(cuid())
+
+  // Fractional units: fund units (1353.5149), grams (2.0180), shares. Decimal so
+  // the quantity is exact; the pure math scales it to a bigint (QUANTITY_SCALE=1e8)
+  // to stay in integer arithmetic (src/lib/holdings.ts). CHECK quantity >= 0.
+  quantity Decimal @db.Decimal(38, 8)
+
+  // Cost per ONE unit, in MINOR units of the instrument's quoteCurrency (always
+  // >= 0 — CHECK). Cost = quantity × this.
+  avgUnitCostMinor BigInt
+
+  // Manual current market price per ONE unit, MINOR units. NULL until the user
+  // enters a price (value then falls back to cost basis, gain 0). CHECK null or >= 0.
+  lastPriceMinor BigInt?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  familyId String
+  family   Family @relation(fields: [familyId], references: [id])
+
+  // Composite (tenant-safe) FKs — Pattern A (ADR-0010), MATCH SIMPLE, Restrict.
+  accountId String
+  account   Account @relation(fields: [accountId, familyId], references: [id, familyId], onDelete: Restrict, onUpdate: Cascade, map: "Holding_accountId_familyId_fkey")
+
+  instrumentId String
+  instrument   Instrument @relation(fields: [instrumentId, familyId], references: [id, familyId], onDelete: Restrict, onUpdate: Cascade, map: "Holding_instrumentId_familyId_fkey")
+
+  @@unique([id, familyId], map: "Holding_id_familyId_key")
+  @@index([familyId, accountId])
 }

--- a/src/lib/holdings.test.ts
+++ b/src/lib/holdings.test.ts
@@ -197,9 +197,9 @@ describe("valuation invariants (property-based)", () => {
       fc.property(wholeArb, fracArb, (whole, frac) => {
         const decimal = frac === "" ? `${whole}` : `${whole}.${frac}`
         const scaled = quantityToScaled(decimal)
+        // padEnd always yields 8 chars ("" -> "00000000" -> 0n), so no guard.
         const expected =
-          BigInt(whole) * QUANTITY_SCALE +
-          BigInt(frac.padEnd(8, "0") === "" ? "0" : frac.padEnd(8, "0"))
+          BigInt(whole) * QUANTITY_SCALE + BigInt(frac.padEnd(8, "0"))
         expect(scaled).toBe(expected)
       })
     )

--- a/src/lib/holdings.test.ts
+++ b/src/lib/holdings.test.ts
@@ -1,0 +1,207 @@
+import fc from "fast-check"
+import { describe, expect, test } from "vite-plus/test"
+import {
+  holdingCostMinor,
+  holdingGainMinor,
+  holdingReturnPct,
+  holdingValueMinor,
+  QUANTITY_SCALE,
+  quantityToScaled,
+  sumHoldingValuesMinor,
+} from "./holdings"
+
+describe("quantityToScaled", () => {
+  test("scales a fractional decimal to 1e8", () => {
+    expect(quantityToScaled("2.0180")).toBe(201_800_000n)
+    expect(quantityToScaled("1353.5149")).toBe(135_351_490_000n)
+  })
+
+  test("integer and zero quantities", () => {
+    expect(quantityToScaled("5")).toBe(500_000_000n)
+    expect(quantityToScaled("0")).toBe(0n)
+    expect(quantityToScaled("0.00000001")).toBe(1n) // full 8-digit precision
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(quantityToScaled("  2.5 ")).toBe(250_000_000n)
+  })
+
+  test("rejects negative, NaN-shaped, exponent, separator and over-precise input", () => {
+    expect(() => quantityToScaled("-1")).toThrow()
+    expect(() => quantityToScaled("")).toThrow()
+    expect(() => quantityToScaled("abc")).toThrow()
+    expect(() => quantityToScaled("1e5")).toThrow()
+    expect(() => quantityToScaled("1,000")).toThrow()
+    expect(() => quantityToScaled("1.2.3")).toThrow()
+    expect(() => quantityToScaled("0.000000001")).toThrow() // 9 fraction digits
+  })
+})
+
+describe("holdingValueMinor / holdingCostMinor (half-up rounding)", () => {
+  test("BSI Gold worked example (ADR-0051): value", () => {
+    // 2.0180 gram × Rp 2,455,000/gram (245_500_000 sen) = Rp 4,954,190.
+    const qty = quantityToScaled("2.0180")
+    expect(holdingValueMinor(qty, 245_500_000n)).toBe(495_419_000n)
+  })
+
+  test("BSI Gold worked example (ADR-0051): cost", () => {
+    // 2.0180 gram × Rp 2,760,809/gram (276_080_900 sen) = Rp 5,571,312.56 →
+    // 557,131,256 sen (half-up on the exact .56 boundary is a no-op here, the
+    // fractional part is below .5 of a sen — the value is already integral sen).
+    const qty = quantityToScaled("2.0180")
+    expect(holdingCostMinor(qty, 276_080_900n)).toBe(557_131_256n)
+  })
+
+  test("zero quantity → zero value and zero cost", () => {
+    expect(holdingValueMinor(0n, 245_500_000n)).toBe(0n)
+    expect(holdingCostMinor(0n, 276_080_900n)).toBe(0n)
+  })
+
+  test("zero price → zero value", () => {
+    expect(holdingValueMinor(quantityToScaled("2.0180"), 0n)).toBe(0n)
+  })
+
+  test("half-up rounds a genuine half-sen up", () => {
+    // quantityScaled × price = QUANTITY_SCALE/2 + k*QUANTITY_SCALE produces an
+    // exact .5 remainder. 0.5 units × 1 minor = 0.5 minor → rounds to 1.
+    const halfUnit = QUANTITY_SCALE / 2n // 0.5 scaled
+    expect(holdingValueMinor(halfUnit, 1n)).toBe(1n)
+    // 0.5 units × 3 minor = 1.5 minor → rounds to 2.
+    expect(holdingValueMinor(halfUnit, 3n)).toBe(2n)
+  })
+
+  test("rounds just below a half down", () => {
+    // (QUANTITY_SCALE/2 - 1) × 1 = 0.4999… → rounds to 0.
+    expect(holdingValueMinor(QUANTITY_SCALE / 2n - 1n, 1n)).toBe(0n)
+  })
+
+  test("rejects negative operands (defence in depth against a bad caller)", () => {
+    expect(() => holdingValueMinor(-1n, 1n)).toThrow()
+    expect(() => holdingValueMinor(1n, -1n)).toThrow()
+    expect(() => holdingCostMinor(-1n, 1n)).toThrow()
+  })
+})
+
+describe("gain and return", () => {
+  test("gain = value − cost, both signs", () => {
+    expect(holdingGainMinor(495_419_000n, 557_131_256n)).toBe(-61_712_256n)
+    expect(holdingGainMinor(600_000_000n, 557_131_256n)).toBe(42_868_744n)
+  })
+
+  test("return pct is the ratio, null when cost is 0", () => {
+    // Bibit example: value 200,837,000 cost 200,000,000 → +0.42% (0.004185).
+    expect(holdingReturnPct(200_837_000n, 200_000_000n)).toBeCloseTo(0.0042, 4)
+    expect(holdingReturnPct(100n, 0n)).toBeNull()
+    expect(holdingReturnPct(0n, 0n)).toBeNull()
+  })
+})
+
+describe("sumHoldingValuesMinor", () => {
+  test("sums per-holding value (account value = Σ holdings)", () => {
+    const total = sumHoldingValuesMinor([
+      {
+        quantityScaled: quantityToScaled("2.0180"),
+        pricePerUnitMinor: 245_500_000n,
+      },
+      { quantityScaled: quantityToScaled("10"), pricePerUnitMinor: 1_000n },
+    ])
+    expect(total).toBe(495_419_000n + 10_000n)
+  })
+
+  test("empty portfolio is 0", () => {
+    expect(sumHoldingValuesMinor([])).toBe(0n)
+  })
+})
+
+// ===========================================================================
+// Property-based invariants (fast-check). Thousands of qty/price combinations.
+// ===========================================================================
+
+describe("valuation invariants (property-based)", () => {
+  const qtyArb = fc.bigInt({ min: 0n, max: 10n ** 18n }) // scaled quantity
+  const priceArb = fc.bigInt({ min: 0n, max: 10n ** 15n }) // minor units/unit
+
+  test("value is non-negative and never NaN", () => {
+    fc.assert(
+      fc.property(qtyArb, priceArb, (qty, price) => {
+        const value = holdingValueMinor(qty, price)
+        expect(value >= 0n).toBe(true)
+        expect(typeof value).toBe("bigint")
+      })
+    )
+  })
+
+  test("value is monotonic non-decreasing in quantity", () => {
+    fc.assert(
+      fc.property(qtyArb, qtyArb, priceArb, (a, b, price) => {
+        const lo = a < b ? a : b
+        const hi = a < b ? b : a
+        expect(
+          holdingValueMinor(lo, price) <= holdingValueMinor(hi, price)
+        ).toBe(true)
+      })
+    )
+  })
+
+  test("value is monotonic non-decreasing in price", () => {
+    fc.assert(
+      fc.property(qtyArb, priceArb, priceArb, (qty, p1, p2) => {
+        const lo = p1 < p2 ? p1 : p2
+        const hi = p1 < p2 ? p2 : p1
+        expect(holdingValueMinor(qty, lo) <= holdingValueMinor(qty, hi)).toBe(
+          true
+        )
+      })
+    )
+  })
+
+  test("Σ of per-holding values equals the account-value helper", () => {
+    const holdingArb = fc.record({
+      quantityScaled: qtyArb,
+      pricePerUnitMinor: priceArb,
+    })
+    fc.assert(
+      fc.property(fc.array(holdingArb, { maxLength: 20 }), (holdings) => {
+        const manual = holdings.reduce(
+          (acc, h) =>
+            acc + holdingValueMinor(h.quantityScaled, h.pricePerUnitMinor),
+          0n
+        )
+        expect(sumHoldingValuesMinor(holdings)).toBe(manual)
+      })
+    )
+  })
+
+  test("gain never NaN and returnPct is null exactly when cost is 0", () => {
+    fc.assert(
+      fc.property(qtyArb, priceArb, priceArb, (qty, price, cost) => {
+        const value = holdingValueMinor(qty, price)
+        const costMinor = holdingCostMinor(qty, cost)
+        const gain = holdingGainMinor(value, costMinor)
+        expect(typeof gain).toBe("bigint")
+        expect(gain).toBe(value - costMinor)
+        const pct = holdingReturnPct(value, costMinor)
+        if (costMinor <= 0n) {
+          expect(pct).toBeNull()
+        } else {
+          expect(Number.isNaN(pct)).toBe(false)
+        }
+      })
+    )
+  })
+
+  test("quantityToScaled round-trips through the 8-digit scale", () => {
+    const wholeArb = fc.nat({ max: 1_000_000 })
+    const fracArb = fc.stringMatching(/^[0-9]{0,8}$/)
+    fc.assert(
+      fc.property(wholeArb, fracArb, (whole, frac) => {
+        const decimal = frac === "" ? `${whole}` : `${whole}.${frac}`
+        const scaled = quantityToScaled(decimal)
+        const expected =
+          BigInt(whole) * QUANTITY_SCALE +
+          BigInt(frac.padEnd(8, "0") === "" ? "0" : frac.padEnd(8, "0"))
+        expect(scaled).toBe(expected)
+      })
+    )
+  })
+})

--- a/src/lib/holdings.ts
+++ b/src/lib/holdings.ts
@@ -1,0 +1,190 @@
+/**
+ * Holdings — pure market-priced valuation math (PER-232 / ADR-0051, Slice 1).
+ * =============================================================================
+ *
+ * A holding is a position of a market-priced instrument (a reksadana fund, a
+ * gram of gold, a share) inside an investment account:
+ *
+ *   value = quantity × current price/unit          (Bibit: units × NAV)
+ *   cost  = quantity × average buy price/unit       (BSI Gold: grams × avg cost)
+ *   gain  = value − cost
+ *
+ * Money everywhere is a signed BigInt in MINOR units (sen for IDR) — the same
+ * contract as src/lib/money.ts. Quantity is fractional (2.0180 gram,
+ * 1353.5149 units) so it CANNOT be an integer minor-unit amount. IEEE-754 float
+ * would silently corrupt a ledger over millions of additions (see money.ts), so
+ * quantity is carried as a **scaled bigint**: the decimal string scaled by
+ * `QUANTITY_SCALE` (1e8, matching the Prisma `Decimal(38, 8)` column). All
+ * arithmetic then stays in exact integer math.
+ *
+ * Rounding: value/cost are `quantityScaled × priceMinor / QUANTITY_SCALE`. That
+ * division is where a fractional minor-unit can appear, and it is rounded
+ * HALF-UP. For a non-negative dividend `a` and positive scale `S`, half-up is
+ * `(a + S/2) / S` in integer division (bigint `/` truncates toward zero, and
+ * every operand here is non-negative — quantity ≥ 0, price ≥ 0 — so truncation
+ * == floor, making `(a + S/2) / S` exactly round-half-up). Half-up (not
+ * banker's rounding like `mulMoney`) is the convention brokers show for a
+ * single position's displayed value, and keeps this module trivially auditable.
+ *
+ * This module is Prisma-free and framework-free: it is unit- and property-tested
+ * in isolation (src/lib/holdings.test.ts) and reused verbatim by the server so
+ * the account-value anchor (src/server/holdings.ts) and the displayed per-holding
+ * numbers can never disagree.
+ */
+
+/** Decimal scale for quantity — 1e8, matching the `Decimal(38, 8)` column. */
+export const QUANTITY_SCALE = 100_000_000n
+
+const QUANTITY_SCALE_DIGITS = 8
+
+/**
+ * Parse a non-negative decimal quantity string ("2.0180", "1353.5149", "5") into
+ * a scaled bigint (× QUANTITY_SCALE). "2.0180" → 201_800_000n.
+ *
+ * Strict — throws (never silently zeroes or truncates, because silent loss in a
+ * ledger is a bug surface):
+ *   - rejects empty / whitespace-only input
+ *   - rejects a leading "-" (quantity is non-negative by domain; the DB CHECK is
+ *     the backstop)
+ *   - rejects exponent notation, thousands separators, multiple dots, any
+ *     non-digit — i.e. anything not matching /^\d+(\.\d+)?$/
+ *   - rejects more than 8 fraction digits (would lose precision below the
+ *     column scale)
+ */
+export function quantityToScaled(quantity: string): bigint {
+  if (typeof quantity !== "string") {
+    throw new TypeError(
+      `quantityToScaled: expected string, got ${typeof quantity}`
+    )
+  }
+  const trimmed = quantity.trim()
+  if (trimmed === "") {
+    throw new TypeError("quantityToScaled: empty string")
+  }
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new TypeError(
+      `quantityToScaled: malformed non-negative decimal: ${JSON.stringify(quantity)}`
+    )
+  }
+
+  const [whole, fractionRaw = ""] = trimmed.split(".")
+  if (fractionRaw.length > QUANTITY_SCALE_DIGITS) {
+    throw new RangeError(
+      `quantityToScaled: at most ${QUANTITY_SCALE_DIGITS} fraction digits, got ${fractionRaw.length} in ${JSON.stringify(quantity)}`
+    )
+  }
+
+  // Pad the fraction to the fixed scale, then concatenate whole+fraction and
+  // read the result as a single bigint — exact by construction.
+  const fraction = fractionRaw.padEnd(QUANTITY_SCALE_DIGITS, "0")
+  const combined = (whole === "" ? "0" : whole) + fraction
+  return BigInt(combined)
+}
+
+/**
+ * Round-half-up integer division of a non-negative dividend by QUANTITY_SCALE.
+ * `(a + S/2) / S` — see the module docstring for why this is exact half-up for
+ * non-negative `a`. Guards the sign so a misuse can never silently round the
+ * wrong way.
+ */
+function divideScaledHalfUp(a: bigint): bigint {
+  if (a < 0n) {
+    throw new RangeError(
+      `divideScaledHalfUp: expected non-negative dividend, got ${a}`
+    )
+  }
+  return (a + QUANTITY_SCALE / 2n) / QUANTITY_SCALE
+}
+
+/**
+ * Current market value of a holding, in MINOR units:
+ *   round_half_up(quantityScaled × pricePerUnitMinor / QUANTITY_SCALE)
+ *
+ * e.g. 2.0180 gram (quantityScaled 201_800_000) × Rp 2,455,000/gram
+ * (pricePerUnitMinor 245_500_000) → 495_419_000 (Rp 4,954,190).
+ *
+ * Both operands must be non-negative (quantity ≥ 0, price ≥ 0 — the DB CHECKs).
+ */
+export function holdingValueMinor(
+  quantityScaled: bigint,
+  pricePerUnitMinor: bigint
+): bigint {
+  if (quantityScaled < 0n) {
+    throw new RangeError(
+      `holdingValueMinor: quantityScaled must be non-negative, got ${quantityScaled}`
+    )
+  }
+  if (pricePerUnitMinor < 0n) {
+    throw new RangeError(
+      `holdingValueMinor: pricePerUnitMinor must be non-negative, got ${pricePerUnitMinor}`
+    )
+  }
+  return divideScaledHalfUp(quantityScaled * pricePerUnitMinor)
+}
+
+/**
+ * Cost basis of a holding, in MINOR units — same formula as value, using the
+ * average unit cost instead of the current price.
+ */
+export function holdingCostMinor(
+  quantityScaled: bigint,
+  avgUnitCostMinor: bigint
+): bigint {
+  if (quantityScaled < 0n) {
+    throw new RangeError(
+      `holdingCostMinor: quantityScaled must be non-negative, got ${quantityScaled}`
+    )
+  }
+  if (avgUnitCostMinor < 0n) {
+    throw new RangeError(
+      `holdingCostMinor: avgUnitCostMinor must be non-negative, got ${avgUnitCostMinor}`
+    )
+  }
+  return divideScaledHalfUp(quantityScaled * avgUnitCostMinor)
+}
+
+/** Unrealized gain (loss if negative) in MINOR units: value − cost. */
+export function holdingGainMinor(value: bigint, cost: bigint): bigint {
+  return value - cost
+}
+
+/**
+ * Unrealized return as a fraction (0.0042 == +0.42%): (value − cost) / cost, or
+ * `null` when cost is 0 (no basis → return is undefined, never a divide-by-zero
+ * or a fabricated 0%). Uses Number only for the final ratio, which is inherently
+ * fractional and display-only — the money values themselves stay bigint.
+ */
+export function holdingReturnPct(value: bigint, cost: bigint): number | null {
+  if (cost <= 0n) return null
+  return Number(value - cost) / Number(cost)
+}
+
+/** A single priced position, scaled for the pure Σ helper. */
+export interface HoldingValuationInput {
+  quantityScaled: bigint
+  /** Price per unit for the CURRENT value (lastPrice ?? avgUnitCost — see server). */
+  pricePerUnitMinor: bigint
+}
+
+/**
+ * Total current market value of a set of holdings, in MINOR units:
+ * Σ holdingValueMinor. This is the single source of truth for
+ * "account value = Σ its holdings' current value" (ADR-0051) — the server's
+ * valuation anchor is written from exactly this fold, so the account balance and
+ * the per-holding displayed values can never drift.
+ *
+ * Caller guarantees every holding shares one currency (single-currency Σ this
+ * slice; the server enforces instrument.quoteCurrency == account.currency).
+ */
+export function sumHoldingValuesMinor(
+  holdings: ReadonlyArray<HoldingValuationInput>
+): bigint {
+  let total = 0n
+  for (const holding of holdings) {
+    total += holdingValueMinor(
+      holding.quantityScaled,
+      holding.pricePerUnitMinor
+    )
+  }
+  return total
+}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -97,7 +97,9 @@ const INSTRUMENT_KINDS = [
 const currencySchema = z
   .string()
   .trim()
-  .regex(/^[A-Za-z]{3}$/, "currency must be a 3-letter ISO 4217 code")
+  // 3–5 chars to match the DB `instrument_quote_currency_shape` CHECK (crypto
+  // symbols can exceed 3); `assertKnownCurrency` still gates membership.
+  .regex(/^[A-Za-z]{3,5}$/, "currency must be a 3–5 letter code")
   .transform((value) => value.toUpperCase())
 
 // A decimal magnitude string in MAJOR units (e.g. "2.0180", "2455000",

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -1,0 +1,802 @@
+import { createServerFn } from "@tanstack/react-start"
+import type { Holding, Instrument } from "@prisma/client"
+import { z } from "zod"
+import { CURRENCIES, type CurrencyCode } from "@/lib/data/currencies"
+import {
+  holdingCostMinor,
+  holdingGainMinor,
+  holdingReturnPct,
+  holdingValueMinor,
+  quantityToScaled,
+  sumHoldingValuesMinor,
+} from "@/lib/holdings"
+import { toMinorUnits } from "@/lib/money"
+import {
+  auditLog,
+  createAuditContext,
+  type AuditContext,
+} from "./middleware/audit"
+import {
+  familyMiddleware,
+  requireCapability,
+  scopedTenantTransaction,
+  type TenantTransactionClient,
+} from "./middleware/with-family"
+import { hashCanonicalPayload } from "./idempotency"
+import {
+  persistIdempotentEndpointResponse,
+  replayIdempotentEndpointResponse,
+} from "./idempotency-records"
+import {
+  isUniqueConstraintError,
+  uuidV7Schema,
+  type RunInTenantTransaction,
+} from "./mutation-kit"
+import { validateTenantReferences } from "./validation/tenant-references"
+import { createValuationWithinTx, type ServerActor } from "./valuations"
+
+// =============================================================================
+// PER-232 / ADR-0051 — Holdings core (Slice 1: market-priced).
+//
+// A `Holding` is a position of a market-priced `Instrument` (reksadana fund,
+// gold, share) inside a valuation-tracked investment `Account`. The account's
+// value is Σ its holdings' current value, written back as a valuation ANCHOR
+// (createValuationWithinTx, ADR-0034/0043) inside the SAME transaction as every
+// holding mutation, so the account balance materializes from holdings and every
+// net-worth / balance / audit / RLS invariant holds for free (ADR-0008 asset-
+// tracking contract). Holdings are the ASSET valuation layer — never a second
+// cash ledger.
+//
+// Every mutation runs the full ledger mutation contract (CLAUDE.md §5A):
+// interactive tenant transaction with the `app.family_id` RLS GUC, tenant-owned
+// reference validation (account + instrument must belong to the family),
+// endpoint-scoped idempotency (`IdempotencyRecord`), and append-only `AuditLog`
+// rows in the same transaction. The pure valuation math lives in
+// `src/lib/holdings.ts` and is reused verbatim so the anchor and the displayed
+// per-holding numbers can never disagree.
+//
+// SLICE SCOPE: market-priced only (priceModel="market"); holdings only on
+// accounts already balanceSource="valuation"; single-currency Σ
+// (instrument.quoteCurrency must equal account.currency). Yield-bearing accrual,
+// buy/sell cash-linked flow, lots/realized gains, market-data feeds, and
+// promoting a non-valuation account to hold holdings are later slices.
+// =============================================================================
+
+const UPSERT_HOLDING_ENDPOINT = "upsertHoldingFn"
+const DELETE_HOLDING_ENDPOINT = "deleteHoldingFn"
+
+// Source tag on the holdings-derived valuation anchor, so a consumer can tell a
+// holdings restatement from a live user reconciliation or a Sure import.
+const HOLDINGS_ANCHOR_SOURCE = "holdings"
+
+/**
+ * Raised for holdings-specific domain rejections (ineligible account, currency
+ * mismatch, unknown instrument, yield instrument in the market-only slice). 422,
+ * mirroring `ValuationError` / `AccountValidationError`.
+ */
+export class HoldingError extends Error {
+  override readonly name = "HoldingError"
+  readonly statusCode = 422
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+// Instrument kinds allowed at the DB layer (mirrors the migration CHECK). Slice 1
+// only ever creates market-priced instruments, but a user may classify one as
+// any kind.
+const INSTRUMENT_KINDS = [
+  "mutual_fund",
+  "metal",
+  "stock",
+  "crypto",
+  "bond",
+  "deposit",
+] as const
+
+const currencySchema = z
+  .string()
+  .trim()
+  .regex(/^[A-Za-z]{3}$/, "currency must be a 3-letter ISO 4217 code")
+  .transform((value) => value.toUpperCase())
+
+// A decimal magnitude string in MAJOR units (e.g. "2.0180", "2455000",
+// "1477.63"). Parsed to minor units with the money helpers; quantity is parsed
+// with the holdings scale helper. Kept permissive here (non-empty string); the
+// exact shape is enforced by `quantityToScaled` / `toMinorUnits`, which throw a
+// precise error surfaced as a `HoldingError`.
+const decimalStringSchema = z.string().trim().min(1)
+
+const inlineInstrumentSchema = z.object({
+  kind: z.enum(INSTRUMENT_KINDS),
+  name: z.string().trim().min(1).max(120),
+  symbol: z.string().trim().min(1).max(32).optional(),
+  quoteCurrency: currencySchema.optional(),
+})
+
+export const upsertHoldingInputSchema = z.object({
+  // Present ⇒ update that holding (instrument identity is fixed on update);
+  // absent ⇒ create a new holding (exactly one of instrumentId / instrument).
+  holdingId: z.string().min(1).optional(),
+  accountId: z.string().min(1),
+  instrumentId: z.string().min(1).optional(),
+  instrument: inlineInstrumentSchema.optional(),
+  quantity: decimalStringSchema,
+  avgUnitCost: decimalStringSchema,
+  lastPrice: decimalStringSchema.optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+export const deleteHoldingInputSchema = z.object({
+  holdingId: z.string().min(1),
+  idempotencyKey: uuidV7Schema,
+})
+
+export const accountHoldingsQuerySchema = z.object({
+  accountId: z.string().min(1),
+})
+
+type UpsertHoldingInput = z.infer<typeof upsertHoldingInputSchema>
+type DeleteHoldingInput = z.infer<typeof deleteHoldingInputSchema>
+
+// -----------------------------------------------------------------------------
+// Serialized shapes — BigInt crosses the wire as minor-unit digit-strings,
+// quantity as a decimal string, derived value/cost/gain computed from the pure
+// helper so the client never re-derives money math (ADR-0051).
+// -----------------------------------------------------------------------------
+
+export interface SerializedInstrument {
+  id: string
+  kind: string
+  name: string
+  symbol: string | null
+  quoteCurrency: string
+  priceModel: string
+}
+
+export interface SerializedHolding {
+  id: string
+  accountId: string
+  instrumentId: string
+  familyId: string
+  instrument: SerializedInstrument
+  /** Fractional units as a decimal string (e.g. "2.01800000"). */
+  quantity: string
+  /** Average buy price per unit, minor units (digit-string). */
+  avgUnitCostMinor: string
+  /** Manual current price per unit, minor units, or null. */
+  lastPriceMinor: string | null
+  /** Currency of every minor-unit field (== account currency this slice). */
+  currency: string
+  /** Current market value = quantity × (lastPrice ?? avgUnitCost), minor units. */
+  valueMinor: string
+  /** Cost basis = quantity × avgUnitCost, minor units. */
+  costMinor: string
+  /** Unrealized gain = value − cost, minor units (signed). */
+  gainMinor: string
+  /** Unrealized return as a fraction, or null when cost is 0. */
+  returnPct: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AccountHoldingsView {
+  accountId: string
+  currency: string
+  holdings: SerializedHolding[]
+  totalValueMinor: string
+  totalCostMinor: string
+  totalGainMinor: string
+}
+
+type HoldingWithInstrument = Holding & { instrument: Instrument }
+
+function serializeInstrument(instrument: Instrument): SerializedInstrument {
+  return {
+    id: instrument.id,
+    kind: instrument.kind,
+    name: instrument.name,
+    symbol: instrument.symbol,
+    quoteCurrency: instrument.quoteCurrency,
+    priceModel: instrument.priceModel,
+  }
+}
+
+// Prisma Decimal(38,8) → canonical fixed-scale string, always non-exponential and
+// exactly 8 fraction digits, so `quantityToScaled` parses it deterministically.
+function quantityToFixedString(holding: Holding): string {
+  return holding.quantity.toFixed(8)
+}
+
+// The price used for the CURRENT value: the manual last price when set, else the
+// average unit cost (a freshly-added holding with no price yet shows value ==
+// cost, gain 0 — honest, never fabricated). ADR-0051 §"Cost basis (honest)".
+function currentPriceMinor(holding: Holding): bigint {
+  return holding.lastPriceMinor ?? holding.avgUnitCostMinor
+}
+
+function serializeHolding(holding: HoldingWithInstrument): SerializedHolding {
+  const quantityScaled = quantityToScaled(quantityToFixedString(holding))
+  const value = holdingValueMinor(quantityScaled, currentPriceMinor(holding))
+  const cost = holdingCostMinor(quantityScaled, holding.avgUnitCostMinor)
+  const gain = holdingGainMinor(value, cost)
+  return {
+    id: holding.id,
+    accountId: holding.accountId,
+    instrumentId: holding.instrumentId,
+    familyId: holding.familyId,
+    instrument: serializeInstrument(holding.instrument),
+    quantity: quantityToFixedString(holding),
+    avgUnitCostMinor: holding.avgUnitCostMinor.toString(),
+    lastPriceMinor: holding.lastPriceMinor?.toString() ?? null,
+    currency: holding.instrument.quoteCurrency,
+    valueMinor: value.toString(),
+    costMinor: cost.toString(),
+    gainMinor: gain.toString(),
+    returnPct: holdingReturnPct(value, cost),
+    createdAt: holding.createdAt.toISOString(),
+    updatedAt: holding.updatedAt.toISOString(),
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Currency + money parsing helpers
+// -----------------------------------------------------------------------------
+
+function assertKnownCurrency(currency: string): CurrencyCode {
+  if (!(currency in CURRENCIES)) {
+    throw new HoldingError(`Unsupported currency ${currency}`)
+  }
+  return currency as CurrencyCode
+}
+
+// Parse a MAJOR-unit decimal string to a non-negative minor-unit bigint, turning
+// a malformed input into a typed HoldingError (never a raw TypeError).
+function parseMinor(
+  raw: string,
+  currency: CurrencyCode,
+  field: string
+): bigint {
+  let minor: bigint
+  try {
+    minor = toMinorUnits(raw, currency)
+  } catch (error) {
+    throw new HoldingError(
+      `${field} is not a valid ${currency} amount: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  if (minor < 0n) {
+    throw new HoldingError(`${field} cannot be negative`)
+  }
+  return minor
+}
+
+// -----------------------------------------------------------------------------
+// Account eligibility
+// -----------------------------------------------------------------------------
+
+interface EligibleAccount {
+  id: string
+  currency: string
+  balanceSource: string
+}
+
+// The account must exist in this family, not be soft-deleted, and be valuation-
+// tracked (balanceSource="valuation"). Enabling holdings on a cash/transaction-
+// flow account would need a taxonomy change (a later slice) — reject clearly
+// here rather than silently mutating a cash account's balance.
+async function fetchEligibleAccount(
+  tx: TenantTransactionClient,
+  familyId: string,
+  accountId: string
+): Promise<EligibleAccount> {
+  const account = await tx.account.findFirst({
+    where: { id: accountId, familyId, deletedAt: null },
+    select: { id: true, currency: true, balanceSource: true },
+  })
+  if (!account) {
+    throw new HoldingError(`Account ${accountId} not found for this family`)
+  }
+  if (account.balanceSource !== "valuation") {
+    throw new HoldingError(
+      `Holdings can only be added to a valuation-tracked investment account (balanceSource="valuation"); account ${accountId} is "${account.balanceSource}". Enabling other accounts is a later slice.`
+    )
+  }
+  return account
+}
+
+// -----------------------------------------------------------------------------
+// Instrument resolution (existing tenant instrument OR inline create)
+// -----------------------------------------------------------------------------
+
+async function resolveInstrument(
+  tx: TenantTransactionClient,
+  familyId: string,
+  accountCurrency: string,
+  data: UpsertHoldingInput,
+  auditCtx: AuditContext
+): Promise<Instrument> {
+  if (data.instrumentId) {
+    const instrument = await tx.instrument.findFirst({
+      where: { id: data.instrumentId, familyId },
+    })
+    if (!instrument) {
+      throw new HoldingError(
+        `Instrument ${data.instrumentId} not found for this family`
+      )
+    }
+    if (instrument.priceModel !== "market") {
+      throw new HoldingError(
+        `Instrument ${data.instrumentId} is priceModel="${instrument.priceModel}"; only market-priced instruments are supported in this slice`
+      )
+    }
+    if (instrument.quoteCurrency !== accountCurrency) {
+      throw new HoldingError(
+        `Instrument currency ${instrument.quoteCurrency} must match account currency ${accountCurrency} (multi-currency holdings are a later slice)`
+      )
+    }
+    return instrument
+  }
+
+  if (!data.instrument) {
+    throw new HoldingError(
+      "Provide either an existing instrumentId or an inline instrument to create"
+    )
+  }
+
+  const quoteCurrency = data.instrument.quoteCurrency ?? accountCurrency
+  if (quoteCurrency !== accountCurrency) {
+    throw new HoldingError(
+      `Instrument currency ${quoteCurrency} must match account currency ${accountCurrency} (multi-currency holdings are a later slice)`
+    )
+  }
+
+  const created = await tx.instrument.create({
+    data: {
+      familyId,
+      kind: data.instrument.kind,
+      name: data.instrument.name,
+      symbol: data.instrument.symbol ?? null,
+      quoteCurrency,
+      priceModel: "market",
+    },
+  })
+  await auditLog(tx, auditCtx, {
+    action: "create",
+    entityType: "Instrument",
+    entityId: created.id,
+    after: serializeInstrument(created),
+  })
+  return created
+}
+
+// -----------------------------------------------------------------------------
+// Account-value anchor: value = Σ holdings' current value, written as a manual
+// valuation anchor so the account balance materializes from holdings (ADR-0051).
+// Runs inside the caller's transaction; createValuationWithinTx signs the value,
+// writes the Valuation row + audit, and re-materializes Account.balance.
+// -----------------------------------------------------------------------------
+
+async function recomputeAccountValueAnchorWithinTx(
+  tx: TenantTransactionClient,
+  familyId: string,
+  accountId: string,
+  currency: string,
+  user: ServerActor,
+  auditCtx: AuditContext
+): Promise<void> {
+  const holdings = await tx.holding.findMany({
+    where: { familyId, accountId },
+    select: { quantity: true, avgUnitCostMinor: true, lastPriceMinor: true },
+  })
+  const totalValue = sumHoldingValuesMinor(
+    holdings.map((holding) => ({
+      quantityScaled: quantityToScaled(holding.quantity.toFixed(8)),
+      pricePerUnitMinor: holding.lastPriceMinor ?? holding.avgUnitCostMinor,
+    }))
+  )
+  await createValuationWithinTx(
+    tx,
+    familyId,
+    {
+      accountId,
+      value: totalValue.toString(),
+      currency,
+      type: "manual",
+      source: HOLDINGS_ANCHOR_SOURCE,
+      idempotencyKey: auditCtx.idempotencyKey ?? "",
+    },
+    user,
+    auditCtx
+  )
+}
+
+async function loadHoldingWithInstrument(
+  tx: TenantTransactionClient,
+  familyId: string,
+  holdingId: string
+): Promise<HoldingWithInstrument> {
+  const holding = await tx.holding.findFirst({
+    where: { id: holdingId, familyId },
+    include: { instrument: true },
+  })
+  if (!holding) {
+    throw new HoldingError(`Holding ${holdingId} not found for this family`)
+  }
+  return holding
+}
+
+// =============================================================================
+// UPSERT
+// =============================================================================
+
+export async function upsertHoldingForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof upsertHoldingInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedHolding> {
+  const data: UpsertHoldingInput = upsertHoldingInputSchema.parse(rawData)
+
+  const requestHash = await hashCanonicalPayload({
+    accountId: data.accountId,
+    avgUnitCost: data.avgUnitCost,
+    holdingId: data.holdingId ?? null,
+    instrument: data.instrument ?? null,
+    instrumentId: data.instrumentId ?? null,
+    lastPrice: data.lastPrice ?? null,
+    quantity: data.quantity,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<SerializedHolding>(
+        tx,
+        {
+          endpoint: UPSERT_HOLDING_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      // Tenant ownership + eligibility of the account (RLS-scoped, composite-FK
+      // backed). Belt-and-braces with validateTenantReferences for parity with
+      // the rest of the ledger mutation contract.
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.accountId,
+      })
+      const account = await fetchEligibleAccount(tx, familyId, data.accountId)
+      const currency = assertKnownCurrency(account.currency)
+
+      // Validate quantity shape (throws HoldingError-worthy TypeError below) —
+      // stored as the decimal string, the scaled value is derived on read.
+      quantityToScaled(data.quantity)
+      const avgUnitCostMinor = parseMinor(
+        data.avgUnitCost,
+        currency,
+        "avgUnitCost"
+      )
+      const lastPriceMinor =
+        data.lastPrice === undefined
+          ? null
+          : parseMinor(data.lastPrice, currency, "lastPrice")
+
+      let holdingId: string
+      if (data.holdingId) {
+        // UPDATE — instrument identity is fixed; only quantity/cost/price move.
+        const existing = await loadHoldingWithInstrument(
+          tx,
+          familyId,
+          data.holdingId
+        )
+        if (existing.accountId !== data.accountId) {
+          throw new HoldingError(
+            `Holding ${data.holdingId} does not belong to account ${data.accountId}`
+          )
+        }
+        const updated = await tx.holding.update({
+          where: { id: existing.id },
+          data: {
+            quantity: data.quantity,
+            avgUnitCostMinor,
+            lastPriceMinor,
+          },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Holding",
+          entityId: updated.id,
+          before: serializeHolding(existing),
+          after: serializeHolding(updated),
+        })
+        holdingId = updated.id
+      } else {
+        // CREATE — resolve/create the instrument, then the holding.
+        const instrument = await resolveInstrument(
+          tx,
+          familyId,
+          account.currency,
+          data,
+          auditCtx
+        )
+        const created = await tx.holding.create({
+          data: {
+            familyId,
+            accountId: data.accountId,
+            instrumentId: instrument.id,
+            quantity: data.quantity,
+            avgUnitCostMinor,
+            lastPriceMinor,
+          },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Holding",
+          entityId: created.id,
+          after: serializeHolding(created),
+        })
+        holdingId = created.id
+      }
+
+      // Re-materialize the account balance from Σ holdings as a valuation anchor.
+      await recomputeAccountValueAnchorWithinTx(
+        tx,
+        familyId,
+        data.accountId,
+        account.currency,
+        user,
+        auditCtx
+      )
+
+      const finalHolding = await loadHoldingWithInstrument(
+        tx,
+        familyId,
+        holdingId
+      )
+      const serialized = serializeHolding(finalHolding)
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: UPSERT_HOLDING_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response: serialized,
+      })
+      return serialized
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<SerializedHolding>(tx, {
+        endpoint: UPSERT_HOLDING_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const upsertHoldingFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof upsertHoldingInputSchema>) =>
+    upsertHoldingInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await upsertHoldingForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// =============================================================================
+// DELETE (idempotent toward its end state, audited)
+// =============================================================================
+
+export interface DeleteHoldingResult {
+  holdingId: string
+  deleted: true
+  accountId: string
+}
+
+export async function deleteHoldingForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof deleteHoldingInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<DeleteHoldingResult> {
+  const data: DeleteHoldingInput = deleteHoldingInputSchema.parse(rawData)
+  const requestHash = await hashCanonicalPayload({ holdingId: data.holdingId })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay =
+        await replayIdempotentEndpointResponse<DeleteHoldingResult>(tx, {
+          endpoint: DELETE_HOLDING_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        })
+      if (replay) return replay
+
+      const existing = await tx.holding.findFirst({
+        where: { id: data.holdingId, familyId },
+        include: { instrument: true },
+      })
+
+      // Idempotent toward the end state: a holding that is already gone is a
+      // quiet success (HTTP DELETE semantics), never a 404 — but we cannot
+      // recompute an anchor for an account we can no longer identify, so we
+      // simply record the no-op.
+      if (!existing) {
+        const response: DeleteHoldingResult = {
+          holdingId: data.holdingId,
+          deleted: true,
+          accountId: "",
+        }
+        await persistIdempotentEndpointResponse(tx, {
+          endpoint: DELETE_HOLDING_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+          response,
+        })
+        return response
+      }
+
+      const accountId = existing.accountId
+      // The account must still be eligible (valuation-tracked) to recompute its
+      // anchor — a holding can only ever have been created on such an account.
+      const account = await fetchEligibleAccount(tx, familyId, accountId)
+
+      await tx.holding.delete({ where: { id: existing.id } })
+      await auditLog(tx, auditCtx, {
+        action: "delete",
+        entityType: "Holding",
+        entityId: existing.id,
+        before: serializeHolding(existing),
+        after: null,
+      })
+
+      await recomputeAccountValueAnchorWithinTx(
+        tx,
+        familyId,
+        accountId,
+        account.currency,
+        user,
+        auditCtx
+      )
+
+      const response: DeleteHoldingResult = {
+        holdingId: existing.id,
+        deleted: true,
+        accountId,
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: DELETE_HOLDING_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<DeleteHoldingResult>(tx, {
+        endpoint: DELETE_HOLDING_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const deleteHoldingFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof deleteHoldingInputSchema>) =>
+    deleteHoldingInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await deleteHoldingForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// =============================================================================
+// READ
+// =============================================================================
+
+export async function getAccountHoldingsForFamily({
+  accountId,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  accountId: string
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<AccountHoldingsView> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const account = await tx.account.findFirst({
+      where: { id: accountId, familyId, deletedAt: null },
+      select: { id: true, currency: true },
+    })
+    if (!account) {
+      throw new HoldingError(`Account ${accountId} not found for this family`)
+    }
+
+    const rows = await tx.holding.findMany({
+      where: { familyId, accountId },
+      include: { instrument: true },
+      orderBy: { createdAt: "asc" },
+    })
+    const holdings = rows.map(serializeHolding)
+
+    let totalValue = 0n
+    let totalCost = 0n
+    for (const holding of holdings) {
+      totalValue += BigInt(holding.valueMinor)
+      totalCost += BigInt(holding.costMinor)
+    }
+
+    return {
+      accountId,
+      currency: account.currency,
+      holdings,
+      totalValueMinor: totalValue.toString(),
+      totalCostMinor: totalCost.toString(),
+      totalGainMinor: (totalValue - totalCost).toString(),
+    }
+  })
+}
+
+export const getAccountHoldingsFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: z.infer<typeof accountHoldingsQuerySchema>) =>
+    accountHoldingsQuerySchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await getAccountHoldingsForFamily({
+      accountId: data.accountId,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })

--- a/tests/integration/holdings.integration.ts
+++ b/tests/integration/holdings.integration.ts
@@ -1,0 +1,491 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  deleteHoldingForFamily,
+  getAccountHoldingsForFamily,
+  HoldingError,
+  upsertHoldingForFamily,
+} from "@/server/holdings"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+describe("holdings core (PER-232 / ADR-0051 — Instrument + Holding + value=Σ holdings)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // ---- shared factories -----------------------------------------------------
+
+  // A valuation-tracked investment account (TRACKED_ASSET → balanceSource
+  // "valuation"), the only kind holdings may attach to this slice.
+  const makeInvestmentAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    openingBalance = "0"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name: "Bibit",
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const makeCashAccount = async (owner: AuthenticatedOnboardedUser) =>
+    await createAccountForFamily({
+      data: {
+        name: "Checking",
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance: "150000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // Add a fresh gold holding (2.0180 gram, avg Rp 2,760,809/gram, last
+  // Rp 2,455,000/gram). Amounts are MAJOR units; the server parses to minor.
+  const addGoldHolding = (
+    owner: AuthenticatedOnboardedUser,
+    accountId: string,
+    overrides: {
+      quantity?: string
+      avgUnitCost?: string
+      lastPrice?: string
+    } = {}
+  ) =>
+    upsertHoldingForFamily({
+      data: {
+        accountId,
+        instrument: {
+          kind: "metal",
+          name: "BSI Gold",
+          symbol: "XAU",
+        },
+        quantity: overrides.quantity ?? "2.0180",
+        avgUnitCost: overrides.avgUnitCost ?? "2760809",
+        lastPrice: overrides.lastPrice ?? "2455000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const accountRow = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: accountId } })
+    )
+
+  // --------------------------------------------------------------------------
+  // Create + value = Σ holdings
+  // --------------------------------------------------------------------------
+  describe("create holding + account value anchor", () => {
+    test("creates a holding with an inline instrument and computes value/cost/gain", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+
+      const holding = await addGoldHolding(owner, account.id)
+
+      // 2.0180 × Rp 2,455,000 = Rp 4,954,190 (495_419_000 sen).
+      expect(holding.valueMinor).toBe("495419000")
+      // 2.0180 × Rp 2,760,809 = Rp 5,571,312.56 → 557_131_256 sen.
+      expect(holding.costMinor).toBe("557131256")
+      expect(holding.gainMinor).toBe("-61712256")
+      expect(holding.currency).toBe("IDR")
+      expect(holding.instrument.kind).toBe("metal")
+      expect(holding.instrument.priceModel).toBe("market")
+      expect(holding.quantity).toBe("2.01800000")
+    })
+
+    test("account balance materializes to Σ holding values via a valuation anchor", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+
+      await addGoldHolding(owner, account.id)
+      // Add a second holding: 10 units × Rp 1,000 = Rp 10,000 (1_000_000 sen).
+      await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "Fund A" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          lastPrice: "1000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const view = await getAccountHoldingsForFamily({
+        accountId: account.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      expect(view.holdings).toHaveLength(2)
+      expect(view.totalValueMinor).toBe("496419000") // 495_419_000 + 1_000_000
+
+      // The account balance equals Σ holding values (holdings-derived anchor).
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(496419000n)
+
+      // The anchor was written as a "manual" valuation sourced from holdings.
+      const anchor = await harness.withFamily(owner.family.id, (tx) =>
+        tx.valuation.findFirst({
+          where: { accountId: account.id, source: "holdings" },
+          orderBy: { createdAt: "desc" },
+        })
+      )
+      expect(anchor?.value).toBe(496419000n)
+      expect(anchor?.type).toBe("manual")
+    })
+
+    test("a holding with no lastPrice values at cost basis (honest, gain 0)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+
+      const holding = await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "stock", name: "No Price Co", symbol: "NPC" },
+          quantity: "3",
+          avgUnitCost: "5000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(holding.lastPriceMinor).toBeNull()
+      expect(holding.valueMinor).toBe(holding.costMinor) // value == cost
+      expect(holding.gainMinor).toBe("0")
+      expect(holding.returnPct).toBe(0)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Update + delete recompute the anchor
+  // --------------------------------------------------------------------------
+  describe("update + delete recompute the account value", () => {
+    test("updating quantity and price recomputes value and balance", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const holding = await addGoldHolding(owner, account.id)
+
+      const updated = await upsertHoldingForFamily({
+        data: {
+          holdingId: holding.id,
+          accountId: account.id,
+          quantity: "4",
+          avgUnitCost: "2760809",
+          lastPrice: "2500000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      // 4 × Rp 2,500,000 = Rp 10,000,000 (1_000_000_000 sen).
+      expect(updated.valueMinor).toBe("1000000000")
+      expect(updated.quantity).toBe("4.00000000")
+
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(1000000000n)
+    })
+
+    test("deleting a holding removes it and recomputes the balance", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const gold = await addGoldHolding(owner, account.id)
+      const fund = await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "Fund A" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          lastPrice: "1000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const result = await deleteHoldingForFamily({
+        data: {
+          holdingId: fund.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(result.deleted).toBe(true)
+      expect(result.accountId).toBe(account.id)
+
+      const view = await getAccountHoldingsForFamily({
+        accountId: account.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      expect(view.holdings).toHaveLength(1)
+      expect(view.holdings[0]?.id).toBe(gold.id)
+      expect(view.totalValueMinor).toBe("495419000")
+
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(495419000n)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Idempotency
+  // --------------------------------------------------------------------------
+  describe("idempotency", () => {
+    test("replaying the same upsert key returns the same holding and writes once", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const key = factories.createIdempotencyKey()
+      const payload = {
+        data: {
+          accountId: account.id,
+          instrument: { kind: "metal" as const, name: "BSI Gold" },
+          quantity: "2.0180",
+          avgUnitCost: "2760809",
+          lastPrice: "2455000",
+          idempotencyKey: key,
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      }
+
+      const first = await upsertHoldingForFamily(payload)
+      const second = await upsertHoldingForFamily(payload)
+      expect(second.id).toBe(first.id)
+
+      const count = await harness.withFamily(owner.family.id, (tx) =>
+        tx.holding.count({ where: { accountId: account.id } })
+      )
+      expect(count).toBe(1)
+
+      const balance = (await accountRow(owner, account.id)).balance
+      expect(balance).toBe(495419000n) // applied exactly once
+    })
+
+    test("replaying the same delete key is a single no-op", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const holding = await addGoldHolding(owner, account.id)
+      const key = factories.createIdempotencyKey()
+
+      const first = await deleteHoldingForFamily({
+        data: { holdingId: holding.id, idempotencyKey: key },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      const second = await deleteHoldingForFamily({
+        data: { holdingId: holding.id, idempotencyKey: key },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(second).toEqual(first)
+
+      const count = await harness.withFamily(owner.family.id, (tx) =>
+        tx.holding.count({ where: { accountId: account.id } })
+      )
+      expect(count).toBe(0)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Eligibility + rejections
+  // --------------------------------------------------------------------------
+  describe("account eligibility", () => {
+    test("rejects adding a holding to a cash (transaction_flow) account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const cash = await makeCashAccount(owner)
+
+      await expect(
+        upsertHoldingForFamily({
+          data: {
+            accountId: cash.id,
+            instrument: { kind: "metal", name: "Gold" },
+            quantity: "1",
+            avgUnitCost: "1000",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+      ).rejects.toBeInstanceOf(HoldingError)
+    })
+
+    test("rejects an instrument whose currency differs from the account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner) // IDR
+
+      await expect(
+        upsertHoldingForFamily({
+          data: {
+            accountId: account.id,
+            instrument: {
+              kind: "stock",
+              name: "US Stock",
+              quoteCurrency: "USD",
+            },
+            quantity: "1",
+            avgUnitCost: "100",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+      ).rejects.toBeInstanceOf(HoldingError)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Tenant isolation
+  // --------------------------------------------------------------------------
+  describe("tenant isolation", () => {
+    test("another family cannot read this family's holdings", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      await addGoldHolding(owner, account.id)
+
+      // Intruder queries the owner's account id under their own family scope.
+      await expect(
+        getAccountHoldingsForFamily({
+          accountId: account.id,
+          familyId: intruder.family.id,
+          userId: intruder.user.id,
+        })
+      ).rejects.toBeInstanceOf(HoldingError)
+    })
+
+    test("another family cannot upsert onto this family's account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+
+      await expect(
+        upsertHoldingForFamily({
+          data: {
+            accountId: account.id,
+            instrument: { kind: "metal", name: "Gold" },
+            quantity: "1",
+            avgUnitCost: "1000",
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: intruder.family.id,
+          user: intruder.user,
+        })
+      ).rejects.toThrow()
+
+      const count = await harness.withFamily(owner.family.id, (tx) =>
+        tx.holding.count({ where: { accountId: account.id } })
+      )
+      expect(count).toBe(0)
+    })
+
+    test("another family cannot delete this family's holding", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const holding = await addGoldHolding(owner, account.id)
+
+      // Under the intruder's scope the holding is invisible → treated as a
+      // no-op (gone) delete, so the owner's holding must survive.
+      await deleteHoldingForFamily({
+        data: {
+          holdingId: holding.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+
+      const count = await harness.withFamily(owner.family.id, (tx) =>
+        tx.holding.count({ where: { id: holding.id } })
+      )
+      expect(count).toBe(1)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Database is the law — constraint rejection (raw writes)
+  // --------------------------------------------------------------------------
+  describe("database constraints", () => {
+    test("rejects a negative quantity at the DB CHECK", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const instrument = await harness.withFamily(owner.family.id, (tx) =>
+        tx.instrument.create({
+          data: {
+            familyId: owner.family.id,
+            kind: "metal",
+            name: "Gold",
+            quoteCurrency: "IDR",
+            priceModel: "market",
+          },
+        })
+      )
+
+      await expect(
+        harness.withFamily(owner.family.id, (tx) =>
+          tx.holding.create({
+            data: {
+              familyId: owner.family.id,
+              accountId: account.id,
+              instrumentId: instrument.id,
+              quantity: "-1",
+              avgUnitCostMinor: 1000n,
+            },
+          })
+        )
+      ).rejects.toThrow()
+    })
+
+    test("rejects an out-of-domain instrument kind at the DB CHECK", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      await expect(
+        harness.withFamily(owner.family.id, (tx) =>
+          tx.instrument.create({
+            data: {
+              familyId: owner.family.id,
+              kind: "bogus",
+              name: "Nope",
+              quoteCurrency: "IDR",
+              priceModel: "market",
+            },
+          })
+        )
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/tests/integration/support/database.ts
+++ b/tests/integration/support/database.ts
@@ -22,6 +22,8 @@ const RESET_TABLES = [
   "BudgetCategory",
   "Budget",
   "Category",
+  "Holding",
+  "Instrument",
   "Account",
   "Session",
   "AuthAccount",


### PR DESCRIPTION
## PER-232 Slice 1 — Investments & Holdings core (ADR-0051)

Backend + pure logic + tests for the market-priced Holdings core. **Market-priced only** — no UI, no buy/sell cash flow, no yield-bearing math, no feeds, no lots, no live-prod migration (all later slices).

### Schema (additive migration `20260804120000_holdings_core`)
- **`Instrument`** (tenant-scoped, v1 manual): `kind` (CHECK `mutual_fund|metal|stock|crypto|bond|deposit`), `name`, `symbol?`, `quoteCurrency` (FK to `iso_4217_currency`, shape CHECK), `priceModel` (CHECK `market|yield`, default `market`). `UNIQUE(id, familyId)` so it can be a composite-FK target; RLS tenant isolation.
- **`Holding`** (tenant-scoped): `quantity Decimal(38,8)` (CHECK ≥ 0), `avgUnitCostMinor BIGINT` (CHECK ≥ 0), `lastPriceMinor BIGINT?` (CHECK null or ≥ 0). **Composite tenant-safe FKs** `(accountId, familyId)→Account` and `(instrumentId, familyId)→Instrument` (ADR-0010 Pattern A, MATCH SIMPLE, `onDelete Restrict`); RLS tenant isolation.
- Additive only; touches no existing row. `vp exec prisma generate` run (no DB writes).

### Valuation math — pure, integer-only (`src/lib/holdings.ts`)
`QUANTITY_SCALE = 1e8` (matches the Decimal scale). Quantity is carried as a **scaled bigint**, so all math stays exact-integer (no float, per the money doctrine).
- `quantityToScaled("2.0180") → 201_800_000n` (strict; rejects negative/NaN/exponent/separator/>8 fraction digits)
- `holdingValueMinor = round_half_up(quantityScaled × priceMinor / QUANTITY_SCALE)` — half-up is `(a + S/2)/S` for non-negative `a` (both operands are non-negative by DB CHECK, so truncation == floor).
- `holdingCostMinor`, `holdingGainMinor = value − cost`, `holdingReturnPct = cost>0 ? (v−c)/c : null`, `sumHoldingValuesMinor`.
- Worked example (ADR-0051): 2.0180 g × Rp 2,455,000/g = Rp 4,954,190 (`495_419_000` sen).
- **Unit + fast-check property tests**: value non-negative & never NaN, monotonic in qty and price, Σ-parity with the account helper, gain never NaN / returnPct null iff cost 0, scale round-trip.

### Server contract (`src/server/holdings.ts`)
`upsertHoldingFn` / `deleteHoldingFn` / `getAccountHoldingsFn` — full ledger mutation contract (CLAUDE.md §5A): interactive scoped tenant transaction with the `app.family_id` RLS GUC, tenant-owned account + instrument validation, endpoint-scoped idempotency (`IdempotencyRecord`, UUIDv7), append-only `AuditLog` in the same tx. BigInt serialized as digit-strings; client types derive via `Awaited<ReturnType<…>>`.

**Account value = Σ holdings** is written back as a valuation **ANCHOR** (`createValuationWithinTx`, type `manual`, source `holdings`) in the same transaction, so the balance materializes from holdings and every net-worth/balance/audit/RLS invariant holds unchanged. Holdings restricted to `balanceSource="valuation"` accounts (clear error otherwise — enabling other accounts is a later slice); single-currency Σ (`instrument.quoteCurrency == account.currency`). A holding with no `lastPrice` values at cost basis (gain 0 — honest, never fabricated).

### Tests
- `src/lib/holdings.test.ts` — 21 unit + property tests.
- `tests/integration/holdings.integration.ts` — 14 real-Postgres tests: create + value=Σ + anchor, value-at-cost fallback, update/delete recompute, idempotency replay (upsert + delete), account-eligibility + currency rejection, tenant isolation (read/upsert/delete), CHECK-constraint rejection (negative quantity, bad kind).
- Harness `RESET_TABLES` extended with the two new tables.

### Results
- `vp check` clean (format + lint + types).
- `src/lib/holdings.test.ts` → 21 passed.
- `tests/integration/holdings.integration.ts` → 14 passed.
- Full integration suite → **38 files / 388 tests passed** (shared-harness change caused no regressions).

Do **not** merge — for review + full CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1