### PR TITLE
fix(investments): PER-232 — accept locale-formatted amounts in Add holding

### DIFF
--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -10,7 +10,7 @@ import {
   quantityToScaled,
   sumHoldingValuesMinor,
 } from "@/lib/holdings"
-import { toMinorUnits } from "@/lib/money"
+import { parseUserInput } from "@/lib/money"
 import {
   auditLog,
   createAuditContext,
@@ -252,20 +252,19 @@ function assertKnownCurrency(currency: string): CurrencyCode {
   return currency as CurrencyCode
 }
 
-// Parse a MAJOR-unit decimal string to a non-negative minor-unit bigint, turning
-// a malformed input into a typed HoldingError (never a raw TypeError).
+// Parse a user-entered MAJOR-unit amount to a non-negative minor-unit bigint.
+// Uses `parseUserInput` (locale-aware: handles the currency's thousands
+// delimiter + decimal separator, so IDR "2.760.809,32" parses correctly) — NOT
+// `toMinorUnits`, which demands a canonical decimal and throws on user-formatted
+// strings. Returns a typed HoldingError on malformed input (never a raw throw).
 function parseMinor(
   raw: string,
   currency: CurrencyCode,
   field: string
 ): bigint {
-  let minor: bigint
-  try {
-    minor = toMinorUnits(raw, currency)
-  } catch (error) {
-    throw new HoldingError(
-      `${field} is not a valid ${currency} amount: ${error instanceof Error ? error.message : String(error)}`
-    )
+  const minor = parseUserInput(raw, currency)
+  if (minor === null) {
+    throw new HoldingError(`${field} is not a valid ${currency} amount`)
   }
   if (minor < 0n) {
     throw new HoldingError(`${field} cannot be negative`)

--- a/tests/integration/holdings.integration.ts
+++ b/tests/integration/holdings.integration.ts
@@ -127,6 +127,26 @@ describe("holdings core (PER-232 / ADR-0051 — Instrument + Holding + value=Σ 
       expect(holding.quantity).toBe("2.01800000")
     })
 
+    test("accepts locale-formatted IDR amounts (thousands '.' + decimal ',')", async () => {
+      // The real bug: a user pastes the BSI-app figures "2.760.809,32" /
+      // "2.520.000,00" (Indonesian formatting) — parseUserInput must handle them,
+      // not toMinorUnits (which only takes a canonical decimal).
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+
+      const holding = await addGoldHolding(owner, account.id, {
+        quantity: "2.0180",
+        avgUnitCost: "2.760.809,32",
+        lastPrice: "2.520.000,00",
+      })
+
+      // 2.0180 × Rp 2,520,000.00 = Rp 5,085,360.00 → 508_536_000 sen.
+      expect(holding.valueMinor).toBe("508536000")
+      // 2.0180 × Rp 2,760,809.32 = Rp 5,571,313.207… → half-up 557_131_321 sen.
+      expect(holding.costMinor).toBe("557131321")
+      expect(holding.gainMinor).toBe("-48595321")
+    })
+
     test("account balance materializes to Σ holding values via a valuation anchor", async () => {
       const owner = await factories.createAuthenticatedOnboardedUser()
       const account = await makeInvestmentAccount(owner)


### PR DESCRIPTION
## Bug (dilaporkan user asli)
Saat mengisi "Add holding" untuk emas Antam dengan angka dari app BSI — `2.760.809,32` (ribuan `.`, desimal `,`) — submit gagal:
`avgUnitCost is not a valid IDR amount: toMinorUnits: malformed decimal "2.760.809,32"`.

## Sebab
Server holdings mem-parse field uang (avgUnitCost/lastPrice) dengan `toMinorUnits`, yang menuntut desimal kanonik dan menolak string berformat lokal. E2e sebelumnya pakai angka bulat ("1000000") sehingga bug ini lolos.

## Fix
`parseMinor` → pakai `parseUserInput` (helper locale-aware yang dipakai di seluruh app, mis. opening balance akun): ia menghapus delimiter ribuan currency + memetakan separator desimal → `.`, jadi `2.760.809,32` / `2.520.000,00` benar. **Quantity sengaja tetap** di jalur strict dot-decimal (locale-normalize unit itu ambigu & akan merusak kasus "2.0180" gram yang sudah jalan).

## Tes
Integration case memakai **angka persis dari laporan asli** → nilai/modal/untung minor yang benar (half-up). **15/15** holdings integration hijau; `vp check` bersih.

Catatan follow-up (bukan di PR ini): placeholder instrument "e.g. BSI Gold" menyesatkan (itu nama account, bukan instrument) + buy/sell flow yang link transfer kas ↔ holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)