### PR TITLE
feat(market-data): PER-238 — wire quotes to holdings valuation (anchor-safe)

### DIFF
--- a/docs/adr/0050-market-data-ingestion.md
+++ b/docs/adr/0050-market-data-ingestion.md
@@ -220,3 +220,63 @@ Files: `prisma/schema.prisma` + migration
 `20260807130000_market_data_core`; `src/lib/market-data.ts` (pure encoding +
 normalizer); `src/server/market-data.server.ts` (provider interface, fixture
 adapter, `ingestMarketDataOnce`); unit + real-Postgres tests.
+
+## Implementation notes (PER-238, Slice 6 — auto-revaluation wiring)
+
+Slice 6 builds the bridge deferred in the PER-233 note: a holdings `Instrument`
+(ADR-0051, a fund/gold/share a family HOLDS) now carries an OPTIONAL, nullable
+FK `marketInstrumentId → MarketInstrument` (global; `onDelete: SetNull`). The
+wiring is one deliberately narrow path:
+
+```
+holdings Instrument.marketInstrumentId
+  → latest MarketQuote (append-only, per (instrument, asOf, source))
+  → holding.lastPriceMinor  (converted to the holding's price basis)
+  → Σ-holdings valuation anchor (source="holdings", the account's own value)
+```
+
+- **Prices stay observations, never clobber user truth (§2 made real).**
+  `refreshHoldingPricesForFamily` (`src/server/holdings.ts`) ONLY ever moves a
+  linked holding's `lastPriceMinor` and re-materializes the derived Σ-holdings
+  anchor for the SAME investment account (via the existing
+  `recomputeAccountValueAnchorWithinTx`). It never writes a cash/funding
+  balance, never an `opening`/`reconciliation`/`manual` user anchor, and never
+  an account that is not a holdings-tracked (`balanceSource="valuation"`)
+  investment account. A refresh whose computed price equals the holding's
+  current `lastPriceMinor` is a NO-OP (no holding write, no re-materialization,
+  no duplicate valuation) — so re-running with unchanged quotes changes nothing.
+
+- **Unit contract (pure, unit-tested).** `marketQuoteToHoldingPriceMinor`
+  (`src/lib/market-data.ts`) converts a canonical quote to minor units per
+  holding unit: a **metal** quote is stored per TROY OUNCE and DERIVED to
+  per-GRAM (`spotPriceScaledPerGram`) because a metal holding's quantity is in
+  grams (ADR-0051); a **security** (fund NAV/unit, share price) or **crypto**
+  quote is per-unit and used directly; an **fx** pair can never price a holding
+  (rejected — it is a currency pair, not a per-unit price). Result =
+  `round_half_even(perUnitScaled × minorUnitConversion / 1e8)`.
+
+- **Same-currency constraint (this slice).** The `MarketInstrument.quoteCurrency`
+  MUST equal the holding's currency (== account currency). A mismatch is
+  rejected at LINK time and skipped (with a clear reason) at refresh time —
+  never silently mis-priced. Cross-currency (quote → holding via FX, ADR-0035)
+  is a later slice.
+
+- **Full §5A contract on the refresh.** One RLS-scoped tenant transaction with
+  the `app.family_id` GUC; endpoint-scoped idempotency (`refreshHoldingPricesFn`
+  `IdempotencyRecord`, replay + unique-race replay); tenant validation of the
+  optional `accountId`; append-only `AuditLog` rows for every `Holding` price
+  update and the holdings anchor. The link itself (set via `upsertHoldingFn`) is
+  likewise audited and validated (existence, non-fx, same-currency).
+
+- **Deferred.** The scheduled refresh worker (PER-237 — this slice is an
+  explicit "Refresh prices" trigger only), real scraper adapters (gold-local
+  Antam/Pegadaian = PER-235, reksadana NAV), and cross-currency quote → holding
+  via FX.
+
+Files: `prisma/schema.prisma` + migration `20260808120000_holding_market_link`;
+`src/lib/market-data.ts` (`marketQuoteToHoldingPriceMinor`); `src/server/holdings.ts`
+(`refreshHoldingPricesForFamily`/`refreshHoldingPricesFn`, `listMarketInstrumentsFn`,
+market link on `upsertHoldingFn`); `src/components/blocks/holding-form-dialog.tsx` +
+`src/routes/_protected/-account-holdings.tsx` + `accounts.$accountId.tsx` (UI);
+unit (`src/lib/market-data.test.ts`) + real-Postgres
+(`tests/integration/holding-market-prices.integration.ts`) tests.

--- a/docs/adr/0051-investments-holdings-domain.md
+++ b/docs/adr/0051-investments-holdings-domain.md
@@ -303,3 +303,41 @@ is **guarded, not deferred**:
 - **FIFO / tax lots** (PER-141), **realized-gain-as-income posting**,
   **market-data auto-pricing** (the next slice sets `lastPrice` from a feed
   rather than leaving positions at cost), and **transfer fees**.
