### PR TITLE
feat(investments): PER-239 — opt-in holdings tracking for investment accounts

### DIFF
--- a/docs/adr/0051-investments-holdings-domain.md
+++ b/docs/adr/0051-investments-holdings-domain.md
@@ -147,3 +147,44 @@ live write. Supersedes PER-239 (its account-level value+cost is the degenerate
 5. **Lots + realized gains** — FIFO/average cost, dividends/coupons reinvest.
 6. **Portfolio + dashboard** — PER-230/231 read holdings (total value, cost,
    gain, allocation by kind), base-currency normalized (ADR-0035).
+
+## Opt-in valuation for investment accounts (PER-239)
+
+Genuine INVESTMENT accounts default to `balanceSource="transaction_flow"`
+(`getBalanceSourceForType` in `src/lib/accounts.ts` maps only `TRACKED_ASSET` →
+`"valuation"`). The holdings core (Slice 1) attaches only to valuation-tracked
+accounts, so an INVESTMENT account cannot record holdings until it is promoted.
+Rather than change the default derivation — which would ripple through the
+account-create path, the negative-balance carve-out, and existing accounts — a
+genuine INVESTMENT account **opts in** through one dedicated, audited endpoint,
+`enableHoldingsTrackingFn` (`src/server/accounts.ts`).
+
+- **Controlled override, not a new default.** `getBalanceSourceForType` and the
+  account-CREATE path are unchanged; the ADR-0008 taxonomy `balanceSource` is now
+  a **derived default, overridable to `valuation` for INVESTMENT via explicit
+  opt-in**. TRACKED_ASSET behavior is untouched.
+- **Safe-seed-anchor invariant (no data loss).** A valuation-tracked account
+  derives its balance from its latest valuation, not from transaction flow.
+  Inside the same tenant transaction, after flipping `balanceSource` →
+  `"valuation"`, the endpoint seeds a `reconciliation` anchor
+  (`source="manual"`, `valuationDate = now`, so it is the latest anchor) equal to
+  the account's current signed balance. `computeCanonicalBalance` then resolves
+  to exactly the pre-flip balance. When the user later adds holdings, the
+  holdings-derived anchor (`source="holdings"`, written afterwards) supersedes
+  the seed. A real-PG test asserts the balance is preserved on flip and equals
+  Σ holdings after the first holding.
+- **Preconditions.** Eligibility is one pure predicate
+  (`evaluateHoldingsTrackingEligibility`) shared by the endpoint and the UI CTA:
+  `accountClass="ASSET"`, `accountType="INVESTMENT"`,
+  `balanceSource="transaction_flow"`, `status="active"`, and **reserve must be
+  clear** (`reserveBalance IS NULL`) and no person-debt link
+  (`counterpartyMerchantId IS NULL`) — a reserve floor is cash-only and a
+  counterparty link is RECEIVABLE/LOAN-only, both incompatible with a
+  valuation-sourced account. TRACKED_ASSET / already-`valuation` accounts are
+  rejected as "already valuation-tracked".
+- **One-way for now.** The reverse (`valuation` → `transaction_flow`) is a later
+  slice; the endpoint only promotes. Full §5A contract: RLS-scoped tenant
+  transaction, endpoint idempotency (replay + unique-race replay so a retry never
+  writes a second anchor or moves the balance again), and before/after `Account`
+  audit rows in the same transaction. Supersedes the PER-239 account-level value
+  approach folded into this ADR.

--- a/prisma/migrations/20260807120000_investment_opt_in_valuation/migration.sql
+++ b/prisma/migrations/20260807120000_investment_opt_in_valuation/migration.sql
@@ -1,0 +1,27 @@
+-- PER-239 / ADR-0051: opt-in valuation tracking for INVESTMENT accounts.
+--
+-- Genuine INVESTMENT accounts default to balanceSource='transaction_flow'
+-- (_per143_balance_source_for_type). To record holdings (ADR-0051) an
+-- INVESTMENT account may be explicitly promoted to 'valuation' through the
+-- `enableHoldingsTrackingFn` endpoint (a controlled, audited, one-way opt-in
+-- that seeds a balance-preserving reconciliation anchor in the same
+-- transaction).
+--
+-- This relaxes the consistency CHECK so an INVESTMENT account may hold EITHER
+-- source, while every other accountType stays pinned to its derived source:
+-- TRACKED_ASSET => 'valuation'; all others => 'transaction_flow'. The default
+-- column value and the account-CREATE path are unchanged (a new INVESTMENT
+-- account is still born 'transaction_flow'); only the explicit opt-in flips it.
+-- One-way for now (reverse valuation => transaction_flow is a later slice).
+
+ALTER TABLE "Account"
+  DROP CONSTRAINT account_balance_source_consistency;
+
+ALTER TABLE "Account"
+  ADD CONSTRAINT account_balance_source_consistency CHECK (
+    CASE
+      WHEN "accountType" = 'INVESTMENT'
+        THEN "balanceSource" IN ('transaction_flow', 'valuation')
+      ELSE "balanceSource" = _per143_balance_source_for_type("accountType")
+    END
+  );

--- a/src/lib/accounts.test.ts
+++ b/src/lib/accounts.test.ts
@@ -5,10 +5,13 @@ import {
   ACCOUNT_TYPE_VALUES,
   BALANCE_SOURCE_VALUES,
   allowsNegativeAssetBalance,
+  canEnableHoldingsTracking,
+  evaluateHoldingsTrackingEligibility,
   getAccountClassForType,
   getAccountNormalBalance,
   getBalanceSourceForType,
   getDefaultAccountSubtype,
+  type HoldingsTrackingEligibilityInput,
   isCashLikeAccount,
   isLiabilityAccountType,
   normalizeAccountTaxonomy,
@@ -144,5 +147,82 @@ describe("account taxonomy", () => {
     expect(allowsNegativeAssetBalance("TRACKED_ASSET")).toBe(false)
     expect(allowsNegativeAssetBalance("CREDIT")).toBe(false)
     expect(allowsNegativeAssetBalance("LOAN")).toBe(false)
+  })
+})
+
+describe("holdings tracking eligibility (PER-239 / ADR-0051)", () => {
+  const eligibleInvestment: HoldingsTrackingEligibilityInput = {
+    accountClass: "ASSET",
+    accountType: "INVESTMENT",
+    balanceSource: "transaction_flow",
+    reserveBalance: null,
+    counterpartyMerchantId: null,
+    status: "active",
+  }
+
+  test("a live, reserve-free INVESTMENT account is eligible", () => {
+    expect(evaluateHoldingsTrackingEligibility(eligibleInvestment)).toEqual({
+      eligible: true,
+    })
+    expect(canEnableHoldingsTracking(eligibleInvestment)).toBe(true)
+  })
+
+  test("rejects a non-INVESTMENT type", () => {
+    const result = evaluateHoldingsTrackingEligibility({
+      ...eligibleInvestment,
+      accountType: "DEPOSITORY",
+    })
+    expect(result.eligible).toBe(false)
+    expect(result).toMatchObject({ reason: /only.*INVESTMENT/i })
+  })
+
+  test("rejects an already valuation-tracked account (balanceSource)", () => {
+    const result = evaluateHoldingsTrackingEligibility({
+      ...eligibleInvestment,
+      balanceSource: "valuation",
+    })
+    expect(result).toEqual({
+      eligible: false,
+      reason: "Account is already valuation-tracked",
+    })
+  })
+
+  test("rejects a TRACKED_ASSET account as already tracked", () => {
+    const result = evaluateHoldingsTrackingEligibility({
+      ...eligibleInvestment,
+      accountType: "TRACKED_ASSET",
+      balanceSource: "valuation",
+    })
+    expect(result).toEqual({
+      eligible: false,
+      reason: "Account is already valuation-tracked",
+    })
+  })
+
+  test("rejects when a reserve balance is set", () => {
+    const result = evaluateHoldingsTrackingEligibility({
+      ...eligibleInvestment,
+      reserveBalance: 1000n,
+    })
+    expect(result).toEqual({
+      eligible: false,
+      reason: "Clear the reserve balance before enabling holdings tracking",
+    })
+  })
+
+  test("rejects a person-debt (counterparty) account", () => {
+    const result = evaluateHoldingsTrackingEligibility({
+      ...eligibleInvestment,
+      counterpartyMerchantId: "merchant_1",
+    })
+    expect(result.eligible).toBe(false)
+  })
+
+  test("rejects a non-active (archived) account", () => {
+    const result = evaluateHoldingsTrackingEligibility({
+      ...eligibleInvestment,
+      status: "closed",
+    })
+    expect(result.eligible).toBe(false)
   })
 })

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -204,6 +204,104 @@ export function allowsNegativeAssetBalance(accountType: AccountType): boolean {
   return NEGATIVE_BALANCE_ALLOWED_ACCOUNT_TYPE_SET.has(accountType)
 }
 
