### PR TITLE
chore(prod): pass LOGAM_MULIA_API_URL to the app container (PER-235)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,6 +62,11 @@ services:
       DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:?BETTER_AUTH_URL is required}
+      # PER-235 market-data: base URL of the self-hosted logam-mulia-api gold
+      # price worker (a Cloudflare Worker). Optional — the gold MarketDataProvider
+      # adapter reads it at call time and fails gracefully when unset, so the app
+      # still boots without it. See docs/adr/0050-market-data-ingestion.md.
+      LOGAM_MULIA_API_URL: ${LOGAM_MULIA_API_URL:-}
     ports:
       - "127.0.0.1:3005:3005"
     networks:


### PR DESCRIPTION
Prod `docker-compose.prod.yml` enumerates the app's env vars explicitly, so a var set in the server-side `.env` is not seen by the container unless listed. This adds `LOGAM_MULIA_API_URL` (optional, empty default) so the PER-235 gold `MarketDataProvider` adapter can reach the self-hosted `logam-mulia-api` Cloudflare Worker. The adapter reads it at call time and degrades gracefully when unset, so app boot is unaffected.

Unblocks the market-data batch deploy (PER-233 + PER-238 + PER-235).

🤖 Generated with [Claude Code](https://claude.com/claude-code)