### PR TITLE
feat(market-data): PER-235b — on-demand price sync (ingest trigger + Refresh = fetch+apply)

### DIFF
--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -83,6 +83,7 @@ import {
   deleteHoldingFn,
   getAccountHoldingsFn,
   refreshHoldingPricesFn,
+  syncMarketPricesFn,
 } from "@/server/holdings"
 import { HoldingsPanel, type HoldingRecord } from "./-account-holdings"
 import { computeAccountHealth } from "@/lib/account-health"
@@ -264,22 +265,40 @@ function AccountDetailPage() {
     }
   }
 
-  // PER-238 — refresh linked holdings' prices from the latest market quotes.
-  // Anchor-safe on the server (only moves lastPrice + the Σ-holdings anchor);
-  // here we just trigger it, then resync the holdings query + account balance.
+  // PER-235b — one "Refresh prices" click = FETCH then APPLY. First trigger a
+  // global market-data sync (fetch the latest quotes into the global quote
+  // store), THEN apply the latest known quotes to this account's linked holdings
+  // (anchor-safe on the server: only moves lastPrice + the Σ-holdings anchor).
+  // The two stay separate operations — a GLOBAL ingest must never nest inside
+  // the family RLS transaction. The sync degrades gracefully (never throws), so
+  // even when the price source is unreachable we still apply the last good data.
   const [refreshingPrices, setRefreshingPrices] = React.useState(false)
   async function handleRefreshPrices() {
     setRefreshingPrices(true)
+    // 1. Fetch latest quotes (best-effort — the server never throws here, but
+    //    guard anyway so a transport error can't skip the apply step below).
+    let syncError: string | undefined
+    try {
+      const sync = await syncMarketPricesFn()
+      syncError = sync.error
+    } catch {
+      syncError = "Couldn't reach the price source"
+    }
+    // 2. Apply the latest known quotes to this account's linked holdings.
     try {
       const result = await refreshHoldingPricesFn({
         data: { accountId, idempotencyKey: createUuidV7() },
       })
       await refreshHoldings()
-      toast.success(
+      const applied =
         result.updatedHoldings > 0
           ? `Updated ${result.updatedHoldings} price${result.updatedHoldings === 1 ? "" : "s"}`
           : "Prices already up to date"
-      )
+      if (syncError) {
+        toast.info(`Couldn't reach the price source — applied last known`)
+      } else {
+        toast.success(applied)
+      }
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to refresh prices"

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -8,6 +8,11 @@ import {
   type MarketPricedHoldingKind,
 } from "@/lib/market-data"
 import {
+  ensureBsiGoldInstrument,
+  syncMarketPricesOnce,
+  type SyncMarketPricesResult,
+} from "./market-data.server"
+import {
   averageUnitCostMinor,
   holdingCostMinor,
   holdingGainMinor,
@@ -1508,6 +1513,12 @@ export async function listMarketInstrumentsForFamily({
   runInTenantTransaction?: RunInTenantTransaction
 }): Promise<SerializedMarketInstrument[]> {
   return await runInTenantTransaction(familyId, userId, async (tx) => {
+    // PER-235b — ensure the canonical BSI-gold series exists so it is LINKABLE
+    // immediately, before any successful worker fetch. Idempotent (unique-race
+    // safe) and writes only the GLOBAL MarketInstrument reference row — no ledger
+    // data, no RLS dependency — so it is safe inside the tenant tx.
+    await ensureBsiGoldInstrument(tx)
+
     // MarketInstrument is GLOBAL (no RLS); reading it inside the tenant tx is
     // fine — it carries no tenant data. Only non-fx series can price a holding.
     const rows = await tx.marketInstrument.findMany({
@@ -1541,6 +1552,32 @@ export const listMarketInstrumentsFn = createServerFn({ method: "GET" })
       familyId: context.familyId,
       userId: context.user.id,
     })
+  })
+
+// -----------------------------------------------------------------------------
+// POST — trigger ONE on-demand market-price sync (PER-235b).
+// -----------------------------------------------------------------------------
+//
+// The ingest trigger the merged-but-inert PER-235 gold feed was missing: it runs
+// `ingestGoldPricesOnce` (fetch the self-hosted worker → RawMarketDataFetch →
+// normalize → MarketQuote) behind a graceful boundary. This is a GLOBAL ingest —
+// it writes ONLY the three global market tables, never the ledger, so it runs
+// OUTSIDE any family RLS transaction. It is capability-gated (`ledger:write`,
+// matching the family-scoped market/holdings mutations) purely to keep the
+// trigger authenticated + authorized; the write itself is family-neutral.
+//
+// GRACEFUL: `LOGAM_MULIA_API_URL` unset, an unreachable/erroring worker, or a
+// `success:false` payload all resolve to `{ ingested: 0, error }` — NEVER a 500
+// — and the last good quote is kept. The caller (the account "Refresh prices"
+// button) then applies the latest known quote via `refreshHoldingPricesFn`, so a
+// sync failure still refreshes holdings from the last good data.
+
+export type { SyncMarketPricesResult }
+
+export const syncMarketPricesFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .handler(async (): Promise<SyncMarketPricesResult> => {
+    return await syncMarketPricesOnce()
   })
 
 // -----------------------------------------------------------------------------

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -7,11 +7,16 @@ import {
   marketQuoteToHoldingPriceMinor,
   type MarketPricedHoldingKind,
 } from "@/lib/market-data"
-import {
-  ensureBsiGoldInstrument,
-  syncMarketPricesOnce,
-  type SyncMarketPricesResult,
-} from "./market-data.server"
+// NOTE: `market-data.server.ts` is a HARD-FENCE server module (imports Prisma).
+// This file (holdings.ts) is in the CLIENT graph because the account route
+// imports its createServerFn values, so a STATIC `import ... from
+// "./market-data.server"` is denied by import-protection at build time (only
+// `vp build` catches it — not tsc/vitest). We therefore keep only a TYPE-ONLY
+// import (fully erased, no runtime edge) and pull the runtime functions via a
+// DYNAMIC `import("./market-data.server")` INSIDE server-fn handler bodies /
+// server-only functions, where the splitter strips the code from the client —
+// mirroring how the rest of the ledger reaches Prisma only inside handlers.
+import type { SyncMarketPricesResult } from "./market-data.server"
 import {
   averageUnitCostMinor,
   holdingCostMinor,
@@ -1516,7 +1521,10 @@ export async function listMarketInstrumentsForFamily({
     // PER-235b — ensure the canonical BSI-gold series exists so it is LINKABLE
     // immediately, before any successful worker fetch. Idempotent (unique-race
     // safe) and writes only the GLOBAL MarketInstrument reference row — no ledger
-    // data, no RLS dependency — so it is safe inside the tenant tx.
+    // data, no RLS dependency — so it is safe inside the tenant tx. Reached via a
+    // DYNAMIC import so the `.server` hard-fence module never enters the client
+    // graph (this fn is server-only; the client never runs this body).
+    const { ensureBsiGoldInstrument } = await import("./market-data.server")
     await ensureBsiGoldInstrument(tx)
 
     // MarketInstrument is GLOBAL (no RLS); reading it inside the tenant tx is
@@ -1577,6 +1585,9 @@ export type { SyncMarketPricesResult }
 export const syncMarketPricesFn = createServerFn({ method: "POST" })
   .middleware([requireCapability("ledger:write")])
   .handler(async (): Promise<SyncMarketPricesResult> => {
+    // DYNAMIC import inside the (client-stripped) handler body keeps the
+    // Prisma-importing `.server` module out of the client graph.
+    const { syncMarketPricesOnce } = await import("./market-data.server")
     return await syncMarketPricesOnce()
   })
 

--- a/src/server/market-data.server.ts
+++ b/src/server/market-data.server.ts
@@ -596,7 +596,7 @@ async function safeReadText(response: Response): Promise<string> {
  * Safe to call repeatedly; recovers from the unique-index race. Returns its id.
  */
 export async function ensureBsiGoldInstrument(
-  db: MarketDataDb = prisma
+  db: Pick<PrismaClient, "marketInstrument"> = prisma
 ): Promise<string> {
   const where = {
     kind: "metal",
@@ -669,4 +669,52 @@ export async function ingestGoldPricesOnce(
     requests: [GOLD_INSTRUMENT_REQUEST],
     db,
   })
+}
+
+// -----------------------------------------------------------------------------
+// On-demand price sync trigger — the graceful boundary the UI/serverFn call
+// (PER-235b). Wraps `ingestGoldPricesOnce` so a MISSING config
+// (`LOGAM_MULIA_API_URL` unset → the provider constructor throws) or ANY other
+// unexpected throw degrades to a structured result instead of a 500. A fetch
+// that reaches the pipeline already degrades internally (a failed
+// `RawMarketDataFetch` + zero quotes), so the last-good quote is always kept.
+// This performs a GLOBAL ingest only — it writes exclusively the three global
+// market tables and NEVER the ledger, so it runs OUTSIDE any family RLS
+// transaction (its caller keeps the family-scoped holdings refresh separate).
+// -----------------------------------------------------------------------------
+
+export interface SyncMarketPricesResult {
+  /** Canonical quotes written this run (0 on any failure). */
+  ingested: number
+  /** Present only when the sync degraded (unreachable / non-2xx / config unset). */
+  error?: string
+}
+
+/**
+ * Run one on-demand market-price sync (currently BSI gold). NEVER throws: an
+ * unreachable worker, a non-2xx / `success:false` payload, or an unset
+ * `LOGAM_MULIA_API_URL` all resolve to `{ ingested: 0, error }`. The canonical
+ * instrument is still ensured on every attempt (linkable before any fetch
+ * succeeds), and the last good quote is left intact on failure.
+ */
+export async function syncMarketPricesOnce(
+  options?: IngestGoldOptions
+): Promise<SyncMarketPricesResult> {
+  try {
+    const summary = await ingestGoldPricesOnce(options)
+    if (summary.status !== "ok") {
+      return {
+        ingested: 0,
+        error: summary.error ?? "market data source unavailable",
+      }
+    }
+    return { ingested: summary.quotesUpserted }
+  } catch (error) {
+    // Config unset (provider constructor throws) or any other unexpected error —
+    // degrade gracefully rather than surfacing a 500 to the browser.
+    return {
+      ingested: 0,
+      error: error instanceof Error ? error.message : "market sync failed",
+    }
+  }
 }

--- a/tests/integration/market-price-sync.integration.ts
+++ b/tests/integration/market-price-sync.integration.ts
@@ -1,0 +1,380 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  listMarketInstrumentsForFamily,
+  refreshHoldingPricesForFamily,
+  upsertHoldingForFamily,
+} from "@/server/holdings"
+import {
+  ensureBsiGoldInstrument,
+  syncMarketPricesOnce,
+  type FetchLike,
+} from "@/server/market-data.server"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// =============================================================================
+// PER-235b / ADR-0050 slice 3 — on-demand price sync trigger (real Postgres,
+// NO network). The self-hosted logam-mulia-api worker is injected as a FIXTURE
+// `fetchImpl`, so the whole sync pipeline (fetch → RawMarketDataFetch →
+// normalize → MarketQuote) runs against a recorded payload with zero live
+// network. Covers: the ensure-before-fetch instrument (linkable before any
+// quote), `syncMarketPricesOnce` idempotency + ledger isolation, TOTAL graceful
+// degradation (throw / success:false / config unset), and the end-to-end
+// fetch → link → apply flow the "Refresh prices" button folds into one click.
+// =============================================================================
+
+const BASE_URL = "http://gold.test"
+
+// The documented logam-mulia-api response contract (recorded as the fixture).
+const GOLD_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "bankbsi",
+      material: "gold",
+      materialType: "BSI",
+      weight: 1,
+      weightUnit: "gr",
+      sellPrice: 2_700_000,
+      buybackPrice: 2_650_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 1,
+  timestamp: "2026-05-16T05:06:58.888Z",
+  cached: true,
+}
+
+// Rp 2,650,000/gram buyback in minor units (sen) — the exact per-gram round trip.
+const EXPECTED_PER_GRAM_MINOR = "265000000"
+const EXPECTED_AS_OF = "2026-05-16T00:00:00.000Z"
+
+const okFetch: FetchLike = () =>
+  Promise.resolve(
+    new Response(JSON.stringify(GOLD_PAYLOAD), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  )
+
+const throwFetch: FetchLike = () => Promise.reject(new Error("ECONNREFUSED"))
+
+const successFalseFetch: FetchLike = () =>
+  Promise.resolve(
+    new Response(JSON.stringify({ ...GOLD_PAYLOAD, success: false }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  )
+
+describe("on-demand market-price sync (PER-235b — ingest trigger, fixture-injected)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const goldInstrument = () =>
+    harness.prisma.marketInstrument.findFirstOrThrow({
+      where: { kind: "metal", symbol: "XAU-BSI", quoteCurrency: "IDR" },
+    })
+
+  // ---------------------------------------------------------------------------
+  // 1. XAU-BSI is linkable immediately — no successful fetch required
+  // ---------------------------------------------------------------------------
+  test("listMarketInstrumentsForFamily returns XAU-BSI even with zero quotes (ensured on demand)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+
+    // No sync has run — the instrument does not exist yet.
+    expect(await harness.prisma.marketInstrument.count()).toBe(0)
+
+    const list = await listMarketInstrumentsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+
+    const gold = list.find((i) => i.symbol === "XAU-BSI")
+    expect(gold).toBeTruthy()
+    expect(gold?.kind).toBe("metal")
+    expect(gold?.quoteCurrency).toBe("IDR")
+    // Ensured, but no quote exists yet (fetch never ran).
+    expect(await harness.prisma.marketQuote.count()).toBe(0)
+
+    // Idempotent: a second list does not create a duplicate instrument.
+    await listMarketInstrumentsForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(
+      await harness.prisma.marketInstrument.count({
+        where: { symbol: "XAU-BSI" },
+      })
+    ).toBe(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 2. syncMarketPricesOnce creates instrument + quote, idempotent, no ledger
+  // ---------------------------------------------------------------------------
+  test("sync (fixture provider) creates the instrument + one MarketQuote", async () => {
+    const result = await syncMarketPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+
+    expect(result.ingested).toBe(1)
+    expect(result.error).toBeUndefined()
+
+    const instrument = await goldInstrument()
+    expect(instrument.name).toBe("BSI Gold")
+    const quote = await harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId: instrument.id },
+    })
+    expect(quote.quoteCurrency).toBe("IDR")
+    expect(quote.source).toBe("bankbsi")
+    expect(quote.asOf.toISOString()).toBe(EXPECTED_AS_OF)
+  })
+
+  test("re-running the sync is idempotent (no duplicate instrument or quote)", async () => {
+    await syncMarketPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+    const second = await syncMarketPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+
+    expect(second.ingested).toBe(1)
+    expect(await harness.prisma.marketInstrument.count()).toBe(1)
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    // Each attempt is staged (provenance of every fetch).
+    expect(await harness.prisma.rawMarketDataFetch.count()).toBe(2)
+  })
+
+  test("a sync writes NO Transaction / balance / valuation (ledger isolation)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const before = await ledgerSnapshot(harness, owner.family.id)
+
+    await syncMarketPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+
+    const after = await ledgerSnapshot(harness, owner.family.id)
+    expect(after).toEqual(before)
+    // Sanity: the sync DID write the global market tables.
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 3. Graceful degradation — never throws, keeps last good quote
+  // ---------------------------------------------------------------------------
+  describe("graceful degradation (structured result, keep last good quote)", () => {
+    for (const [label, fetchImpl] of [
+      ["worker unreachable (throws)", throwFetch],
+      ["success:false payload", successFalseFetch],
+    ] as const) {
+      test(`${label} returns { ingested: 0, error } and keeps the last good quote`, async () => {
+        // A good sync first, then a failing one.
+        await syncMarketPricesOnce({
+          baseUrl: BASE_URL,
+          fetchImpl: okFetch,
+          db: harness.prisma,
+        })
+        expect(await harness.prisma.marketQuote.count()).toBe(1)
+
+        const failed = await syncMarketPricesOnce({
+          baseUrl: BASE_URL,
+          fetchImpl,
+          db: harness.prisma,
+        })
+
+        expect(failed.ingested).toBe(0)
+        expect(failed.error).toBeTruthy()
+        // The last good quote is untouched.
+        expect(await harness.prisma.marketQuote.count()).toBe(1)
+        const quote = await harness.prisma.marketQuote.findFirstOrThrow({})
+        expect(quote.source).toBe("bankbsi")
+      })
+    }
+
+    test("LOGAM_MULIA_API_URL unset returns { ingested: 0, error } (no throw) and leaves the instrument linkable", async () => {
+      const saved = process.env.LOGAM_MULIA_API_URL
+      delete process.env.LOGAM_MULIA_API_URL
+      try {
+        // No baseUrl / fetchImpl injected — the provider constructor reads the
+        // (now unset) env and throws; syncMarketPricesOnce must swallow it.
+        const result = await syncMarketPricesOnce({ db: harness.prisma })
+        expect(result.ingested).toBe(0)
+        expect(result.error).toContain("LOGAM_MULIA_API_URL")
+        // The canonical instrument was still ensured (linkable) despite no fetch.
+        const instrument = await goldInstrument()
+        expect(instrument.id).toBeTruthy()
+        expect(await harness.prisma.marketQuote.count()).toBe(0)
+      } finally {
+        if (saved !== undefined) process.env.LOGAM_MULIA_API_URL = saved
+      }
+    })
+
+    test("ensureBsiGoldInstrument accepts the shared prisma client and is idempotent", async () => {
+      const a = await ensureBsiGoldInstrument(harness.prisma)
+      const b = await ensureBsiGoldInstrument(harness.prisma)
+      expect(a).toBe(b)
+      expect(await harness.prisma.marketInstrument.count()).toBe(1)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // 4. END-TO-END — sync → link a gold holding → apply → value = buyback × grams
+  // ---------------------------------------------------------------------------
+  test("END-TO-END: sync then refresh marks a linked gold holding at buyback × grams", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await makeInvestmentAccount(owner, factories)
+
+    // FETCH: the global sync ingests the fixture gold quote.
+    const sync = await syncMarketPricesOnce({
+      baseUrl: BASE_URL,
+      fetchImpl: okFetch,
+      db: harness.prisma,
+    })
+    expect(sync.ingested).toBe(1)
+    const marketInstrumentId = (await goldInstrument()).id
+
+    // A 3-gram gold holding with NO manual price, linked to the market series.
+    const holding = await upsertHoldingForFamily({
+      data: {
+        accountId: account.id,
+        instrument: { kind: "metal", name: "BSI Gold", symbol: "XAU" },
+        quantity: "3",
+        avgUnitCost: "2500000",
+        marketInstrumentId,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(holding.lastPriceMinor).toBeNull()
+
+    // APPLY: the family-scoped refresh marks the holding from the latest quote.
+    const applied = await refreshHoldingPricesForFamily({
+      data: {
+        accountId: account.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(applied.updatedHoldings).toBe(1)
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: account.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    const marked = view.holdings[0]
+    expect(marked?.lastPriceMinor).toBe(EXPECTED_PER_GRAM_MINOR)
+    // 3 grams × Rp 2,650,000 = Rp 7,950,000 (795,000,000 sen).
+    expect(marked?.valueMinor).toBe("795000000")
+    expect(marked?.latestMarketQuoteAsOf).toBe(EXPECTED_AS_OF)
+
+    // The account value re-materialized from Σ holdings (holdings anchor).
+    const row = await harness.withFamily(owner.family.id, (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: account.id } })
+    )
+    expect(row.balance).toBe(795_000_000n)
+  })
+})
+
+async function makeInvestmentAccount(
+  owner: AuthenticatedOnboardedUser,
+  factories: TestFactories
+) {
+  return await createAccountForFamily({
+    data: {
+      name: "BSI Gold",
+      accountType: "TRACKED_ASSET" as AccountType,
+      accountSubtype: "brokerage",
+      openingBalance: "0",
+      idempotencyKey: factories.createIdempotencyKey(),
+    },
+    familyId: owner.family.id,
+    user: owner.user,
+  })
+}
+
+interface LedgerSnapshot {
+  transactions: number
+  transfers: number
+  valuations: number
+  splitEntries: number
+  auditLogs: number
+  balances: string
+}
+
+// Snapshot the family's ledger WITHIN its tenant scope (app.family_id set), so
+// the before/after equality is a real "the sync changed nothing" assertion.
+async function ledgerSnapshot(
+  harness: IntegrationHarness,
+  familyId: string
+): Promise<LedgerSnapshot> {
+  return await harness.withFamily(familyId, async (tx) => {
+    const [
+      transactions,
+      transfers,
+      valuations,
+      splitEntries,
+      auditLogs,
+      accounts,
+    ] = await Promise.all([
+      tx.transaction.count(),
+      tx.transfer.count(),
+      tx.valuation.count(),
+      tx.splitEntry.count(),
+      tx.auditLog.count(),
+      tx.account.findMany({
+        select: { id: true, balance: true },
+        orderBy: { id: "asc" },
+      }),
+    ])
+    return {
+      transactions,
+      transfers,
+      valuations,
+      splitEntries,
+      auditLogs,
+      balances: accounts.map((a) => `${a.id}:${a.balance}`).join(","),
+    }
+  })
+}


### PR DESCRIPTION
## The gap

PER-233 (core), PER-235 (gold provider), and PER-238 (apply-quote refresh) all merged and deployed, but the ingest trigger was never wired. On prod `MarketInstrument` was **empty** (ingest never ran) → the holding-form "Live price source" selector was empty → no holding could be linked → `refreshHoldingPricesFn` had nothing to apply. This slice closes that last mile with **no schema change**.

## What changed

### 1. Ensure-instrument fix (linkable immediately)
`listMarketInstrumentsForFamily` now calls `ensureBsiGoldInstrument(tx)` on demand, so `XAU-BSI` appears in the selector **before any successful worker fetch**. Idempotent (unique-race safe), writes only the global `MarketInstrument` reference row (no ledger, no RLS dependency). `ensureBsiGoldInstrument`'s parameter was widened from `MarketDataDb` to `Pick<PrismaClient, "marketInstrument">` so it accepts a tenant transaction client (same pattern `resolveInstrumentId` already uses).

### 2. `syncMarketPricesFn` — the ingest trigger
- `syncMarketPricesOnce` (`market-data.server.ts`): wraps `ingestGoldPricesOnce` (fetch worker → `RawMarketDataFetch` → normalize → `MarketQuote`). **GLOBAL ingest** — writes only the three global market tables, never the ledger, no family RLS transaction.
- `syncMarketPricesFn` (`holdings.ts`): `createServerFn({ method: "POST" })`, `requireCapability("ledger:write")` (matches the other market/holdings mutations — keeps the trigger authenticated/authorized; the write itself is family-neutral).
- **Injectable** provider/fetch via `IngestGoldOptions` (`baseUrl`, `fetchImpl`, `db`), reusing the PER-233/235 seam so tests run against a fixture with zero live network.

### 3. Graceful degradation (never a 500)
`LOGAM_MULIA_API_URL` unset (provider constructor throws), an unreachable/erroring worker, a non-2xx / `success:false` payload → all resolve to `{ ingested: 0, error }`. The canonical instrument is still ensured on every attempt, and the last good quote is left intact.

### 4. Folded "Refresh prices" flow (one click = fetch + apply)
`handleRefreshPrices` (`accounts.$accountId.tsx`) now calls `syncMarketPricesFn()` (fetch) **then** `refreshHoldingPricesFn` (apply). The two stay **separate** operations — a global ingest never nests inside the family RLS transaction. Clear toast: `Prices updated` / `Couldn't reach the price source — applied last known`. `try/catch` throughout (a sync transport error still falls through to the apply step); no `useEffect`; client types derived via return inference (no Prisma types in UI).

## Tests (real Postgres + fixtures, no network)
`tests/integration/market-price-sync.integration.ts` (9 tests):
- `listMarketInstrumentsForFamily` returns `XAU-BSI` with **zero** quotes (ensured on demand), idempotent.
- sync (fixture provider) creates instrument + `MarketQuote`; idempotent re-run (no dup instrument/quote, 2 raw fetches); **no** Transaction/balance/valuation written.
- graceful: throw / `success:false` / `LOGAM_MULIA_API_URL` unset → `{ ingested: 0, error }`, no throw, last-good quote kept, instrument still linkable.
- end-to-end: sync → link a 3g gold holding to `XAU-BSI` → `refreshHoldingPricesForFamily` → value = buyback × grams (Rp 7,950,000).

`vp check`, full `vp test run` (643), and the adjacent gold-price-feed / holding-market-prices / market-data integration suites (26) all pass.

## Out of scope
Scheduled worker (PER-237), reksadana adapter, any change to `refreshHoldingPricesFn`'s apply/anchor-safety logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)