### PR TITLE
feat(investments): PER-198 — Buy/Sell atomic cash↔holding trade

### DIFF
--- a/docs/adr/0051-investments-holdings-domain.md
+++ b/docs/adr/0051-investments-holdings-domain.md
@@ -265,17 +265,41 @@ costRemoved` (signed, minor units). It is DERIVED and returned for display
   written (the cash `Transaction`, the `Transfer`, the `Holding`, and the
   `Valuation`) in the same transaction.
 
+### Guarded: trade transactions cannot be deleted until trade reversal exists
+
+A trade posts a normal valuation-linked transfer `Transaction` that shows in the
+transaction list, so the delete UI can reach it. The generic valuation-linked
+delete (`softDeleteValuationLinkedTransferWithinTx`) reverses the cash leg and
+tombstones the trade's `Valuation`, but the paired `Holding` is outside the
+transfer graph and would NOT be reversed — the account would re-materialize from
+the prior valuation while the position still shows the traded units, silently
+inflating net worth (the read-only drift detector would flag it, but the data
+would already be wrong). That is a UI-reachable corruption of money data, so it
+is **guarded, not deferred**:
+
+- `softDeleteValuationLinkedTransferWithinTx` throws
+  `HoldingsTradeDeleteUnsupportedError` (422) **before mutating anything** when
+  the linked `Valuation.source === HOLDINGS_VALUATION_SOURCE` (`"holdings"`) —
+  the exact, per-transfer, definitional marker of a trade (its tracked-side move
+  is a Σ-holdings anchor). The constant lives in `valuations.ts` and is shared by
+  the holdings anchor writer and this guard. A per-account heuristic ("the
+  account has any `Holding` rows") was rejected because it would false-block a
+  legitimate plain valuation transfer to an account that also holds positions;
+  the per-transfer valuation source cannot false-block — a plain valuation-linked
+  transfer's own `Valuation.source` is `"transfer"`, so it still deletes
+  normally.
+- Full trade reversal (also undoing the `Holding` position, and eventually
+  restoring sold-to-zero closes) is a later slice that pairs naturally with lots
+  (PER-141-adjacent). Until then, trade transactions cannot be deleted; a real-PG
+  test asserts the delete is rejected with the funding balance, investment value,
+  and holding all unchanged.
+
 ### Deferred (out of scope this slice)
 
-- **Trade EDIT / DELETE that reverses the position.** Deleting the linked
-  transfer through the existing valuation-linked delete path reverses the cash
-  leg and tombstones the trade's `Valuation`, but does NOT reverse the `Holding`
-  mutation — the account would then re-materialize from the prior valuation while
-  the position still shows the traded units (drift the read-only detector would
-  flag). A correct trade reversal must also undo the position and needs its own
-  design (it pairs naturally with lots, PER-141). Until then, trade recording is
-  create-only, mirroring ADR-0048 §4's deferral of valuation-linked transfer
-  editing.
+- **Trade EDIT and full trade REVERSAL** (see the guard above): editing a trade,
+  or a delete that also undoes the position, needs its own design (PER-141-
+  adjacent). This slice is create-only, mirroring ADR-0048 §4's deferral of
+  valuation-linked transfer editing.
 - **FIFO / tax lots** (PER-141), **realized-gain-as-income posting**,
   **market-data auto-pricing** (the next slice sets `lastPrice` from a feed
   rather than leaving positions at cost), and **transfer fees**.

--- a/docs/adr/0051-investments-holdings-domain.md
+++ b/docs/adr/0051-investments-holdings-domain.md
@@ -188,3 +188,94 @@ genuine INVESTMENT account **opts in** through one dedicated, audited endpoint,
   writes a second anchor or moves the balance again), and before/after `Account`
   audit rows in the same transaction. Supersedes the PER-239 account-level value
   approach folded into this ADR.
+
+## Buy / Sell trade primitive (PER-198)
+
+Recording a purchase or sale used to be two manual motions: a valuation-linked
+transfer (ADR-0048) to move the cash, then a separate holding edit to update the
+position. PER-198 collapses them into ONE atomic ledger action,
+`recordTradeForFamily` (`src/server/holdings.ts`), exposed as `recordTradeFn`.
+Semantically: cash **into** a valuation-tracked investment account is a BUY; cash
+**out** is a SELL.
+
+- **Atomic cash ↔ holding link.** A trade is a single valuation-linked transfer
+  whose tracked-side `Valuation` is the Σ-holdings anchor, plus the position
+  mutation, all in one `scopedTenantTransaction`. It reuses the ADR-0048 double-
+  entry primitive `postValuationLinkedTransferLegs` (factored out of the transfer
+  path so a non-transfer caller can drive it): the funding (cash-like,
+  `balanceSource="transaction_flow"`) leg is a real, guarded `Transaction`; the
+  investment (`balanceSource="valuation"`) side never takes an incremental
+  balance write. One `Transfer` row (ADR-0048 §4 shape: one `Transaction` FK +
+  `valuationId`) links them, so delete, drift detection, and reporting treat a
+  trade exactly like any other valuation-linked move.
+
+- **Dependence on the PER-196 valuation-transfer guard.** The whole design rests
+  on ADR-0048 §3 / PER-196: `applyAccountBalanceDelta` refuses to mutate a
+  `balanceSource="valuation"` account's stored balance. The funding leg
+  decrements/credits normally; the investment account moves ONLY through the
+  Σ-holdings valuation this primitive supplies. Without that guard a trade would
+  double-count (a cash leg AND a valuation both hitting the tracked balance). The
+  guard was verified to leave a valuation account's balance untouched while
+  decrementing the funding account — this is what makes the trade a clean
+  net-worth-conserving swap. See ADR-0048 (amends ADR-0042/ADR-0043 dual-leg).
+
+- **Net-worth conservation.** The funding account moves by exactly `cashAmount`
+  and the investment account's COST BASIS moves by exactly `cashAmount` (buy) /
+  `costRemoved` (sell). When holdings are carried at cost (no market `lastPrice`
+  — the freshly-traded case), the investment account's materialized value moves
+  by the same amount, so family net worth is unchanged. A holding already
+  carrying a market `lastPrice` values at market (honest cost basis, above); the
+  difference is unrealized gain already recognized, not a conservation
+  violation. Fractional-quantity rounding is bounded by one minor unit per
+  holding (inherent to carrying cost as a rounded per-unit price). A trade never
+  touches `lastPrice`.
+
+- **Average cost.** BUY blends: `newAvgUnitCost = round_half_up((oldUnits ×
+oldAvg + cashAmount) × SCALE / newUnits)` (`averageUnitCostMinor`,
+  `src/lib/holdings.ts`), so `cost += cashAmount`. SELL removes cost pro-rata at
+  the current average (`costRemoved = quantity × avgUnitCost`) and leaves the
+  average of the remaining units unchanged — the average-cost method, not FIFO.
+
+- **Derived realized gain.** SELL returns `realizedGain = cashAmount −
+costRemoved` (signed, minor units). It is DERIVED and returned for display
+  only — this slice does NOT post an income/expense row for it.
+
+- **One-way holding close at zero.** Selling the last unit
+  (`newUnits === 0`) closes the position by hard-deleting the `Holding` row
+  (mirroring `deleteHoldingForFamily`); the ledger history (`Transaction`,
+  `Valuation`, `Transfer`, `AuditLog`) is preserved.
+
+- **`kind` reuse (not a new domain value).** A trade posts under the existing
+  transfer kind the account pair implies (`deriveTransferKindForAccounts`;
+  cash ↔ investment ⇒ `funds_movement`, or `liability_draw`/`cc_payment` when the
+  funding account is a credit line). The DB trigger
+  `enforce_transfer_liability_kind_invariant` derives the expected kind purely
+  from account class/type, so it cannot distinguish a "trade" from a plain
+  valuation-linked cash move between the same accounts — a dedicated
+  `investment_buy`/`investment_sell` kind would have to teach that trigger the
+  same pair means two different kinds, which is not expressible. The trade's
+  identity lives in the position mutation and the `source="holdings"` valuation,
+  not in a new kind.
+
+- **Full §5A contract.** One interactive tenant transaction with the
+  `app.family_id` RLS GUC; endpoint-scoped idempotency (`recordTradeFn`
+  `IdempotencyRecord`, replay + unique-race replay so a retry never posts a
+  second transfer or moves a balance/position again); tenant-owned validation of
+  BOTH accounts and the instrument; append-only `AuditLog` rows for every entity
+  written (the cash `Transaction`, the `Transfer`, the `Holding`, and the
+  `Valuation`) in the same transaction.
+
+### Deferred (out of scope this slice)
+
+- **Trade EDIT / DELETE that reverses the position.** Deleting the linked
+  transfer through the existing valuation-linked delete path reverses the cash
+  leg and tombstones the trade's `Valuation`, but does NOT reverse the `Holding`
+  mutation — the account would then re-materialize from the prior valuation while
+  the position still shows the traded units (drift the read-only detector would
+  flag). A correct trade reversal must also undo the position and needs its own
+  design (it pairs naturally with lots, PER-141). Until then, trade recording is
+  create-only, mirroring ADR-0048 §4's deferral of valuation-linked transfer
+  editing.
+- **FIFO / tax lots** (PER-141), **realized-gain-as-income posting**,
+  **market-data auto-pricing** (the next slice sets `lastPrice` from a feed
+  rather than leaving positions at cost), and **transfer fees**.

--- a/src/components/blocks/holding-form-dialog.tsx
+++ b/src/components/blocks/holding-form-dialog.tsx
@@ -21,6 +21,11 @@ import {
 } from "@/components/ui/select"
 import { MoneyInput } from "@/components/blocks/money-input"
 import type { CurrencyCode } from "@/lib/data/currencies"
+import {
+  INSTRUMENT_KIND_OPTIONS,
+  instrumentKindLabel,
+  type InstrumentKind,
+} from "@/lib/instruments"
 import { parseMoneyInput, toDecimalString } from "@/lib/money"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
@@ -33,29 +38,6 @@ import { upsertHoldingFn } from "@/server/holdings"
 // decimal strings straight to `upsertHoldingFn` (quantity as units, avgUnitCost
 // / lastPrice as MAJOR-unit amounts); the server parses + computes value/cost/
 // gain and re-materializes the account balance from the holdings anchor.
-
-// The six instrument kinds (ADR-0051), machine token → human label. The union
-// mirrors upsertHoldingFn's `instrument.kind` enum so no `any`/loose string
-// reaches the server contract.
-type InstrumentKind =
-  | "mutual_fund"
-  | "metal"
-  | "stock"
-  | "crypto"
-  | "bond"
-  | "deposit"
-
-const INSTRUMENT_KINDS: ReadonlyArray<{
-  value: InstrumentKind
-  label: string
-}> = [
-  { value: "mutual_fund", label: "Mutual fund" },
-  { value: "metal", label: "Metal" },
-  { value: "stock", label: "Stock" },
-  { value: "crypto", label: "Crypto" },
-  { value: "bond", label: "Bond" },
-  { value: "deposit", label: "Deposit" },
-]
 
 export type HoldingFormState =
   | { mode: "create" }
@@ -195,9 +177,7 @@ export function HoldingFormDialog({
                 </p>
               </div>
               <Badge variant="secondary" className="shrink-0">
-                {INSTRUMENT_KINDS.find(
-                  (k) => k.value === editing.instrument.kind
-                )?.label ?? editing.instrument.kind}
+                {instrumentKindLabel(editing.instrument.kind)}
               </Badge>
             </div>
           ) : (
@@ -222,7 +202,7 @@ export function HoldingFormDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {INSTRUMENT_KINDS.map((k) => (
+                    {INSTRUMENT_KIND_OPTIONS.map((k) => (
                       <SelectItem key={k.value} value={k.value}>
                         {k.label}
                       </SelectItem>

--- a/src/components/blocks/trade-dialog.tsx
+++ b/src/components/blocks/trade-dialog.tsx
@@ -1,0 +1,381 @@
+import * as React from "react"
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { MoneyInput } from "@/components/blocks/money-input"
+import { formatCurrency } from "@/lib/currency"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { holdingCostMinor, quantityToScaled } from "@/lib/holdings"
+import { parseMoneyInput } from "@/lib/money"
+import { cn } from "@/lib/utils"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
+import { recordTradeFn } from "@/server/holdings"
+
+// PER-198 / ADR-0051 — Buy / Sell trade dialog.
+// One atomic action that moves cash between a funding (cash-like) account and
+// this valuation-tracked investment account while updating the position. The
+// heavy lifting (double-entry, cost-basis blend, valuation anchor, audit) is
+// SERVER-side (`recordTradeFn`); this dialog only collects the inputs and shows
+// the cash total live. Money math on the client is limited to deriving the
+// total from quantity × unit price via the SAME pure helper the server uses, so
+// the previewed total is exactly what will move.
+
+// Machine token → human label for the instrument kinds (ADR-0051), reused for
+// the "new instrument" branch of a BUY.
+type InstrumentKind =
+  | "mutual_fund"
+  | "metal"
+  | "stock"
+  | "crypto"
+  | "bond"
+  | "deposit"
+
+const INSTRUMENT_KINDS: ReadonlyArray<{
+  value: InstrumentKind
+  label: string
+}> = [
+  { value: "mutual_fund", label: "Mutual fund" },
+  { value: "metal", label: "Metal" },
+  { value: "stock", label: "Stock" },
+  { value: "crypto", label: "Crypto" },
+  { value: "bond", label: "Bond" },
+  { value: "deposit", label: "Deposit" },
+]
+
+// Sentinel option value for "create a new instrument" (BUY only).
+const NEW_INSTRUMENT = "__new__"
+
+export interface TradeFundingAccount {
+  id: string
+  name: string
+  currency: string
+}
+
+export type TradeDialogState =
+  | { side: "buy" | "sell" }
+  | { side: "buy" | "sell"; holding: HoldingRecord }
+
+export function TradeDialog({
+  state,
+  investmentAccountId,
+  currency,
+  fundingAccounts,
+  holdings,
+  onClose,
+  onSaved,
+}: {
+  state: TradeDialogState
+  investmentAccountId: string
+  currency: string
+  fundingAccounts: ReadonlyArray<TradeFundingAccount>
+  holdings: ReadonlyArray<HoldingRecord>
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const currencyCode = currency as CurrencyCode
+  const presetHolding = "holding" in state ? state.holding : null
+
+  const [side, setSide] = React.useState<"buy" | "sell">(state.side)
+  const [fundingAccountId, setFundingAccountId] = React.useState<string>(
+    fundingAccounts[0]?.id ?? ""
+  )
+  // Instrument choice: an existing holding's instrumentId, or NEW_INSTRUMENT.
+  const [instrumentChoice, setInstrumentChoice] = React.useState<string>(
+    presetHolding?.instrument.id ?? holdings[0]?.instrument.id ?? NEW_INSTRUMENT
+  )
+  const [newName, setNewName] = React.useState<string>("")
+  const [newKind, setNewKind] = React.useState<InstrumentKind>("mutual_fund")
+  const [quantity, setQuantity] = React.useState<string>("")
+  const [unitPrice, setUnitPrice] = React.useState<string>("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const isBuy = side === "buy"
+  const creatingInstrument = isBuy && instrumentChoice === NEW_INSTRUMENT
+
+  // Live cash total = quantity × unit price, via the SAME pure helper the server
+  // uses for cost basis — pure derivation, no effect.
+  const cashPreview = React.useMemo<
+    { kind: "empty" } | { kind: "invalid" } | { kind: "valid"; minor: bigint }
+  >(() => {
+    if (quantity.trim() === "" || unitPrice.trim() === "") {
+      return { kind: "empty" }
+    }
+    const price = parseMoneyInput(unitPrice, currencyCode)
+    if (price === null || price <= 0n) return { kind: "invalid" }
+    try {
+      const scaled = quantityToScaled(quantity.trim())
+      if (scaled <= 0n) return { kind: "invalid" }
+      return { kind: "valid", minor: holdingCostMinor(scaled, price) }
+    } catch {
+      return { kind: "invalid" }
+    }
+  }, [quantity, unitPrice, currencyCode])
+
+  // A SELL needs an existing position; the instrument options are then just the
+  // holdings. A BUY can additionally create a new instrument.
+  const sellablePositions = holdings
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+    if (cashPreview.kind !== "valid") {
+      setError("Enter a valid quantity and unit price.")
+      return
+    }
+    const price = parseMoneyInput(unitPrice, currencyCode)
+    if (price === null) {
+      setError("Enter a valid unit price.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const shared = {
+        investmentAccountId,
+        fundingAccountId,
+        side,
+        cashAmount: cashPreview.minor.toString(),
+        quantity: quantity.trim(),
+        unitPrice: price.toString(),
+        idempotencyKey: createUuidV7(),
+      }
+      if (!isBuy) {
+        // SELL — must reference an existing position.
+        await recordTradeFn({
+          data: { ...shared, instrumentId: instrumentChoice },
+        })
+      } else if (creatingInstrument) {
+        await recordTradeFn({
+          data: {
+            ...shared,
+            instrument: { kind: newKind, name: newName.trim() },
+          },
+        })
+      } else {
+        await recordTradeFn({
+          data: { ...shared, instrumentId: instrumentChoice },
+        })
+      }
+      await onSaved()
+    } catch (caught) {
+      // The HoldingError message survives the RPC boundary and surfaces here.
+      setError(caught instanceof Error ? caught.message : String(caught))
+      setSubmitting(false)
+    }
+  }
+
+  const submitDisabled =
+    submitting ||
+    fundingAccountId === "" ||
+    quantity.trim() === "" ||
+    unitPrice.trim() === "" ||
+    cashPreview.kind !== "valid" ||
+    (creatingInstrument && newName.trim() === "") ||
+    (!isBuy && sellablePositions.length === 0)
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {isBuy ? (
+                <ArrowDownLeft className="size-4 text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <ArrowUpRight className="size-4 text-destructive" />
+              )}
+              {isBuy ? "Buy" : "Sell"}
+            </DialogTitle>
+            <DialogDescription>
+              {isBuy
+                ? "Move cash into this account and grow a position. Net worth stays the same."
+                : "Sell a position; cash returns to your funding account. Realized gain is shown after."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label>Side</Label>
+              <Select
+                value={side}
+                onValueChange={(value) => setSide(value as "buy" | "sell")}
+              >
+                <SelectTrigger aria-label="Trade side">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="buy">Buy</SelectItem>
+                  <SelectItem value="sell">Sell</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label>Funding account</Label>
+              <Select
+                value={fundingAccountId}
+                onValueChange={setFundingAccountId}
+              >
+                <SelectTrigger aria-label="Funding account">
+                  <SelectValue placeholder="Choose account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {fundingAccounts.map((account) => (
+                    <SelectItem key={account.id} value={account.id}>
+                      {account.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Instrument</Label>
+            <Select
+              value={instrumentChoice}
+              onValueChange={setInstrumentChoice}
+            >
+              <SelectTrigger aria-label="Instrument">
+                <SelectValue placeholder="Choose instrument" />
+              </SelectTrigger>
+              <SelectContent>
+                {(isBuy ? holdings : sellablePositions).map((holding) => (
+                  <SelectItem
+                    key={holding.instrument.id}
+                    value={holding.instrument.id}
+                  >
+                    {holding.instrument.name}
+                  </SelectItem>
+                ))}
+                {isBuy ? (
+                  <SelectItem value={NEW_INSTRUMENT}>
+                    New instrument…
+                  </SelectItem>
+                ) : null}
+              </SelectContent>
+            </Select>
+            {!isBuy && sellablePositions.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No positions to sell yet.
+              </p>
+            ) : null}
+          </div>
+
+          {creatingInstrument ? (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="trade-new-name">Instrument name</Label>
+                <Input
+                  id="trade-new-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="e.g. BSI Gold"
+                  required
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label>Kind</Label>
+                <Select
+                  value={newKind}
+                  onValueChange={(value) => setNewKind(value as InstrumentKind)}
+                >
+                  <SelectTrigger aria-label="New instrument kind">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INSTRUMENT_KINDS.map((k) => (
+                      <SelectItem key={k.value} value={k.value}>
+                        {k.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="trade-quantity">Quantity</Label>
+              <Input
+                id="trade-quantity"
+                inputMode="decimal"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                placeholder="e.g. 2.018"
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="trade-unit-price">Unit price ({currency})</Label>
+              <MoneyInput
+                id="trade-unit-price"
+                currency={currencyCode}
+                value={unitPrice}
+                onChange={setUnitPrice}
+                placeholder="0"
+                required
+              />
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "flex items-center justify-between rounded-md border p-3 text-sm",
+              cashPreview.kind === "valid"
+                ? "bg-muted/50"
+                : "text-muted-foreground"
+            )}
+          >
+            <span className="text-muted-foreground">
+              {isBuy ? "Cash out" : "Cash in"}
+            </span>
+            <span className="font-semibold tabular-nums">
+              {cashPreview.kind === "valid"
+                ? formatCurrency(cashPreview.minor.toString(), currency)
+                : "—"}
+            </span>
+          </div>
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {submitting ? "Recording…" : isBuy ? "Record buy" : "Record sell"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/blocks/trade-dialog.tsx
+++ b/src/components/blocks/trade-dialog.tsx
@@ -23,6 +23,7 @@ import { MoneyInput } from "@/components/blocks/money-input"
 import { formatCurrency } from "@/lib/currency"
 import type { CurrencyCode } from "@/lib/data/currencies"
 import { holdingCostMinor, quantityToScaled } from "@/lib/holdings"
+import { INSTRUMENT_KIND_OPTIONS, type InstrumentKind } from "@/lib/instruments"
 import { parseMoneyInput } from "@/lib/money"
 import { cn } from "@/lib/utils"
 import { createUuidV7 } from "@/lib/uuid-v7"
@@ -37,28 +38,6 @@ import { recordTradeFn } from "@/server/holdings"
 // the cash total live. Money math on the client is limited to deriving the
 // total from quantity × unit price via the SAME pure helper the server uses, so
 // the previewed total is exactly what will move.
-
-// Machine token → human label for the instrument kinds (ADR-0051), reused for
-// the "new instrument" branch of a BUY.
-type InstrumentKind =
-  | "mutual_fund"
-  | "metal"
-  | "stock"
-  | "crypto"
-  | "bond"
-  | "deposit"
-
-const INSTRUMENT_KINDS: ReadonlyArray<{
-  value: InstrumentKind
-  label: string
-}> = [
-  { value: "mutual_fund", label: "Mutual fund" },
-  { value: "metal", label: "Metal" },
-  { value: "stock", label: "Stock" },
-  { value: "crypto", label: "Crypto" },
-  { value: "bond", label: "Bond" },
-  { value: "deposit", label: "Deposit" },
-]
 
 // Sentinel option value for "create a new instrument" (BUY only).
 const NEW_INSTRUMENT = "__new__"
@@ -301,7 +280,7 @@ export function TradeDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {INSTRUMENT_KINDS.map((k) => (
+                    {INSTRUMENT_KIND_OPTIONS.map((k) => (
                       <SelectItem key={k.value} value={k.value}>
                         {k.label}
                       </SelectItem>

--- a/src/lib/holdings.test.ts
+++ b/src/lib/holdings.test.ts
@@ -1,12 +1,14 @@
 import fc from "fast-check"
 import { describe, expect, test } from "vite-plus/test"
 import {
+  averageUnitCostMinor,
   holdingCostMinor,
   holdingGainMinor,
   holdingReturnPct,
   holdingValueMinor,
   QUANTITY_SCALE,
   quantityToScaled,
+  scaledToQuantityString,
   sumHoldingValuesMinor,
 } from "./holdings"
 
@@ -203,5 +205,49 @@ describe("valuation invariants (property-based)", () => {
         expect(scaled).toBe(expected)
       })
     )
+  })
+})
+
+describe("averageUnitCostMinor (PER-198 trade cost blend)", () => {
+  test("inverts holdingCostMinor for exact divisions", () => {
+    // 200 units, total cost 3,000,000 → 15,000/unit.
+    const units = quantityToScaled("200")
+    const avg = averageUnitCostMinor(3_000_000n, units)
+    expect(avg).toBe(15_000n)
+    expect(holdingCostMinor(units, avg)).toBe(3_000_000n)
+  })
+
+  test("blends two buys to the weighted average", () => {
+    // 100 @ 10,000 then 100 @ 20,000 → 200 units, cost 3,000,000, avg 15,000.
+    const units = quantityToScaled("100") + quantityToScaled("100")
+    expect(averageUnitCostMinor(1_000_000n + 2_000_000n, units)).toBe(15_000n)
+  })
+
+  test("rounds half-up and rejects non-positive units", () => {
+    // 3 units, cost 1,000 → 333.33/unit → 333 (rounds to nearest sen).
+    expect(averageUnitCostMinor(1_000n, quantityToScaled("3"))).toBe(333n)
+    expect(() => averageUnitCostMinor(1_000n, 0n)).toThrow()
+    expect(() => averageUnitCostMinor(-1n, quantityToScaled("1"))).toThrow()
+  })
+})
+
+describe("scaledToQuantityString", () => {
+  test("renders the canonical fixed-scale decimal string", () => {
+    expect(scaledToQuantityString(quantityToScaled("100"))).toBe("100.00000000")
+    expect(scaledToQuantityString(quantityToScaled("2.018"))).toBe("2.01800000")
+    expect(scaledToQuantityString(0n)).toBe("0.00000000")
+    expect(scaledToQuantityString(1n)).toBe("0.00000001")
+  })
+
+  test("round-trips with quantityToScaled", () => {
+    fc.assert(
+      fc.property(fc.bigInt({ min: 0n, max: 10n ** 20n }), (scaled) => {
+        expect(quantityToScaled(scaledToQuantityString(scaled))).toBe(scaled)
+      })
+    )
+  })
+
+  test("rejects a negative scaled quantity", () => {
+    expect(() => scaledToQuantityString(-1n)).toThrow()
   })
 })

--- a/src/lib/holdings.ts
+++ b/src/lib/holdings.ts
@@ -97,6 +97,54 @@ function divideScaledHalfUp(a: bigint): bigint {
 }
 
 /**
+ * Average unit cost (per-unit, MINOR units) implied by a total cost basis over a
+ * quantity — the exact inverse of `holdingCostMinor`:
+ *   avgUnitCost = round_half_up(totalCostMinor × QUANTITY_SCALE / unitsScaled)
+ *
+ * Used by the buy/sell trade primitive (PER-198) to blend a new average cost
+ * when units are added at a fresh cash outlay. `unitsScaled` must be positive
+ * (a zero-unit position has no meaningful average) and the total cost
+ * non-negative. Half-up rounding keeps the stored per-unit figure as close as
+ * the per-unit representation allows; the residual sub-unit is inherent to
+ * carrying cost basis as a rounded per-unit price (the same rounding
+ * `holdingCostMinor` already exhibits) and is bounded by one minor unit.
+ */
+export function averageUnitCostMinor(
+  totalCostMinor: bigint,
+  unitsScaled: bigint
+): bigint {
+  if (totalCostMinor < 0n) {
+    throw new RangeError(
+      `averageUnitCostMinor: totalCostMinor must be non-negative, got ${totalCostMinor}`
+    )
+  }
+  if (unitsScaled <= 0n) {
+    throw new RangeError(
+      `averageUnitCostMinor: unitsScaled must be positive, got ${unitsScaled}`
+    )
+  }
+  return (totalCostMinor * QUANTITY_SCALE + unitsScaled / 2n) / unitsScaled
+}
+
+/**
+ * Render a scaled-bigint quantity back to the canonical fixed-scale decimal
+ * string the `Holding.quantity` `Decimal(38, 8)` column stores ("6.00000000").
+ * Exact inverse of `quantityToScaled`; never uses float. A negative input is a
+ * bug (quantity is non-negative by domain) and throws.
+ */
+export function scaledToQuantityString(scaled: bigint): string {
+  if (scaled < 0n) {
+    throw new RangeError(
+      `scaledToQuantityString: expected non-negative scaled quantity, got ${scaled}`
+    )
+  }
+  const digits = scaled.toString().padStart(QUANTITY_SCALE_DIGITS + 1, "0")
+  const whole = digits.slice(0, digits.length - QUANTITY_SCALE_DIGITS)
+  const fraction = digits.slice(digits.length - QUANTITY_SCALE_DIGITS)
+  return `${whole}.${fraction}`
+}
+
+/**
  * Current market value of a holding, in MINOR units:
  *   round_half_up(quantityScaled × pricePerUnitMinor / QUANTITY_SCALE)
  *

--- a/src/lib/instruments.ts
+++ b/src/lib/instruments.ts
@@ -1,0 +1,41 @@
+// Instrument kinds (PER-232 / ADR-0051) — the single client-side source of truth
+// for the six market-priced instrument kinds and their human labels. The server
+// mirrors these tokens in its Zod `inlineInstrumentSchema` enum (the DB CHECK is
+// the backstop); this module owns the token → label mapping the UI renders, so
+// the add-holding dialog, the buy/sell trade dialog, and the holdings list all
+// agree without copy-pasting the list. Pure and framework-free.
+
+export const INSTRUMENT_KINDS = [
+  "mutual_fund",
+  "metal",
+  "stock",
+  "crypto",
+  "bond",
+  "deposit",
+] as const
+
+export type InstrumentKind = (typeof INSTRUMENT_KINDS)[number]
+
+const INSTRUMENT_KIND_LABELS: Record<InstrumentKind, string> = {
+  mutual_fund: "Mutual fund",
+  metal: "Metal",
+  stock: "Stock",
+  crypto: "Crypto",
+  bond: "Bond",
+  deposit: "Deposit",
+}
+
+// Select-ready {value, label} options, in the canonical kind order.
+export const INSTRUMENT_KIND_OPTIONS: ReadonlyArray<{
+  value: InstrumentKind
+  label: string
+}> = INSTRUMENT_KINDS.map((value) => ({
+  value,
+  label: INSTRUMENT_KIND_LABELS[value],
+}))
+
+// Human label for a stored kind token; falls back to the raw token for any
+// value outside the known set (never throws — the DB stores the machine token).
+export function instrumentKindLabel(kind: string): string {
+  return (INSTRUMENT_KIND_LABELS as Record<string, string>)[kind] ?? kind
+}

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -13,6 +13,7 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { formatCurrency } from "@/lib/currency"
+import { instrumentKindLabel } from "@/lib/instruments"
 import { cn } from "@/lib/utils"
 import type { getAccountHoldingsFn } from "@/server/holdings"
 
@@ -29,21 +30,6 @@ export type AccountHoldingsView = Awaited<
   ReturnType<typeof getAccountHoldingsFn>
 >
 export type HoldingRecord = AccountHoldingsView["holdings"][number]
-
-// Human labels for the six instrument kinds (ADR-0051). Kept local to the UI —
-// the DB stores the machine token.
-const KIND_LABEL: Record<string, string> = {
-  mutual_fund: "Mutual fund",
-  metal: "Metal",
-  stock: "Stock",
-  crypto: "Crypto",
-  bond: "Bond",
-  deposit: "Deposit",
-}
-
-function kindLabel(kind: string): string {
-  return KIND_LABEL[kind] ?? kind
-}
 
 function GainText({
   gainMinor,
@@ -156,7 +142,7 @@ export function HoldingsPanel({
                       {holding.instrument.name}
                     </p>
                     <Badge variant="secondary" className="shrink-0">
-                      {kindLabel(holding.instrument.kind)}
+                      {instrumentKindLabel(holding.instrument.kind)}
                     </Badge>
                   </div>
                   <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -1,4 +1,6 @@
 import {
+  ArrowDownLeft,
+  ArrowUpRight,
   Coins,
   PiggyBank,
   Plus,
@@ -95,6 +97,9 @@ export function HoldingsPanel({
   onAdd,
   onEdit,
   onDelete,
+  onBuy,
+  onBuyHolding,
+  onSellHolding,
 }: Readonly<{
   view: AccountHoldingsView | undefined
   currency: string
@@ -102,6 +107,9 @@ export function HoldingsPanel({
   onAdd: () => void
   onEdit: (holding: HoldingRecord) => void
   onDelete: (holding: HoldingRecord) => void
+  onBuy: () => void
+  onBuyHolding: (holding: HoldingRecord) => void
+  onSellHolding: (holding: HoldingRecord) => void
 }>) {
   const holdings = view?.holdings ?? []
 
@@ -112,10 +120,16 @@ export function HoldingsPanel({
           <PiggyBank className="size-3.5" aria-hidden />
           Holdings
         </h2>
-        <Button size="sm" variant="outline" onClick={onAdd}>
-          <Plus className="size-4" />
-          Add holding
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={onBuy}>
+            <ArrowDownLeft className="size-4" />
+            Buy
+          </Button>
+          <Button size="sm" variant="outline" onClick={onAdd}>
+            <Plus className="size-4" />
+            Add holding
+          </Button>
+        </div>
       </div>
 
       {isLoading ? (
@@ -124,8 +138,8 @@ export function HoldingsPanel({
         <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed py-8 text-center">
           <Coins className="size-6 text-muted-foreground" aria-hidden />
           <p className="max-w-xs text-sm text-muted-foreground">
-            No holdings yet — add your funds, gold, or shares to track value and
-            returns.
+            No holdings yet — record a buy, or add a position you already own to
+            track value and returns.
           </p>
         </div>
       ) : (
@@ -150,6 +164,26 @@ export function HoldingsPanel({
                     {formatCurrency(holding.costMinor, currency)}
                   </p>
                   <div className="mt-1.5 flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => onBuyHolding(holding)}
+                    >
+                      <ArrowDownLeft className="size-3.5" />
+                      Buy
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => onSellHolding(holding)}
+                    >
+                      <ArrowUpRight className="size-3.5" />
+                      Sell
+                    </Button>
                     <Button
                       type="button"
                       variant="ghost"

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -46,6 +46,10 @@ import {
   HoldingFormDialog,
   type HoldingFormState,
 } from "@/components/blocks/holding-form-dialog"
+import {
+  TradeDialog,
+  type TradeDialogState,
+} from "@/components/blocks/trade-dialog"
 import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
@@ -136,6 +140,10 @@ function AccountDetailPage() {
   // PER-232 — add/edit holding dialog (create vs edit a single position).
   const [holdingDialog, setHoldingDialog] =
     React.useState<HoldingFormState | null>(null)
+  // PER-198 — buy/sell trade dialog (atomic cash ↔ holding).
+  const [tradeDialog, setTradeDialog] = React.useState<TradeDialogState | null>(
+    null
+  )
 
   const { data: accounts } = useLiveQuery((q) =>
     q.from({ a: accountCollection })
@@ -215,6 +223,22 @@ function AccountDetailPage() {
   async function refreshHoldings() {
     await Promise.all([refetchHoldings(), refreshAccountData()])
   }
+
+  // PER-198 — cash-like accounts (same currency, active, not this account) that
+  // can fund a buy or receive a sell. Derived from the live account collection.
+  const fundingAccounts = React.useMemo(
+    () =>
+      (accounts ?? [])
+        .filter(
+          (a) =>
+            a.id !== accountId &&
+            a.balanceSource === "transaction_flow" &&
+            a.status === "active" &&
+            a.currency === currency
+        )
+        .map((a) => ({ id: a.id, name: a.name, currency: a.currency })),
+    [accounts, accountId, currency]
+  )
 
   // PER-239 / ADR-0051 — flip this INVESTMENT account to valuation tracking,
   // then resync the account collections (so `tracked` becomes true and the
@@ -485,6 +509,13 @@ function AccountDetailPage() {
               onAdd={() => setHoldingDialog({ mode: "create" })}
               onEdit={(holding) => setHoldingDialog({ mode: "edit", holding })}
               onDelete={handleDeleteHolding}
+              onBuy={() => setTradeDialog({ side: "buy" })}
+              onBuyHolding={(holding) =>
+                setTradeDialog({ side: "buy", holding })
+              }
+              onSellHolding={(holding) =>
+                setTradeDialog({ side: "sell", holding })
+              }
             />
           ) : null}
           {health ? <AccountHealthPanel health={health} /> : null}
@@ -669,6 +700,27 @@ function AccountDetailPage() {
           onSaved={async () => {
             await refreshHoldings()
             setHoldingDialog(null)
+          }}
+        />
+      ) : null}
+
+      {tradeDialog ? (
+        <TradeDialog
+          // Remount per open so the form re-initializes cleanly.
+          key={
+            "holding" in tradeDialog
+              ? `trade-${tradeDialog.side}-${tradeDialog.holding.id}`
+              : `trade-${tradeDialog.side}`
+          }
+          state={tradeDialog}
+          investmentAccountId={accountId}
+          currency={currency}
+          fundingAccounts={fundingAccounts}
+          holdings={holdingsView?.holdings ?? []}
+          onClose={() => setTradeDialog(null)}
+          onSaved={async () => {
+            await refreshHoldings()
+            setTradeDialog(null)
           }}
         />
       ) : null}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -1,16 +1,27 @@
 import { createServerFn } from "@tanstack/react-start"
-import type { Holding, Instrument } from "@prisma/client"
+import type { Holding, Instrument, Valuation } from "@prisma/client"
 import { z } from "zod"
 import { CURRENCIES, type CurrencyCode } from "@/lib/data/currencies"
 import {
+  averageUnitCostMinor,
   holdingCostMinor,
   holdingGainMinor,
   holdingReturnPct,
   holdingValueMinor,
   quantityToScaled,
+  scaledToQuantityString,
   sumHoldingValuesMinor,
 } from "@/lib/holdings"
+import {
+  deriveTransferKindForAccounts,
+  parseAccountType,
+} from "@/lib/liability-semantics"
 import { toMinorUnits } from "@/lib/money"
+import { getFamilyBaseCurrency } from "./fx"
+import {
+  postValuationLinkedTransferLegs,
+  type ValuationLinkedTransferLeg,
+} from "./transactions"
 import {
   auditLog,
   createAuditContext,
@@ -315,7 +326,10 @@ async function resolveInstrument(
   tx: TenantTransactionClient,
   familyId: string,
   accountCurrency: string,
-  data: UpsertHoldingInput,
+  data: {
+    instrumentId?: string
+    instrument?: z.infer<typeof inlineInstrumentSchema>
+  },
   auditCtx: AuditContext
 ): Promise<Instrument> {
   if (data.instrumentId) {
@@ -386,7 +400,7 @@ async function recomputeAccountValueAnchorWithinTx(
   currency: string,
   user: ServerActor,
   auditCtx: AuditContext
-): Promise<void> {
+): Promise<Valuation> {
   const holdings = await tx.holding.findMany({
     where: { familyId, accountId },
     select: { quantity: true, avgUnitCostMinor: true, lastPriceMinor: true },
@@ -397,7 +411,7 @@ async function recomputeAccountValueAnchorWithinTx(
       pricePerUnitMinor: holding.lastPriceMinor ?? holding.avgUnitCostMinor,
     }))
   )
-  await createValuationWithinTx(
+  const { valuation } = await createValuationWithinTx(
     tx,
     familyId,
     {
@@ -411,6 +425,7 @@ async function recomputeAccountValueAnchorWithinTx(
     user,
     auditCtx
   )
+  return valuation
 }
 
 async function loadHoldingWithInstrument(
@@ -800,5 +815,479 @@ export const getAccountHoldingsFn = createServerFn({ method: "GET" })
       accountId: data.accountId,
       familyId: context.familyId,
       userId: context.user.id,
+    })
+  })
+
+// =============================================================================
+// BUY / SELL — atomic cash ↔ holding trade (PER-198 / ADR-0051)
+// =============================================================================
+//
+// Recording a purchase or sale in an investment account used to be two manual
+// steps (a valuation-linked transfer + a holding edit). `recordTradeForFamily`
+// makes it ONE ledger transaction, conserving net worth:
+//
+//   BUY  — cash leaves the funding account; the position's cost basis grows by
+//          exactly that cash (units += quantity, cost += cashAmount, AVERAGE
+//          cost). The investment account's value re-materializes from Σ holdings.
+//   SELL — cash enters the funding account; the position shrinks (units -=
+//          quantity, cost removed pro-rata at the average unit cost). A DERIVED
+//          realized gain/loss (cashAmount − costRemoved) is RETURNED, not posted
+//          this slice. Selling the last unit closes (deletes) the position.
+//
+// The money movement rides the EXISTING valuation-linked transfer primitive
+// (`postValuationLinkedTransferLegs`, transactions.ts): the funding (cash-like,
+// balanceSource="transaction_flow") leg is a real, guarded `Transaction`; the
+// investment (balanceSource="valuation") side never takes an incremental
+// balance write (PER-196 / ADR-0048 §3 guard) — it moves ONLY through the
+// Σ-holdings valuation this function supplies. One `Transfer` row links them
+// (ADR-0048 §4 shape), so delete/drift/reporting treat a trade like any other
+// valuation-linked move.
+//
+// Net-worth conservation: the funding account is debited/credited by exactly
+// `cashAmount`, and the investment account's COST BASIS moves by exactly
+// `cashAmount` (buy) / `costRemoved` (sell). When holdings are carried at cost
+// (no market lastPrice — the freshly-traded case), the investment account's
+// materialized value moves by the same amount, so family net worth is
+// unchanged. A holding that already carries a market `lastPrice` values at
+// market (ADR-0051 honest cost basis); the difference is unrealized gain
+// already recognized, not a conservation violation. Fractional-quantity
+// rounding is bounded by one minor unit per holding (inherent to per-unit cost).
+//
+// DEFERRED (out of scope, documented in ADR-0051): trade EDIT/DELETE that also
+// reverses the position (this slice records trades; deleting the linked
+// transfer reverses cash + valuation but not the holding — see ADR-0051),
+// FIFO/tax lots (PER-141), realized-gain-as-income posting, market-data
+// auto-pricing, and transfer fees.
+
+const RECORD_TRADE_ENDPOINT = "recordTradeFn"
+
+const tradeSideSchema = z.enum(["buy", "sell"])
+
+// A strictly-positive amount already in MINOR units (sen), as a digit-string —
+// the same wire contract as valuations' `valueMagnitudeSchema`, but non-negative
+// and non-zero. The UI derives this from the shared money parser.
+const positiveMinorDigitsSchema = z
+  .string()
+  .trim()
+  .regex(/^\d+$/, "must be a whole number of minor units")
+  .refine((value) => BigInt(value) > 0n, {
+    message: "must be greater than zero",
+  })
+
+export const recordTradeInputSchema = z.object({
+  investmentAccountId: z.string().min(1),
+  fundingAccountId: z.string().min(1),
+  // Exactly one of instrumentId / instrument on a BUY; instrumentId REQUIRED on
+  // a SELL (you can only sell a position you already hold).
+  instrumentId: z.string().min(1).optional(),
+  instrument: inlineInstrumentSchema.optional(),
+  side: tradeSideSchema,
+  // Cash that actually moves — AUTHORITATIVE for the ledger and the cost basis.
+  cashAmount: positiveMinorDigitsSchema,
+  quantity: decimalStringSchema,
+  // Execution price per unit (advisory/provenance): cashAmount is authoritative
+  // for money; unitPrice is recorded in the audit payload. Never drives balances.
+  unitPrice: positiveMinorDigitsSchema.optional(),
+  tradeDate: z.coerce.date().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+type RecordTradeInput = z.infer<typeof recordTradeInputSchema>
+
+export interface RecordTradeResult {
+  side: "buy" | "sell"
+  investmentAccountId: string
+  fundingAccountId: string
+  /** The cash leg posted on the funding account (already serialized). */
+  transaction: Awaited<ReturnType<typeof postValuationLinkedTransferLegs>>
+  /** Resulting position, or null when a SELL closed it to zero. */
+  holding: SerializedHolding | null
+  /** SELL only: realized gain/loss vs average cost, minor units, signed. */
+  realizedGainMinor: string | null
+  /** Cost basis moved by this trade (added on BUY, removed on SELL), minor units. */
+  costBasisDeltaMinor: string
+  /** Funding account balance after the cash leg, minor units. */
+  fundingBalanceAfterMinor: string
+  /** Investment account value after re-materializing from Σ holdings, minor units. */
+  investmentValueAfterMinor: string
+}
+
+// A cash-like funding account: exists, active, not soft-deleted,
+// balanceSource="transaction_flow". Returns the full row (needed by the
+// transfer primitive).
+async function fetchActiveAccount(
+  tx: TenantTransactionClient,
+  familyId: string,
+  accountId: string,
+  label: string
+) {
+  const account = await tx.account.findFirst({
+    where: { id: accountId, familyId, deletedAt: null },
+  })
+  if (!account) {
+    throw new HoldingError(
+      `${label} account ${accountId} not found for this family`
+    )
+  }
+  if (account.status !== "active") {
+    throw new HoldingError(`${label} account ${accountId} is not active`)
+  }
+  return account
+}
+
+export async function recordTradeForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordTradeInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<RecordTradeResult> {
+  const data: RecordTradeInput = recordTradeInputSchema.parse(rawData)
+  const isBuy = data.side === "buy"
+
+  const requestHash = await hashCanonicalPayload({
+    cashAmount: data.cashAmount,
+    fundingAccountId: data.fundingAccountId,
+    instrument: data.instrument ?? null,
+    instrumentId: data.instrumentId ?? null,
+    investmentAccountId: data.investmentAccountId,
+    quantity: data.quantity,
+    side: data.side,
+    tradeDate: data.tradeDate?.toISOString() ?? null,
+    unitPrice: data.unitPrice ?? null,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<RecordTradeResult>(
+        tx,
+        {
+          endpoint: RECORD_TRADE_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      // Tenant ownership of BOTH accounts (RLS-scoped, composite-FK backed).
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.fundingAccountId,
+        toAccountId: data.investmentAccountId,
+      })
+
+      const fundingAccount = await fetchActiveAccount(
+        tx,
+        familyId,
+        data.fundingAccountId,
+        "Funding"
+      )
+      if (fundingAccount.balanceSource !== "transaction_flow") {
+        throw new HoldingError(
+          `Funding account ${fundingAccount.id} must be a cash-like account (balanceSource="transaction_flow"); it is "${fundingAccount.balanceSource}"`
+        )
+      }
+
+      const investmentAccount = await fetchActiveAccount(
+        tx,
+        familyId,
+        data.investmentAccountId,
+        "Investment"
+      )
+      if (investmentAccount.balanceSource !== "valuation") {
+        throw new HoldingError(
+          `Investment account ${investmentAccount.id} must be a valuation-tracked account (balanceSource="valuation"); it is "${investmentAccount.balanceSource}"`
+        )
+      }
+
+      // Single-currency slice: the cash leg and the position share one currency.
+      if (fundingAccount.currency !== investmentAccount.currency) {
+        throw new HoldingError(
+          `Cross-currency trades are not supported this slice (funding ${fundingAccount.currency}, investment ${investmentAccount.currency})`
+        )
+      }
+      // Validate the currency is one we support (throws a typed HoldingError).
+      assertKnownCurrency(investmentAccount.currency)
+
+      const cashAmount = BigInt(data.cashAmount)
+      let quantityScaled: bigint
+      try {
+        quantityScaled = quantityToScaled(data.quantity)
+      } catch (error) {
+        throw new HoldingError(
+          `quantity is not a valid amount: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+      if (quantityScaled <= 0n) {
+        throw new HoldingError("quantity must be greater than zero")
+      }
+
+      // Resolve the instrument. A BUY may create one inline; a SELL must name an
+      // existing instrument (you cannot sell a position you do not hold).
+      if (!isBuy && (data.instrument || !data.instrumentId)) {
+        throw new HoldingError(
+          "A sell must reference an existing instrumentId (you can only sell a position you hold)"
+        )
+      }
+      const instrument = await resolveInstrument(
+        tx,
+        familyId,
+        investmentAccount.currency,
+        { instrumentId: data.instrumentId, instrument: data.instrument },
+        auditCtx
+      )
+
+      // Side-channel outputs captured from the position mutation (which runs
+      // inside resolveValuation, after the cash leg posts). An object (not bare
+      // primitives) so closure assignments keep their declared union type.
+      const tradeOut: {
+        holdingId: string | null
+        realizedGainMinor: bigint | null
+        costBasisDeltaMinor: bigint
+      } = { holdingId: null, realizedGainMinor: null, costBasisDeltaMinor: 0n }
+
+      const existing = await tx.holding.findFirst({
+        where: {
+          familyId,
+          accountId: investmentAccount.id,
+          instrumentId: instrument.id,
+        },
+        include: { instrument: true },
+      })
+
+      // Direction + kind mirror the DB trigger exactly (source→destination):
+      //   BUY  = contribution (funding → investment)
+      //   SELL = redemption   (investment → funding)
+      const direction = isBuy ? "contribution" : "redemption"
+      const kind = isBuy
+        ? deriveTransferKindForAccounts({
+            fromAccountType: parseAccountType(fundingAccount.accountType),
+            toAccountType: parseAccountType(investmentAccount.accountType),
+          })
+        : deriveTransferKindForAccounts({
+            fromAccountType: parseAccountType(investmentAccount.accountType),
+            toAccountType: parseAccountType(fundingAccount.accountType),
+          })
+
+      const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+      const tradeDate = data.tradeDate ?? new Date()
+      const description = `${isBuy ? "Buy" : "Sell"} ${instrument.name}`
+
+      const leg: ValuationLinkedTransferLeg = {
+        amount: cashAmount,
+        date: tradeDate,
+        description,
+        notes: null,
+        status: "CLEARED",
+        idempotencyKey: data.idempotencyKey,
+      }
+
+      const serializedTransaction = await postValuationLinkedTransferLegs(tx, {
+        cashAccount: fundingAccount,
+        trackedAccount: investmentAccount,
+        direction,
+        kind,
+        leg,
+        familyId,
+        user,
+        auditCtx,
+        baseCurrency,
+        resolveValuation: async (t) => {
+          if (isBuy) {
+            if (existing) {
+              const oldUnitsScaled = quantityToScaled(
+                existing.quantity.toFixed(8)
+              )
+              const oldCost = holdingCostMinor(
+                oldUnitsScaled,
+                existing.avgUnitCostMinor
+              )
+              const newUnitsScaled = oldUnitsScaled + quantityScaled
+              const newAvg = averageUnitCostMinor(
+                oldCost + cashAmount,
+                newUnitsScaled
+              )
+              const updated = await t.holding.update({
+                where: { id: existing.id },
+                data: {
+                  quantity: scaledToQuantityString(newUnitsScaled),
+                  avgUnitCostMinor: newAvg,
+                },
+                include: { instrument: true },
+              })
+              await auditLog(t, auditCtx, {
+                action: "update",
+                entityType: "Holding",
+                entityId: updated.id,
+                before: serializeHolding(existing),
+                after: serializeHolding(updated),
+              })
+              tradeOut.holdingId = updated.id
+            } else {
+              const newAvg = averageUnitCostMinor(cashAmount, quantityScaled)
+              const created = await t.holding.create({
+                data: {
+                  familyId,
+                  accountId: investmentAccount.id,
+                  instrumentId: instrument.id,
+                  quantity: scaledToQuantityString(quantityScaled),
+                  avgUnitCostMinor: newAvg,
+                  lastPriceMinor: null,
+                },
+                include: { instrument: true },
+              })
+              await auditLog(t, auditCtx, {
+                action: "create",
+                entityType: "Holding",
+                entityId: created.id,
+                after: serializeHolding(created),
+              })
+              tradeOut.holdingId = created.id
+            }
+            tradeOut.costBasisDeltaMinor = cashAmount
+          } else {
+            // SELL — must have an existing position with enough units.
+            if (!existing) {
+              throw new HoldingError(
+                `No ${instrument.name} position to sell in this account`
+              )
+            }
+            const oldUnitsScaled = quantityToScaled(
+              existing.quantity.toFixed(8)
+            )
+            if (quantityScaled > oldUnitsScaled) {
+              throw new HoldingError(
+                `Cannot sell ${data.quantity} units; only ${existing.quantity.toFixed(8)} held`
+              )
+            }
+            // Average-cost method: cost removed = units sold × average unit cost;
+            // the average unit cost of the remaining units is unchanged.
+            const costRemoved = holdingCostMinor(
+              quantityScaled,
+              existing.avgUnitCostMinor
+            )
+            tradeOut.costBasisDeltaMinor = costRemoved
+            tradeOut.realizedGainMinor = cashAmount - costRemoved
+            const newUnitsScaled = oldUnitsScaled - quantityScaled
+            if (newUnitsScaled === 0n) {
+              // Sold to zero — close (delete) the position, mirroring
+              // deleteHoldingForFamily's hard delete of the position row.
+              await t.holding.delete({ where: { id: existing.id } })
+              await auditLog(t, auditCtx, {
+                action: "delete",
+                entityType: "Holding",
+                entityId: existing.id,
+                before: serializeHolding(existing),
+                after: null,
+              })
+              tradeOut.holdingId = null
+            } else {
+              const updated = await t.holding.update({
+                where: { id: existing.id },
+                data: { quantity: scaledToQuantityString(newUnitsScaled) },
+                include: { instrument: true },
+              })
+              await auditLog(t, auditCtx, {
+                action: "update",
+                entityType: "Holding",
+                entityId: updated.id,
+                before: serializeHolding(existing),
+                after: serializeHolding(updated),
+              })
+              tradeOut.holdingId = updated.id
+            }
+          }
+
+          // Re-materialize the investment account value = Σ holdings, written as
+          // the valuation anchor that pairs with the cash leg under one Transfer.
+          const valuation = await recomputeAccountValueAnchorWithinTx(
+            t,
+            familyId,
+            investmentAccount.id,
+            investmentAccount.currency,
+            user,
+            auditCtx
+          )
+          return { valuation }
+        },
+      })
+
+      const finalHolding =
+        tradeOut.holdingId === null
+          ? null
+          : serializeHolding(
+              await loadHoldingWithInstrument(tx, familyId, tradeOut.holdingId)
+            )
+
+      const [fundingAfter, investmentAfter] = await Promise.all([
+        tx.account.findUniqueOrThrow({
+          where: { id: fundingAccount.id },
+          select: { balance: true },
+        }),
+        tx.account.findUniqueOrThrow({
+          where: { id: investmentAccount.id },
+          select: { balance: true },
+        }),
+      ])
+
+      const response: RecordTradeResult = {
+        side: data.side,
+        investmentAccountId: investmentAccount.id,
+        fundingAccountId: fundingAccount.id,
+        transaction: serializedTransaction,
+        holding: finalHolding,
+        realizedGainMinor:
+          tradeOut.realizedGainMinor === null
+            ? null
+            : tradeOut.realizedGainMinor.toString(),
+        costBasisDeltaMinor: tradeOut.costBasisDeltaMinor.toString(),
+        fundingBalanceAfterMinor: fundingAfter.balance.toString(),
+        investmentValueAfterMinor: investmentAfter.balance.toString(),
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: RECORD_TRADE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<RecordTradeResult>(tx, {
+        endpoint: RECORD_TRADE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const recordTradeFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordTradeInputSchema>) =>
+    recordTradeInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordTradeForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
     })
   })

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -44,7 +44,11 @@ import {
   type RunInTenantTransaction,
 } from "./mutation-kit"
 import { validateTenantReferences } from "./validation/tenant-references"