+// PER-239 / ADR-0051 — opt-in holdings tracking eligibility (pure).
+//
+// Genuine INVESTMENT accounts default to balanceSource="transaction_flow"
+// (getBalanceSourceForType), so they cannot hold `Holding` rows until they are
+// explicitly promoted to valuation-tracked. This is the single, pure predicate
+// that decides whether an account may be promoted — kept Prisma-free so the
+// server endpoint (enableHoldingsTrackingForFamily) and the UI CTA gate read
+// ONE source of truth and can never disagree about who is eligible.
+//
+// It is deliberately a controlled OVERRIDE of the `getBalanceSourceForType`
+// default: the default derivation and the account-create path are unchanged;
+// only this explicit opt-in flips an INVESTMENT account to "valuation".
+
+export interface HoldingsTrackingEligibilityInput {
+  accountClass: string
+  accountType: string
+  balanceSource: string
+  reserveBalance: bigint | null
+  counterpartyMerchantId: string | null
+  status: string
+}
+
+export type HoldingsTrackingEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: string }
+
+/**
+ * Whether a (live, non-deleted) account may opt into holdings tracking. Returns
+ * a machine-checkable verdict with a user-facing reason on rejection. Existence
+ * and `deletedAt` are the caller's concern (they surface as a not-found error
+ * before this runs). Reserve/counterparty must be clear because holdings
+ * tracking re-materializes the balance from a valuation anchor: a reserve floor
+ * (cash-only) and a person-debt link (RECEIVABLE/LOAN only) are incompatible
+ * with a valuation-sourced INVESTMENT account.
+ */
+export function evaluateHoldingsTrackingEligibility(
+  account: HoldingsTrackingEligibilityInput
+): HoldingsTrackingEligibility {
+  if (account.status !== "active") {
+    return {
+      eligible: false,
+      reason: "Only an active account can enable holdings tracking",
+    }
+  }
+  if (account.accountClass !== "ASSET") {
+    return {
+      eligible: false,
+      reason: `Holdings tracking is only available for ASSET accounts, not ${account.accountClass}`,
+    }
+  }
+  // TRACKED_ASSET (and anything already valuation-sourced) is already tracked.
+  if (
+    account.accountType === "TRACKED_ASSET" ||
+    account.balanceSource === "valuation"
+  ) {
+    return {
+      eligible: false,
+      reason: "Account is already valuation-tracked",
+    }
+  }
+  if (account.accountType !== "INVESTMENT") {
+    return {
+      eligible: false,
+      reason: `Holdings tracking is only available for INVESTMENT accounts, not ${account.accountType}`,
+    }
+  }
+  if (account.balanceSource !== "transaction_flow") {
+    return {
+      eligible: false,
+      reason: `Account balanceSource must be transaction_flow to enable holdings tracking, not ${account.balanceSource}`,
+    }
+  }
+  if (account.reserveBalance !== null) {
+    return {
+      eligible: false,
+      reason: "Clear the reserve balance before enabling holdings tracking",
+    }
+  }
+  if (account.counterpartyMerchantId !== null) {
+    return {
+      eligible: false,
+      reason: "Holdings tracking is not available for a person-debt account",
+    }
+  }
+  return { eligible: true }
+}
+
+/**
+ * UI convenience over `evaluateHoldingsTrackingEligibility` — a boolean gate for
+ * rendering the "Track as holdings portfolio" CTA. Same predicate, so the CTA
+ * can never offer an account the server would reject.
+ */
+export function canEnableHoldingsTracking(
+  account: HoldingsTrackingEligibilityInput
+): boolean {
+  return evaluateHoldingsTrackingEligibility(account).eligible
+}
+
 export function normalizeAccountTaxonomy(
   input: AccountTaxonomyInput
 ): AccountTaxonomy {

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -11,6 +11,7 @@ import {
   Receipt,
   Scale,
   Search,
+  TrendingUp,
 } from "lucide-react"
 
 import { AppSidebar } from "@/components/app-sidebar"
@@ -20,6 +21,24 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { AccountVisual } from "@/components/blocks/account-visual"
 import { AccountFormDialog } from "@/components/blocks/account-form-dialog"
 import { ValuationActionDialog } from "@/components/blocks/valuation-action-dialog"
@@ -54,6 +73,8 @@ import { computeAccountRunway } from "@/lib/account-runway"
 import { computeIdleCash } from "@/lib/account-idle-cash"
 import { computeAccountPerformance } from "@/lib/account-performance"
 import { getAccountOpeningValueFn } from "@/server/valuations"
+import { enableHoldingsTrackingFn } from "@/server/accounts"
+import { canEnableHoldingsTracking } from "@/lib/accounts"
 import { deleteHoldingFn, getAccountHoldingsFn } from "@/server/holdings"
 import { HoldingsPanel, type HoldingRecord } from "./-account-holdings"
 import { computeAccountHealth } from "@/lib/account-health"
@@ -146,6 +167,22 @@ function AccountDetailPage() {
   const tracked = account?.balanceSource === "valuation"
   const currentBalance = account ? BigInt(account.balance) : 0n
 
+  // PER-239 / ADR-0051 — whether this INVESTMENT account can opt into holdings
+  // (valuation) tracking. Same pure predicate the server enforces, so the CTA
+  // never offers an account the server would reject.
+  const eligibleForHoldings = React.useMemo(() => {
+    if (!account) return false
+    return canEnableHoldingsTracking({
+      accountClass: account.accountClass,
+      accountType: account.accountType,
+      balanceSource: account.balanceSource,
+      reserveBalance:
+        account.reserveBalance !== null ? BigInt(account.reserveBalance) : null,
+      counterpartyMerchantId: account.counterpartyMerchantId,
+      status: account.status,
+    })
+  }, [account])
+
   // PER-229 — the opening valuation scalar (the one piece the client can't
   // derive) for investment/gold cost basis. Fetched declaratively; only for
   // valuation-tracked accounts. No useEffect (no-use-effect rule).
@@ -177,6 +214,26 @@ function AccountDetailPage() {
   // collections the hero/KPIs read from.
   async function refreshHoldings() {
     await Promise.all([refetchHoldings(), refreshAccountData()])
+  }
+
+  // PER-239 / ADR-0051 — flip this INVESTMENT account to valuation tracking,
+  // then resync the account collections (so `tracked` becomes true and the
+  // HoldingsPanel renders) and the holdings query.
+  async function handleEnableHoldingsTracking() {
+    try {
+      await enableHoldingsTrackingFn({
+        data: { accountId, idempotencyKey: createUuidV7() },
+      })
+      await refreshAccountData()
+      await refetchHoldings()
+      toast.success("Holdings tracking enabled")
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to enable holdings tracking"
+      )
+    }
   }
 
   async function handleDeleteHolding(holding: HoldingRecord) {
@@ -414,6 +471,12 @@ function AccountDetailPage() {
           {performance ? (
             <PerformancePanel performance={performance} currency={currency} />
           ) : null}
+          {eligibleForHoldings ? (
+            <EnableHoldingsCta
+              balanceLabel={formatCurrency(currentBalance, currency)}
+              onConfirm={handleEnableHoldingsTracking}
+            />
+          ) : null}
           {tracked ? (
             <HoldingsPanel
               view={holdingsView}
@@ -621,6 +684,64 @@ async function refreshAccountData() {
     accountCollection.utils.refetch(),
     transactionCollection.utils.refetch(),
   ])
+}
+
+// PER-239 / ADR-0051 — CTA that promotes an eligible INVESTMENT account to
+// holdings (valuation) tracking. Confirm is guarded by an AlertDialog because
+// the flip is one-way for now. Self-contained pending state so a double-click
+// can't fire the mutation twice.
+function EnableHoldingsCta({
+  balanceLabel,
+  onConfirm,
+}: Readonly<{ balanceLabel: string; onConfirm: () => Promise<void> }>) {
+  const [pending, setPending] = React.useState(false)
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <TrendingUp className="size-4" />
+          Track as holdings portfolio
+        </CardTitle>
+        <CardDescription>
+          Record each fund or position (units × market price). Your current
+          balance {balanceLabel} becomes the starting value until you add
+          holdings.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button size="sm" disabled={pending}>
+              <TrendingUp className="size-4" />
+              Enable holdings tracking
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Enable holdings tracking?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This account&apos;s balance will be tracked from the holdings
+                you add. Your current balance {balanceLabel} is kept as the
+                starting value until you record your first position. This
+                can&apos;t be undone yet.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  setPending(true)
+                  void onConfirm().finally(() => setPending(false))
+                }}
+              >
+                Enable
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  )
 }
 
 function BackLink() {

--- a/src/server/accounts.ts
+++ b/src/server/accounts.ts
@@ -4,6 +4,7 @@ import { z } from "zod"
 import {
   ACCOUNT_TYPE_VALUES,
   allowsNegativeAssetBalance,
+  evaluateHoldingsTrackingEligibility,
   normalizeAccountTaxonomy,
   type AccountType,
 } from "@/lib/accounts"
@@ -32,6 +33,7 @@ import {
   softDeleteTransactionWithinTenantTransaction,
   TransactionGoneError,
 } from "./transactions"
+import { createValuationWithinTx } from "./valuations"
 
 // =============================================================================
 // PER-143 — Account manual UX vertical slice (CRUD, archive, cash-vs-tracked).
@@ -55,6 +57,7 @@ const CREATE_ACCOUNT_ENDPOINT = "createAccountFn"
 const UPDATE_ACCOUNT_ENDPOINT = "updateAccountFn"
 const ARCHIVE_ACCOUNT_ENDPOINT = "archiveAccountFn"
 const REACTIVATE_ACCOUNT_ENDPOINT = "reactivateAccountFn"
+const ENABLE_HOLDINGS_TRACKING_ENDPOINT = "enableHoldingsTrackingFn"
 
 /**
  * Raised when a mutation targets an account id that does not belong to the
@@ -166,6 +169,15 @@ export const updateAccountInputSchema = z.object({
 
 export const accountIdActionInputSchema = z.object({
   id: z.string().min(1),
+  idempotencyKey: uuidV7Schema,
+})
+
+// PER-239 / ADR-0051 — opt an INVESTMENT account into holdings (valuation)
+// tracking. Deliberately its own schema (accountId, not id) to keep it distinct
+// from the generic id-actions: this is a one-way ledger-shape change, not a
+// metadata edit.
+export const enableHoldingsTrackingInputSchema = z.object({
+  accountId: z.string().min(1),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -667,6 +679,163 @@ export const updateAccountFn = createServerFn({ method: "POST" })
   )
   .handler(async ({ data, context }) => {
     return await updateAccountForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// ============================================================================
+// ENABLE HOLDINGS TRACKING (PER-239 / ADR-0051)
+// ============================================================================
+//
+// Genuine INVESTMENT accounts default to balanceSource="transaction_flow"
+// (getBalanceSourceForType), so the holdings layer's eligibility gate
+// (src/server/holdings.ts) rejects them — even though the whole holdings core
+// (Instrument + Holding + value=Σ holdings) is already built. This endpoint is
+// the ONE explicit, controlled override of that default: it flips a qualifying
+// INVESTMENT account to balanceSource="valuation" so it can record holdings.
+//
+// The safe-seed-anchor invariant: a valuation-tracked account derives its
+// balance from its LATEST valuation, not from transaction flow. Flipping the
+// source alone would make the balance resolve to the account's opening
+// valuation and silently drop any accumulated flow. So, inside the SAME
+// transaction and AFTER the flip, we seed a `reconciliation` anchor equal to
+// the account's CURRENT signed balance (valuationDate = now, hence the latest
+// anchor). computeCanonicalBalance then resolves to exactly the old balance —
+// zero data loss — until the user enters holdings, at which point the
+// holdings-derived anchor (source="holdings", written later) supersedes it.
+//
+// One-way for now: the reverse (valuation → transaction_flow) is a later slice.
+// Full §5A contract: RLS-scoped tenant tx, endpoint idempotency (replay +
+// unique-race replay), before/after Account audit, tenant-owned validation.
+
+export async function enableHoldingsTrackingForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof enableHoldingsTrackingInputSchema>
+  familyId: string
+  user: ServerUser
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedAccount> {
+  const data = enableHoldingsTrackingInputSchema.parse(rawData)
+  const requestHash = await hashCanonicalPayload({ accountId: data.accountId })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<SerializedAccount>(
+        tx,
+        {
+          endpoint: ENABLE_HOLDINGS_TRACKING_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      // Tenant isolation: RLS + the explicit familyId filter. A soft-deleted or
+      // cross-tenant account is simply "not found" here.
+      const before = await tx.account.findFirst({
+        where: { id: data.accountId, familyId },
+      })
+      if (!before || before.deletedAt !== null) {
+        throw new AccountNotFoundError(data.accountId)
+      }
+
+      // Single pure predicate shared with the UI CTA gate (no drift).
+      const eligibility = evaluateHoldingsTrackingEligibility(before)
+      if (!eligibility.eligible) {
+        throw new AccountValidationError(eligibility.reason)
+      }
+
+      // (a) Flip the balance source FIRST, so the seed anchor below is written
+      // and re-materialized under valuation semantics (latest valuation wins).
+      await tx.account.update({
+        where: { id: data.accountId },
+        data: { balanceSource: "valuation" },
+      })
+
+      // (b) Seed the balance-preserving anchor. createValuationWithinTx signs
+      // the magnitude, writes the Valuation + its audit row, and re-materializes
+      // Account.balance from canonical rows. For an INVESTMENT (ASSET) account
+      // the stored balance is a non-negative magnitude, so passing it straight
+      // through is exactly the current signed value. This anchor is the latest
+      // (valuationDate = now), so canonical resolves to it == old balance.
+      await createValuationWithinTx(
+        tx,
+        familyId,
+        {
+          accountId: data.accountId,
+          value: before.balance.toString(),
+          currency: before.currency,
+          type: "reconciliation",
+          source: "manual",
+          valuationDate: new Date(),
+          idempotencyKey: data.idempotencyKey,
+        },
+        user,
+        auditCtx
+      )
+
+      // Re-read: the flip + seed anchor may have touched balance/version.
+      const after = await tx.account.findFirstOrThrow({
+        where: { id: data.accountId, familyId },
+      })
+      const serialized = serializeAccount(after)
+      await auditLog(tx, auditCtx, {
+        action: "update",
+        entityType: "Account",
+        entityId: after.id,
+        before: serializeAccount(before),
+        after: serialized,
+      })
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: ENABLE_HOLDINGS_TRACKING_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response: serialized,
+      })
+      return serialized
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    // Concurrent same-key request won the IdempotencyRecord unique race; resolve
+    // by replaying the stored response (mirrors createAccountForFamily).
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(
+      familyId,
+      user.id,
+      async (tx) =>
+        replayIdempotentEndpointResponse<SerializedAccount>(tx, {
+          endpoint: ENABLE_HOLDINGS_TRACKING_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const enableHoldingsTrackingFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("account:write")])
+  .inputValidator((data: z.input<typeof enableHoldingsTrackingInputSchema>) =>
+    enableHoldingsTrackingInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await enableHoldingsTrackingForFamily({
       data,
       familyId: context.familyId,
       user: context.user,

--- a/tests/integration/enable-holdings-tracking.integration.ts
+++ b/tests/integration/enable-holdings-tracking.integration.ts
@@ -1,0 +1,326 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import {
+  AccountNotFoundError,
+  AccountValidationError,
+  createAccountForFamily,
+  enableHoldingsTrackingForFamily,
+} from "@/server/accounts"
+import { upsertHoldingForFamily } from "@/server/holdings"
+import { computeCanonicalBalance, fetchAccountFacts } from "@/server/valuations"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// =============================================================================
+// PER-239 / ADR-0051 — opt-in holdings tracking for INVESTMENT accounts.
+//
+// Genuine INVESTMENT accounts default to balanceSource="transaction_flow" and
+// so cannot record holdings. `enableHoldingsTrackingForFamily` flips a
+// qualifying INVESTMENT account to "valuation" and seeds a balance-preserving
+// reconciliation anchor in the SAME transaction. These real-PG tests prove the
+// safe-seed-anchor invariant (no data loss), idempotent replay, the eligibility
+// rejections, tenant isolation, and that the holdings layer then works
+// unchanged (enable → add holding → balance == Σ holdings).
+// =============================================================================
+
+describe("enable holdings tracking (PER-239 / ADR-0051 — opt-in valuation)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // A genuine INVESTMENT account (accountType="INVESTMENT" →
+  // balanceSource="transaction_flow"), the exact case this slice unblocks.
+  const makeInvestmentAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    options: { openingBalance?: string; reserveBalance?: string } = {}
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name: "Bibit",
+        accountType: "INVESTMENT" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: options.openingBalance ?? "5000000",
+        ...(options.reserveBalance
+          ? { reserveBalance: options.reserveBalance }
+          : {}),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const accountRow = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: accountId } })
+    )
+
+  const canonicalBalance = (
+    owner: AuthenticatedOnboardedUser,
+    accountId: string
+  ) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const facts = await fetchAccountFacts(tx, owner.family.id, accountId)
+      if (!facts) throw new Error("account not found")
+      return await computeCanonicalBalance(tx, owner.family.id, facts)
+    })
+
+  const reconciliationAnchors = (
+    owner: AuthenticatedOnboardedUser,
+    accountId: string
+  ) =>
+    harness.withFamily(owner.family.id, (tx) =>
+      tx.valuation.findMany({
+        where: { accountId, type: "reconciliation" },
+        orderBy: { createdAt: "asc" },
+      })
+    )
+
+  // --------------------------------------------------------------------------
+  // Happy path — safe-seed-anchor invariant (no data loss on flip)
+  // --------------------------------------------------------------------------
+  describe("enable happy path", () => {
+    test("flips balanceSource to valuation and preserves the balance as an anchor", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner, {
+        openingBalance: "5000000",
+      })
+      expect(account.balanceSource).toBe("transaction_flow")
+
+      const result = await enableHoldingsTrackingForFamily({
+        data: {
+          accountId: account.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      expect(result.balanceSource).toBe("valuation")
+      // Balance is unchanged by the flip (safe-seed-anchor invariant).
+      expect(result.balance).toBe("5000000")
+
+      const row = await accountRow(owner, account.id)
+      expect(row.balanceSource).toBe("valuation")
+      expect(row.balance).toBe(5000000n)
+
+      // computeCanonicalBalance resolves to the OLD balance — zero data loss.
+      expect(await canonicalBalance(owner, account.id)).toBe(5000000n)
+
+      // Exactly one reconciliation anchor was seeded, equal to the old balance.
+      const anchors = await reconciliationAnchors(owner, account.id)
+      expect(anchors).toHaveLength(1)
+      expect(anchors[0]?.value).toBe(5000000n)
+      expect(anchors[0]?.source).toBe("manual")
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Idempotency
+  // --------------------------------------------------------------------------
+  describe("idempotency", () => {
+    test("replaying the same key writes no second anchor and does not move the balance", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner, {
+        openingBalance: "5000000",
+      })
+      const key = factories.createIdempotencyKey()
+
+      const first = await enableHoldingsTrackingForFamily({
+        data: { accountId: account.id, idempotencyKey: key },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      const second = await enableHoldingsTrackingForFamily({
+        data: { accountId: account.id, idempotencyKey: key },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      expect(second).toEqual(first)
+
+      const anchors = await reconciliationAnchors(owner, account.id)
+      expect(anchors).toHaveLength(1)
+
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(5000000n)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Eligibility rejections
+  // --------------------------------------------------------------------------
+  describe("eligibility rejections", () => {
+    test("rejects a non-INVESTMENT (cash) account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const cash = await createAccountForFamily({
+        data: {
+          name: "Checking",
+          accountType: "DEPOSITORY" as AccountType,
+          openingBalance: "150000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      await expect(
+        enableHoldingsTrackingForFamily({
+          data: {
+            accountId: cash.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+      ).rejects.toBeInstanceOf(AccountValidationError)
+
+      // The account was not mutated.
+      const row = await accountRow(owner, cash.id)
+      expect(row.balanceSource).toBe("transaction_flow")
+    })
+
+    test("rejects an INVESTMENT account that has a reserve balance set", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner, {
+        openingBalance: "5000000",
+        reserveBalance: "100000",
+      })
+      expect(account.reserveBalance).toBe("100000")
+
+      await expect(
+        enableHoldingsTrackingForFamily({
+          data: {
+            accountId: account.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+      ).rejects.toBeInstanceOf(AccountValidationError)
+
+      const row = await accountRow(owner, account.id)
+      expect(row.balanceSource).toBe("transaction_flow")
+    })
+
+    test("rejects an already valuation-tracked (TRACKED_ASSET) account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const tracked = await createAccountForFamily({
+        data: {
+          name: "House",
+          accountType: "TRACKED_ASSET" as AccountType,
+          accountSubtype: "real_estate",
+          openingBalance: "9000000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(tracked.balanceSource).toBe("valuation")
+
+      await expect(
+        enableHoldingsTrackingForFamily({
+          data: {
+            accountId: tracked.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+      ).rejects.toBeInstanceOf(AccountValidationError)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Tenant isolation
+  // --------------------------------------------------------------------------
+  describe("tenant isolation", () => {
+    test("another family cannot enable tracking on this family's account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner, {
+        openingBalance: "5000000",
+      })
+
+      await expect(
+        enableHoldingsTrackingForFamily({
+          data: {
+            accountId: account.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: intruder.family.id,
+          user: intruder.user,
+        })
+      ).rejects.toBeInstanceOf(AccountNotFoundError)
+
+      // The owner's account is untouched.
+      const row = await accountRow(owner, account.id)
+      expect(row.balanceSource).toBe("transaction_flow")
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Holdings layer works unchanged once enabled
+  // --------------------------------------------------------------------------
+  describe("holdings after enable", () => {
+    test("enable → add holding → balance equals Σ holdings", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner, {
+        openingBalance: "5000000",
+      })
+
+      await enableHoldingsTrackingForFamily({
+        data: {
+          accountId: account.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      // 10 units × Rp 1,000 = Rp 10,000 (1_000_000 sen).
+      const holding = await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "Fund A" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          lastPrice: "1000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(holding.valueMinor).toBe("1000000")
+
+      // The holdings-derived anchor supersedes the seed: balance == Σ holdings.
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(1000000n)
+    })
+  })
+})


### PR DESCRIPTION
## What & why

Genuine `INVESTMENT` accounts (e.g. a Bibit reksadana) default to `balanceSource="transaction_flow"`, so the holdings core shipped in PER-232 could not attach to them — the whole Instrument/Holding engine was built but unreachable for real portfolios. This PR adds **one dedicated, audited opt-in** that promotes a qualifying INVESTMENT account to valuation tracking so it can record holdings.

Unblocks the creator recording their Bibit reksadana. Closes the PER-239 gap (reactivated).

## How

- **`enableHoldingsTrackingFn`** (`src/server/accounts.ts`) — full CLAUDE.md §5A contract: RLS-scoped tenant tx, endpoint idempotency (replay + unique-race replay), before/after `Account` audit rows in the same tx. Inside one transaction it flips `balanceSource`→`"valuation"` **first**, then seeds a `reconciliation` anchor equal to the account's current signed balance (`valuationDate=now`, so it is the latest anchor).
- **Safe-seed-anchor invariant** — a valuation account derives its balance from its latest valuation, not transaction flow. The seed keeps `computeCanonicalBalance` == the pre-flip balance (zero data loss) until the user records holdings, at which point the holdings-derived anchor supersedes it.
- **Migration** `20260807120000_investment_opt_in_valuation` — relaxes `account_balance_source_consistency` so only INVESTMENT may hold either source; every other `accountType` stays pinned to its derived source. Default column + account-CREATE path unchanged. One-way for now.
- **Single pure eligibility predicate** (`evaluateHoldingsTrackingEligibility` / `canEnableHoldingsTracking`, `src/lib/accounts.ts`) shared by the server and the UI CTA — they can never disagree. Reserve floor / person-debt link must be clear.
- **UI** — "Track as holdings portfolio" CTA + confirm dialog on the account detail page (declarative `useMemo` gate, try/catch + toast, double-fire guard, shadcn + lucide, English copy).
- **ADR-0051** amended (opt-in valuation override + safe-seed-anchor invariant + preconditions + one-way).

## Tests

- **7 real-PG integration** (`tests/integration/enable-holdings-tracking.integration.ts`): balance preserved on flip (exactly one `reconciliation` anchor == old balance), idempotent replay (no second anchor, balance unmoved), reject non-INVESTMENT, reject reserve set, reject already-valuation, tenant isolation, enable→add holding→balance==Σ holdings. ✅
- **7 unit** eligibility cases + existing taxonomy tests. ✅
- `vp check` clean (format + lint + types). ✅
- Full integration suite green **except** 3 `sure-migration` crash-resume tests that fail with a `TRUNCATE` deadlock in `beforeEach reset` **only under heavy concurrent DB load** — they pass in isolation on both this branch and `main` on a settled DB (verified 3 ways). Pre-existing test-infra flake, unrelated code path; filed separately.

## Out of scope (separate tickets)

Buy-flow linkage (transfer→holding) → PER-198 · market auto-NAV → PER-197/233 · reverse toggle → later.

## Rollout

Additive migration (relaxes a CHECK; no data rewrite). **Flipping the creator's real prod Bibit/gold accounts stays gated on backup + explicit go-ahead** — this PR only ships the capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)