+
+## Market-data auto-pricing (PER-238)
+
+The holdings `Instrument` now carries an OPTIONAL, nullable
+`marketInstrumentId → MarketInstrument` (ADR-0050's global price series;
+`onDelete: SetNull`). This is the bridge the PER-233 note deferred, and it makes
+ADR-0050 §5's promise concrete: a linked position values at `quantity × latest
+price/unit` from the quote store instead of at cost.
+
+- **The link is on the holdings `Instrument`, priced onto the `Holding`.** When
+  a holding's instrument is linked, `refreshHoldingPricesForFamily`
+  (`src/server/holdings.ts`) reads the latest `MarketQuote`, converts it to the
+  holding's price basis (`marketQuoteToHoldingPriceMinor`, pure — metal derives
+  per-gram from the canonical per-troy-ounce quote; security/crypto are
+  per-unit), sets `Holding.lastPriceMinor`, and re-materializes the Σ-holdings
+  anchor via the SAME `recomputeAccountValueAnchorWithinTx` that every holding
+  mutation uses. So value/cost/gain and the account balance stay derived from
+  ONE mechanism.
+
+- **Anchor-safe — a price is an OBSERVATION (ADR-0043/0050 §2).** The refresh
+  only ever moves a holding's `lastPriceMinor` and the derived `source="holdings"`
+  valuation of the SAME investment account. It never touches a cash balance, a
+  user `opening`/`reconciliation`/`manual` anchor, or a non-holdings account, and
+  a refresh with unchanged quotes is a NO-OP (no duplicate anchor, no balance
+  move). Same-currency (`MarketInstrument.quoteCurrency` == account currency) is
+  required this slice; cross-currency via FX is deferred.
+
+- **Contract.** Setting the link (`upsertHoldingFn`) and the refresh
+  (`refreshHoldingPricesFn`) both run the full §5A ledger-mutation contract
+  (RLS-scoped tenant tx, idempotency, tenant validation, append-only audit).
+  Real-Postgres tests cover link, refresh, anchor-safety (cash + non-holdings
+  anchors untouched), idempotent re-refresh, same-currency rejection, unlinked
+  holdings, and tenant isolation
+  (`tests/integration/holding-market-prices.integration.ts`).
+
+- **Deferred:** the scheduled refresh worker (PER-237 — this slice exposes an
+  explicit "Refresh prices" action only), real scraper adapters (PER-235
+  gold-local; reksadana NAV), and cross-currency quote → holding.

--- a/prisma/migrations/20260808120000_holding_market_link/migration.sql
+++ b/prisma/migrations/20260808120000_holding_market_link/migration.sql
@@ -1,0 +1,38 @@
+-- PER-238 / ADR-0050 + ADR-0051 — wire market-data quotes to holdings valuation.
+--
+-- Adds the intended (previously documented-as-future) bridge from the tenant-
+-- scoped holdings `Instrument` (a fund/gold/share a family HOLDS) to the GLOBAL,
+-- family-neutral `MarketInstrument` (a tradeable PRICE SERIES). One OPTIONAL,
+-- nullable FK column:
+--
+--   Instrument.marketInstrumentId -> MarketInstrument.id
+--
+-- WHY THIS IS SAFE / ANCHOR-SAFE (ADR-0050 §2, CLAUDE.md §5A):
+-- -----------------------------------------------------------
+-- A MarketQuote is an OBSERVATION, never money movement. The refresh path
+-- (`refreshHoldingPricesForFamily`) only ever moves a holding's `lastPriceMinor`
+-- and the DERIVED Σ-holdings valuation anchor (source="holdings", the account's
+-- own value mechanism). It NEVER touches a cash/funding balance, nor any
+-- opening/reconciliation/manual user anchor, nor any account that is not a
+-- holdings-tracked investment account. This column merely records WHICH global
+-- price series a holding's instrument follows; it carries no tenant data.
+--
+-- TENANCY: `Instrument` stays family-scoped + RLS. The FK target is a global row
+-- with NO familyId — existence is validated in the app; there is nothing to
+-- tenant-isolate on the market side (a USD/IDR rate or XAU spot is identical for
+-- every family, see 20260807130000_market_data_core). ON DELETE SET NULL: if a
+-- price series is ever retired, holdings quietly fall back to manual pricing
+-- rather than blocking the delete or orphaning the FK.
+--
+-- ADDITIVE ONLY — adds one nullable column + FK; touches no existing row and
+-- changes no existing balance, valuation, or transaction.
+
+ALTER TABLE "Instrument" ADD COLUMN "marketInstrumentId" TEXT;
+
+ALTER TABLE "Instrument" ADD CONSTRAINT "instrument_market_instrument_fkey"
+  FOREIGN KEY ("marketInstrumentId") REFERENCES "MarketInstrument"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Lookups by market series (the refresh scans a family's linked holdings) and
+-- the SET NULL cascade both benefit from an index on the FK column.
+CREATE INDEX "Instrument_marketInstrumentId_idx" ON "Instrument"("marketInstrumentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -970,6 +970,17 @@ model Instrument {
   // (this slice). "yield" (principal + accrued interest) is a later slice.
   priceModel String @default("market")
 
+  // PER-238 / ADR-0050+0051 — OPTIONAL link to a GLOBAL market-data price series
+  // (MarketInstrument). When set, `refreshHoldingPricesForFamily` reads the
+  // latest MarketQuote for it and marks this instrument's holdings' lastPrice
+  // (anchor-safe: a price is an observation, ADR-0050 §2 — it only ever moves a
+  // holding's lastPrice and the derived Σ-holdings anchor, never a cash balance
+  // or a user opening/reconciliation/manual anchor). NULL = manual pricing.
+  // The target is a family-NEUTRAL row (no tenant data); onDelete: SetNull so
+  // retiring a price series quietly unlinks holdings rather than blocking.
+  marketInstrumentId String?
+  marketInstrument   MarketInstrument? @relation("HoldingInstrumentMarketLink", fields: [marketInstrumentId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "instrument_market_instrument_fkey")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -1072,6 +1083,10 @@ model MarketInstrument {
   updatedAt DateTime @default(now()) @updatedAt
 
   quotes MarketQuote[]
+
+  // PER-238 — holdings `Instrument` rows that link here for auto-pricing. Back-
+  // relation only; the link + onDelete: SetNull live on the holdings side.
+  linkedHoldingInstruments Instrument[] @relation("HoldingInstrumentMarketLink")
 
   // Instrument identity is (kind, symbol, mic, quoteCurrency). Enforced by a
   // COALESCE(mic,'') UNIQUE INDEX in the migration so NULL mics still dedupe.

--- a/src/components/blocks/holding-form-dialog.tsx
+++ b/src/components/blocks/holding-form-dialog.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useQuery } from "@tanstack/react-query"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -29,7 +30,11 @@ import {
 import { parseMoneyInput, toDecimalString } from "@/lib/money"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
-import { upsertHoldingFn } from "@/server/holdings"
+import { listMarketInstrumentsFn, upsertHoldingFn } from "@/server/holdings"
+
+// Sentinel Select value for "no live price source" (manual pricing). Radix
+// Select forbids an empty-string item value, so null is modeled explicitly.
+const MANUAL_PRICE_VALUE = "__manual__"
 
 // PER-232 / ADR-0051 — shared add/edit holding dialog. Mirrors
 // account-form-dialog.tsx: self-contained (its own idempotency key + submit +
@@ -88,8 +93,20 @@ export function HoldingFormDialog({
   const [lastPrice, setLastPrice] = React.useState<string>(() =>
     editing ? majorFromMinor(editing.lastPriceMinor, currencyCode) : ""
   )
+  // PER-238 — optional live price source (a global MarketInstrument). null =
+  // manual pricing. When linked, "Refresh prices" on the account marks the
+  // holding's last price from the latest quote (anchor-safe observation).
+  const [marketInstrumentId, setMarketInstrumentId] = React.useState<
+    string | null
+  >(editing?.instrument.marketInstrumentId ?? null)
   const [error, setError] = React.useState<string | null>(null)
   const [submitting, setSubmitting] = React.useState(false)
+
+  // Same-currency series only (cross-currency auto-pricing is a later slice).
+  const { data: marketInstruments } = useQuery({
+    queryKey: ["market_instruments", currency],
+    queryFn: async () => await listMarketInstrumentsFn({ data: { currency } }),
+  })
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -124,6 +141,7 @@ export function HoldingFormDialog({
             quantity: quantity.trim(),
             avgUnitCost: avgUnitCostValue,
             lastPrice: lastPriceValue,
+            marketInstrumentId,
             idempotencyKey: createUuidV7(),
           },
         })
@@ -135,6 +153,7 @@ export function HoldingFormDialog({
             quantity: quantity.trim(),
             avgUnitCost: avgUnitCostValue,
             lastPrice: lastPriceValue,
+            marketInstrumentId,
             idempotencyKey: createUuidV7(),
           },
         })
@@ -259,6 +278,38 @@ export function HoldingFormDialog({
             Price per unit. Leave last price empty to show value at cost (no
             gain fabricated) until you have today&apos;s price.
           </p>
+
+          <div className="flex flex-col gap-2">
+            <Label>Live price source</Label>
+            <Select
+              value={marketInstrumentId ?? MANUAL_PRICE_VALUE}
+              onValueChange={(value) =>
+                setMarketInstrumentId(
+                  value === MANUAL_PRICE_VALUE ? null : value
+                )
+              }
+            >
+              <SelectTrigger aria-label="Live price source">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={MANUAL_PRICE_VALUE}>
+                  Manual (no live price)
+                </SelectItem>
+                {(marketInstruments ?? []).map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.symbol}
+                    {m.name ? ` · ${m.name}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Link a market price series to auto-fill the last price on
+              &ldquo;Refresh prices&rdquo;. Only same-currency ({currency})
+              sources are shown.
+            </p>
+          </div>
 
           {error ? (
             <p className="text-sm text-destructive" role="alert">

--- a/src/lib/market-data.test.ts
+++ b/src/lib/market-data.test.ts
@@ -7,6 +7,7 @@ import {
   FX_PRICE_DECIMALS,
   isMarketInstrumentKind,
   MARKET_INSTRUMENT_KINDS,
+  marketQuoteToHoldingPriceMinor,
   normalizeObservations,
   priceScaleForKind,
   SPOT_PRICE_DECIMALS,
@@ -178,5 +179,87 @@ describe("normalizeObservations", () => {
     ])
     expect(result.quotes).toHaveLength(0)
     expect(result.rejected[0]?.reason).toContain("only valid for fx")
+  })
+})
+
+// PER-238 — quote -> holding-price conversion (pure). Verifies the unit contract
+// (metal per-gram derivation, security/crypto per-unit) and the scaled-integer →
+// minor-unit scaling. IDR/USD minorUnitConversion = 100 (sen/cents).
+describe("marketQuoteToHoldingPriceMinor (PER-238 quote -> holding price)", () => {
+  test("security NAV/unit maps straight to minor units (per unit)", () => {
+    // Reksadana NAV Rp 1,477.63/unit -> 147763 sen/unit.
+    const nav = encodeSpotPrice("1477.63")
+    expect(
+      marketQuoteToHoldingPriceMinor({
+        kind: "security",
+        priceScaled: nav,
+        priceScale: SPOT_PRICE_DECIMALS,
+        minorUnitConversion: 100n,
+      })
+    ).toBe(147763n)
+  })
+
+  test("crypto per-coin price rounds 8dp precision to minor units", () => {
+    // BTC $67000.12345678/coin -> 6700012 cents/coin (round-half-to-even).
+    const btc = encodeSpotPrice("67000.12345678")
+    expect(
+      marketQuoteToHoldingPriceMinor({
+        kind: "crypto",
+        priceScaled: btc,
+        priceScale: SPOT_PRICE_DECIMALS,
+        minorUnitConversion: 100n,
+      })
+    ).toBe(6700012n)
+  })
+
+  test("metal price per TROY OUNCE is derived to per-GRAM then minor units", () => {
+    // Gold $2400.53/oz -> per gram = 2400.53 / 31.1034768 = $77.178.../g -> 7718 cents/g.
+    const perOunce = encodeSpotPrice("2400.53")
+    // The derivation must match the canonical per-gram helper composed with scaling.
+    const perGramScaled = spotPriceScaledPerGram(perOunce)
+    expect(perGramScaled).toBe(7717883166n)
+    expect(
+      marketQuoteToHoldingPriceMinor({
+        kind: "metal",
+        priceScaled: perOunce,
+        priceScale: SPOT_PRICE_DECIMALS,
+        minorUnitConversion: 100n,
+      })
+    ).toBe(7718n)
+  })
+
+  test("a zero-fraction currency (JPY, conversion 1) keeps whole units", () => {
+    // A ¥3500/share stock -> 3500 (no minor subdivision).
+    const price = encodeSpotPrice("3500")
+    expect(
+      marketQuoteToHoldingPriceMinor({
+        kind: "security",
+        priceScaled: price,
+        priceScale: SPOT_PRICE_DECIMALS,
+        minorUnitConversion: 1n,
+      })
+    ).toBe(3500n)
+  })
+
+  test("rejects a non-spot price scale (an fx pair cannot price a holding)", () => {
+    expect(() =>
+      marketQuoteToHoldingPriceMinor({
+        kind: "security",
+        priceScaled: 100n,
+        priceScale: FX_PRICE_DECIMALS, // 12 — fx scale, not a per-unit spot price
+        minorUnitConversion: 100n,
+      })
+    ).toThrow()
+  })
+
+  test("rejects a non-positive price", () => {
+    expect(() =>
+      marketQuoteToHoldingPriceMinor({
+        kind: "crypto",
+        priceScaled: 0n,
+        priceScale: SPOT_PRICE_DECIMALS,
+        minorUnitConversion: 100n,
+      })
+    ).toThrow()
   })
 })