-import { createValuationWithinTx, type ServerActor } from "./valuations"
+import {
+  createValuationWithinTx,
+  HOLDINGS_VALUATION_SOURCE,
+  type ServerActor,
+} from "./valuations"
 
 // =============================================================================
 // PER-232 / ADR-0051 — Holdings core (Slice 1: market-priced).
@@ -76,9 +80,9 @@ import { createValuationWithinTx, type ServerActor } from "./valuations"
 const UPSERT_HOLDING_ENDPOINT = "upsertHoldingFn"
 const DELETE_HOLDING_ENDPOINT = "deleteHoldingFn"
 
-// Source tag on the holdings-derived valuation anchor, so a consumer can tell a
-// holdings restatement from a live user reconciliation or a Sure import.
-const HOLDINGS_ANCHOR_SOURCE = "holdings"
+// Source tag on the holdings-derived valuation anchor (shared with the trade-
+// delete guard in transactions.ts, hence defined once in valuations.ts).
+const HOLDINGS_ANCHOR_SOURCE = HOLDINGS_VALUATION_SOURCE
 
 /**
  * Raised for holdings-specific domain rejections (ineligible account, currency

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from "@tanstack/react-start"
-import type { Account, Prisma } from "@prisma/client"
+import type { Account, Prisma, Valuation } from "@prisma/client"
 import { z } from "zod"
 import {
   deriveTransferKindForAccounts,
@@ -1630,6 +1630,151 @@ async function normalizeBulkDeleteTransactionsTransportInput(
 // (valuationId set, exactly one of outflowTransactionId/inflowTransactionId
 // set) — never a raw dual-leg transfer. Called from createTransactionForFamily's
 // transfer branch once it detects either side is valuation-tracked.
+// The cash-side leg fields a valuation-linked move needs. A narrow view of
+// `CreateTransactionInput` so a non-transfer caller (PER-198 trades) can drive
+// the same double-entry primitive without constructing a full transaction
+// payload.
+export interface ValuationLinkedTransferLeg {
+  amount: bigint
+  date: Date
+  description: string
+  notes?: string | null
+  id?: string
+  categoryId?: string | null
+  merchantId?: string | null
+  status: string
+  attachmentUrl?: string | null
+  idempotencyKey: string
+}
+
+// PER-196 / ADR-0048 §1/§4 — the shared double-entry primitive for a valuation-
+// linked move: decrement/credit the CASH account through the guarded
+// `applyAccountBalanceDelta` path, post the single cash `Transaction` leg, and
+// pair it with a `Valuation` on the tracked-asset side under one `Transfer`
+// row (valuationId set, exactly one of outflow/inflow Transaction FKs set —
+// the ADR-0048 §4 shape). It never mutates the tracked account's balance
+// directly (the PER-196 guard forbids that); the tracked side moves ONLY
+// through the `Valuation` the caller supplies via `resolveValuation`.
+//
+// `resolveValuation` runs AFTER the cash leg is posted and BEFORE the Transfer
+// is created, inside the same transaction. The default valuation-linked
+// transfer supplies the ADR-0048 prefill (latest ∓ cashAmount); PER-198 trades
+// supply Σ-holdings after applying the position change — same structural shape,
+// different source of the tracked account's new value.
+export async function postValuationLinkedTransferLegs(
+  tx: TenantTransactionClient,
+  {
+    cashAccount,
+    trackedAccount,
+    direction,
+    kind,
+    leg,
+    familyId,
+    user,
+    auditCtx,
+    baseCurrency,
+    resolveValuation,
+  }: {
+    cashAccount: Account
+    trackedAccount: Account
+    direction: "contribution" | "redemption"
+    kind: string
+    leg: ValuationLinkedTransferLeg
+    familyId: string
+    user: { id: string }
+    auditCtx: AuditContext
+    baseCurrency: string
+    resolveValuation: (
+      tx: TenantTransactionClient
+    ) => Promise<{ valuation: Valuation }>
+  }
+) {
+  // v1 scope (ADR-0048 §1): the cash leg and the tracked account are both
+  // denominated in one currency. Cross-currency valuation-linked moves need
+  // their own FX design and are not supported yet — fail loud rather than
+  // silently mixing currencies.
+  if (cashAccount.currency !== trackedAccount.currency) {
+    throw new ValuationError(
+      `Valuation-linked transfer requires matching currencies (cash account ${cashAccount.currency}, tracked account ${trackedAccount.currency}); cross-currency is not yet supported`
+    )
+  }
+
+  const isContribution = direction === "contribution"
+  const cashAmount = absMoney(leg.amount)
+  const cashDelta = isContribution ? negateMoney(cashAmount) : cashAmount
+
+  const cashMutation = await applyAccountBalanceDelta(tx, {
+    accountId: cashAccount.id,
+    delta: cashDelta,
+    familyId,
+    notFoundMessage: "Cash account not found or access denied!",
+  })
+  const cashBalanceAfter = cashMutation.after.balance
+
+  const projection = await computeBaseProjectionForAmount(tx, familyId, {
+    amount: cashDelta,
+    currency: cashAccount.currency,
+    date: leg.date,
+    baseCurrency,
+  })
+
+  const cashTx = await tx.transaction.create({
+    data: {
+      ...(leg.id ? { id: leg.id } : {}),
+      type: "transfer",
+      kind,
+      currency: cashAccount.currency,
+      amount: cashDelta,
+      description: leg.description,
+      date: leg.date,
+      notes: leg.notes || null,
+      accountId: cashAccount.id,
+      toAccountId: trackedAccount.id,
+      categoryId: leg.categoryId || null,
+      merchantId: leg.merchantId || null,
+      userId: user.id,
+      familyId,
+      status: leg.status,
+      baseAmount: projection.baseAmount,
+      baseCurrency: projection.baseCurrency,
+      fxRateScaled: projection.fxRateScaled,
+      fxRateSnapshotId: projection.fxRateSnapshotId,
+      accountBalanceAfter: cashBalanceAfter,
+      attachmentUrl: leg.attachmentUrl,
+      idempotencyKey: leg.idempotencyKey,
+    },
+  })
+
+  // Tracked side: whatever Valuation the caller decides. A redemption that
+  // would drive the tracked value negative is rejected by
+  // createValuationWithinTx's existing ADR-0045 sign check.
+  const { valuation } = await resolveValuation(tx)
+
+  const createdTransfer = await tx.transfer.create({
+    data: {
+      ...(isContribution
+        ? { outflowTransactionId: cashTx.id }
+        : { inflowTransactionId: cashTx.id }),
+      valuationId: valuation.id,
+    },
+  })
+
+  const newCashAccount = await tx.account.findUniqueOrThrow({
+    where: { id: cashAccount.id },
+  })
+
+  await auditLogs(tx, auditCtx, [
+    ...accountBalanceAuditEntries([cashAccount], [newCashAccount]),
+    ...createdAuditEntries("Transaction", [cashTx]),
+    ...createdAuditEntries("Transfer", [createdTransfer]),
+  ])
+
+  return serializeTransaction({
+    ...cashTx,
+    amount: absMoney(cashTx.amount),
+  })
+}
+
 async function createValuationLinkedTransferWithinTx(
   tx: TenantTransactionClient,
   {
@@ -1654,116 +1799,59 @@ async function createValuationLinkedTransferWithinTx(
     baseCurrency: string
   }
 ) {
-  // v1 scope (ADR-0048 §1): the prefill formula (latest ∓ cashAmount) and the
-  // cash leg's own amount are both denominated in one currency. Cross-
-  // currency valuation-linked transfers need their own FX design and are not
-  // supported yet — fail loud rather than silently mixing currencies.
-  if (cashAccount.currency !== trackedAccount.currency) {
-    throw new ValuationError(
-      `Valuation-linked transfer requires matching currencies (cash account ${cashAccount.currency}, tracked account ${trackedAccount.currency}); cross-currency is not yet supported`
-    )
-  }
-
-  const isContribution = direction === "contribution"
-  const cashAmount = absMoney(data.amount)
-  const cashDelta = isContribution ? negateMoney(cashAmount) : cashAmount
-
-  const cashMutation = await applyAccountBalanceDelta(tx, {
-    accountId: cashAccount.id,
-    delta: cashDelta,
-    familyId,
-    notFoundMessage: "Cash account not found or access denied!",
-  })
-  const cashBalanceAfter = cashMutation.after.balance
-
-  const projection = await computeBaseProjectionForAmount(tx, familyId, {
-    amount: cashDelta,
-    currency: cashAccount.currency,
-    date: data.date,
-    baseCurrency,
-  })
-
-  const cashTx = await tx.transaction.create({
-    data: {
-      ...(data.id ? { id: data.id } : {}),
-      type: "transfer",
-      kind,
-      currency: cashAccount.currency,
-      amount: cashDelta,
-      description: data.description,
+  return postValuationLinkedTransferLegs(tx, {
+    cashAccount,
+    trackedAccount,
+    direction,
+    kind,
+    leg: {
+      amount: data.amount,
       date: data.date,
-      notes: data.notes || null,
-      accountId: cashAccount.id,
-      toAccountId: trackedAccount.id,
-      categoryId: data.categoryId || null,
-      merchantId: data.merchantId || null,
-      userId: user.id,
-      familyId,
+      description: data.description,
+      notes: data.notes,
+      id: data.id,
+      categoryId: data.categoryId,
+      merchantId: data.merchantId,
       status: data.status,
-      baseAmount: projection.baseAmount,
-      baseCurrency: projection.baseCurrency,
-      fxRateScaled: projection.fxRateScaled,
-      fxRateSnapshotId: projection.fxRateSnapshotId,
-      accountBalanceAfter: cashBalanceAfter,
       attachmentUrl: data.attachmentUrl,
       idempotencyKey: data.idempotencyKey,
     },
-  })
-
-  // New valuation value (ADR-0048 §1): prefilled latest ∓ cashAmount,
-  // editable via data.newValuationValue. A redemption that would drive the
-  // tracked value negative is rejected by createValuationWithinTx's existing
-  // ADR-0045 sign check — you cannot redeem more than the tracked asset is
-  // currently worth.
-  const latest = await latestValuation(tx, familyId, trackedAccount.id)
-  const latestValue = latest?.value ?? toMoney(trackedAccount.balance)
-  const prefill = isContribution
-    ? addMoney(latestValue, cashAmount)
-    : subMoney(latestValue, cashAmount)
-  const newValuationMagnitude = data.newValuationValue
-    ? BigInt(data.newValuationValue)
-    : prefill
-
-  const valuationInput: CreateValuationInput = {
-    accountId: trackedAccount.id,
-    value: newValuationMagnitude.toString(),
-    currency: trackedAccount.currency,
-    valuationDate: data.date,
-    type: "manual",
-    source: "transfer",
-    note: null,
-    idempotencyKey: data.idempotencyKey,
-  }
-  const { valuation } = await createValuationWithinTx(
-    tx,
     familyId,
-    valuationInput,
     user,
-    auditCtx
-  )
-
-  const createdTransfer = await tx.transfer.create({
-    data: {
-      ...(isContribution
-        ? { outflowTransactionId: cashTx.id }
-        : { inflowTransactionId: cashTx.id }),
-      valuationId: valuation.id,
+    auditCtx,
+    baseCurrency,
+    // ADR-0048 §1 prefill: latest ∓ cashAmount, editable via
+    // data.newValuationValue. Runs after the cash leg is posted (order
+    // preserved from the pre-refactor path).
+    resolveValuation: async (t) => {
+      const isContribution = direction === "contribution"
+      const cashAmount = absMoney(data.amount)
+      const latest = await latestValuation(t, familyId, trackedAccount.id)
+      const latestValue = latest?.value ?? toMoney(trackedAccount.balance)
+      const prefill = isContribution
+        ? addMoney(latestValue, cashAmount)
+        : subMoney(latestValue, cashAmount)
+      const newValuationMagnitude = data.newValuationValue
+        ? BigInt(data.newValuationValue)
+        : prefill
+      const valuationInput: CreateValuationInput = {
+        accountId: trackedAccount.id,
+        value: newValuationMagnitude.toString(),
+        currency: trackedAccount.currency,
+        valuationDate: data.date,
+        type: "manual",
+        source: "transfer",
+        note: null,
+        idempotencyKey: data.idempotencyKey,
+      }
+      return createValuationWithinTx(
+        t,
+        familyId,
+        valuationInput,
+        user,
+        auditCtx
+      )
     },
-  })
-
-  const newCashAccount = await tx.account.findUniqueOrThrow({
-    where: { id: cashAccount.id },
-  })
-
-  await auditLogs(tx, auditCtx, [
-    ...accountBalanceAuditEntries([cashAccount], [newCashAccount]),
-    ...createdAuditEntries("Transaction", [cashTx]),
-    ...createdAuditEntries("Transfer", [createdTransfer]),
-  ])
-
-  return serializeTransaction({
-    ...cashTx,
-    amount: absMoney(cashTx.amount),
   })
 }
 

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -50,6 +50,7 @@ import {
 import {
   createValuationWithinTx,
   fetchAccountFacts,
+  HOLDINGS_VALUATION_SOURCE,
   latestValuation,
   rebuildWithinTx,
   valueMagnitudeSchema,
@@ -631,6 +632,26 @@ export class ValuationLinkedTransferUnsupportedError extends Error {
   readonly statusCode = 422
   constructor(
     message = "Editing a valuation-linked transfer is not yet supported. Delete it and record a new transfer instead."
+  ) {
+    super(message)
+  }
+}
+
+// PER-198 / ADR-0051: deleting a valuation-linked transfer that is a Buy/Sell
+// TRADE is blocked. Such a transfer's tracked-side move is a Σ-holdings anchor
+// (its Valuation.source === HOLDINGS_VALUATION_SOURCE), but the paired Holding
+// position is NOT part of the transfer graph. The generic valuation-linked
+// delete reverses the cash leg + tombstones the anchor while the Holding stays,
+// so Σ-holdings would no longer equal the reverted balance — silent net-worth
+// drift. Full trade reversal (also undoing the position) is a later slice
+// (PER-141-adjacent); until then trade transactions cannot be deleted. This is
+// a fail-safe guard, not a weakening of any invariant: a plain valuation-linked
+// transfer (no holding involved; source !== "holdings") still deletes normally.
+export class HoldingsTradeDeleteUnsupportedError extends Error {
+  override readonly name = "HoldingsTradeDeleteUnsupportedError"
+  readonly statusCode = 422
+  constructor(
+    message = "This is a Buy/Sell trade. Deleting it would leave the holding un-reversed; trade reversal isn't supported yet."
   ) {
     super(message)
   }
@@ -2307,6 +2328,17 @@ async function softDeleteValuationLinkedTransferWithinTx(
   const oldValuation = await tx.valuation.findUniqueOrThrow({
     where: { id: transfer.valuationId },
   })
+
+  // PER-198 / ADR-0051 — fail-safe TRADE guard. When the tracked-side move was a
+  // Σ-holdings restatement (a Buy/Sell trade), the paired Holding is outside the
+  // transfer graph and would NOT be reversed here, silently drifting the account
+  // off Σ holdings. Block the delete before mutating anything (the surrounding
+  // transaction rolls back, so no balance/tombstone is written). A plain
+  // valuation-linked transfer (source !== "holdings") is unaffected.
+  if (oldValuation.source === HOLDINGS_VALUATION_SOURCE) {
+    throw new HoldingsTradeDeleteUnsupportedError()
+  }
+
   const trackedAccountFacts = await fetchAccountFacts(
     tx,
     familyId,

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -61,6 +61,14 @@ import { validateTenantReferences } from "./validation/tenant-references"
 
 const CREATE_VALUATION_ENDPOINT = "createValuationFn"
 
+// The `source` tag on a valuation written from Σ holdings (PER-232 / ADR-0051).
+// A DURABLE, purpose-built discriminator: it lets a consumer tell a holdings
+// restatement from a live reconciliation or a Sure import. PER-198 also keys the
+// trade-delete guard off it — a valuation-linked Transfer whose Valuation has
+// this source IS a Buy/Sell trade (its tracked-side move is a holdings anchor),
+// which is exactly what must not be deleted until trade reversal exists.
+export const HOLDINGS_VALUATION_SOURCE = "holdings"
+
 // Valuation types a user/provider may record. "opening" is intentionally NOT
 // here: it is written exactly once, inside account create (ADR-0034 §3).
 const PUBLIC_VALUATION_TYPES = ["reconciliation", "market", "manual"] as const

--- a/tests/integration/trades.integration.ts
+++ b/tests/integration/trades.integration.ts
@@ -1,0 +1,498 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  HoldingError,
+  recordTradeForFamily,
+} from "@/server/holdings"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-198 / ADR-0051 — Buy / Sell atomic cash ↔ holding trade.
+// Money amounts are in MINOR units (IDR sen). Fixtures use exact-division
+// quantities/prices so net-worth conservation is provable to the sen.
+
+describe("buy/sell trades (PER-198 / ADR-0051)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // A valuation-tracked investment account (TRACKED_ASSET → balanceSource
+  // "valuation").
+  const makeInvestmentAccount = async (owner: AuthenticatedOnboardedUser) =>
+    await createAccountForFamily({
+      data: {
+        name: "Bibit",
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // A cash-like funding account (DEPOSITORY → balanceSource "transaction_flow").
+  // Opening balance 150,000 major = 15,000,000 sen.
+  const makeCashAccount = async (owner: AuthenticatedOnboardedUser) =>
+    await createAccountForFamily({
+      data: {
+        name: "Checking",
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance: "150000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const balanceOf = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const row = await tx.account.findUniqueOrThrow({
+        where: { id: accountId },
+        select: { balance: true },
+      })
+      return row.balance
+    })
+
+  const fundInline = { kind: "mutual_fund" as const, name: "Fund A" }
+
+  // --------------------------------------------------------------------------
+  // BUY conserves net worth
+  // --------------------------------------------------------------------------
+  test("BUY: funding −cash, investment +cash via holding, net worth unchanged", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const cashBefore = await balanceOf(owner, cash.id)
+    const netBefore = cashBefore + (await balanceOf(owner, investment.id))
+
+    // 100 units × Rp 100.00/unit (10,000 sen) = Rp 10,000 (1,000,000 sen).
+    const result = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result.side).toBe("buy")
+    expect(result.realizedGainMinor).toBeNull()
+    expect(result.costBasisDeltaMinor).toBe("1000000")
+    expect(result.transaction.amount).toBe("1000000") // abs cash leg
+    expect(result.holding?.quantity).toBe("100.00000000")
+    expect(result.holding?.avgUnitCostMinor).toBe("10000")
+    expect(result.holding?.valueMinor).toBe("1000000") // value at cost
+    expect(result.holding?.gainMinor).toBe("0")
+
+    const cashAfter = await balanceOf(owner, cash.id)
+    const investAfter = await balanceOf(owner, investment.id)
+    expect(cashAfter).toBe(cashBefore - 1_000_000n)
+    expect(investAfter).toBe(1_000_000n)
+    // Net worth unchanged.
+    expect(cashAfter + investAfter).toBe(netBefore)
+  })
+
+  // --------------------------------------------------------------------------
+  // Multiple BUYs → average cost + summed units
+  // --------------------------------------------------------------------------
+  test("two BUYs of the same instrument blend to the correct average cost", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const first = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000", // 100 × 10,000
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const instrumentId = first.holding?.instrumentId
+    expect(instrumentId).toBeTruthy()
+
+    await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId: instrumentId ?? undefined,
+        side: "buy",
+        cashAmount: "2000000", // 100 × 20,000
+        quantity: "100",
+        unitPrice: "20000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(1)
+    const holding = view.holdings[0]
+    // 200 units, total cost 3,000,000 → avg 15,000/unit.
+    expect(holding?.quantity).toBe("200.00000000")
+    expect(holding?.avgUnitCostMinor).toBe("15000")
+    expect(holding?.costMinor).toBe("3000000")
+    expect(view.totalValueMinor).toBe("3000000")
+    expect(await balanceOf(owner, investment.id)).toBe(3_000_000n)
+  })
+
+  // --------------------------------------------------------------------------
+  // SELL: funding credited, holding reduced, realized gain vs avg cost
+  // --------------------------------------------------------------------------
+  test("SELL reduces the position, credits cash, and reports the realized gain", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    // Establish 200 units @ avg 15,000 (cost 3,000,000).
+    const buy1 = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const instrumentId = buy1.holding?.instrumentId ?? undefined
+    await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "buy",
+        cashAmount: "2000000",
+        quantity: "100",
+        unitPrice: "20000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const cashBeforeSell = await balanceOf(owner, cash.id)
+    const netBeforeSell =
+      cashBeforeSell + (await balanceOf(owner, investment.id))
+
+    // Sell 50 units @ Rp 250.00/unit (25,000 sen) → proceeds 1,250,000.
+    const sell = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "sell",
+        cashAmount: "1250000",
+        quantity: "50",
+        unitPrice: "25000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // cost removed = 50 × 15,000 = 750,000; realized gain = 1,250,000 − 750,000.
+    expect(sell.costBasisDeltaMinor).toBe("750000")
+    expect(sell.realizedGainMinor).toBe("500000")
+    expect(sell.holding?.quantity).toBe("150.00000000")
+    expect(sell.holding?.avgUnitCostMinor).toBe("15000") // avg unchanged
+    expect(sell.holding?.costMinor).toBe("2250000")
+
+    const cashAfter = await balanceOf(owner, cash.id)
+    const investAfter = await balanceOf(owner, investment.id)
+    expect(cashAfter).toBe(cashBeforeSell + 1_250_000n)
+    expect(investAfter).toBe(2_250_000n)
+    // Net worth moves by exactly the realized gain (cash premium over cost).
+    expect(cashAfter + investAfter - netBeforeSell).toBe(500_000n)
+  })
+
+  test("SELL to zero closes (deletes) the position", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const instrumentId = buy.holding?.instrumentId ?? undefined
+
+    const sell = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "sell",
+        cashAmount: "1500000", // sold above cost
+        quantity: "100",
+        unitPrice: "15000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(sell.holding).toBeNull()
+    expect(sell.realizedGainMinor).toBe("500000") // 1,500,000 − 1,000,000
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(0)
+    expect(view.totalValueMinor).toBe("0")
+    expect(await balanceOf(owner, investment.id)).toBe(0n)
+  })
+
+  test("SELL more units than held is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    await expect(
+      recordTradeForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          fundingAccountId: cash.id,
+          instrumentId: buy.holding?.instrumentId ?? undefined,
+          side: "sell",
+          cashAmount: "2000000",
+          quantity: "200",
+          unitPrice: "10000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  // --------------------------------------------------------------------------
+  // Idempotency
+  // --------------------------------------------------------------------------
+  test("replaying the same trade key is a single no-op", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy" as const,
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+
+    const first = await recordTradeForFamily(payload)
+    const second = await recordTradeForFamily(payload)
+    // Compare the WIRE shape (both results serialize to JSON across the RPC
+    // boundary): the fresh call returns Date objects on the cash Transaction,
+    // the replay returns the persisted JSON (ISO strings) — equivalent once
+    // normalized, and semantically the same trade.
+    const normalize = (value: unknown): unknown =>
+      JSON.parse(JSON.stringify(value))
+    expect(normalize(second)).toEqual(normalize(first))
+
+    // Exactly one holding, applied once.
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(1)
+    expect(view.holdings[0]?.quantity).toBe("100.00000000")
+
+    // Cash moved exactly once.
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 1_000_000n)
+
+    // Exactly one Transfer + one cash Transaction.
+    const counts = await harness.withFamily(owner.family.id, async (tx) => ({
+      transfers: await tx.transfer.count({ where: { deletedAt: null } }),
+      cashTxns: await tx.transaction.count({
+        where: { accountId: cash.id, type: "transfer", deletedAt: null },
+      }),
+    }))
+    expect(counts.transfers).toBe(1)
+    expect(counts.cashTxns).toBe(1)
+  })
+
+  // --------------------------------------------------------------------------
+  // Tenant isolation
+  // --------------------------------------------------------------------------
+  test("a trade referencing another family's accounts is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const intruder = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    await expect(
+      recordTradeForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          fundingAccountId: cash.id,
+          instrument: fundInline,
+          side: "buy",
+          cashAmount: "1000000",
+          quantity: "100",
+          unitPrice: "10000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+    ).rejects.toThrow()
+
+    // Owner's accounts untouched, no holding created.
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(0)
+  })
+
+  test("rejects a funding account that is not cash-like", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const otherInvestment = await makeInvestmentAccount(owner)
+
+    // Both sides valuation-tracked — the funding side is not cash-like.
+    await expect(
+      recordTradeForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          fundingAccountId: otherInvestment.id,
+          instrument: fundInline,
+          side: "buy",
+          cashAmount: "1000000",
+          quantity: "100",
+          unitPrice: "10000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  // --------------------------------------------------------------------------
+  // Audit
+  // --------------------------------------------------------------------------
+  test("a BUY writes audit rows for every entity it mutates", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const key = factories.createIdempotencyKey()
+
+    await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const audit = await harness.withFamily(owner.family.id, async (tx) => {
+      const rows = await tx.auditLog.findMany({
+        where: { familyId: owner.family.id, idempotencyKey: key },
+        select: { entityType: true, action: true },
+      })
+      return rows
+    })
+    const entityTypes = new Set(audit.map((r) => r.entityType))
+    // Cash leg, the transfer pairing, the holding, and the valuation anchor.
+    expect(entityTypes.has("Transaction")).toBe(true)
+    expect(entityTypes.has("Transfer")).toBe(true)
+    expect(entityTypes.has("Holding")).toBe(true)
+    expect(entityTypes.has("Valuation")).toBe(true)
+  })
+})

--- a/tests/integration/trades.integration.ts
+++ b/tests/integration/trades.integration.ts
@@ -14,6 +14,10 @@ import {
   recordTradeForFamily,
 } from "@/server/holdings"
 import {
+  deleteTransactionForFamily,
+  HoldingsTradeDeleteUnsupportedError,
+} from "@/server/transactions"
+import {
   createIntegrationHarness,
   type IntegrationHarness,
 } from "./support/database"
@@ -494,5 +498,68 @@ describe("buy/sell trades (PER-198 / ADR-0051)", () => {
     expect(entityTypes.has("Transfer")).toBe(true)
     expect(entityTypes.has("Holding")).toBe(true)
     expect(entityTypes.has("Valuation")).toBe(true)
+  })
+
+  // --------------------------------------------------------------------------
+  // Trade-delete guard (PER-198): deleting a trade transaction is BLOCKED so it
+  // can never leave the holding un-reversed (silent net-worth drift).
+  // --------------------------------------------------------------------------
+  test("deleting a trade's transaction is rejected and causes no drift", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const cashAfterBuy = await balanceOf(owner, cash.id)
+    const investAfterBuy = await balanceOf(owner, investment.id)
+
+    // Attempt to delete the trade's cash Transaction via the SAME path the UI
+    // uses (deleteTransactionFn → deleteTransactionForFamily).
+    await expect(
+      deleteTransactionForFamily({
+        id: buy.transaction.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingsTradeDeleteUnsupportedError)
+
+    // No drift: funding balance, investment value, and the holding are all
+    // exactly as they were after the buy (the delete rolled back entirely).
+    expect(await balanceOf(owner, cash.id)).toBe(cashAfterBuy)
+    expect(await balanceOf(owner, investment.id)).toBe(investAfterBuy)
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(1)
+    expect(view.holdings[0]?.quantity).toBe("100.00000000")
+    expect(view.holdings[0]?.valueMinor).toBe("1000000")
+
+    // The trade's Transaction, Transfer, and Valuation are all still live.
+    const live = await harness.withFamily(owner.family.id, async (tx) => ({
+      txns: await tx.transaction.count({
+        where: { id: buy.transaction.id, deletedAt: null },
+      }),
+      transfers: await tx.transfer.count({ where: { deletedAt: null } }),
+    }))
+    expect(live.txns).toBe(1)
+    expect(live.transfers).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

Recording a purchase or sale in a valuation-tracked investment account used to be two manual steps (a valuation-linked transfer + a holding edit). This slice makes it **one atomic ledger action**, `recordTradeFn` (`src/server/holdings.ts`): cash **into** the account is a **BUY**, cash **out** is a **SELL**, and net worth is conserved.

## Ledger design

- **Reuses the ADR-0048 valuation-linked transfer double-entry.** `createValuationLinkedTransferWithinTx` was refactored into a shared primitive `postValuationLinkedTransferLegs(tx, {…, resolveValuation})` (transactions.ts). The default transfer path supplies the ADR-0048 prefill valuation; a trade supplies the **Σ-holdings** valuation after applying the position change. The existing path's behavior and write order are preserved exactly.
- **One `Transfer` row** (ADR-0048 §4 shape: one `Transaction` FK + `valuationId`) links the funding cash leg to the holdings anchor, so delete / drift detection / reporting treat a trade like any other valuation-linked move.
- **Average cost:** BUY blends `newAvgUnitCost = round_half_up((oldUnits×oldAvg + cashAmount)×SCALE / newUnits)` (`averageUnitCostMinor`); SELL removes cost pro-rata at the average and leaves the remaining average unchanged. Selling the last unit closes (hard-deletes) the position, mirroring `deleteHoldingForFamily`.
- **Realized gain is DERIVED** (`cashAmount − costRemoved`) and returned for display — **not** posted as an income row this slice.
- **`kind` reuse (`funds_movement`, or `liability_draw`/`cc_payment` for a credit funding line):** derived via `deriveTransferKindForAccounts(source→dest)`, which matches the DB trigger `enforce_transfer_liability_kind_invariant` exactly. A dedicated `investment_buy`/`investment_sell` kind was rejected — the trigger derives the expected kind purely from account class/type and cannot distinguish a trade from a plain valuation-linked move between the same accounts.
- **Full §5A contract:** one interactive tenant transaction with the `app.family_id` RLS GUC; endpoint idempotency (`recordTradeFn` `IdempotencyRecord`, replay + unique-race replay); tenant-owned validation of **both** accounts and the instrument; append-only `AuditLog` rows for every entity written (cash `Transaction`, `Transfer`, `Holding`, `Valuation`).

## PER-196 guard verification (the whole design depends on it)

Verified in code and by regression tests: `applyAccountBalanceDelta` throws `ValuationAccountLedgerError` before mutating a `balanceSource="valuation"` account's stored balance (ADR-0048 §3, DB trigger backstop). In a trade the funding (`transaction_flow`) leg decrements/credits normally, while the investment side's balance moves **only** through the Σ-holdings `Valuation` — never an incremental delta. Without this guard a trade would double-count (a cash leg **and** a valuation both hitting the tracked balance). `tests/integration/valuation-account-balance-guard.integration.ts` still passes unchanged.

## Net-worth conservation proof

- **BUY:** funding `−cashAmount`; the position's cost basis `+cashAmount`; carried at cost (no market price) the investment value `+cashAmount` ⇒ **net worth unchanged** (integration-tested to the sen).
- **SELL:** funding `+cashAmount`; investment value `−costRemoved`; net worth moves by exactly `realizedGain = cashAmount − costRemoved` — the real cash premium over cost (integration-tested). Deferring realized-gain-as-income posting means the gain surfaces as net-worth change at sale rather than an income row; the balance is accurate.
- Fractional-quantity rounding is bounded by one minor unit per holding (inherent to per-unit cost); fixtures use exact divisions so conservation is provable.

## UI

Buy/Sell dialog (`src/components/blocks/trade-dialog.tsx`) on the investment account detail page (panel header + per-holding "Buy"/"Sell") → funding account + instrument (existing or new) + side + quantity + unit price, with a live cash-total preview via `MoneyInput` and the shared `holdingCostMinor` helper. Declarative (no `useEffect`), try/catch + inline error, client types via `Awaited<ReturnType<typeof recordTradeFn>>`.

## Deferred (documented in ADR-0051)

Trade **edit/delete** that also reverses the position (deleting the linked transfer reverses cash + valuation but not the holding → drift; needs lots), FIFO/tax lots (PER-141), realized-gain-as-income posting, market-data auto-pricing, transfer fees.

## Tests

- **Real-PG integration** (`tests/integration/trades.integration.ts`, 9 tests): BUY conservation, two-BUY average cost, SELL realized gain, SELL-to-zero close, sell-more-than-held reject, idempotent replay, tenant isolation, non-cash funding reject, audit rows.
- **Unit** (`src/lib/holdings.test.ts`): `averageUnitCostMinor`, `scaledToQuantityString` (incl. property round-trip).
- **Regression:** `holdings`, `valuation-linked-transfer`, `valuation-account-balance-guard`, `transfer-graph-invariants`, `transfer-soft-delete` integration suites all pass; full unit suite (612) + `vp check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
