### PR TITLE
feat(market-data): PER-235 — gold price feed (self-hosted logam-mulia-api adapter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,19 @@ DATABASE_URL="postgres://permoney:permoney@localhost:5433/permoney"
 # PERMONEY_SEED_PRIVILEGED_DATABASE_URL="postgres://SEED_ROLE:PW@HOST:5432/DB?sslmode=require"
 
 # -----------------------------------------------------------------------------
+# Market data — gold price feed (PER-235 / ADR-0050 slice 3)
+# -----------------------------------------------------------------------------
+# Base URL of the SELF-HOSTED `iamutaki/logam-mulia-api` worker (MIT, a separate
+# Cloudflare Worker service that scrapes Indonesian gold sources and exposes
+# clean JSON). Permoney consumes ONLY its HTTPS JSON — the fragile scraping stays
+# in the worker. Read ONLY inside the `.server.ts` adapter, at call time.
+#
+# The adapter fetches `{LOGAM_MULIA_API_URL}/api/prices/bankbsi` (BSI Gold, the
+# primary source). Unset = the gold ingest throws a clear, actionable error at
+# call time (never at module scope). No trailing slash needed.
+# LOGAM_MULIA_API_URL="https://logam-mulia-api.example.workers.dev"
+
+# -----------------------------------------------------------------------------
 # Auth (FUTURE — not yet wired, see ADRs)
 # -----------------------------------------------------------------------------
 # AUTH_SECRET="<openssl rand -base64 32>"

--- a/docs/adr/0050-market-data-ingestion.md
+++ b/docs/adr/0050-market-data-ingestion.md
@@ -280,3 +280,65 @@ market link on `upsertHoldingFn`); `src/components/blocks/holding-form-dialog.ts
 `src/routes/_protected/-account-holdings.tsx` + `accounts.$accountId.tsx` (UI);
 unit (`src/lib/market-data.test.ts`) + real-Postgres
 (`tests/integration/holding-market-prices.integration.ts`) tests.
+
+## Implementation notes (PER-235, Slice 3 — gold price feed)
+
+Slice 3 lands the FIRST real market-data adapter: gold, sourced from a
+SELF-HOSTED `iamutaki/logam-mulia-api` worker (MIT, a separate Cloudflare Worker
+service). The fragile scraping of Indonesian gold sources stays entirely in the
+worker; Permoney consumes only its clean HTTPS JSON. The adapter slots into the
+PER-233 `MarketDataProvider` seam with ZERO schema change and ZERO consumer
+change — proof the raw → staged → canonical boundary holds.
+
+- **The adapter (vendor seam).** `LogamMuliaGoldProvider`
+  (`src/server/market-data.server.ts`) fetches
+  `GET {LOGAM_MULIA_API_URL}/api/prices/bankbsi` (BSI Gold — the creator's
+  primary source; `/logammulia` (Antam) and `/pegadaian` are documented
+  fallbacks). The base URL is env config, read ONLY inside the `.server.ts`
+  adapter at CALL time (never module scope); unset throws a clear, actionable
+  error. `fetchImpl` is injectable so tests exercise the whole pipeline against a
+  recorded fixture with NO live network.
+
+- **Price choice — `buybackPrice` (documented, flippable).** The quote uses
+  BSI's `buybackPrice` (what BSI pays to buy a gram BACK) — the realizable
+  current value of gold you HOLD, the honest mark for a position. It is a named
+  constant (`BSI_GOLD_PRICE_FIELD`) so a flip to `sellPrice` is one line, pending
+  the creator confirming which number their BSI app shows as position value.
+
+- **Unit — stored per TROY OUNCE (consistency over the ticket wording).** BSI
+  publishes per GRAM, but the canonical metal store is per TROY OUNCE (the
+  PER-233 metal convention; PER-238's `marketQuoteToHoldingPriceMinor` DERIVES
+  per-gram from a per-ounce quote). Rather than fork the metal unit or touch the
+  merged PER-238 refresh, the pure parser
+  (`parseLogamMuliaGoldResponse`/`goldPerGramMajorToPerOunceDecimal`,
+  `src/lib/market-data.ts`) converts BSI's per-gram price to a per-troy-ounce
+  `priceDecimal` before the normalizer. The conversion is EXACT for integer
+  per-gram prices (`price × 31.1034768`, then the reverse `/ 31.1034768` cancels
+  with zero loss), so a linked gold holding still marks at exactly
+  `pricePerGram × grams`. The BSI series symbol is `XAU-BSI` (a metal, quote
+  currency IDR).
+
+- **Idempotent ensure/seed.** `ensureBsiGoldInstrument` upserts the canonical
+  `XAU-BSI` `MarketInstrument` (idempotent, unique-race-safe). `ingestGoldPricesOnce`
+  calls it FIRST, so the instrument is linkable (PER-238) even when the fetch
+  then fails — no data migration needed.
+
+- **Graceful degradation (total).** A worker outage (throw), a non-2xx status,
+  non-JSON, `success:false`, an empty/absent `data` array, no 1-gram row, or a
+  non-positive price all record a failed `RawMarketDataFetch` and write ZERO
+  canonical quotes — the last good quote is untouched, the pipeline never throws.
+
+- **Ledger isolation (tested).** A gold ingest writes ONLY the three global
+  market tables; a real onboarded family's ledger snapshot is byte-identical
+  before/after. Quotes → holdings/valuations remain PER-238's separate,
+  anchor-safe refresh — unchanged here.
+
+- **Deferred.** The scheduled refresh worker (PER-237 — this slice is a single
+  `ingestGoldPricesOnce` trigger), the reksadana NAV adapter, and the Antam /
+  Pegadaian fallbacks.
+
+Files: `src/lib/market-data.ts` (pure BSI parser + per-gram→per-ounce
+conversion); `src/server/market-data.server.ts` (`LogamMuliaGoldProvider`,
+`ensureBsiGoldInstrument`, `ingestGoldPricesOnce`); `.env.example`
+(`LOGAM_MULIA_API_URL`); unit (`src/lib/market-data.test.ts`) + real-Postgres
+(`tests/integration/gold-price-feed.integration.ts`) tests.

--- a/src/lib/market-data.test.ts
+++ b/src/lib/market-data.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, test } from "vite-plus/test"
 import { encodeRate } from "./fx"
 import {
+  BSI_GOLD_SOURCE,
+  BSI_GOLD_SYMBOL,
   decodeSpotPrice,
   encodePriceForKind,
   encodeSpotPrice,
   FX_PRICE_DECIMALS,
+  goldPerGramMajorToPerOunceDecimal,
   isMarketInstrumentKind,
   MARKET_INSTRUMENT_KINDS,
   marketQuoteToHoldingPriceMinor,
   normalizeObservations,
+  parseLogamMuliaGoldResponse,
   priceScaleForKind,
   SPOT_PRICE_DECIMALS,
   SPOT_PRICE_SCALE,
@@ -261,5 +265,149 @@ describe("marketQuoteToHoldingPriceMinor (PER-238 quote -> holding price)", () =
         minorUnitConversion: 100n,
       })
     ).toThrow()
+  })
+})
+
+// =============================================================================
+// BSI gold feed — logam-mulia-api parsing (PER-235)
+// =============================================================================
+
+// The documented logam-mulia-api response contract (recorded as the fixture).
+const GOLD_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "bankbsi",
+      material: "gold",
+      materialType: "BSI",
+      weight: 1,
+      weightUnit: "gr",
+      sellPrice: 2_700_000,
+      buybackPrice: 2_650_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 1,
+  timestamp: "2026-05-16T05:06:58.888Z",
+  cached: true,
+}
+
+describe("goldPerGramMajorToPerOunceDecimal (per-gram -> per-troy-ounce, exact)", () => {
+  test("converts an integer per-gram price with zero float error", () => {
+    // Rp 2,650,000/gram × 31.1034768 g/oz = Rp 82,424,213.52/oz.
+    expect(goldPerGramMajorToPerOunceDecimal(2_650_000)).toBe("82424213.52")
+    // Rp 2,700,000/gram × 31.1034768 = Rp 83,979,387.36/oz.
+    expect(goldPerGramMajorToPerOunceDecimal(2_700_000)).toBe("83979387.36")
+  })
+
+  test("round-trips per-ounce -> per-gram with ZERO loss (integer per-gram)", () => {
+    const perOunceDecimal = goldPerGramMajorToPerOunceDecimal(2_650_000)
+    const perOunceScaled = encodeSpotPrice(perOunceDecimal)
+    // The PER-238 derivation gives back exactly 2,650,000 × 1e8 (per gram).
+    expect(spotPriceScaledPerGram(perOunceScaled)).toBe(
+      2_650_000n * SPOT_PRICE_SCALE
+    )
+  })
+
+  test("throws on a non-positive or non-finite price", () => {
+    expect(() => goldPerGramMajorToPerOunceDecimal(0)).toThrow()
+    expect(() => goldPerGramMajorToPerOunceDecimal(-1)).toThrow()
+    expect(() => goldPerGramMajorToPerOunceDecimal(Number.NaN)).toThrow()
+  })
+})
+
+describe("parseLogamMuliaGoldResponse", () => {
+  test("maps the bankbsi fixture -> one per-troy-ounce metal observation (buyback)", () => {
+    const result = parseLogamMuliaGoldResponse(GOLD_PAYLOAD)
+    expect(result.status).toBe("ok")
+    expect(result.observations).toHaveLength(1)
+    const obs = result.observations[0]
+    expect(obs?.kind).toBe("metal")
+    expect(obs?.symbol).toBe(BSI_GOLD_SYMBOL) // "XAU-BSI"
+    expect(obs?.quoteCurrency).toBe("IDR")
+    expect(obs?.priceDecimal).toBe("82424213.52") // buyback per gram -> per oz
+    expect(obs?.providerRef).toBe(BSI_GOLD_SOURCE) // "bankbsi"
+    expect(obs?.asOf.toISOString()).toBe("2026-05-16T00:00:00.000Z")
+  })
+
+  test("normalizes to a canonical spot quote (priceScale=8) whose per-gram mark equals buyback", () => {
+    const result = parseLogamMuliaGoldResponse(GOLD_PAYLOAD)
+    const normalized = normalizeObservations(result.observations)
+    expect(normalized.rejected).toHaveLength(0)
+    const quote = normalized.quotes[0]
+    expect(quote?.priceScale).toBe(8)
+    expect(quote?.price).toBe(encodeSpotPrice("82424213.52"))
+    // Priced through the UNCHANGED PER-238 metal path: Rp 2,650,000/gram in sen.
+    const perGramMinor = marketQuoteToHoldingPriceMinor({
+      kind: "metal",
+      priceScaled: quote?.price ?? 0n,
+      priceScale: quote?.priceScale ?? 0,
+      minorUnitConversion: 100n,
+    })
+    expect(perGramMinor).toBe(265_000_000n) // Rp 2,650,000.00
+  })
+
+  test("honors the sellPrice option", () => {
+    const result = parseLogamMuliaGoldResponse(GOLD_PAYLOAD, {
+      priceField: "sellPrice",
+    })
+    expect(result.observations[0]?.priceDecimal).toBe("83979387.36")
+  })
+
+  test("picks the 1-gram row when several weights are present", () => {
+    const multi = {
+      ...GOLD_PAYLOAD,
+      data: [
+        { ...GOLD_PAYLOAD.data[0], weight: 5, buybackPrice: 13_000_000 },
+        GOLD_PAYLOAD.data[0],
+        { ...GOLD_PAYLOAD.data[0], weight: 10, buybackPrice: 26_000_000 },
+      ],
+    }
+    const result = parseLogamMuliaGoldResponse(multi)
+    expect(result.status).toBe("ok")
+    expect(result.observations[0]?.priceDecimal).toBe("82424213.52")
+  })
+
+  test("success:false -> graceful skip (no throw, no observations)", () => {
+    const result = parseLogamMuliaGoldResponse({
+      ...GOLD_PAYLOAD,
+      success: false,
+    })
+    expect(result.status).toBe("error")
+    expect(result.observations).toHaveLength(0)
+    expect(result.error).toContain("success")
+  })
+
+  test("empty data -> graceful skip", () => {
+    const result = parseLogamMuliaGoldResponse({ ...GOLD_PAYLOAD, data: [] })
+    expect(result.status).toBe("error")
+    expect(result.observations).toHaveLength(0)
+  })
+
+  test("no 1-gram row -> graceful skip", () => {
+    const result = parseLogamMuliaGoldResponse({
+      ...GOLD_PAYLOAD,
+      data: [{ ...GOLD_PAYLOAD.data[0], weight: 5 }],
+    })
+    expect(result.status).toBe("error")
+    expect(result.error).toContain("1-gram")
+  })
+
+  test("malformed payloads -> graceful skip (no throw)", () => {
+    expect(parseLogamMuliaGoldResponse(null).status).toBe("error")
+    expect(parseLogamMuliaGoldResponse("nope").status).toBe("error")
+    expect(parseLogamMuliaGoldResponse({}).status).toBe("error")
+    expect(
+      parseLogamMuliaGoldResponse({ success: true, data: "not-array" }).status
+    ).toBe("error")
+  })
+
+  test("a non-positive price -> graceful skip", () => {
+    const result = parseLogamMuliaGoldResponse({
+      ...GOLD_PAYLOAD,
+      data: [{ ...GOLD_PAYLOAD.data[0], buybackPrice: 0 }],
+    })
+    expect(result.status).toBe("error")
   })
 })

--- a/src/lib/market-data.ts
+++ b/src/lib/market-data.ts
@@ -413,3 +413,209 @@ export function normalizeObservations(
 
   return { quotes: [...byKey.values()], rejected }
 }
+
+// =============================================================================
+// BSI gold feed — logam-mulia-api parsing (PER-235 / ADR-0050 slice 3)
+// =============================================================================
+//
+// We self-host `iamutaki/logam-mulia-api` (MIT, a Cloudflare Worker) as a
+// SEPARATE service that scrapes Indonesian gold sources and exposes clean JSON.
+// Permoney consumes only its HTTPS JSON; the fragile scraping stays in the
+// worker. This section is the PURE parser + unit conversion — no network, no
+// Prisma, no secrets — so it is fully unit-testable. The network adapter and
+// ingest trigger live in `src/server/market-data.server.ts`.
+//
+// UNIT DECISION (load-bearing): BSI publishes gold prices per GRAM, but the
+// canonical metal store is per TROY OUNCE (PER-233 metal convention; PER-238's
+// `marketQuoteToHoldingPriceMinor` DERIVES per-gram from a per-ounce quote via
+// `spotPriceScaledPerGram`). To stay consistent with that ONE metal unit — and
+// so a linked gold holding auto-prices correctly through the UNCHANGED PER-238
+// refresh — this parser converts BSI's per-gram price to a per-TROY-OUNCE
+// `priceDecimal` before handing it to the normalizer. The conversion is exact
+// (integer per-gram prices round-trip with zero loss), so a holding still marks
+// at exactly `pricePerGram × grams`.
+
+/** Canonical symbol of the self-hosted BSI gold price series (a metal). */
+export const BSI_GOLD_SYMBOL = "XAU-BSI"
+
+/** Quote `source` / provider label for the BSI gold feed (endpoint path). */
+export const BSI_GOLD_SOURCE = "bankbsi"
+
+/** BSI gold is quoted in Indonesian rupiah. */
+export const BSI_GOLD_QUOTE_CURRENCY = "IDR"
+
+/**
+ * Which published price we treat as the quote. `buybackPrice` is what BSI pays
+ * to buy a gram BACK from you — the realizable current value of gold you HOLD —
+ * so it is the honest mark for a holding's worth. Flip to `sellPrice` (the price
+ * to acquire a new gram) ONLY if the creator confirms their BSI app shows that
+ * number as the position value. Kept a named constant so the flip is one line.
+ */
+export type GoldPriceField = "buybackPrice" | "sellPrice"
+export const BSI_GOLD_PRICE_FIELD: GoldPriceField = "buybackPrice"
+
+/** One published price row from logam-mulia-api (documented response shape). */
+export interface LogamMuliaPriceRow {
+  source: string
+  material: string
+  materialType: string
+  weight: number
+  weightUnit: string
+  sellPrice: number
+  buybackPrice: number
+  currency: string
+  recordedDate: string
+}
+
+/** The logam-mulia-api response envelope (documented response shape). */
+export interface LogamMuliaResponse {
+  success: boolean
+  data: LogamMuliaPriceRow[]
+  count: number
+  timestamp: string
+  cached?: boolean
+}
+
+/** The outcome of parsing a logam-mulia-api payload into observations. */
+export interface LogamMuliaParseResult {
+  status: "ok" | "error"
+  /** Human-readable reason when `status` is "error" (graceful skip, no throw). */
+  error?: string
+  observations: MarketObservation[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function renderScaledDecimal(value: bigint, decimals: number): string {
+  if (decimals === 0) return value.toString()
+  const divisor = 10n ** BigInt(decimals)
+  const whole = value / divisor
+  const frac = value % divisor
+  if (frac === 0n) return whole.toString()
+  const fracText = frac.toString().padStart(decimals, "0").replace(/0+$/, "")
+  return `${whole.toString()}.${fracText}`
+}
+
+/**
+ * Convert a metal price quoted per GRAM (major currency units, as the BSI feed
+ * publishes it) into the per-TROY-OUNCE decimal string the canonical metal store
+ * uses. Exact BigInt math via `TROY_OUNCE_GRAMS` (31.1034768 = 311034768 / 1e7)
+ * — no float. An integer per-gram price round-trips through
+ * `spotPriceScaledPerGram` with ZERO loss. Throws on a non-finite / non-positive
+ * input (a corrupt price must fail loud, never mis-mark money).
+ */
+export function goldPerGramMajorToPerOunceDecimal(
+  perGramMajor: number
+): string {
+  if (!Number.isFinite(perGramMajor) || perGramMajor <= 0) {
+    throw new RangeError(
+      `goldPerGramMajorToPerOunceDecimal: price must be a positive finite number, got ${perGramMajor}`
+    )
+  }
+  const gramText = perGramMajor.toString()
+  if (!/^\d+(\.\d+)?$/.test(gramText)) {
+    throw new RangeError(
+      `goldPerGramMajorToPerOunceDecimal: unrepresentable price ${gramText}`
+    )
+  }
+  const [whole, fraction = ""] = gramText.split(".")
+  const gramScaled = BigInt(whole + fraction) // value × 10^fraction.length
+  const ounceScaled = gramScaled * 311_034_768n // × 10^(fraction.length + 7)
+  return renderScaledDecimal(ounceScaled, fraction.length + 7)
+}
+
+function resolveGoldAsOf(
+  recordedDate: unknown,
+  timestamp: unknown,
+  fallback: Date | undefined
+): Date | null {
+  if (typeof recordedDate === "string" && recordedDate.trim().length > 0) {
+    const d = new Date(`${recordedDate.trim()}T00:00:00.000Z`)
+    if (!Number.isNaN(d.getTime())) return d
+  }
+  if (typeof timestamp === "string" && timestamp.trim().length > 0) {
+    const d = new Date(timestamp)
+    if (!Number.isNaN(d.getTime())) return d
+  }
+  if (fallback && !Number.isNaN(fallback.getTime())) return fallback
+  return null
+}
+
+/**
+ * Parse a logam-mulia-api gold payload into a single canonical metal observation
+ * (per TROY OUNCE — see the unit decision above). Defensive: any shape problem
+ * (`success !== true`, empty/absent `data`, no 1-gram row, a non-positive price,
+ * an unparseable date) yields `status: "error"` with a reason and ZERO
+ * observations — NEVER a throw — so the ingest pipeline degrades gracefully and
+ * keeps the last good quote.
+ *
+ * Pure: no DB, no network, no secrets.
+ */
+export function parseLogamMuliaGoldResponse(
+  payload: unknown,
+  opts?: { priceField?: GoldPriceField; fallbackAsOf?: Date }
+): LogamMuliaParseResult {
+  const priceField = opts?.priceField ?? BSI_GOLD_PRICE_FIELD
+  const err = (reason: string): LogamMuliaParseResult => ({
+    status: "error",
+    error: reason,
+    observations: [],
+  })
+
+  if (!isRecord(payload)) return err("payload is not an object")
+  if (payload.success !== true) {
+    return err(`provider reported success=${String(payload.success)}`)
+  }
+  const data = payload.data
+  if (!Array.isArray(data) || data.length === 0) {
+    return err("payload data is empty")
+  }
+
+  // BSI publishes several weights; we price per gram, so take the 1-gram row.
+  const row = data.find(
+    (candidate) =>
+      isRecord(candidate) &&
+      Number(candidate.weight) === 1 &&
+      String(candidate.weightUnit).toLowerCase() === "gr"
+  )
+  if (!isRecord(row)) return err("no 1-gram (weightUnit=gr) row in payload")
+
+  const perGram = Number(row[priceField])
+  if (!Number.isFinite(perGram) || perGram <= 0) {
+    return err(`invalid ${priceField} ${String(row[priceField])}`)
+  }
+
+  const currency = typeof row.currency === "string" ? row.currency.trim() : ""
+  if (currency.length === 0) return err("row is missing a currency")
+
+  const asOf = resolveGoldAsOf(
+    row.recordedDate,
+    payload.timestamp,
+    opts?.fallbackAsOf
+  )
+  if (asOf === null) return err("row has no parseable recordedDate/timestamp")
+
+  let priceDecimal: string
+  try {
+    priceDecimal = goldPerGramMajorToPerOunceDecimal(perGram)
+  } catch (error) {
+    return err(error instanceof Error ? error.message : "unconvertible price")
+  }
+
+  return {
+    status: "ok",
+    observations: [
+      {
+        kind: "metal",
+        symbol: BSI_GOLD_SYMBOL,
+        quoteCurrency: currency,
+        asOf,
+        priceDecimal,
+        providerRef:
+          typeof row.source === "string" ? row.source : BSI_GOLD_SOURCE,
+      },
+    ],
+  }
+}

--- a/src/server/market-data.server.ts
+++ b/src/server/market-data.server.ts
@@ -31,7 +31,12 @@
 
 import type { Prisma, PrismaClient } from "@prisma/client"
 import {
+  BSI_GOLD_QUOTE_CURRENCY,
+  BSI_GOLD_SOURCE,
+  BSI_GOLD_SYMBOL,
   normalizeObservations,
+  parseLogamMuliaGoldResponse,
+  type GoldPriceField,
   type MarketInstrumentIdentity,
   type MarketInstrumentKind,
   type MarketObservation,
@@ -416,4 +421,252 @@ function isUniqueViolation(error: unknown): boolean {
 
 function toJson(value: unknown): Prisma.InputJsonValue {
   return (value ?? null) as Prisma.InputJsonValue
+}
+
+// -----------------------------------------------------------------------------
+// Gold feed adapter — self-hosted logam-mulia-api (PER-235 / ADR-0050 slice 3)
+// -----------------------------------------------------------------------------
+//
+// The ONLY code that knows the gold vendor exists. It fetches the worker's
+// `GET {base}/api/prices/bankbsi` endpoint, stages the raw JSON verbatim, and
+// hands the pure parser (`parseLogamMuliaGoldResponse`, @/lib/market-data) a
+// single per-troy-ounce metal observation. Secrets/config (`LOGAM_MULIA_API_URL`)
+// are read ONLY here, at CALL time (never module scope). Graceful degradation is
+// total: a worker outage, a non-2xx status, non-JSON, `success:false`, or a
+// malformed shape all return `status:"error"` with the raw payload captured —
+// never a throw, never a bad quote (ADR-0050 §4).
+
+/**
+ * Minimal fetch surface the gold adapter needs (typed, no `any`). Tests inject a
+ * fixture returning a canned `Response`; production uses the global `fetch`.
+ */
+export type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> }
+) => Promise<Response>
+
+/** The canonical BSI-gold instrument identity (metal, IDR, per-troy-ounce). */
+export const GOLD_INSTRUMENT_IDENTITY: MarketInstrumentIdentity = {
+  kind: "metal",
+  symbol: BSI_GOLD_SYMBOL,
+  baseCurrency: null,
+  quoteCurrency: BSI_GOLD_QUOTE_CURRENCY,
+  mic: null,
+}
+
+/** The request recorded on the raw fetch when ingesting BSI gold. */
+export const GOLD_INSTRUMENT_REQUEST: MarketInstrumentRequest = {
+  kind: "metal",
+  symbol: BSI_GOLD_SYMBOL,
+  quoteCurrency: BSI_GOLD_QUOTE_CURRENCY,
+}
+
+/** Read the worker base URL at CALL time; a clear error if unset (never module scope). */
+function requireLogamMuliaApiUrl(): string {
+  const raw = process.env.LOGAM_MULIA_API_URL
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new Error(
+      "LOGAM_MULIA_API_URL is not set — configure the self-hosted logam-mulia-api base URL to ingest gold prices (ADR-0050 / PER-235)."
+    )
+  }
+  return raw.trim().replace(/\/+$/, "")
+}
+
+export interface LogamMuliaGoldProviderOptions {
+  /** Base URL; defaults to reading `LOGAM_MULIA_API_URL` at call time. */
+  baseUrl?: string
+  /** Injectable fetch (tests pass a fixture; prod uses the global `fetch`). */
+  fetchImpl?: FetchLike
+  /** Which published price to quote (buyback default). */
+  priceField?: GoldPriceField
+  /** Clock for the as-of fallback (tests pin it). */
+  now?: () => Date
+}
+
+/**
+ * The self-hosted logam-mulia-api gold adapter. Serves gold spot only; FX/other
+ * spot are different feeds (a no-op empty-ok result here, so a mixed ingest never
+ * errors on this provider).
+ */
+export class LogamMuliaGoldProvider implements MarketDataProvider {
+  readonly name = BSI_GOLD_SOURCE
+  private readonly baseUrl: string
+  private readonly fetchImpl: FetchLike
+  private readonly priceField: GoldPriceField | undefined
+  private readonly now: () => Date
+
+  constructor(options?: LogamMuliaGoldProviderOptions) {
+    this.baseUrl = options?.baseUrl ?? requireLogamMuliaApiUrl()
+    this.fetchImpl = options?.fetchImpl ?? ((url, init) => fetch(url, init))
+    this.priceField = options?.priceField
+    this.now = options?.now ?? (() => new Date())
+  }
+
+  fetchFxRates(): Promise<MarketFetchResult> {
+    return Promise.resolve({
+      status: "ok",
+      httpStatus: 200,
+      observations: [],
+      rawPayload: null,
+    })
+  }
+
+  fetchSpot(): Promise<MarketFetchResult> {
+    return this.fetchGold()
+  }
+
+  fetchQuotes(): Promise<MarketFetchResult> {
+    return this.fetchGold()
+  }
+
+  private async fetchGold(): Promise<MarketFetchResult> {
+    const url = `${this.baseUrl}/api/prices/bankbsi`
+
+    let response: Response
+    try {
+      response = await this.fetchImpl(url, {
+        headers: { accept: "application/json" },
+      })
+    } catch (error) {
+      return {
+        status: "error",
+        error: error instanceof Error ? error.message : "gold fetch failed",
+        observations: [],
+        rawPayload: { error: String(error) },
+      }
+    }
+
+    if (!response.ok) {
+      const body = await safeReadText(response)
+      return {
+        status: "error",
+        httpStatus: response.status,
+        error: `gold feed HTTP ${response.status}`,
+        observations: [],
+        rawPayload: { httpStatus: response.status, body },
+      }
+    }
+
+    let json: unknown
+    try {
+      json = await response.json()
+    } catch (error) {
+      return {
+        status: "error",
+        httpStatus: response.status,
+        error: "gold feed returned non-JSON",
+        observations: [],
+        rawPayload: { httpStatus: response.status, parseError: String(error) },
+      }
+    }
+
+    const parsed = parseLogamMuliaGoldResponse(json, {
+      priceField: this.priceField,
+      fallbackAsOf: this.now(),
+    })
+    if (parsed.status !== "ok") {
+      return {
+        status: "error",
+        httpStatus: response.status,
+        error: parsed.error,
+        observations: [],
+        rawPayload: json,
+      }
+    }
+    return {
+      status: "ok",
+      httpStatus: response.status,
+      observations: parsed.observations,
+      rawPayload: json,
+    }
+  }
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text()
+  } catch {
+    return ""
+  }
+}
+
+/**
+ * Idempotently ensure the canonical BSI-gold `MarketInstrument` exists so a
+ * holding can be LINKED to it (PER-238) even before the first successful fetch.
+ * Safe to call repeatedly; recovers from the unique-index race. Returns its id.
+ */
+export async function ensureBsiGoldInstrument(
+  db: MarketDataDb = prisma
+): Promise<string> {
+  const where = {
+    kind: "metal",
+    symbol: BSI_GOLD_SYMBOL,
+    baseCurrency: null,
+    quoteCurrency: BSI_GOLD_QUOTE_CURRENCY,
+    mic: null,
+  } as const
+
+  const existing = await db.marketInstrument.findFirst({
+    where,
+    select: { id: true },
+  })
+  if (existing) return existing.id
+
+  try {
+    const created = await db.marketInstrument.create({
+      data: {
+        kind: "metal",
+        symbol: BSI_GOLD_SYMBOL,
+        name: "BSI Gold",
+        quoteCurrency: BSI_GOLD_QUOTE_CURRENCY,
+      },
+      select: { id: true },
+    })
+    return created.id
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      const raced = await db.marketInstrument.findFirst({
+        where,
+        select: { id: true },
+      })
+      if (raced) return raced.id
+    }
+    throw error
+  }
+}
+
+export interface IngestGoldOptions {
+  /** Base URL; defaults to reading `LOGAM_MULIA_API_URL` at call time. */
+  baseUrl?: string
+  /** Injectable fetch (tests pass a fixture; prod uses the global `fetch`). */
+  fetchImpl?: FetchLike
+  /** Which published price to quote (buyback default). */
+  priceField?: GoldPriceField
+  /** Clock for the as-of fallback (tests pin it). */
+  now?: () => Date
+  db?: MarketDataDb
+}
+
+/**
+ * Run ONE BSI-gold ingest cycle. No scheduler — that is PER-237. First ENSURES
+ * the canonical instrument exists (so it stays linkable even when the fetch then
+ * fails), then runs the shared raw → staged → canonical pipeline. Safe to call
+ * repeatedly: the canonical write path is idempotent.
+ */
+export async function ingestGoldPricesOnce(
+  options?: IngestGoldOptions
+): Promise<IngestSummary> {
+  const db = options?.db ?? prisma
+  await ensureBsiGoldInstrument(db)
+  const provider = new LogamMuliaGoldProvider({
+    baseUrl: options?.baseUrl,
+    fetchImpl: options?.fetchImpl,
+    priceField: options?.priceField,
+    now: options?.now,
+  })
+  return await ingestMarketDataOnce({
+    provider,
+    requests: [GOLD_INSTRUMENT_REQUEST],
+    db,
+  })
 }

--- a/tests/integration/gold-price-feed.integration.ts
+++ b/tests/integration/gold-price-feed.integration.ts
@@ -1,0 +1,377 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { encodeSpotPrice } from "@/lib/market-data"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  refreshHoldingPricesForFamily,
+  upsertHoldingForFamily,
+} from "@/server/holdings"
+import {
+  ensureBsiGoldInstrument,
+  ingestGoldPricesOnce,
+  type FetchLike,
+} from "@/server/market-data.server"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// =============================================================================
+// PER-235 / ADR-0050 slice 3 — BSI gold price feed (real Postgres, NO network).
+//
+// The self-hosted logam-mulia-api worker is injected as a FIXTURE `fetchImpl`
+// returning the documented `GET /api/prices/bankbsi` payload — no live network
+// is ever touched. The ingest lands the raw JSON, normalizes ONE canonical metal
+// MarketQuote (stored per TROY OUNCE — the canonical metal unit — from BSI's
+// per-gram buyback), and never mutates the ledger. The END-TO-END test proves a
+// linked gold holding auto-marks at buyback × grams through the UNCHANGED PER-238
+// refresh (`marketQuoteToHoldingPriceMinor` derives per-gram from the per-ounce
+// quote).
+// =============================================================================
+
+const BASE_URL = "http://gold.test"
+
+// The documented logam-mulia-api response contract (recorded as the fixture).
+const GOLD_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "bankbsi",
+      material: "gold",
+      materialType: "BSI",
+      weight: 1,
+      weightUnit: "gr",
+      sellPrice: 2_700_000,
+      buybackPrice: 2_650_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 1,
+  timestamp: "2026-05-16T05:06:58.888Z",
+  cached: true,
+}
+
+// Rp 2,650,000/gram buyback -> per troy ounce -> stored spot quote (scale 1e8).
+const EXPECTED_PER_OUNCE = encodeSpotPrice("82424213.52")
+// Rp 2,650,000/gram in minor units (sen).
+const EXPECTED_PER_GRAM_MINOR = "265000000"
+const EXPECTED_AS_OF = "2026-05-16T00:00:00.000Z"
+
+const okFetch: FetchLike = () =>
+  Promise.resolve(
+    new Response(JSON.stringify(GOLD_PAYLOAD), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  )
+
+const http500Fetch: FetchLike = () =>
+  Promise.resolve(new Response("upstream boom", { status: 500 }))
+
+const throwFetch: FetchLike = () => Promise.reject(new Error("ECONNREFUSED"))
+
+const successFalseFetch: FetchLike = () =>
+  Promise.resolve(
+    new Response(JSON.stringify({ ...GOLD_PAYLOAD, success: false }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  )
+
+describe("gold price feed (PER-235 — logam-mulia-api adapter, fixture-injected)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const goldInstrument = () =>
+    harness.prisma.marketInstrument.findFirstOrThrow({
+      where: { kind: "metal", symbol: "XAU-BSI", quoteCurrency: "IDR" },
+    })
+
+  // ---------------------------------------------------------------------------
+  // Ingest creates the instrument + a canonical quote
+  // ---------------------------------------------------------------------------
+  test("ingest creates the BSI-gold MarketInstrument + one canonical MarketQuote", async () => {
+    const summary = await ingestGoldPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+
+    expect(summary.status).toBe("ok")
+    expect(summary.quotesUpserted).toBe(1)
+    expect(summary.instrumentsResolved).toBe(1)
+    expect(summary.rejected).toBe(0)
+
+    const instrument = await goldInstrument()
+    expect(instrument.name).toBe("BSI Gold")
+    expect(instrument.baseCurrency).toBeNull()
+
+    const quote = await harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId: instrument.id },
+    })
+    expect(quote.price).toBe(EXPECTED_PER_OUNCE)
+    expect(quote.priceScale).toBe(8)
+    expect(quote.quoteCurrency).toBe("IDR")
+    expect(quote.source).toBe("bankbsi")
+    expect(quote.providerRef).toBe("bankbsi")
+    expect(quote.asOf.toISOString()).toBe(EXPECTED_AS_OF)
+    expect(quote.rawFetchId).toBe(summary.rawFetchId)
+
+    // The raw payload was staged verbatim (provenance).
+    const raw = await harness.prisma.rawMarketDataFetch.findUniqueOrThrow({
+      where: { id: summary.rawFetchId },
+    })
+    expect(raw.provider).toBe("bankbsi")
+    expect(raw.status).toBe("ok")
+    expect(raw.httpStatus).toBe(200)
+  })
+
+  test("re-ingesting the same fetch is idempotent (no duplicate quote/instrument)", async () => {
+    await ingestGoldPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+    const second = await ingestGoldPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+
+    expect(second.status).toBe("ok")
+    expect(await harness.prisma.marketInstrument.count()).toBe(1)
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    // Both attempts are staged (provenance of each fetch).
+    expect(await harness.prisma.rawMarketDataFetch.count()).toBe(2)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Graceful degradation
+  // ---------------------------------------------------------------------------
+  describe("graceful degradation (keep last good quote, record the failure)", () => {
+    for (const [label, fetchImpl] of [
+      ["worker unreachable (throws)", throwFetch],
+      ["HTTP 500", http500Fetch],
+      ["success:false", successFalseFetch],
+    ] as const) {
+      test(`${label} keeps the last good quote and records the failure`, async () => {
+        await ingestGoldPricesOnce({
+          baseUrl: BASE_URL,
+          fetchImpl: okFetch,
+          db: harness.prisma,
+        })
+        const goodCount = await harness.prisma.marketQuote.count()
+        expect(goodCount).toBe(1)
+
+        const failed = await ingestGoldPricesOnce({
+          baseUrl: BASE_URL,
+          fetchImpl,
+          db: harness.prisma,
+        })
+
+        expect(failed.status).toBe("error")
+        expect(failed.quotesUpserted).toBe(0)
+        // The last good quote is untouched.
+        expect(await harness.prisma.marketQuote.count()).toBe(goodCount)
+        const quote = await harness.prisma.marketQuote.findFirstOrThrow({})
+        expect(quote.price).toBe(EXPECTED_PER_OUNCE)
+        // The failure is recorded (provenance).
+        const raw = await harness.prisma.rawMarketDataFetch.findUniqueOrThrow({
+          where: { id: failed.rawFetchId },
+        })
+        expect(raw.status).toBe("error")
+        expect(raw.provider).toBe("bankbsi")
+      })
+    }
+
+    test("a first ingest that FAILS still leaves the instrument linkable (ensure-before-fetch)", async () => {
+      const failed = await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl: throwFetch,
+        db: harness.prisma,
+      })
+      expect(failed.status).toBe("error")
+      // The canonical instrument exists (ensured) despite the fetch failure ...
+      const instrument = await goldInstrument()
+      expect(instrument.id).toBeTruthy()
+      // ... but no bad quote was written.
+      expect(await harness.prisma.marketQuote.count()).toBe(0)
+    })
+
+    test("ensureBsiGoldInstrument is idempotent", async () => {
+      const a = await ensureBsiGoldInstrument(harness.prisma)
+      const b = await ensureBsiGoldInstrument(harness.prisma)
+      expect(a).toBe(b)
+      expect(await harness.prisma.marketInstrument.count()).toBe(1)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Ledger isolation
+  // ---------------------------------------------------------------------------
+  test("a gold ingest writes NO Transaction / balance / valuation (ledger isolation)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const before = await ledgerSnapshot(harness, owner.family.id)
+
+    await ingestGoldPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+
+    const after = await ledgerSnapshot(harness, owner.family.id)
+    expect(after).toEqual(before)
+    // Sanity: the ingest DID write the global market tables.
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // END-TO-END — a linked gold holding auto-marks at buyback × grams
+  // ---------------------------------------------------------------------------
+  test("END-TO-END: a linked gold holding marks at buyback × grams after ingest + refresh", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await makeInvestmentAccount(owner, factories)
+
+    // Ingest gold (fixture) -> ensures + creates the XAU-BSI series + quote.
+    await ingestGoldPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+    const marketInstrumentId = (await goldInstrument()).id
+
+    // A 3-gram gold holding with NO manual price, linked to the market series.
+    const holding = await upsertHoldingForFamily({
+      data: {
+        accountId: account.id,
+        instrument: { kind: "metal", name: "BSI Gold", symbol: "XAU" },
+        quantity: "3",
+        avgUnitCost: "2500000",
+        marketInstrumentId,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(holding.lastPriceMinor).toBeNull()
+    expect(holding.instrument.marketInstrumentId).toBe(marketInstrumentId)
+
+    const result = await refreshHoldingPricesForFamily({
+      data: {
+        accountId: account.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(result.updatedHoldings).toBe(1)
+    expect(result.updatedAccounts).toBe(1)
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: account.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    const marked = view.holdings[0]
+    // Rp 2,650,000/gram buyback (in sen) — the exact per-gram round trip.
+    expect(marked?.lastPriceMinor).toBe(EXPECTED_PER_GRAM_MINOR)
+    // 3 grams × Rp 2,650,000 = Rp 7,950,000 (795,000,000 sen).
+    expect(marked?.valueMinor).toBe("795000000")
+    expect(marked?.latestMarketQuoteAsOf).toBe(EXPECTED_AS_OF)
+
+    // The account value re-materialized from Σ holdings (holdings anchor).
+    const row = await harness.withFamily(owner.family.id, (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: account.id } })
+    )
+    expect(row.balance).toBe(795_000_000n)
+  })
+})
+
+async function makeInvestmentAccount(
+  owner: AuthenticatedOnboardedUser,
+  factories: TestFactories
+) {
+  return await createAccountForFamily({
+    data: {
+      name: "BSI Gold",
+      accountType: "TRACKED_ASSET" as AccountType,
+      accountSubtype: "brokerage",
+      openingBalance: "0",
+      idempotencyKey: factories.createIdempotencyKey(),
+    },
+    familyId: owner.family.id,
+    user: owner.user,
+  })
+}
+
+interface LedgerSnapshot {
+  transactions: number
+  transfers: number
+  valuations: number
+  splitEntries: number
+  auditLogs: number
+  balances: string
+}
+
+// Snapshot the family's ledger WITHIN its tenant scope (app.family_id set), so
+// the before/after equality is a real "the ingest changed nothing" assertion.
+async function ledgerSnapshot(
+  harness: IntegrationHarness,
+  familyId: string
+): Promise<LedgerSnapshot> {
+  return await harness.withFamily(familyId, async (tx) => {
+    const [
+      transactions,
+      transfers,
+      valuations,
+      splitEntries,
+      auditLogs,
+      accounts,
+    ] = await Promise.all([
+      tx.transaction.count(),
+      tx.transfer.count(),
+      tx.valuation.count(),
+      tx.splitEntry.count(),
+      tx.auditLog.count(),
+      tx.account.findMany({
+        select: { id: true, balance: true },
+        orderBy: { id: "asc" },
+      }),
+    ])
+    return {
+      transactions,
+      transfers,
+      valuations,
+      splitEntries,
+      auditLogs,
+      balances: accounts.map((a) => `${a.id}:${a.balance}`).join(","),
+    }
+  })
+}


### PR DESCRIPTION
## PER-235 — Gold price feed (self-hosted logam-mulia-api adapter)

First real `MarketDataProvider` adapter (ADR-0050 slice 3): gold, sourced from a **self-hosted `iamutaki/logam-mulia-api`** worker (MIT, a separate Cloudflare Worker). The fragile scraping stays in the worker; Permoney consumes only its clean HTTPS JSON. Slots into the PER-233 provider seam with **zero schema change and zero consumer change**.

### The adapter
`LogamMuliaGoldProvider` (`src/server/market-data.server.ts`) fetches `GET {LOGAM_MULIA_API_URL}/api/prices/bankbsi` (BSI Gold — primary; `/logammulia` Antam + `/pegadaian` documented as fallbacks). The base URL is env config, read **only** inside the `.server.ts` adapter **at call time** (unset throws a clear, actionable error — never at module scope). `fetchImpl` is injectable so tests exercise the whole pipeline against a recorded fixture with **no live network**. Raw JSON is staged in `RawMarketDataFetch` first; the pure parser maps it → one canonical `MarketQuote`.

### Price choice — `buybackPrice`
The quote uses BSI's `buybackPrice` (what BSI pays to buy a gram **back** — the realizable value of gold you HOLD, the honest mark for a position). It's a named constant (`BSI_GOLD_PRICE_FIELD`) so flipping to `sellPrice` is one line. **Question for the creator:** which number does your BSI app show as the position value — buyback or sell?

### Unit decision — stored per TROY OUNCE (flag)
The ticket says store "per gram, priceScale=8", but the **actual** merged metal contract (PER-233/PER-238) stores metals **per troy ounce** and derives per-gram in `marketQuoteToHoldingPriceMinor` (which PER-238's refresh calls with the *market instrument's* kind). To make the end-to-end test mark correctly through the **unchanged** PER-238 refresh — and keep one canonical metal unit — the pure parser converts BSI's per-gram price to a **per-troy-ounce** `priceDecimal` before the normalizer. The conversion is **exact** for integer per-gram prices (`× 31.1034768` then the reverse `÷ 31.1034768` cancels with zero loss), so a linked holding still marks at exactly `pricePerGram × grams`.
- **Symbol:** `XAU-BSI` (metal, quoteCurrency IDR). The coordinator suggested `GOLD-BSI-GRAM`, but since storage is per-ounce that name would mislead. **Question:** confirm `XAU-BSI` vs another symbol.

### Idempotent ensure/seed
`ensureBsiGoldInstrument` upserts the canonical `XAU-BSI` `MarketInstrument` (idempotent, unique-race-safe). `ingestGoldPricesOnce` calls it **first**, so the instrument is linkable (PER-238) even when the fetch then fails — no data migration needed.

### Graceful degradation (total)
Worker outage (throw), non-2xx status, non-JSON, `success:false`, empty/absent `data`, no 1-gram row, or a non-positive price → a failed `RawMarketDataFetch` is recorded, **zero** canonical quotes written, the last good quote is untouched, the pipeline never throws.

### Ledger isolation
A gold ingest writes ONLY the three global market tables; a real onboarded family's ledger snapshot is byte-identical before/after. Quotes → holdings/valuations stay PER-238's separate, anchor-safe refresh (unchanged here).

### Tests (no live network)
- **Unit** (`src/lib/market-data.test.ts`): parse the `bankbsi` fixture → per-troy-ounce metal observation; per-gram↔per-ounce exactness + zero-loss round trip; normalize → `priceScale=8`, per-gram mark == buyback; sellPrice option; multi-weight → picks 1-gram; `success:false` / empty / no-1g-row / malformed / non-positive → graceful skip (no throw).
- **Integration** (`tests/integration/gold-price-feed.integration.ts`, real PG, fixture-injected): ingest creates instrument + quote; idempotent re-ingest (no dup, 2 raw fetches); 3 failure modes keep last good quote + record the failure; ensure-before-fetch leaves the instrument linkable after a failed fetch; ledger untouched; **END-TO-END** — seed a gold holding, link to `XAU-BSI`, ingest, `refreshHoldingPricesFn`, assert value == `buyback × grams` (Rp 2,650,000/g × 3 = Rp 7,950,000).

### Out of scope
Scheduler (PER-237 — this is a single `ingestGoldPricesOnce` trigger), reksadana NAV adapter, Antam/Pegadaian fallbacks, any change to PER-238's refresh.

### Verification
- `vp check`: pass (0 errors, 362 files formatted, 278 type-checked)
- `vp test run` (unit): 643 passed
- gold integration: 9 passed; related (market-data + holding-market-prices): 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
