### PR TITLE
feat(money): PER-240 — locale-forgiving money-input parser + live preview

### DIFF
--- a/src/components/blocks/account-form-dialog.tsx
+++ b/src/components/blocks/account-form-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { MoneyInput } from "@/components/blocks/money-input"
 import {
   Select,
   SelectContent,
@@ -32,7 +33,7 @@ import { accountSupportsReserve } from "@/lib/account-reserve"
 import type { AccountRecord } from "@/lib/account-collections"
 import { CURRENCY_OPTIONS } from "@/lib/currency"
 import type { CurrencyCode } from "@/lib/data/currencies"
-import { parseUserInput, toDisplayNumber } from "@/lib/money"
+import { parseMoneyInput, toDecimalString } from "@/lib/money"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import { createAccountFn, updateAccountFn } from "@/server/accounts"
 
@@ -81,11 +82,9 @@ export function AccountFormDialog({
   // edit, seed from the stored minor-unit value (lazy init, no useEffect).
   const [reserveInput, setReserveInput] = React.useState<string>(() =>
     editing?.reserveBalance
-      ? String(
-          toDisplayNumber(
-            BigInt(editing.reserveBalance),
-            (editing.currency as CurrencyCode) ?? "IDR"
-          )
+      ? toDecimalString(
+          BigInt(editing.reserveBalance),
+          (editing.currency as CurrencyCode) ?? "IDR"
         )
       : ""
   )
@@ -124,8 +123,8 @@ export function AccountFormDialog({
         if (reserveInput.trim() === "") {
           reserveMinor = editing ? null : undefined
         } else {
-          const parsedReserve = parseUserInput(
-            reserveInput.trim(),
+          const parsedReserve = parseMoneyInput(
+            reserveInput,
             currency as CurrencyCode
           )
           if (parsedReserve === null || parsedReserve < 0n) {
@@ -150,14 +149,15 @@ export function AccountFormDialog({
           },
         })
       } else {
-        // PER-207: parse the user-typed opening balance with `parseUserInput`
-        // (handles thousands separators / locale decimal, returns null on
-        // malformed) — NOT `toMinorUnits`, which expects a canonical decimal
-        // and throws on user-formatted strings.
+        // PER-207/PER-240: parse the user-typed opening balance with
+        // `parseMoneyInput` (locale-agnostic, handles thousands separators /
+        // either decimal convention, returns null on malformed) — NOT
+        // `toMinorUnits`, which expects a canonical decimal and throws on
+        // user-formatted strings. `<MoneyInput>` previews the same value.
         let openingMinor = "0"
         if (openingBalance.trim() !== "") {
-          const parsed = parseUserInput(
-            openingBalance.trim(),
+          const parsed = parseMoneyInput(
+            openingBalance,
             currency as CurrencyCode
           )
           if (parsed === null) {
@@ -277,11 +277,11 @@ export function AccountFormDialog({
               <Label htmlFor="opening-balance">
                 Opening balance ({currency})
               </Label>
-              <Input
+              <MoneyInput
                 id="opening-balance"
-                inputMode="decimal"
+                currency={currency as CurrencyCode}
                 value={openingBalance}
-                onChange={(e) => setOpeningBalance(e.target.value)}
+                onChange={setOpeningBalance}
                 placeholder="0"
               />
               <p className="text-xs text-muted-foreground">
@@ -313,11 +313,11 @@ export function AccountFormDialog({
               <Label htmlFor="reserve-balance">
                 Reserve / minimum balance ({currency})
               </Label>
-              <Input
+              <MoneyInput
                 id="reserve-balance"
-                inputMode="decimal"
+                currency={currency as CurrencyCode}
                 value={reserveInput}
-                onChange={(e) => setReserveInput(e.target.value)}
+                onChange={setReserveInput}
                 placeholder="0"
               />
               <p className="text-xs text-muted-foreground">

--- a/src/components/blocks/holding-form-dialog.tsx
+++ b/src/components/blocks/holding-form-dialog.tsx
@@ -19,8 +19,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { MoneyInput } from "@/components/blocks/money-input"
 import type { CurrencyCode } from "@/lib/data/currencies"
-import { toDisplayNumber } from "@/lib/money"
+import { parseMoneyInput, toDecimalString } from "@/lib/money"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
 import { upsertHoldingFn } from "@/server/holdings"
@@ -60,17 +61,13 @@ export type HoldingFormState =
   | { mode: "create" }
   | { mode: "edit"; holding: HoldingRecord }
 
-// Prefill a MAJOR-unit amount from a stored minor-unit digit-string. Convenience
-// only — the server re-parses and is the source of truth.
+// Prefill a MAJOR-unit amount from a stored minor-unit digit-string, using the
+// EXACT bigint inverse (`toDecimalString`) so a large IDR amount never loses
+// precision through a float round-trip. Convenience only — the server re-parses
+// and is the source of truth.
 function majorFromMinor(minor: string | null, currency: CurrencyCode): string {
   if (minor === null) return ""
-  // toLocaleString (not String()) so a large amount never prefills in scientific
-  // notation, which the number input would reject. Convenience only — the server
-  // re-parses and is the source of truth.
-  return toDisplayNumber(BigInt(minor), currency).toLocaleString("en-US", {
-    useGrouping: false,
-    maximumFractionDigits: 8,
-  })
+  return toDecimalString(BigInt(minor), currency)
 }
 
 // Trim trailing zeros from a fixed-scale quantity string ("2.01800000" → "2.018")
@@ -117,8 +114,25 @@ export function HoldingFormDialog({
     setError(null)
     setSubmitting(true)
     try {
-      const lastPriceValue =
-        lastPrice.trim() === "" ? undefined : lastPrice.trim()
+      // PER-240: `avgUnitCost` / `lastPrice` are money; the server parses them
+      // as CANONICAL major-unit decimals (`toMinorUnits`). Canonicalize the
+      // user's forgiving input (e.g. "5.000" / "5,000" / "Rp 5.000") through
+      // `parseMoneyInput` → `toDecimalString` so the value the server stores is
+      // EXACTLY the one previewed under the field. Quantity is units, not money.
+      const avgCostMoney = parseMoneyInput(avgUnitCost, currencyCode)
+      if (avgCostMoney === null) {
+        throw new Error("Enter a valid average unit cost.")
+      }
+      const avgUnitCostValue = toDecimalString(avgCostMoney, currencyCode)
+
+      let lastPriceValue: string | undefined
+      if (lastPrice.trim() !== "") {
+        const lastPriceMoney = parseMoneyInput(lastPrice, currencyCode)
+        if (lastPriceMoney === null) {
+          throw new Error("Enter a valid last price.")
+        }
+        lastPriceValue = toDecimalString(lastPriceMoney, currencyCode)
+      }
       if (editing) {
         // Instrument identity is fixed on edit — only quantity/cost/price move.
         await upsertHoldingFn({
@@ -126,7 +140,7 @@ export function HoldingFormDialog({
             holdingId: editing.id,
             accountId,
             quantity: quantity.trim(),
-            avgUnitCost: avgUnitCost.trim(),
+            avgUnitCost: avgUnitCostValue,
             lastPrice: lastPriceValue,
             idempotencyKey: createUuidV7(),
           },
@@ -137,7 +151,7 @@ export function HoldingFormDialog({
             accountId,
             instrument: { kind, name: name.trim() },
             quantity: quantity.trim(),
-            avgUnitCost: avgUnitCost.trim(),
+            avgUnitCost: avgUnitCostValue,
             lastPrice: lastPriceValue,
             idempotencyKey: createUuidV7(),
           },
@@ -239,11 +253,11 @@ export function HoldingFormDialog({
               <Label htmlFor="holding-avg-cost">
                 Average unit cost ({currency})
               </Label>
-              <Input
+              <MoneyInput
                 id="holding-avg-cost"
-                inputMode="decimal"
+                currency={currencyCode}
                 value={avgUnitCost}
-                onChange={(e) => setAvgUnitCost(e.target.value)}
+                onChange={setAvgUnitCost}
                 placeholder="0"
                 required
               />
@@ -252,11 +266,11 @@ export function HoldingFormDialog({
               <Label htmlFor="holding-last-price">
                 Last price ({currency})
               </Label>
-              <Input
+              <MoneyInput
                 id="holding-last-price"
-                inputMode="decimal"
+                currency={currencyCode}
                 value={lastPrice}
-                onChange={(e) => setLastPrice(e.target.value)}
+                onChange={setLastPrice}
                 placeholder="Optional"
               />
             </div>

--- a/src/components/blocks/money-input.tsx
+++ b/src/components/blocks/money-input.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { Input } from "@/components/ui/input"
+import { formatCurrency } from "@/lib/currency"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { parseMoneyInput } from "@/lib/money"
+import { cn } from "@/lib/utils"
+
+// PER-240 — shared money entry field. Wraps the shadcn <Input> and renders a
+// live, locale-agnostic preview beneath it so what will actually be SAVED is
+// never ambiguous. The app displays money via Intl (en-US: comma thousands,
+// dot decimal), but users may type either convention; `parseMoneyInput`
+// auto-detects the decimal separator from the input's own shape, and this
+// component echoes the resolved value back as `= Rp 5,085,360.00`.
+//
+// Deep-module contract: the field is controlled purely by a RAW STRING. The
+// PARENT keeps that raw text and derives `Money` on submit via
+// `parseMoneyInput` (single source of truth) — this component does not push
+// parsed state upward, so there is no callback plumbing or effect to keep in
+// sync. The preview is a pure `useMemo` derivation (no useEffect).
+
+type MoneyInputProps = {
+  /** Raw, user-typed text. The parent owns this string. */
+  readonly value: string
+  /** Called with the new raw text on every keystroke. */
+  readonly onChange: (raw: string) => void
+  /** Currency the preview formats in and the parser targets. */
+  readonly currency: CurrencyCode
+  /** Optional class for the wrapping element (not the input). */
+  readonly className?: string
+} & Omit<
+  React.ComponentProps<typeof Input>,
+  "value" | "onChange" | "type" | "inputMode" | "className"
+>
+
+export function MoneyInput({
+  value,
+  onChange,
+  currency,
+  className,
+  ...inputProps
+}: MoneyInputProps) {
+  // Pure derivation of the preview — recomputed only when the text or currency
+  // changes. `parseMoneyInput` never throws; it returns null for the
+  // "not a valid amount yet" state.
+  const preview = React.useMemo<
+    { kind: "empty" } | { kind: "valid"; text: string } | { kind: "invalid" }
+  >(() => {
+    if (value.trim() === "") return { kind: "empty" }
+    const money = parseMoneyInput(value, currency)
+    if (money === null) return { kind: "invalid" }
+    return { kind: "valid", text: formatCurrency(money, currency) }
+  }, [value, currency])
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <Input
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        {...inputProps}
+      />
+      {preview.kind === "empty" ? null : (
+        <p
+          className={cn(
+            "text-xs tabular-nums",
+            preview.kind === "valid"
+              ? "text-muted-foreground"
+              : "text-muted-foreground/70"
+          )}
+        >
+          {preview.kind === "valid"
+            ? `= ${preview.text}`
+            : "Enter a valid amount"}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/blocks/valuation-action-dialog.tsx
+++ b/src/components/blocks/valuation-action-dialog.tsx
@@ -10,12 +10,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { MoneyInput } from "@/components/blocks/money-input"
 import type { AccountRecord } from "@/lib/account-collections"
 import { formatCurrency } from "@/lib/currency"
 import type { CurrencyCode } from "@/lib/data/currencies"
-import { negateMoney, parseUserInput } from "@/lib/money"
+import { negateMoney, parseMoneyInput } from "@/lib/money"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import { createValuationFn, getAccountBalanceFn } from "@/server/valuations"
 
@@ -50,14 +50,15 @@ export function ValuationActionDialog({
   })
 
   const currentMinor = BigInt(account.balance)
-  // PER-207: `parseUserInput` (locale-aware, returns null on malformed) — NOT
-  // `toMinorUnits`, which throws on user-formatted strings. This runs at RENDER
-  // on every keystroke, so a throw here crashes the dialog into the error
-  // boundary; null is the safe "not a valid amount yet" state instead.
+  // PER-207/PER-240: `parseMoneyInput` (locale-agnostic, returns null on
+  // malformed) — NOT `toMinorUnits`, which throws on user-formatted strings.
+  // This runs at RENDER on every keystroke, so a throw here would crash the
+  // dialog into the error boundary; null is the safe "not a valid amount yet"
+  // state instead. `<MoneyInput>` shows the same parsed value as a live preview.
   const targetMagnitude =
     valueInput.trim() === ""
       ? null
-      : parseUserInput(valueInput.trim(), account.currency as CurrencyCode)
+      : parseMoneyInput(valueInput, account.currency as CurrencyCode)
   const signedTarget =
     targetMagnitude === null
       ? null
@@ -153,11 +154,11 @@ export function ValuationActionDialog({
                 ? `Real balance (${account.currency})`
                 : `New value (${account.currency})`}
             </Label>
-            <Input
+            <MoneyInput
               id="valuation-value"
-              inputMode="decimal"
+              currency={account.currency as CurrencyCode}
               value={valueInput}
-              onChange={(e) => setValueInput(e.target.value)}
+              onChange={setValueInput}
               placeholder="0"
               autoFocus
             />

--- a/src/lib/data/currencies.ts
+++ b/src/lib/data/currencies.ts
@@ -17,6 +17,18 @@ export interface CurrencyDefinition {
   readonly minorUnitConversion: number
   /** Smallest physical denomination (UX hint, NOT a storage constraint). null for non-physical. */
   readonly smallestDenomination: number | null
+  /**
+   * Locale decimal/thousands separators from the source dataset.
+   *
+   * NOT used for PARSING anymore (PER-240): `parseMoneyInput` is
+   * locale-agnostic and auto-detects the decimal separator from the input's
+   * own shape, because the app DISPLAYS money via `Intl.NumberFormat`
+   * (en-US: comma thousands, dot decimal) rather than these flags. Parsing
+   * with them caused a 100× IDR misparse. They are also NOT read by
+   * `formatMoney`/`formatCurrency` (which delegate to `Intl`). Kept only as
+   * descriptive reference metadata; do not reintroduce a parse/format
+   * dependency on them.
+   */
   readonly separator: string
   readonly delimiter: string
   /** Format string: `%u` = currency symbol/code, `%n` = number. */

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -542,6 +542,16 @@ describe("parseMoneyInput", () => {
     it("9 fraction digits → null (over-precision)", () => {
       expect(parseMoneyInput("1.234567891", "BTC")).toBeNull()
     })
+
+    it("PER-240 precision-aware: single dot + 3 trailing digits stays DECIMAL for high-precision (no 1000× inflation)", () => {
+      // For fiat, "1.234" reads as thousands (1,234). For BTC (8dp) it is a
+      // genuine decimal 1.234 — must NOT become 1234 BTC.
+      expect(parseMoneyInput("1.234", "BTC")).toBe(123_400_000n)
+      expect(parseMoneyInput("0.500", "BTC")).toBe(50_000_000n)
+      // Contrast: the SAME string is thousands for a 2dp fiat currency.
+      expect(parseMoneyInput("1.234", "IDR")).toBe(123_400n)
+      expect(parseMoneyInput("1.234", "USD")).toBe(123_400n)
+    })
   })
 
   describe("parseUserInput delegates to parseMoneyInput", () => {

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -16,6 +16,7 @@ import {
   isWireMoney,
   mulMoney,
   negateMoney,
+  parseMoneyInput,
   parseUserInput,
   subMoney,
   sumMoney,
@@ -416,8 +417,153 @@ describe("parseUserInput", () => {
     })
 
     it("excessive precision is rejected", () => {
-      expect(parseUserInput("$1.234", "USD")).toBeNull()
+      // PER-240: genuine over-precision (single dot, 4 trailing digits, or an
+      // explicit decimal separator with >2 fraction digits) is rejected.
+      expect(parseUserInput("$1.2345", "USD")).toBeNull()
+      expect(parseUserInput("$1,234.567", "USD")).toBeNull()
     })
+
+    it("PER-240: single dot with exactly 3 trailing digits is thousands, not over-precision", () => {
+      // Previously `$1.234` → null (treated as 3-dp over-precision). The
+      // locale-agnostic parser now reads it as the finance-convention
+      // thousands grouping `1,234` — symmetric with `5,000`/`5.000` — because
+      // a bare `1.234` cannot be a valid 2-dp amount and dot-as-thousands is
+      // the dominant real-world Indonesian input. See parseMoneyInput docs.
+      expect(parseUserInput("$1.234", "USD")).toBe(123_400n)
+    })
+  })
+})
+
+// =============================================================================
+// parseMoneyInput — locale-agnostic, forgiving parser (PER-240)
+// =============================================================================
+
+describe("parseMoneyInput", () => {
+  describe("the PER-240 acceptance matrix (IDR, 2dp)", () => {
+    // Every string a user could read (en-US display) or type (either
+    // convention) must resolve to the SAME minor-unit value.
+    const cases: ReadonlyArray<readonly [string, bigint]> = [
+      ["5000000", 500_000_000n], // plain → 5,000,000.00
+      ["5,085,360.00", 508_536_000n], // US-style display echo
+      ["5.085.360,00", 508_536_000n], // ID-style
+      ["2760809.32", 276_080_932n], // THE regression case
+      ["2.760.809,32", 276_080_932n], // ID-style w/ decimals
+      ["1000", 100_000n],
+      ["1000,00", 100_000n], // comma decimal, 2 trailing
+      ["1000.00", 100_000n], // dot decimal, 2 trailing
+      ["5,000", 500_000n], // comma thousands (finance convention)
+      ["5.000", 500_000n], // dot thousands (finance convention)
+      ["0.32", 32n],
+      [".32", 32n], // leading-dot decimal
+      ["Rp 5.085.360,00", 508_536_000n], // symbol + ID-style
+      ["Rp 5,085,360.00", 508_536_000n], // symbol + US-style
+    ]
+    for (const [input, expected] of cases) {
+      it(`"${input}" → ${expected}n`, () => {
+        expect(parseMoneyInput(input, "IDR")).toBe(expected)
+      })
+    }
+
+    it("THE 100× regression is fixed: 2760809.32 → 276080932 (NOT 27608093200)", () => {
+      expect(parseMoneyInput("2760809.32", "IDR")).toBe(276_080_932n)
+      expect(parseMoneyInput("2760809.32", "IDR")).not.toBe(27_608_093_200n)
+    })
+  })
+
+  describe("invalid input → null (IDR)", () => {
+    const invalid = ["", "-", ".", "1.2.3", "abc", "1.234.5", "1,2,3"]
+    for (const input of invalid) {
+      it(`"${input}" → null`, () => {
+        expect(parseMoneyInput(input, "IDR")).toBeNull()
+      })
+    }
+
+    it("over-precision for a 2dp currency → null", () => {
+      expect(parseMoneyInput("1,234.567", "IDR")).toBeNull() // 3 dp via decimal
+      expect(parseMoneyInput("1.2345", "IDR")).toBeNull() // 4 dp via single dot
+    })
+
+    it("non-string input → null", () => {
+      // @ts-expect-error runtime-guard coverage
+      expect(parseMoneyInput(123, "IDR")).toBeNull()
+      // @ts-expect-error runtime-guard coverage
+      expect(parseMoneyInput(null, "IDR")).toBeNull()
+    })
+  })
+
+  describe("USD (2dp) — symbols, ISO prefixes, negatives, whitespace", () => {
+    it("symbol + thousands + decimals", () => {
+      expect(parseMoneyInput("$1,234,567.89", "USD")).toBe(123_456_789n)
+      expect(parseMoneyInput("$ 1,234,567.89", "USD")).toBe(123_456_789n)
+    })
+
+    it("ISO code prefix (any case)", () => {
+      expect(parseMoneyInput("USD 100", "USD")).toBe(10_000n)
+      expect(parseMoneyInput("usd 100.50", "USD")).toBe(10_050n)
+    })
+
+    it("negatives with symbol/sign in either order", () => {
+      expect(parseMoneyInput("-100.50", "USD")).toBe(-10_050n)
+      expect(parseMoneyInput("$-100.50", "USD")).toBe(-10_050n)
+      expect(parseMoneyInput("-$100.50", "USD")).toBe(-10_050n)
+    })
+
+    it("internal whitespace stripped", () => {
+      expect(parseMoneyInput("1 000 000.00", "USD")).toBe(100_000_000n)
+    })
+
+    it("double sign → null", () => {
+      expect(parseMoneyInput("--5", "USD")).toBeNull()
+    })
+  })
+
+  describe("JPY (0dp) — no fraction allowed", () => {
+    it("plain and grouped integers", () => {
+      expect(parseMoneyInput("12345", "JPY")).toBe(12_345n)
+      expect(parseMoneyInput("12,345", "JPY")).toBe(12_345n)
+      expect(parseMoneyInput("12.345", "JPY")).toBe(12_345n) // dot thousands
+      expect(parseMoneyInput("¥1,000,000", "JPY")).toBe(1_000_000n)
+    })
+
+    it("any fraction → null (0dp currency)", () => {
+      expect(parseMoneyInput("1.5", "JPY")).toBeNull()
+      expect(parseMoneyInput("100,50", "JPY")).toBeNull()
+    })
+  })
+
+  describe("BTC (8dp) — high-precision subunit", () => {
+    it("accepts up to 8 fraction digits", () => {
+      expect(parseMoneyInput("1", "BTC")).toBe(100_000_000n)
+      expect(parseMoneyInput("1.23456789", "BTC")).toBe(123_456_789n)
+      expect(parseMoneyInput("0.00000001", "BTC")).toBe(1n)
+      expect(parseMoneyInput("₿1.5", "BTC")).toBe(150_000_000n)
+    })
+
+    it("9 fraction digits → null (over-precision)", () => {
+      expect(parseMoneyInput("1.234567891", "BTC")).toBeNull()
+    })
+  })
+
+  describe("parseUserInput delegates to parseMoneyInput", () => {
+    const samples: ReadonlyArray<readonly [string, CurrencyCode]> = [
+      ["5.085.360,00", "IDR"],
+      ["5,085,360.00", "IDR"],
+      ["2760809.32", "IDR"],
+      ["$1,234,567.89", "USD"],
+      ["-100.50", "USD"],
+      ["1.23456789", "BTC"],
+      ["12,345", "JPY"],
+      ["1.2.3", "IDR"],
+      ["abc", "USD"],
+      ["", "USD"],
+    ]
+    for (const [input, currency] of samples) {
+      it(`"${input}" (${currency}) matches parseMoneyInput`, () => {
+        expect(parseUserInput(input, currency)).toBe(
+          parseMoneyInput(input, currency)
+        )
+      })
+    }
   })
 })
 

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -302,11 +302,13 @@ export function toDisplayNumber(
  *    digits). Return `null` on ANY malformed / over-precision input; never
  *    throw.
  *
- * NOTE on the single-separator finance convention: `1.234` (single dot, 3
- * trailing digits) parses as **1,234** (thousands), NOT as an over-precision
- * `1.234` → null. This is deliberate and symmetric with `5,000`/`5.000`: a
- * bare `1.234` cannot be a valid 2-dp amount anyway, and dot-as-thousands is
- * the dominant real-world input for Indonesian users. See PER-240.
+ * NOTE on the single-separator finance convention: for a currency that cannot
+ * represent 3 fraction digits (fiat — IDR/USD 2dp, JPY 0dp), `1.234` (single
+ * dot, 3 trailing digits) parses as **1,234** (thousands), NOT an over-
+ * precision `1.234` → null — symmetric with `5,000`/`5.000`, matching the
+ * dominant real-world Indonesian `Rp 5.000` input. For a high-precision
+ * currency (BTC, 8dp) the SAME `1.234` stays a genuine decimal (1.234), so the
+ * value is never 1000×-inflated. The rule is precision-aware. See PER-240.
  */
 export function parseMoneyInput(
   raw: string,
@@ -373,10 +375,17 @@ export function parseMoneyInput(
       const idx = body.indexOf(sep)
       const leading = body.slice(0, idx)
       const trailing = body.slice(idx + 1)
-      if (/^\d{3}$/.test(trailing) && /\d/.test(leading)) {
-        thouSep = sep // "5,000" / "5.000" → thousands (finance convention)
+      // A single separator with exactly 3 trailing digits ("5,000" / "5.000")
+      // is the finance-convention thousands group — BUT only for a currency
+      // that cannot represent 3 fraction digits (fiat: IDR/USD 2dp, JPY 0dp).
+      // For a high-precision currency (BTC, 8dp) "1.234" is a genuine decimal
+      // amount, so it must stay decimal. Precision-aware disambiguation keeps
+      // the IDR `Rp 5.000`→5000 reading while never 1000×-inflating BTC.
+      const maxFraction = decimalPlacesOf(def.minorUnitConversion)
+      if (/^\d{3}$/.test(trailing) && /\d/.test(leading) && maxFraction < 3) {
+        thouSep = sep // "5,000" / "5.000" → thousands (fiat only)
       } else {
-        decSep = sep // "1000.00", "0.32", ".32", "1000,5" → decimal
+        decSep = sep // "1000.00", "0.32", ".32", "1000,5", BTC "1.234" → decimal
       }
     }
   }

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -159,6 +159,39 @@ export function toMinorUnits(decimal: string, currency: CurrencyCode): Money {
 }
 
 /**
+ * Inverse of {@link toMinorUnits}: render a Money as a CANONICAL major-unit
+ * decimal string (dot decimal, NO thousands separators, trailing zeros
+ * trimmed) — e.g. `10050n` USD → `"100.5"`, `500000n` IDR → `"5000"`.
+ *
+ * Exact for every power-of-10 currency (all realistic ones): it does bigint
+ * division, never `Number`, so large IDR balances never lose precision. Use
+ * this to feed a parsed `Money` back into a server contract that accepts a
+ * major-unit decimal string (e.g. `upsertHoldingFn`), so the value the user
+ * saw in the live preview is exactly what gets re-parsed server-side.
+ */
+export function toDecimalString(
+  money: Money | bigint,
+  currency: CurrencyCode
+): string {
+  const def = CURRENCIES[currency]
+  const conv = BigInt(def.minorUnitConversion)
+  const m = money as bigint
+  const negative = m < 0n
+  const abs = negative ? -m : m
+  const sign = negative ? "-" : ""
+  if (conv === 1n) return sign + abs.toString()
+  const whole = abs / conv
+  const fraction = abs % conv
+  // Width = decimal places = digits of the (power-of-10) conversion minus one.
+  const width = def.minorUnitConversion.toString().length - 1
+  const fractionStr = fraction
+    .toString()
+    .padStart(width, "0")
+    .replace(/0+$/, "")
+  return sign + whole.toString() + (fractionStr === "" ? "" : `.${fractionStr}`)
+}
+
+/**
  * Convert Money back to a structured decimal representation.
  *
  * Returns `{ whole, fraction, isNegative }` so display layers can format
@@ -227,67 +260,175 @@ export function toDisplayNumber(
 // =============================================================================
 
 /**
- * Parse a user-typed string into Money. Tolerant of:
- *   - currency symbols/codes ("Rp ", "$", "USD ") — stripped
- *   - thousands separators (`.` or `,` based on currency)
- *   - decimal separator (the OPPOSITE of thousands separator)
- *   - leading/trailing whitespace
+ * Locale-agnostic, forgiving money parser — the single source of truth for
+ * turning any human-typed amount into `Money` minor units.
+ * =============================================================================
  *
- * Returns `null` on un-parseable input (rather than throwing) so the form
- * layer can attach a structured validation error instead of crashing.
+ * WHY flag-independent (does NOT read `CURRENCIES[c].delimiter`/`.separator`)?
+ * --------------------------------------------------------------------------
+ * The app DISPLAYS money via `Intl.NumberFormat` defaulting to en-US
+ * (`Rp 5,085,360.00` — comma thousands, dot decimal), regardless of the
+ * currency's Indonesian `separator`/`delimiter` metadata. If we parsed using
+ * those per-currency flags, the exact string the user just READ and retyped
+ * (`5,085,360.00`) would be misparsed — for IDR the `.` would be treated as a
+ * thousands delimiter, stripping the decimal and inflating the value 100×
+ * (PER-240). So parsing must NOT depend on the currency's locale flags. It
+ * auto-detects the decimal separator from the string's own shape instead.
  *
- * Indonesian convention (IDR): "Rp 15.000.000,50"
- *   - thousands = "."
- *   - decimal   = ","
- * US convention (USD): "$15,000,000.50"
- *   - thousands = ","
- *   - decimal   = "."
+ * ALGORITHM
+ * ---------
+ * 1. Trim; strip a leading currency symbol (`def.symbol`, e.g. `Rp`, `$`) and
+ *    /or ISO-code prefix (in either order relative to a leading `-`); strip
+ *    ALL internal whitespace; extract an optional single leading `-`.
+ * 2. Consider only `.` and `,` as possible separators. Decide which is the
+ *    DECIMAL separator:
+ *      - BOTH occur → the LAST-occurring of the two is decimal, the other is
+ *        thousands (handles both `5,085,360.00` US and `5.085.360,00` ID).
+ *        The decimal separator must occur exactly once.
+ *      - ONE type occurs:
+ *          · more than once → thousands separator, no decimal (`15.000.000`).
+ *          · exactly once → DECIMAL, UNLESS it has exactly 3 trailing digits
+ *            AND ≥1 leading digit (`5,000` / `5.000`), which is treated as
+ *            THOUSANDS (finance convention — critical so an Indonesian typing
+ *            `Rp 5.000` dot-thousands is NOT rejected as over-precision).
+ *            Everything else (`1000,00`, `1000.00`, `1000,5`, `0.32`, `.32`)
+ *            is DECIMAL.
+ * 3. When a thousands separator is present, validate the integer grouping
+ *    (first group 1-3 digits, every later group exactly 3) so garbage like
+ *    `1.2.3` is rejected rather than silently concatenated.
+ * 4. Remove the thousands separator; normalize the decimal separator to `.`;
+ *    prepend a `0` to a leading-dot value (`.32` → `0.32`); then delegate to
+ *    `toMinorUnits` (which enforces `minorUnitConversion` + max fraction
+ *    digits). Return `null` on ANY malformed / over-precision input; never
+ *    throw.
  *
- * The currency's `separator` (decimal) and `delimiter` (thousands) drive the
- * parse rules.
+ * NOTE on the single-separator finance convention: `1.234` (single dot, 3
+ * trailing digits) parses as **1,234** (thousands), NOT as an over-precision
+ * `1.234` → null. This is deliberate and symmetric with `5,000`/`5.000`: a
+ * bare `1.234` cannot be a valid 2-dp amount anyway, and dot-as-thousands is
+ * the dominant real-world input for Indonesian users. See PER-240.
  */
-export function parseUserInput(
+export function parseMoneyInput(
   raw: string,
   currency: CurrencyCode
 ): Money | null {
   if (typeof raw !== "string") return null
   const def = CURRENCIES[currency]
 
-  // Strip currency symbol, ISO code, and surrounding whitespace.
+  // --- Step 1: normalize surface (symbol/ISO/whitespace/sign) ----------------
   let body = raw.trim()
   if (body === "") return null
-
-  // Remove the symbol if present (case-sensitive: `Rp`, `$`, `oz t`).
-  if (def.symbol && body.startsWith(def.symbol)) {
-    body = body.slice(def.symbol.length).trim()
-  }
-  // Also strip the ISO code prefix (e.g. "USD 100").
-  if (body.toUpperCase().startsWith(currency)) {
-    body = body.slice(currency.length).trim()
-  }
-
-  // Replace the currency's thousands delimiter with empty, then map its
-  // decimal separator to ".". Order matters: strip delimiter first.
-  // Use a `replaceAll` loop because the separators may overlap with regex
-  // metacharacters when inserted naively.
-  if (def.delimiter !== "") {
-    body = body.split(def.delimiter).join("")
-  }
-  if (def.separator !== "." && def.separator !== "") {
-    // Map locale decimal to canonical "."
-    body = body.split(def.separator).join(".")
-  }
-
-  // Strip any remaining whitespace inside the body (e.g. "1 000 000").
+  // Collapse all internal whitespace first ("1 000 000", "$ 100", "Rp 5.000").
   body = body.replace(/\s+/g, "")
 
-  if (body === "" || body === "-" || body === ".") return null
+  // Strip a leading currency symbol / ISO code that may appear before OR after
+  // a leading sign ("$-100.50", "-$100"). Peel prefixes, then a single sign,
+  // then prefixes again to cover both orderings.
+  const stripPrefixes = (s: string): string => {
+    let changed = true
+    while (changed) {
+      changed = false
+      if (def.symbol !== "" && s.startsWith(def.symbol)) {
+        s = s.slice(def.symbol.length)
+        changed = true
+      } else if (s.toUpperCase().startsWith(currency)) {
+        s = s.slice(currency.length)
+        changed = true
+      }
+    }
+    return s
+  }
+
+  body = stripPrefixes(body)
+  let negative = false
+  if (body.startsWith("-")) {
+    negative = true
+    body = body.slice(1)
+  }
+  body = stripPrefixes(body)
+
+  if (body === "") return null
+  // Only digits and the two candidate separators may remain.
+  if (!/^[0-9.,]+$/.test(body)) return null
+
+  // --- Step 2: decide the decimal separator from the string's own shape ------
+  const dotCount = (body.match(/\./g) ?? []).length
+  const commaCount = (body.match(/,/g) ?? []).length
+
+  let decSep: "." | "," | null = null
+  let thouSep: "." | "," | null = null
+
+  if (dotCount > 0 && commaCount > 0) {
+    // Last-occurring separator is the decimal; the other is thousands.
+    decSep = body.lastIndexOf(".") > body.lastIndexOf(",") ? "." : ","
+    thouSep = decSep === "." ? "," : "."
+    const decCount = decSep === "." ? dotCount : commaCount
+    if (decCount !== 1) return null // decimal separator must be unique
+  } else if (dotCount > 0 || commaCount > 0) {
+    const sep: "." | "," = dotCount > 0 ? "." : ","
+    const count = dotCount > 0 ? dotCount : commaCount
+    if (count > 1) {
+      thouSep = sep // repeated single type → grouping only
+    } else {
+      const idx = body.indexOf(sep)
+      const leading = body.slice(0, idx)
+      const trailing = body.slice(idx + 1)
+      if (/^\d{3}$/.test(trailing) && /\d/.test(leading)) {
+        thouSep = sep // "5,000" / "5.000" → thousands (finance convention)
+      } else {
+        decSep = sep // "1000.00", "0.32", ".32", "1000,5" → decimal
+      }
+    }
+  }
+
+  // --- Step 3: split integer / fraction and validate thousands grouping ------
+  let integerPart: string
+  let fractionPart: string | null = null
+  if (decSep !== null) {
+    const idx = body.indexOf(decSep)
+    integerPart = body.slice(0, idx)
+    fractionPart = body.slice(idx + 1)
+  } else {
+    integerPart = body
+  }
+
+  if (thouSep !== null) {
+    const groups = integerPart.split(thouSep)
+    if (groups.length < 2) return null
+    const [first, ...rest] = groups
+    if (!/^\d{1,3}$/.test(first)) return null
+    if (!rest.every((g) => /^\d{3}$/.test(g))) return null
+    integerPart = groups.join("")
+  }
+
+  // --- Step 4: build a canonical decimal string and delegate -----------------
+  if (integerPart === "") integerPart = "0" // ".32" → "0.32"
+  if (!/^\d+$/.test(integerPart)) return null
+  if (fractionPart !== null && !/^\d*$/.test(fractionPart)) return null
+
+  const normalized =
+    (negative ? "-" : "") +
+    integerPart +
+    (fractionPart !== null ? `.${fractionPart}` : "")
 
   try {
-    return toMinorUnits(body, currency)
+    return toMinorUnits(normalized, currency)
   } catch {
     return null
   }
+}
+
+/**
+ * @deprecated Prefer {@link parseMoneyInput}. Retained as a thin alias so the
+ * existing call sites keep working; it now delegates to the locale-agnostic
+ * parser (PER-240) — the currency's `separator`/`delimiter` flags are NO
+ * LONGER consulted for parsing.
+ */
+export function parseUserInput(
+  raw: string,
+  currency: CurrencyCode
+): Money | null {
+  return parseMoneyInput(raw, currency)
 }
 
 // =============================================================================


### PR DESCRIPTION
## PER-240 — locale-forgiving money-input parser + live preview

### Problem (verified on main)
Money **display** and money **parse** disagreed, creating a real 100× misparse:
- `formatMoney`/`formatCurrency` render via `Intl.NumberFormat` defaulting to **en-US** → `Rp 5,085,360.00` (comma thousands, **dot** decimal).
- `parseUserInput` normalized using the per-currency `.delimiter`/`.separator` flags. For IDR those are Indonesian (`delimiter="."`, `separator=","`), so the dot-decimal string the user just read and retyped — e.g. `2760809.32` — had its `.` treated as a thousands separator, stripped → `276080932` → **100× too large**.

### The parse algorithm (`parseMoneyInput`, flag-independent)
1. Trim; strip a leading currency symbol (`Rp`, `$`, …) and/or ISO prefix (either order vs a leading `-`); strip all internal whitespace; extract an optional single `-`.
2. Consider only `.` and `,`. Decide the **decimal** separator from the string's own shape:
   - **Both** occur → the **last-occurring** is decimal, the other is thousands (handles `5,085,360.00` US **and** `5.085.360,00` ID); the decimal separator must occur exactly once.
   - **One** type occurs: more than once → thousands (no decimal); exactly once → **decimal**, **unless** it has exactly 3 trailing digits **and** ≥1 leading digit (`5,000` / `5.000`) → **thousands** (finance convention).
3. Validate thousands grouping (first group 1–3 digits, every later group exactly 3) so `1.2.3` → `null` rather than silently concatenating.
4. Remove thousands sep, normalize decimal → `.`, `0`-pad a leading dot (`.32`→`0.32`), delegate to `toMinorUnits`. Never throws; `null` on any malformed / over-precision input.

Parses all of: `5000000`, `5,085,360.00`, `5.085.360,00`, `2760809.32`, `2.760.809,32`, `1000`, `1000,00`, `1000.00`, `5,000`, `0.32`, `Rp 5.085.360,00`. Returns `null` for `""`, `-`, `.`, `1.2.3`, `abc`, and genuine over-precision (`1,234.567`, `1.2345` for a 2-dp currency).

### Delegation & config reconciliation
- `parseUserInput` is now a thin alias that calls `parseMoneyInput`, so **every existing caller** (accounts, valuations, debts route, csv-import) is auto-upgraded with zero churn and identical signature/return.
- `src/lib/data/currencies.ts`: documented that `.separator`/`.delimiter` are **no longer used for parsing** (or formatting — `formatMoney` uses `Intl`). Grep confirmed the only consumers were inside `parseUserInput`; they're gone. Flags kept as descriptive metadata only.
- Added `toDecimalString` — the exact (bigint, no `Number`) inverse of `toMinorUnits` — to canonicalize a parsed `Money` back into a major-unit decimal string for server contracts that accept decimal strings, and for precise prefills.

### `<MoneyInput>` + adopted call sites
New `src/components/blocks/money-input.tsx`: wraps the shadcn `Input`, controlled by a **raw string** (parent owns the text, derives `Money` on submit via `parseMoneyInput`). Renders a live preview beneath via `useMemo` (**no useEffect**): `= {formatCurrency(money, currency)}` when valid, a muted "Enter a valid amount" when non-empty & unparseable, nothing when empty. shadcn + Tailwind + `cn()` + English copy.

Adopted at:
- `account-form-dialog.tsx` — opening balance **and** reserve/minimum balance (reserve prefill switched to exact `toDecimalString`).
- `valuation-action-dialog.tsx` — reconcile / update-value.
- `holding-form-dialog.tsx` — avg unit cost + last price (quantity left as-is — it's units, not money). Submit canonicalizes via `parseMoneyInput` → `toDecimalString` so the strict server parse (`toMinorUnits`) matches the forgiving preview.

### Decisions / edge cases
- **Ambiguous single separator, `1.234`:** resolved as **`1,234` (thousands)**, symmetric with `5,000`/`5.000`, rather than `null`. A bare `1.234` cannot be a valid 2-dp amount, and dot-as-thousands is the dominant Indonesian input. This contradicted one existing USD test (`$1.234`→null) and the ticket's own null-list; that line conflicts with the ticket's `5.000`→5000 rule, and making them asymmetric (dot-3-trailing = decimal) would break the real-world `Rp 5.000` case. Updated that test to assert `123400n` with a comment, and demonstrate genuine over-precision with 4-decimal / explicit-decimal cases.
- **Transaction form deferred:** the create/edit form uses a native `type="number"` + `z.number()` TanStack Form pipeline (split/destination/FX arithmetic on numbers). Native number inputs reject comma-thousands, so they are **not** subject to this display/parse mismatch. Converting that numeric ledger-core pipeline to string-based `MoneyInput` is a larger, higher-risk refactor that touches the transaction core — deferred as a follow-up rather than risk ledger correctness here.

### Tests
- `vp check` — clean (format + lint + types, 269 files).
- `vp test run` — **605 passed** (37 files). Includes an exhaustive `parseMoneyInput` matrix (IDR 2dp, USD 2dp, JPY 0dp, BTC 8dp: both conventions, single/double separators, symbol/ISO prefixes, negatives, whitespace, invalid, over-precision), the exact `2760809.32`→`276080932` regression, and a `parseUserInput`-delegates-to-`parseMoneyInput` proof.
- **e2e** (ephemeral harness, Postgres :5433, port 3010 — never the dev/prod DB): money-form specs pass — `valuation-formatted-input` (drives `5.571.313,20`→`Rp 5,571,313.20` end-to-end), `holdings-ui`, `investment-performance`, `account-detail`, `account-delete`, `valuation-linked-transfer`, `import`, `transaction-quick-create`, `budgets`. Per-test timeout raised to 180s because first Vite compile of heavy routes exceeds the default 60s in this environment (the only cause of an initial flake). Full 22-spec suite not run end-to-end here due to per-run recompile cost; the money-form subset covers every touched call site plus the delegation consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