--- a/src/lib/market-data.ts
+++ b/src/lib/market-data.ts
@@ -196,6 +196,66 @@ export function spotPriceScaledPerGram(perOunceScaled: bigint): bigint {
   return divRoundHalfEven(perOunceScaled * 10_000_000n, 311_034_768n)
 }
 
+/**
+ * Kinds that can price a HOLDING (PER-238). An `fx` MarketInstrument is a
+ * currency PAIR, not a per-unit price, so it can never back a holding's price.
+ */
+export type MarketPricedHoldingKind = Exclude<MarketInstrumentKind, "fx">
+
+/**
+ * Convert a canonical `MarketQuote` price into a holding's `lastPriceMinor`
+ * (MINOR units of the holding's currency, per ONE holding unit) — PER-238.
+ *
+ * UNIT CONTRACT (the load-bearing part — must match the holding's quantity unit):
+ *   * metal    — the quote is stored CANONICALLY per TROY OUNCE (spot scale 1e8);
+ *     a metal holding's quantity is in GRAMS (ADR-0051 gold = grams), so we
+ *     derive the per-gram price first (`spotPriceScaledPerGram`) before scaling
+ *     to minor units.
+ *   * security — the quote is per UNIT (a fund's NAV/unit, a share's last price)
+ *     at spot scale 1e8; used directly (a reksadana/stock holding's quantity is
+ *     units/shares).
+ *   * crypto   — the quote is per COIN at spot scale 1e8; used directly.
+ *   * fx       — NOT a holding price basis (excluded from the input type).
+ *
+ * `minorUnitConversion` is the currency's major→minor multiplier (100 for
+ * IDR/USD, 1 for JPY). The result is
+ *   lastPriceMinor = round( perUnitScaled * minorUnitConversion / 1e8 )
+ * with round-half-to-even, matching every other scaled-integer conversion in the
+ * codebase. Same-currency (quote currency == account currency) is enforced by
+ * the caller; cross-currency (FX) is a later slice.
+ *
+ * Pure: no DB, no side effects. Throws on a non-positive price, an unexpected
+ * price scale (metal/security/crypto quotes are always spot-scaled), or a
+ * non-positive conversion — a corrupt price must fail loud, never mis-mark money.
+ */
+export function marketQuoteToHoldingPriceMinor(params: {
+  kind: MarketPricedHoldingKind
+  priceScaled: bigint
+  priceScale: number
+  minorUnitConversion: bigint
+}): bigint {
+  const { kind, priceScaled, priceScale, minorUnitConversion } = params
+  if (priceScaled <= 0n) {
+    throw new RangeError(
+      `marketQuoteToHoldingPriceMinor: price must be positive, got ${priceScaled}`
+    )
+  }
+  if (priceScale !== SPOT_PRICE_DECIMALS) {
+    throw new RangeError(
+      `marketQuoteToHoldingPriceMinor: expected spot price scale ${SPOT_PRICE_DECIMALS}, got ${priceScale} (an fx pair cannot price a holding)`
+    )
+  }
+  if (minorUnitConversion <= 0n) {
+    throw new RangeError(
+      `marketQuoteToHoldingPriceMinor: minorUnitConversion must be positive, got ${minorUnitConversion}`
+    )
+  }
+  const perUnitScaled =
+    kind === "metal" ? spotPriceScaledPerGram(priceScaled) : priceScaled
+  const scaleDivisor = 10n ** BigInt(SPOT_PRICE_DECIMALS)
+  return divRoundHalfEven(perUnitScaled * minorUnitConversion, scaleDivisor)
+}
+
 /** Convert `RATE_SCALE` fx price + `SPOT_PRICE_SCALE` — exported for callers. */
 export { RATE_SCALE }
 

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -4,10 +4,12 @@ import {
   Coins,
   PiggyBank,
   Plus,
+  RefreshCw,
   TrendingDown,
   TrendingUp,
   Trash2,
   Wallet,
+  Zap,
 } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
@@ -86,6 +88,8 @@ export function HoldingsPanel({
   onBuy,
   onBuyHolding,
   onSellHolding,
+  onRefreshPrices,
+  refreshingPrices,
 }: Readonly<{
   view: AccountHoldingsView | undefined
   currency: string
@@ -96,8 +100,14 @@ export function HoldingsPanel({
   onBuy: () => void
   onBuyHolding: (holding: HoldingRecord) => void
   onSellHolding: (holding: HoldingRecord) => void
+  onRefreshPrices: () => void
+  refreshingPrices: boolean
 }>) {
   const holdings = view?.holdings ?? []
+  // Any linked holding means "Refresh prices" can do something.
+  const hasLinkedHolding = holdings.some(
+    (holding) => holding.instrument.marketInstrumentId !== null
+  )
 
   return (
     <div className="rounded-2xl border p-4">
@@ -107,6 +117,20 @@ export function HoldingsPanel({
           Holdings
         </h2>
         <div className="flex items-center gap-2">
+          {hasLinkedHolding ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onRefreshPrices}
+              disabled={refreshingPrices}
+              aria-label="Refresh prices"
+            >
+              <RefreshCw
+                className={cn("size-4", refreshingPrices && "animate-spin")}
+              />
+              Refresh prices
+            </Button>
+          ) : null}
           <Button size="sm" onClick={onBuy}>
             <ArrowDownLeft className="size-4" />
             Buy
@@ -144,6 +168,27 @@ export function HoldingsPanel({
                     <Badge variant="secondary" className="shrink-0">
                       {instrumentKindLabel(holding.instrument.kind)}
                     </Badge>
+                    {holding.instrument.marketInstrumentId !== null ? (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 gap-1 text-xs"
+                        title={
+                          holding.latestMarketQuoteAsOf
+                            ? `Latest quote ${new Date(holding.latestMarketQuoteAsOf).toLocaleDateString()}`
+                            : "Linked to a live price source"
+                        }
+                      >
+                        <Zap className="size-3" aria-hidden />
+                        Auto
+                        {holding.latestMarketQuoteAsOf ? (
+                          <span className="text-muted-foreground">
+                            {new Date(
+                              holding.latestMarketQuoteAsOf
+                            ).toLocaleDateString()}
+                          </span>
+                        ) : null}
+                      </Badge>
+                    ) : null}
                   </div>
                   <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
                     {holding.quantity} {holding.instrument.name} · cost{" "}

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -79,7 +79,11 @@ import { computeAccountPerformance } from "@/lib/account-performance"
 import { getAccountOpeningValueFn } from "@/server/valuations"
 import { enableHoldingsTrackingFn } from "@/server/accounts"
 import { canEnableHoldingsTracking } from "@/lib/accounts"
-import { deleteHoldingFn, getAccountHoldingsFn } from "@/server/holdings"
+import {
+  deleteHoldingFn,
+  getAccountHoldingsFn,
+  refreshHoldingPricesFn,
+} from "@/server/holdings"
 import { HoldingsPanel, type HoldingRecord } from "./-account-holdings"
 import { computeAccountHealth } from "@/lib/account-health"
 import { selectDriftBadge } from "@/lib/account-drift-presentation"
@@ -257,6 +261,31 @@ function AccountDetailPage() {
           ? error.message
           : "Failed to enable holdings tracking"
       )
+    }
+  }
+
+  // PER-238 — refresh linked holdings' prices from the latest market quotes.
+  // Anchor-safe on the server (only moves lastPrice + the Σ-holdings anchor);
+  // here we just trigger it, then resync the holdings query + account balance.
+  const [refreshingPrices, setRefreshingPrices] = React.useState(false)
+  async function handleRefreshPrices() {
+    setRefreshingPrices(true)
+    try {
+      const result = await refreshHoldingPricesFn({
+        data: { accountId, idempotencyKey: createUuidV7() },
+      })
+      await refreshHoldings()
+      toast.success(
+        result.updatedHoldings > 0
+          ? `Updated ${result.updatedHoldings} price${result.updatedHoldings === 1 ? "" : "s"}`
+          : "Prices already up to date"
+      )
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to refresh prices"
+      )
+    } finally {
+      setRefreshingPrices(false)
     }
   }
 
@@ -516,6 +545,8 @@ function AccountDetailPage() {
               onSellHolding={(holding) =>
                 setTradeDialog({ side: "sell", holding })
               }
+              onRefreshPrices={handleRefreshPrices}
+              refreshingPrices={refreshingPrices}
             />
           ) : null}
           {health ? <AccountHealthPanel health={health} /> : null}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -3,6 +3,11 @@ import type { Holding, Instrument, Valuation } from "@prisma/client"
 import { z } from "zod"
 import { CURRENCIES, type CurrencyCode } from "@/lib/data/currencies"
 import {
+  isMarketInstrumentKind,
+  marketQuoteToHoldingPriceMinor,
+  type MarketPricedHoldingKind,
+} from "@/lib/market-data"
+import {
   averageUnitCostMinor,
   holdingCostMinor,
   holdingGainMinor,
@@ -141,6 +146,11 @@ export const upsertHoldingInputSchema = z.object({
   quantity: decimalStringSchema,
   avgUnitCost: decimalStringSchema,
   lastPrice: decimalStringSchema.optional(),
+  // PER-238 — OPTIONAL link to a global MarketInstrument for auto-pricing.
+  // `undefined` leaves the link unchanged; `null` unlinks; a string links (and
+  // is validated to exist, be non-fx, and share the account's currency). The
+  // link alone never changes a price — it takes effect on the next refresh.
+  marketInstrumentId: z.string().min(1).nullable().optional(),
   idempotencyKey: uuidV7Schema,
 })
 
@@ -169,6 +179,8 @@ export interface SerializedInstrument {
   symbol: string | null
   quoteCurrency: string
   priceModel: string
+  /** PER-238 — linked global MarketInstrument for auto-pricing, or null. */
+  marketInstrumentId: string | null
 }
 
 export interface SerializedHolding {
@@ -193,6 +205,13 @@ export interface SerializedHolding {
   gainMinor: string
   /** Unrealized return as a fraction, or null when cost is 0. */
   returnPct: number | null
+  /**
+   * PER-238 — as-of of the latest MarketQuote for the linked MarketInstrument
+   * (ISO string), or null when the holding is not linked / has no quote yet.
+   * Populated by the read view (getAccountHoldingsForFamily); a bare
+   * serializeHolding (audit snapshots) leaves it null.
+   */
+  latestMarketQuoteAsOf: string | null
   createdAt: string
   updatedAt: string
 }
@@ -216,6 +235,7 @@ function serializeInstrument(instrument: Instrument): SerializedInstrument {
     symbol: instrument.symbol,
     quoteCurrency: instrument.quoteCurrency,
     priceModel: instrument.priceModel,
+    marketInstrumentId: instrument.marketInstrumentId,
   }
 }
 
@@ -251,6 +271,7 @@ function serializeHolding(holding: HoldingWithInstrument): SerializedHolding {
     costMinor: cost.toString(),
     gainMinor: gain.toString(),
     returnPct: holdingReturnPct(value, cost),
+    latestMarketQuoteAsOf: null,
     createdAt: holding.createdAt.toISOString(),
     updatedAt: holding.updatedAt.toISOString(),
   }
@@ -391,6 +412,77 @@ async function resolveInstrument(
 }
 
 // -----------------------------------------------------------------------------
+// PER-238 — market-data price link (holdings Instrument -> global MarketInstrument)
+// -----------------------------------------------------------------------------
+
+// Validate a market-instrument link before persisting it. The MarketInstrument
+// is GLOBAL (family-neutral, no RLS): we validate EXISTENCE (reference data, not
+// tenant data) plus the two slice constraints — it must NOT be an fx pair (a
+// currency pair is not a per-unit price) and its quoteCurrency MUST equal the
+// holding/account currency (cross-currency auto-pricing via FX is a later
+// slice). Throws a typed HoldingError; returns the validated market kind.
+async function validateMarketInstrumentLink(
+  tx: TenantTransactionClient,
+  marketInstrumentId: string,
+  accountCurrency: string
+): Promise<MarketPricedHoldingKind> {
+  const market = await tx.marketInstrument.findUnique({
+    where: { id: marketInstrumentId },
+    select: { id: true, kind: true, quoteCurrency: true },
+  })
+  if (!market) {
+    throw new HoldingError(`Market instrument ${marketInstrumentId} not found`)
+  }
+  if (!isMarketInstrumentKind(market.kind) || market.kind === "fx") {
+    throw new HoldingError(
+      `Market instrument ${marketInstrumentId} (kind "${market.kind}") cannot price a holding; an FX pair is a currency pair, not a per-unit price`
+    )
+  }
+  if (market.quoteCurrency !== accountCurrency) {
+    throw new HoldingError(
+      `Market instrument currency ${market.quoteCurrency} must match the holding currency ${accountCurrency} (cross-currency auto-pricing is a later slice)`
+    )
+  }
+  return market.kind
+}
+
+// Persist (or clear) a holdings Instrument's market link inside the caller's
+// transaction, audited. A no-op when the value is unchanged (so idempotent
+// re-saves write nothing). Validation runs only when linking (non-null).
+async function applyMarketLinkWithinTx(
+  tx: TenantTransactionClient,
+  familyId: string,
+  instrumentId: string,
+  marketInstrumentId: string | null,
+  accountCurrency: string,
+  auditCtx: AuditContext
+): Promise<void> {
+  const before = await tx.instrument.findFirst({
+    where: { id: instrumentId, familyId },
+  })
+  if (!before) {
+    throw new HoldingError(
+      `Instrument ${instrumentId} not found for this family`
+    )
+  }
+  if (before.marketInstrumentId === marketInstrumentId) return
+  if (marketInstrumentId !== null) {
+    await validateMarketInstrumentLink(tx, marketInstrumentId, accountCurrency)
+  }
+  const after = await tx.instrument.update({
+    where: { id: instrumentId },
+    data: { marketInstrumentId },
+  })
+  await auditLog(tx, auditCtx, {
+    action: "update",
+    entityType: "Instrument",
+    entityId: instrumentId,
+    before: serializeInstrument(before),
+    after: serializeInstrument(after),
+  })
+}
+
+// -----------------------------------------------------------------------------
 // Account-value anchor: value = Σ holdings' current value, written as a manual
 // valuation anchor so the account balance materializes from holdings (ADR-0051).
 // Runs inside the caller's transaction; createValuationWithinTx signs the value,
@@ -471,6 +563,10 @@ export async function upsertHoldingForFamily({
     instrument: data.instrument ?? null,
     instrumentId: data.instrumentId ?? null,
     lastPrice: data.lastPrice ?? null,
+    marketInstrumentId:
+      data.marketInstrumentId === undefined
+        ? "__unset__"
+        : data.marketInstrumentId,
     quantity: data.quantity,
   })
   const auditCtx = await createAuditContext(
@@ -514,6 +610,7 @@ export async function upsertHoldingForFamily({
           : parseMinor(data.lastPrice, currency, "lastPrice")
 
       let holdingId: string
+      let resolvedInstrumentId: string
       if (data.holdingId) {
         // UPDATE — instrument identity is fixed; only quantity/cost/price move.
         const existing = await loadHoldingWithInstrument(
@@ -543,6 +640,7 @@ export async function upsertHoldingForFamily({
           after: serializeHolding(updated),
         })
         holdingId = updated.id
+        resolvedInstrumentId = existing.instrumentId
       } else {
         // CREATE — resolve/create the instrument, then the holding.
         const instrument = await resolveInstrument(
@@ -570,6 +668,21 @@ export async function upsertHoldingForFamily({
           after: serializeHolding(created),
         })
         holdingId = created.id
+        resolvedInstrumentId = created.instrumentId
+      }
+
+      // PER-238 — persist/clear the optional market-data price link (audited,
+      // no-op when unchanged). The link never changes a price; it takes effect
+      // on the next `refreshHoldingPricesFn`. Applied for BOTH create + update.
+      if (data.marketInstrumentId !== undefined) {
+        await applyMarketLinkWithinTx(
+          tx,
+          familyId,
+          resolvedInstrumentId,
+          data.marketInstrumentId,
+          account.currency,
+          auditCtx
+        )
       }
 
       // Re-materialize the account balance from Σ holdings as a valuation anchor.
@@ -789,7 +902,45 @@ export async function getAccountHoldingsForFamily({
       include: { instrument: true },
       orderBy: { createdAt: "asc" },
     })
-    const holdings = rows.map(serializeHolding)
+
+    // PER-238 — attach each linked holding's latest MarketQuote as-of (for the
+    // "auto" indicator + freshness in the UI). MarketQuote is GLOBAL (no RLS);
+    // one query per distinct linked series, memoized.
+    const linkedIds = [
+      ...new Set(
+        rows
+          .map((row) => row.instrument.marketInstrumentId)
+          .filter((id): id is string => id !== null)
+      ),
+    ]
+    const latestAsOfByMarketId = new Map<string, string>()
+    await Promise.all(
+      linkedIds.map(async (marketInstrumentId) => {
+        const latest = await tx.marketQuote.findFirst({
+          where: { marketInstrumentId },
+          orderBy: { asOf: "desc" },
+          select: { asOf: true },
+        })
+        if (latest) {
+          latestAsOfByMarketId.set(
+            marketInstrumentId,
+            latest.asOf.toISOString()
+          )
+        }
+      })
+    )
+
+    const holdings = rows.map((row) => {
+      const serialized = serializeHolding(row)
+      const marketId = row.instrument.marketInstrumentId
+      return {
+        ...serialized,
+        latestMarketQuoteAsOf:
+          marketId === null
+            ? null
+            : (latestAsOfByMarketId.get(marketId) ?? null),
+      }
+    })
 
     let totalValue = 0n
     let totalCost = 0n
@@ -1290,6 +1441,347 @@ export const recordTradeFn = createServerFn({ method: "POST" })
   )
   .handler(async ({ data, context }) => {
     return await recordTradeForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// =============================================================================
+// MARKET-DATA PRICE LINK + AUTO-REVALUATION (PER-238 / ADR-0050 + ADR-0051)
+// =============================================================================
+//
+// A holdings `Instrument` may OPTIONALLY link to a GLOBAL `MarketInstrument`
+// (a price series). `refreshHoldingPricesForFamily` reads the LATEST
+// `MarketQuote` for each linked series, converts it to the holding's price
+// basis (`marketQuoteToHoldingPriceMinor`, pure), marks the holding's
+// `lastPriceMinor`, and re-materializes each affected account's Σ-holdings
+// anchor via the SAME primitive holdings CRUD uses.
+//
+// ANCHOR-SAFETY (the load-bearing invariant, ADR-0050 §2 / ADR-0043):
+//   A quote is an OBSERVATION. This path ONLY ever moves a holding's
+//   `lastPriceMinor` and the DERIVED Σ-holdings valuation (source="holdings" —
+//   the investment account's OWN value mechanism). It NEVER writes a cash /
+//   funding balance, NEVER an opening/reconciliation/manual user anchor, and
+//   NEVER an account that is not a holdings-tracked (balanceSource="valuation")
+//   investment account. Re-running with unchanged quotes is a NO-OP: a holding
+//   whose computed price equals its current `lastPriceMinor` is skipped, so no
+//   account is re-materialized and no duplicate valuation is written.
+//
+// SAME-CURRENCY constraint (this slice): the MarketInstrument.quoteCurrency MUST
+// equal the holding's currency (== account currency). A mismatch is SKIPPED with
+// a clear reason (never silently mis-priced); cross-currency via FX is a later
+// slice. An `fx` series is never a holding price basis. Unlinked holdings are
+// untouched.
+
+const REFRESH_HOLDING_PRICES_ENDPOINT = "refreshHoldingPricesFn"
+
+// -----------------------------------------------------------------------------
+// GET — list the global market instruments a holding can link to (non-fx).
+// -----------------------------------------------------------------------------
+
+export interface SerializedMarketInstrument {
+  id: string
+  kind: string
+  symbol: string
+  name: string | null
+  quoteCurrency: string
+  baseCurrency: string | null
+  mic: string | null
+}
+
+export const listMarketInstrumentsQuerySchema = z.object({
+  // Optional currency filter — the dialog passes the holding account's currency
+  // so the picker only offers same-currency (linkable) series this slice.
+  currency: z.string().trim().optional(),
+})
+
+export async function listMarketInstrumentsForFamily({
+  currency,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  currency?: string
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedMarketInstrument[]> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    // MarketInstrument is GLOBAL (no RLS); reading it inside the tenant tx is
+    // fine — it carries no tenant data. Only non-fx series can price a holding.
+    const rows = await tx.marketInstrument.findMany({
+      where: {
+        kind: { not: "fx" },
+        ...(currency ? { quoteCurrency: currency.toUpperCase() } : {}),
+      },
+      orderBy: [{ kind: "asc" }, { symbol: "asc" }],
+      select: {
+        id: true,
+        kind: true,
+        symbol: true,
+        name: true,
+        quoteCurrency: true,
+        baseCurrency: true,
+        mic: true,
+      },
+    })
+    return rows
+  })
+}
+
+export const listMarketInstrumentsFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: z.infer<typeof listMarketInstrumentsQuerySchema>) =>
+    listMarketInstrumentsQuerySchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await listMarketInstrumentsForFamily({
+      currency: data.currency,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+// -----------------------------------------------------------------------------
+// POST — refresh linked holdings' prices from the latest quotes (anchor-safe).
+// -----------------------------------------------------------------------------
+
+export const refreshHoldingPricesInputSchema = z.object({
+  // Optional: restrict to one account; omit to refresh every linked holding in
+  // the family. Either way ONLY holdings whose Instrument.marketInstrumentId is
+  // set are ever touched — unlinked holdings are guaranteed untouched.
+  accountId: z.string().min(1).optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+type RefreshHoldingPricesInput = z.infer<typeof refreshHoldingPricesInputSchema>
+
+export interface RefreshHoldingPricesResult {
+  /** Holdings whose lastPrice was moved by a fresher quote. */
+  updatedHoldings: number
+  /** Distinct accounts whose Σ-holdings anchor was re-materialized. */
+  updatedAccounts: number
+  /** Linked holdings considered (had a market link). */
+  consideredHoldings: number
+  /** Linked holdings left unchanged, with the reason (no quote / same price / skipped). */
+  skipped: { holdingId: string; reason: string }[]
+}
+
+// The market series + its latest quote, loaded once per marketInstrumentId.
+interface LatestMarketPrice {
+  kind: string
+  quoteCurrency: string
+  latest: { price: bigint; priceScale: number; asOf: Date } | null
+}
+
+export async function refreshHoldingPricesForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof refreshHoldingPricesInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<RefreshHoldingPricesResult> {
+  const data: RefreshHoldingPricesInput =
+    refreshHoldingPricesInputSchema.parse(rawData)
+  const requestHash = await hashCanonicalPayload({
+    accountId: data.accountId ?? null,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay =
+        await replayIdempotentEndpointResponse<RefreshHoldingPricesResult>(tx, {
+          endpoint: REFRESH_HOLDING_PRICES_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        })
+      if (replay) return replay
+
+      // If scoped to one account, validate tenant ownership up front (a cross-
+      // tenant accountId short-circuits before any read of holdings).
+      if (data.accountId) {
+        await validateTenantReferences(tx, familyId, {
+          accountId: data.accountId,
+        })
+      }
+
+      // Only LINKED holdings are ever considered (marketInstrumentId set). RLS
+      // guarantees family scoping; the optional accountId narrows further.
+      const holdings = await tx.holding.findMany({
+        where: {
+          familyId,
+          ...(data.accountId ? { accountId: data.accountId } : {}),
+          instrument: { marketInstrumentId: { not: null } },
+        },
+        include: { instrument: true },
+      })
+
+      const priceCache = new Map<string, LatestMarketPrice>()
+      const loadLatestPrice = async (
+        marketInstrumentId: string
+      ): Promise<LatestMarketPrice> => {
+        const cached = priceCache.get(marketInstrumentId)
+        if (cached) return cached
+        const market = await tx.marketInstrument.findUnique({
+          where: { id: marketInstrumentId },
+          select: {
+            kind: true,
+            quoteCurrency: true,
+            quotes: {
+              orderBy: { asOf: "desc" },
+              take: 1,
+              select: { price: true, priceScale: true, asOf: true },
+            },
+          },
+        })
+        const value: LatestMarketPrice = market
+          ? {
+              kind: market.kind,
+              quoteCurrency: market.quoteCurrency,
+              latest: market.quotes[0] ?? null,
+            }
+          : { kind: "", quoteCurrency: "", latest: null }
+        priceCache.set(marketInstrumentId, value)
+        return value
+      }
+
+      const skipped: { holdingId: string; reason: string }[] = []
+      const affectedAccounts = new Set<string>()
+      let updatedHoldings = 0
+
+      for (const holding of holdings) {
+        const marketId = holding.instrument.marketInstrumentId
+        if (marketId === null) continue // impossible (filtered), keeps types honest
+        const market = await loadLatestPrice(marketId)
+
+        if (!isMarketInstrumentKind(market.kind) || market.kind === "fx") {
+          skipped.push({
+            holdingId: holding.id,
+            reason: `market series is not priceable (kind "${market.kind}")`,
+          })
+          continue
+        }
+        const marketKind: MarketPricedHoldingKind = market.kind
+        if (!market.latest) {
+          skipped.push({ holdingId: holding.id, reason: "no quote yet" })
+          continue
+        }
+        // SAME-CURRENCY constraint: the quote currency must equal the holding's
+        // currency (== account currency). Never silently mis-price a mismatch.
+        if (market.quoteCurrency !== holding.instrument.quoteCurrency) {
+          skipped.push({
+            holdingId: holding.id,
+            reason: `currency mismatch: quote ${market.quoteCurrency} vs holding ${holding.instrument.quoteCurrency} (same-currency required this slice)`,
+          })
+          continue
+        }
+
+        const currency = assertKnownCurrency(holding.instrument.quoteCurrency)
+        const minorUnitConversion = BigInt(
+          CURRENCIES[currency].minorUnitConversion
+        )
+        const newLastPrice = marketQuoteToHoldingPriceMinor({
+          kind: marketKind,
+          priceScaled: market.latest.price,
+          priceScale: market.latest.priceScale,
+          minorUnitConversion,
+        })
+
+        // Idempotent: an unchanged price writes nothing (no holding mutation, no
+        // account re-materialization, no duplicate valuation).
+        if (holding.lastPriceMinor === newLastPrice) {
+          skipped.push({
+            holdingId: holding.id,
+            reason: "price unchanged",
+          })
+          continue
+        }
+
+        const updated = await tx.holding.update({
+          where: { id: holding.id },
+          data: { lastPriceMinor: newLastPrice },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Holding",
+          entityId: updated.id,
+          before: serializeHolding(holding),
+          after: serializeHolding(updated),
+        })
+        updatedHoldings += 1
+        affectedAccounts.add(holding.accountId)
+      }
+
+      // Re-materialize each affected account's Σ-holdings anchor ONCE. Anchor-
+      // safety: recompute only ever writes a source="holdings" valuation for a
+      // valuation-tracked account; a defensive eligibility check refuses any
+      // non-valuation account (holdings can only exist on such accounts, so this
+      // is belt-and-braces — it can never touch a cash/user anchor).
+      let updatedAccounts = 0
+      for (const accountId of affectedAccounts) {
+        const account = await fetchEligibleAccount(tx, familyId, accountId)
+        await recomputeAccountValueAnchorWithinTx(
+          tx,
+          familyId,
+          accountId,
+          account.currency,
+          user,
+          auditCtx
+        )
+        updatedAccounts += 1
+      }
+
+      const response: RefreshHoldingPricesResult = {
+        updatedHoldings,
+        updatedAccounts,
+        consideredHoldings: holdings.length,
+        skipped,
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: REFRESH_HOLDING_PRICES_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<RefreshHoldingPricesResult>(tx, {
+        endpoint: REFRESH_HOLDING_PRICES_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const refreshHoldingPricesFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof refreshHoldingPricesInputSchema>) =>
+    refreshHoldingPricesInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await refreshHoldingPricesForFamily({
       data,
       familyId: context.familyId,
       user: context.user,

--- a/tests/integration/holding-market-prices.integration.ts
+++ b/tests/integration/holding-market-prices.integration.ts
@@ -1,0 +1,584 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { marketQuoteToHoldingPriceMinor } from "@/lib/market-data"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  HoldingError,
+  refreshHoldingPricesForFamily,
+  upsertHoldingForFamily,
+} from "@/server/holdings"
+import {
+  ingestMarketDataOnce,
+  MarketFixtureProvider,
+  type FixtureQuote,
+  type MarketInstrumentRequest,
+} from "@/server/market-data.server"
+import { createValuationForFamily } from "@/server/valuations"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// =============================================================================
+// PER-238 / ADR-0050 + ADR-0051 — auto-revaluation wiring (real Postgres).
+//
+// A holdings `Instrument` links to a GLOBAL `MarketInstrument`; refreshing reads
+// the latest `MarketQuote`, marks the holding's lastPrice, and re-materializes
+// the Σ-holdings anchor. The load-bearing invariant is ANCHOR-SAFETY: a quote is
+// an OBSERVATION (ADR-0050 §2) — it only ever moves a holding's lastPrice + the
+// derived source="holdings" valuation, NEVER a cash balance or a user
+// opening/reconciliation/manual anchor, and is a NO-OP when nothing changed.
+// =============================================================================
+
+const AS_OF = new Date("2026-08-07T00:00:00.000Z")
+
+describe("holding market-price refresh (PER-238 — quotes -> holdings, anchor-safe)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // ---- shared factories -----------------------------------------------------
+
+  const makeInvestmentAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Bibit"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const makeCashAccount = async (owner: AuthenticatedOnboardedUser) =>
+    await createAccountForFamily({
+      data: {
+        name: "Checking",
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance: "150000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // Seed one canonical MarketQuote via the PER-233 fixture provider + real
+  // ingest pipeline, and return the resolved global MarketInstrument id.
+  const seedQuote = async (
+    quote: FixtureQuote,
+    request: MarketInstrumentRequest,
+    asOf = AS_OF
+  ): Promise<string> => {
+    await ingestMarketDataOnce({
+      provider: new MarketFixtureProvider({
+        asOf,
+        quotes: [quote],
+        name: "fixture",
+      }),
+      requests: [request],
+      db: harness.prisma,
+    })
+    const instrument = await harness.prisma.marketInstrument.findFirstOrThrow({
+      where: {
+        kind: quote.kind,
+        symbol: quote.symbol,
+        quoteCurrency: quote.quoteCurrency,
+      },
+      select: { id: true },
+    })
+    return instrument.id
+  }
+
+  // A reksadana NAV of Rp 1,500.00/unit (150000 sen/unit after conversion).
+  const FUND_NAV_DECIMAL = "1500"
+
+  const seedIdrFund = () =>
+    seedQuote(
+      {
+        kind: "security",
+        symbol: "RDABC",
+        quoteCurrency: "IDR",
+        priceDecimal: FUND_NAV_DECIMAL,
+      },
+      { kind: "security", symbol: "RDABC", quoteCurrency: "IDR" }
+    )
+
+  const accountRow = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: accountId } })
+    )
+
+  const latestQuoteFor = (marketInstrumentId: string) =>
+    harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId },
+      orderBy: { asOf: "desc" },
+      select: { price: true, priceScale: true },
+    })
+
+  // ---------------------------------------------------------------------------
+  // Link + refresh
+  // ---------------------------------------------------------------------------
+  describe("link + refresh sets lastPrice from the latest quote", () => {
+    test("refresh marks lastPrice and updates the Σ-holdings account value", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const marketInstrumentId = await seedIdrFund()
+
+      // Create a holding with NO manual price, linked to the market series.
+      const holding = await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "RD ABC" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(holding.lastPriceMinor).toBeNull()
+      expect(holding.instrument.marketInstrumentId).toBe(marketInstrumentId)
+      // Value at cost until a refresh: 10 × Rp 1,000 = Rp 10,000 (1_000_000 sen).
+      expect(holding.valueMinor).toBe("1000000")
+
+      const result = await refreshHoldingPricesForFamily({
+        data: {
+          accountId: account.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(result.updatedHoldings).toBe(1)
+      expect(result.updatedAccounts).toBe(1)
+      expect(result.consideredHoldings).toBe(1)
+
+      // The lastPrice equals the pure conversion of the latest quote.
+      const quote = await latestQuoteFor(marketInstrumentId)
+      const expectedPrice = marketQuoteToHoldingPriceMinor({
+        kind: "security",
+        priceScaled: quote.price,
+        priceScale: quote.priceScale,
+        minorUnitConversion: 100n,
+      })
+      expect(expectedPrice).toBe(150000n) // Rp 1,500.00/unit
+
+      const view = await getAccountHoldingsForFamily({
+        accountId: account.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      const refreshed = view.holdings[0]
+      expect(refreshed?.lastPriceMinor).toBe("150000")
+      // 10 × Rp 1,500 = Rp 15,000 (1_500_000 sen).
+      expect(refreshed?.valueMinor).toBe("1500000")
+      expect(refreshed?.latestMarketQuoteAsOf).toBe(AS_OF.toISOString())
+
+      // The account balance re-materialized from Σ holdings (holdings anchor).
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(1500000n)
+      const anchor = await harness.withFamily(owner.family.id, (tx) =>
+        tx.valuation.findFirst({
+          where: { accountId: account.id, source: "holdings" },
+          orderBy: { createdAt: "desc" },
+        })
+      )
+      expect(anchor?.value).toBe(1500000n)
+    })
+
+    test("gold: a per-troy-ounce metal quote prices a gram-denominated holding", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner, "BSI Gold")
+      // Rp 76,359,035.544 per troy ounce -> ~Rp 2,455,000/gram after derivation.
+      const marketInstrumentId = await seedQuote(
+        {
+          kind: "metal",
+          symbol: "XAU",
+          quoteCurrency: "IDR",
+          priceDecimal: "76359035.544",
+        },
+        { kind: "metal", symbol: "XAU", quoteCurrency: "IDR" }
+      )
+
+      await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "metal", name: "Gold", symbol: "XAU" },
+          quantity: "2",
+          avgUnitCost: "2760809",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      await refreshHoldingPricesForFamily({
+        data: {
+          accountId: account.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const quote = await latestQuoteFor(marketInstrumentId)
+      const expectedPerGram = marketQuoteToHoldingPriceMinor({
+        kind: "metal",
+        priceScaled: quote.price,
+        priceScale: quote.priceScale,
+        minorUnitConversion: 100n,
+      })
+      const view = await getAccountHoldingsForFamily({
+        accountId: account.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      // The refresh used the same pure per-gram derivation.
+      expect(view.holdings[0]?.lastPriceMinor).toBe(expectedPerGram.toString())
+      // Value = 2 grams × per-gram price.
+      expect(view.holdings[0]?.valueMinor).toBe(
+        (expectedPerGram * 2n).toString()
+      )
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(expectedPerGram * 2n)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Anchor-safety
+  // ---------------------------------------------------------------------------
+  describe("anchor-safety — an observation never touches cash or user anchors", () => {
+    test("a family-wide refresh does NOT change a cash account balance", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const cash = await makeCashAccount(owner)
+      const investment = await makeInvestmentAccount(owner)
+      const marketInstrumentId = await seedIdrFund()
+
+      await upsertHoldingForFamily({
+        data: {
+          accountId: investment.id,
+          instrument: { kind: "mutual_fund", name: "RD ABC" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const cashValuationsBefore = await harness.withFamily(
+        owner.family.id,
+        (tx) => tx.valuation.count({ where: { accountId: cash.id } })
+      )
+
+      // Family-wide refresh (no accountId) — must only touch linked holdings.
+      await refreshHoldingPricesForFamily({
+        data: { idempotencyKey: factories.createIdempotencyKey() },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      // Cash balance + its opening anchor are untouched (no new valuation).
+      const cashRow = await accountRow(owner, cash.id)
+      expect(cashRow.balance).toBe(150000n)
+      const cashValuationsAfter = await harness.withFamily(
+        owner.family.id,
+        (tx) => tx.valuation.count({ where: { accountId: cash.id } })
+      )
+      expect(cashValuationsAfter).toBe(cashValuationsBefore)
+    })
+
+    test("refresh does NOT overwrite a reconciliation anchor on a non-holdings account", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      // A second valuation-tracked account with a USER reconciliation anchor and
+      // NO holdings — the refresh must leave it entirely alone.
+      const other = await makeInvestmentAccount(owner, "Other Tracked")
+      await createValuationForFamily({
+        data: {
+          accountId: other.id,
+          value: "777777",
+          type: "reconciliation",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      const otherBefore = await accountRow(owner, other.id)
+      expect(otherBefore.balance).toBe(777777n)
+
+      // A linked holding on a DIFFERENT account (so the refresh has work to do).
+      const investment = await makeInvestmentAccount(owner)
+      const marketInstrumentId = await seedIdrFund()
+      await upsertHoldingForFamily({
+        data: {
+          accountId: investment.id,
+          instrument: { kind: "mutual_fund", name: "RD ABC" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const otherValuationsBefore = await harness.withFamily(
+        owner.family.id,
+        (tx) => tx.valuation.count({ where: { accountId: other.id } })
+      )
+
+      await refreshHoldingPricesForFamily({
+        data: { idempotencyKey: factories.createIdempotencyKey() },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      const otherAfter = await accountRow(owner, other.id)
+      expect(otherAfter.balance).toBe(777777n) // reconciliation anchor intact
+      const otherValuationsAfter = await harness.withFamily(
+        owner.family.id,
+        (tx) => tx.valuation.count({ where: { accountId: other.id } })
+      )
+      expect(otherValuationsAfter).toBe(otherValuationsBefore) // no new anchor
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Idempotent re-refresh
+  // ---------------------------------------------------------------------------
+  describe("idempotent re-refresh (unchanged quotes -> no-op)", () => {
+    test("re-refreshing with unchanged quotes writes no new valuation and no balance change", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const marketInstrumentId = await seedIdrFund()
+      await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "RD ABC" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      // First refresh moves the price (fresh key each call).
+      const first = await refreshHoldingPricesForFamily({
+        data: { idempotencyKey: factories.createIdempotencyKey() },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(first.updatedHoldings).toBe(1)
+      const balanceAfterFirst = (await accountRow(owner, account.id)).balance
+      const valuationsAfterFirst = await harness.withFamily(
+        owner.family.id,
+        (tx) => tx.valuation.count({ where: { accountId: account.id } })
+      )
+
+      // Second refresh with a DIFFERENT key but the SAME quote — a true no-op.
+      const second = await refreshHoldingPricesForFamily({
+        data: { idempotencyKey: factories.createIdempotencyKey() },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(second.updatedHoldings).toBe(0)
+      expect(second.updatedAccounts).toBe(0)
+      expect(second.skipped[0]?.reason).toContain("unchanged")
+
+      expect((await accountRow(owner, account.id)).balance).toBe(
+        balanceAfterFirst
+      )
+      const valuationsAfterSecond = await harness.withFamily(
+        owner.family.id,
+        (tx) => tx.valuation.count({ where: { accountId: account.id } })
+      )
+      expect(valuationsAfterSecond).toBe(valuationsAfterFirst) // no duplicate anchor
+    })
+
+    test("replaying the SAME refresh key returns the cached response", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const marketInstrumentId = await seedIdrFund()
+      await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "RD ABC" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      const key = factories.createIdempotencyKey()
+      const payload = {
+        data: { idempotencyKey: key },
+        familyId: owner.family.id,
+        user: owner.user,
+      }
+      const first = await refreshHoldingPricesForFamily(payload)
+      const second = await refreshHoldingPricesForFamily(payload)
+      expect(second).toEqual(first)
+      // The balance moved exactly once.
+      expect((await accountRow(owner, account.id)).balance).toBe(1500000n)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Same-currency constraint + unlinked holdings + tenant isolation
+  // ---------------------------------------------------------------------------
+  describe("constraints", () => {
+    test("rejects linking a holding to a different-currency market instrument", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner) // IDR
+      // A USD market series — cross-currency auto-pricing is a later slice.
+      const usdMarketId = await seedQuote(
+        {
+          kind: "security",
+          symbol: "AAPL",
+          quoteCurrency: "USD",
+          priceDecimal: "150",
+        },
+        { kind: "security", symbol: "AAPL", quoteCurrency: "USD" }
+      )
+
+      await expect(
+        upsertHoldingForFamily({
+          data: {
+            accountId: account.id,
+            instrument: { kind: "stock", name: "Apple" },
+            quantity: "1",
+            avgUnitCost: "1000",
+            marketInstrumentId: usdMarketId,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: owner.family.id,
+          user: owner.user,
+        })
+      ).rejects.toBeInstanceOf(HoldingError)
+    })
+
+    test("a holding with NO market link is untouched by refresh", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      // Seed a series but do NOT link the holding to it.
+      await seedIdrFund()
+      const holding = await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "Manual Fund" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          lastPrice: "1200",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(holding.instrument.marketInstrumentId).toBeNull()
+
+      const result = await refreshHoldingPricesForFamily({
+        data: { idempotencyKey: factories.createIdempotencyKey() },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      expect(result.consideredHoldings).toBe(0)
+      expect(result.updatedHoldings).toBe(0)
+
+      const view = await getAccountHoldingsForFamily({
+        accountId: account.id,
+        familyId: owner.family.id,
+        userId: owner.user.id,
+      })
+      // The manual last price (Rp 1,200) is unchanged.
+      expect(view.holdings[0]?.lastPriceMinor).toBe("120000")
+      expect(view.holdings[0]?.valueMinor).toBe("1200000")
+    })
+
+    test("tenant isolation — a refresh only ever sees its own family's holdings", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+      const marketInstrumentId = await seedIdrFund()
+      await upsertHoldingForFamily({
+        data: {
+          accountId: account.id,
+          instrument: { kind: "mutual_fund", name: "RD ABC" },
+          quantity: "10",
+          avgUnitCost: "1000",
+          marketInstrumentId,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+
+      // The intruder refreshes under THEIR scope — the owner's linked holding is
+      // invisible, so nothing is considered or changed.
+      const intruderResult = await refreshHoldingPricesForFamily({
+        data: { idempotencyKey: factories.createIdempotencyKey() },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+      expect(intruderResult.consideredHoldings).toBe(0)
+      expect(intruderResult.updatedHoldings).toBe(0)
+
+      // The owner's holding is still at cost (never priced by the intruder).
+      const row = await accountRow(owner, account.id)
+      expect(row.balance).toBe(1000000n) // 10 × Rp 1,000, unchanged
+    })
+
+    test("scoping refresh to a foreign accountId is rejected (tenant validation)", async () => {
+      const owner = await factories.createAuthenticatedOnboardedUser()
+      const intruder = await factories.createAuthenticatedOnboardedUser()
+      const account = await makeInvestmentAccount(owner)
+
+      await expect(
+        refreshHoldingPricesForFamily({
+          data: {
+            accountId: account.id,
+            idempotencyKey: factories.createIdempotencyKey(),
+          },
+          familyId: intruder.family.id,
+          user: intruder.user,
+        })
+      ).rejects.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## PER-238 — Market data → holdings auto-revaluation (anchor-safe)

Wires the global market-data price store (ADR-0050) to the holdings domain (ADR-0051). A holdings `Instrument` may OPTIONALLY link to a global `MarketInstrument`; an explicit "Refresh prices" marks each linked holding's `lastPrice` from the latest `MarketQuote` and re-materializes the Σ-holdings anchor.

### The link
`Instrument.marketInstrumentId → MarketInstrument.id` — additive, nullable FK to the family-neutral (no RLS) price series, `onDelete: SetNull`. Migration `20260808120000_holding_market_link` (additive only).

```
holdings Instrument.marketInstrumentId
  → latest MarketQuote  → holding.lastPriceMinor  → Σ-holdings valuation anchor (source="holdings")
```

### The auto-mark flow
`refreshHoldingPricesForFamily`/`refreshHoldingPricesFn` (`src/server/holdings.ts`), full CLAUDE.md §5A contract: RLS-scoped tenant tx, endpoint idempotency (replay + unique-race), tenant validation of the optional `accountId`, append-only audit for every `Holding` price update and the anchor. For each linked holding it reads the latest quote, converts it via the pure `marketQuoteToHoldingPriceMinor` (metal derives per-gram from the canonical per-troy-ounce quote; security/crypto per-unit; fx rejected), sets `lastPriceMinor`, and recomputes each affected account's anchor via the existing `recomputeAccountValueAnchorWithinTx`.

### Anchor-safety invariant (how tested)
A quote is an **observation** (ADR-0043/0050 §2). The refresh only ever moves a holding's `lastPriceMinor` and the derived `source="holdings"` valuation of the same valuation-tracked investment account. It never writes a cash/funding balance, never an `opening`/`reconciliation`/`manual` user anchor, and never a non-holdings account; an unchanged quote is a no-op (no duplicate valuation, no balance move). Real-Postgres tests assert: a family-wide refresh leaves a cash account's balance + its opening anchor untouched; a `reconciliation` anchor on a non-holdings valuation account is untouched; re-refresh with unchanged quotes writes no new valuation and no balance change.

### Same-currency constraint
`MarketInstrument.quoteCurrency` must equal the holding/account currency — rejected at link time and skipped (with a clear reason) at refresh time. Cross-currency via FX is deferred.

### UI
"Live price source" selector in the holding add/edit dialog (lists same-currency series via `listMarketInstrumentsFn`), a "Refresh prices" action on the account detail page, and a subtle per-holding "Auto" indicator showing the latest quote's as-of.

### Test evidence
- Unit (`src/lib/market-data.test.ts`): quote→holding-price conversion (security NAV, crypto 8dp, metal per-gram derivation, JPY zero-fraction, fx/zero rejection). `19 passed`.
- Integration (`tests/integration/holding-market-prices.integration.ts`, real PG): link + refresh sets lastPrice + updates Σ-holdings value; gold per-ounce→per-gram; anchor-safety (cash + reconciliation anchor untouched); idempotent re-refresh + same-key replay; same-currency rejection; unlinked untouched; tenant isolation. `10 passed`.
- `vp check` clean; full unit suite `631 passed`; adjacent holdings/market-data/enable-holdings integration `28 passed`.

Scope deferred: scheduled worker (PER-237), real scraper adapters (PER-235 gold-local; reksadana NAV), cross-currency quote→holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1