### PR TITLE
fix(market-data): PER-235c — gold source fallback chain (bankbsi → anekalogam → pegadaian)

### DIFF
--- a/docs/adr/0050-market-data-ingestion.md
+++ b/docs/adr/0050-market-data-ingestion.md
@@ -342,3 +342,56 @@ conversion); `src/server/market-data.server.ts` (`LogamMuliaGoldProvider`,
 `ensureBsiGoldInstrument`, `ingestGoldPricesOnce`); `.env.example`
 (`LOGAM_MULIA_API_URL`); unit (`src/lib/market-data.test.ts`) + real-Postgres
 (`tests/integration/gold-price-feed.integration.ts`) tests.
+
+## Implementation notes (PER-235c — gold source fallback chain)
+
+Slice 3 hardcoded ONE endpoint (`/api/prices/bankbsi`). That source scrapes BSI
+via a Google-Translate proxy that is persistently HTTP 429, so every
+`syncMarketPricesFn` returned `{ ingested: 0, error }` and the user's "Refresh
+prices" showed "Couldn't reach the price source" even though egress and the OTHER
+worker endpoints were healthy. PER-235c makes the gold provider try sources in a
+PRIORITY FALLBACK CHAIN and use the FIRST that returns `success: true`, so gold
+ALWAYS gets a number as close to the user's BSI Gold as is currently available.
+
+- **The chain (a small, reorderable constant).** `GOLD_SOURCE_CHAIN =
+["bankbsi", "anekalogam", "pegadaian"]` (`src/server/market-data.server.ts`).
+  Each label is BOTH the worker endpoint path (`/api/prices/{source}`) AND the
+  quote `source`/provenance tag. `bankbsi` = exact BSI price; `anekalogam` =
+  Antam LM (BSI SELLS Antam gold, so ≈1% below BSI's mark — the closest reliable
+  proxy); `pegadaian` = final fallback.
+
+- **Per-source normalization to a per-gram IDR buyback (shapes differ).** The
+  three feeds share the `{ success, data: [ { weight, weightUnit, buybackPrice }
+] }` envelope but not the shape: `bankbsi` is one `1 gr` row, `anekalogam` is
+  many bars (pick the `1 gr` plain-LM row), `pegadaian` is one `0.01 gram` row.
+  The generalized pure parser (`parseLogamMuliaGoldResponse` +
+  `chooseGoldEntry`/`perGramBuybackDecimal`, `src/lib/market-data.ts`) prefers a
+  1-gram bar, else the smallest-weight valid gram row, and applies the GENERAL
+  rule `perGramBuyback = buyback / weightInGrams` via EXACT BigInt rational math
+  (no float — `26500 / 0.01` in IEEE-754 is not 2_650_000). It still converts to
+  the canonical per-TROY-OUNCE quote, so the merged PER-238 holding refresh is
+  untouched. `buybackPrice` remains the priced field (PER-235 decision).
+
+- **Provenance = the winning source.** All sources price the ONE `XAU-BSI`
+  `MarketInstrument`; the quote `source` (and staged `RawMarketDataFetch`
+  provider) is the source that actually succeeded — `LogamMuliaGoldProvider.name`
+  became a getter returning the winner. Idempotency stays
+  `UNIQUE (marketInstrumentId, asOf, source)`; the apply path already reads the
+  latest quote by `asOf` regardless of source.
+
+- **Graceful all-fail preserved.** If EVERY source fails (429 / unreachable /
+  non-JSON / `success:false`), the chain returns one aggregated `status:"error"`
+  with the per-source reasons staged — never a throw, zero quotes written, the
+  last good quote intact. No schema, `syncMarketPricesFn`, or `XAU-BSI` identity
+  change.
+
+- **Known approximation (flagged).** On fallback, `anekalogam`/`pegadaian` are
+  NOT the exact BSI mark. BSI sells Antam gold, so Antam buyback ≈1% below BSI's;
+  the value is the closest reliable proxy until `bankbsi` recovers, not an exact
+  BSI position value. If exactness on fallback matters, a per-source calibration
+  factor is a future slice.
+
+Files: `src/lib/market-data.ts` (generalized parser + exact per-gram
+normalization); `src/server/market-data.server.ts` (`GOLD_SOURCE_CHAIN`,
+chained `LogamMuliaGoldProvider`); unit (`src/lib/market-data.test.ts`) +
+real-Postgres (`tests/integration/gold-price-feed.integration.ts`) tests.

--- a/src/lib/market-data.test.ts
+++ b/src/lib/market-data.test.ts
@@ -385,13 +385,113 @@ describe("parseLogamMuliaGoldResponse", () => {
     expect(result.observations).toHaveLength(0)
   })
 
-  test("no 1-gram row -> graceful skip", () => {
+  test("no 1-gram row -> falls back to buyback / weightInGrams (PER-235c general rule)", () => {
+    // A single 5-gram bar priced Rp 13,250,000 -> per-gram Rp 2,650,000 -> the
+    // same per-troy-ounce mark as the 1-gram row. The general rule prices ANY
+    // gram-weighted bar, so a source that omits the 1-gram row is no longer a skip.
     const result = parseLogamMuliaGoldResponse({
       ...GOLD_PAYLOAD,
-      data: [{ ...GOLD_PAYLOAD.data[0], weight: 5 }],
+      data: [{ ...GOLD_PAYLOAD.data[0], weight: 5, buybackPrice: 13_250_000 }],
+    })
+    expect(result.status).toBe("ok")
+    expect(result.observations[0]?.priceDecimal).toBe("82424213.52")
+  })
+
+  test("anekalogam shape (many bars) -> prefers the 1-gram bar", () => {
+    // Antam LM list: 0.5gr, 1gr, 2gr. The 1-gram bar's buyback is the per-gram.
+    const anekalogam = {
+      success: true,
+      data: [
+        {
+          source: "anekalogam",
+          weight: 0.5,
+          weightUnit: "gr",
+          buybackPrice: 1_310_000,
+          currency: "IDR",
+          recordedDate: "2026-05-16",
+        },
+        {
+          source: "anekalogam",
+          weight: 1,
+          weightUnit: "gr",
+          buybackPrice: 2_620_000,
+          currency: "IDR",
+          recordedDate: "2026-05-16",
+        },
+        {
+          source: "anekalogam",
+          weight: 2,
+          weightUnit: "gr",
+          buybackPrice: 5_240_000,
+          currency: "IDR",
+          recordedDate: "2026-05-16",
+        },
+      ],
+      count: 3,
+      timestamp: "2026-05-16T05:06:58.888Z",
+    }
+    const result = parseLogamMuliaGoldResponse(anekalogam, {
+      sourceLabel: "anekalogam",
+    })
+    expect(result.status).toBe("ok")
+    // Rp 2,620,000/gram -> per troy ounce (exact).
+    expect(result.observations[0]?.priceDecimal).toBe(
+      goldPerGramMajorToPerOunceDecimal(2_620_000)
+    )
+    expect(result.observations[0]?.providerRef).toBe("anekalogam")
+    // Round-trips per-ounce -> per-gram minor with ZERO loss.
+    const quote = normalizeObservations(result.observations).quotes[0]
+    const perGramMinor = marketQuoteToHoldingPriceMinor({
+      kind: "metal",
+      priceScaled: quote?.price ?? 0n,
+      priceScale: quote?.priceScale ?? 0,
+      minorUnitConversion: 100n,
+    })
+    expect(perGramMinor).toBe(262_000_000n) // Rp 2,620,000.00
+  })
+
+  test("pegadaian shape (weight 0.01 gram) -> per-gram = buyback x 100 (exact)", () => {
+    const pegadaian = {
+      success: true,
+      data: [
+        {
+          source: "pegadaian",
+          weight: 0.01,
+          weightUnit: "gram",
+          buybackPrice: 25_900,
+          currency: "IDR",
+          recordedDate: "2026-05-16",
+        },
+      ],
+      count: 1,
+      timestamp: "2026-05-16T05:06:58.888Z",
+    }
+    const result = parseLogamMuliaGoldResponse(pegadaian, {
+      sourceLabel: "pegadaian",
+    })
+    expect(result.status).toBe("ok")
+    // Rp 25,900 per 0.01 gram = Rp 2,590,000/gram -> per troy ounce (exact).
+    expect(result.observations[0]?.priceDecimal).toBe(
+      goldPerGramMajorToPerOunceDecimal(2_590_000)
+    )
+    expect(result.observations[0]?.providerRef).toBe("pegadaian")
+    const quote = normalizeObservations(result.observations).quotes[0]
+    const perGramMinor = marketQuoteToHoldingPriceMinor({
+      kind: "metal",
+      priceScaled: quote?.price ?? 0n,
+      priceScale: quote?.priceScale ?? 0,
+      minorUnitConversion: 100n,
+    })
+    expect(perGramMinor).toBe(259_000_000n) // Rp 2,590,000.00 (exact x100)
+  })
+
+  test("a non-gram unit row -> graceful skip (no usable row)", () => {
+    const result = parseLogamMuliaGoldResponse({
+      ...GOLD_PAYLOAD,
+      data: [{ ...GOLD_PAYLOAD.data[0], weight: 1, weightUnit: "oz" }],
     })
     expect(result.status).toBe("error")
-    expect(result.error).toContain("1-gram")
+    expect(result.error).toContain("no usable")
   })
 
   test("malformed payloads -> graceful skip (no throw)", () => {

--- a/src/lib/market-data.ts
+++ b/src/lib/market-data.ts
@@ -499,8 +499,8 @@ function renderScaledDecimal(value: bigint, decimals: number): string {
 }
 
 /**
- * Convert a metal price quoted per GRAM (major currency units, as the BSI feed
- * publishes it) into the per-TROY-OUNCE decimal string the canonical metal store
+ * Convert a metal price quoted per GRAM (major currency units, as the gold feeds
+ * publish it) into the per-TROY-OUNCE decimal string the canonical metal store
  * uses. Exact BigInt math via `TROY_OUNCE_GRAMS` (31.1034768 = 311034768 / 1e7)
  * — no float. An integer per-gram price round-trips through
  * `spotPriceScaledPerGram` with ZERO loss. Throws on a non-finite / non-positive
@@ -514,16 +514,130 @@ export function goldPerGramMajorToPerOunceDecimal(
       `goldPerGramMajorToPerOunceDecimal: price must be a positive finite number, got ${perGramMajor}`
     )
   }
-  const gramText = perGramMajor.toString()
-  if (!/^\d+(\.\d+)?$/.test(gramText)) {
+  return goldPerGramDecimalToPerOunceDecimal(perGramMajor.toString())
+}
+
+/**
+ * Exact per-GRAM decimal string → per-TROY-OUNCE decimal string (the string core
+ * of `goldPerGramMajorToPerOunceDecimal`, used when the per-gram price is derived
+ * via BigInt from a source whose entry is priced per some other weight — see
+ * `perGramBuybackDecimal`). No float: `× 311034768 / 1e7`. Throws on a malformed
+ * or non-positive input.
+ */
+function goldPerGramDecimalToPerOunceDecimal(gramText: string): string {
+  const trimmed = gramText.trim()
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
     throw new RangeError(
-      `goldPerGramMajorToPerOunceDecimal: unrepresentable price ${gramText}`
+      `goldPerGramDecimalToPerOunceDecimal: unrepresentable price ${gramText}`
     )
   }
-  const [whole, fraction = ""] = gramText.split(".")
+  const [whole, fraction = ""] = trimmed.split(".")
   const gramScaled = BigInt(whole + fraction) // value × 10^fraction.length
+  if (gramScaled <= 0n) {
+    throw new RangeError(
+      `goldPerGramDecimalToPerOunceDecimal: price must be positive, got ${gramText}`
+    )
+  }
   const ounceScaled = gramScaled * 311_034_768n // × 10^(fraction.length + 7)
   return renderScaledDecimal(ounceScaled, fraction.length + 7)
+}
+
+/**
+ * Parse a positive decimal string ("2650000", "0.01", "0.5") into a scaled
+ * BigInt plus its fraction-digit count, so the caller can do exact rational math
+ * with no float error. Throws on a malformed / non-positive-shaped input.
+ */
+function decimalToScaled(text: string): { scaled: bigint; fracDigits: number } {
+  const t = text.trim()
+  if (!/^\d+(\.\d+)?$/.test(t)) {
+    throw new RangeError(`decimalToScaled: not a positive decimal: ${text}`)
+  }
+  const [whole, frac = ""] = t.split(".")
+  return { scaled: BigInt(whole + frac), fracDigits: frac.length }
+}
+
+/**
+ * Exact per-GRAM (major-currency) decimal for a chosen feed entry:
+ * `perGram = priceMajor / weightGrams`, computed as an exact rational with
+ * BigInt (NO float division — `26500 / 0.01` in IEEE-754 is NOT 2_650_000) and
+ * rounded half-to-even to at most `SPOT_PRICE_DECIMALS` (8) fraction digits.
+ *
+ * This is the GENERAL rule that unifies the three gold sources' differing shapes:
+ *   - a `weight == 1 gr` bar (bankbsi / anekalogam plain LM) → perGram = buyback,
+ *   - a `weight == 0.01 gram` row (pegadaian) → perGram = buyback × 100,
+ *   - any other bar → perGram = buyback / weightInGrams.
+ * Integer per-gram results round-trip through `spotPriceScaledPerGram` with zero
+ * loss, so a linked holding still marks at exactly `pricePerGram × grams`.
+ */
+function perGramBuybackDecimal(
+  priceMajor: number,
+  weightGrams: number
+): string {
+  const b = decimalToScaled(String(priceMajor))
+  const w = decimalToScaled(String(weightGrams))
+  // perGram = (b.scaled / 10^b.frac) / (w.scaled / 10^w.frac)
+  //         = (b.scaled × 10^w.frac) / (w.scaled × 10^b.frac)
+  const num = b.scaled * 10n ** BigInt(w.fracDigits)
+  const den = w.scaled * 10n ** BigInt(b.fracDigits)
+  if (den <= 0n) {
+    throw new RangeError(`perGramBuybackDecimal: weight must be positive`)
+  }
+  const scaled = divRoundHalfEven(num * 10n ** BigInt(SPOT_PRICE_DECIMALS), den)
+  if (scaled <= 0n) {
+    throw new RangeError(`perGramBuybackDecimal: non-positive per-gram price`)
+  }
+  return renderScaledDecimal(scaled, SPOT_PRICE_DECIMALS)
+}
+
+/**
+ * A feed row's weight expressed in GRAMS, or `null` when the row's weight/unit is
+ * not a usable positive gram weight. Accepts the gram units the three sources use
+ * (`gr` — bankbsi/anekalogam, `gram`/`grams` — pegadaian); any other unit is
+ * rejected (fail closed rather than mis-scale a price).
+ */
+function weightInGrams(weight: unknown, unit: unknown): number | null {
+  const w = Number(weight)
+  if (!Number.isFinite(w) || w <= 0) return null
+  const u = typeof unit === "string" ? unit.trim().toLowerCase() : ""
+  if (u === "gr" || u === "gram" || u === "grams") return w
+  return null
+}
+
+/**
+ * Choose the pricing row from a gold feed's `data` array. Prefers a plain
+ * 1-gram bar (the exact per-gram source: bankbsi's single row, anekalogam's `1gr`
+ * entry); failing that, the smallest-weight valid entry (so pegadaian's
+ * `0.01 gram` row and any multi-weight list still yield a per-gram price via the
+ * general `buyback / weightInGrams` rule). Rows with a non-gram unit or a
+ * non-positive price are skipped. Returns `null` when no row is usable.
+ */
+function chooseGoldEntry(
+  data: readonly unknown[],
+  priceField: GoldPriceField
+): {
+  row: Record<string, unknown>
+  weightGrams: number
+  priceMajor: number
+} | null {
+  const candidates: {
+    row: Record<string, unknown>
+    weightGrams: number
+    priceMajor: number
+  }[] = []
+  for (const candidate of data) {
+    if (!isRecord(candidate)) continue
+    const grams = weightInGrams(candidate.weight, candidate.weightUnit)
+    if (grams === null) continue
+    const priceMajor = Number(candidate[priceField])
+    if (!Number.isFinite(priceMajor) || priceMajor <= 0) continue
+    candidates.push({ row: candidate, weightGrams: grams, priceMajor })
+  }
+  if (candidates.length === 0) return null
+  const oneGram = candidates.find((entry) => entry.weightGrams === 1)
+  if (oneGram) return oneGram
+  return candidates.reduce((best, entry) =>
+    entry.weightGrams < best.weightGrams ? entry : best
+  )
 }
 
 function resolveGoldAsOf(
@@ -544,18 +658,31 @@ function resolveGoldAsOf(
 }
 
 /**
- * Parse a logam-mulia-api gold payload into a single canonical metal observation
- * (per TROY OUNCE — see the unit decision above). Defensive: any shape problem
- * (`success !== true`, empty/absent `data`, no 1-gram row, a non-positive price,
- * an unparseable date) yields `status: "error"` with a reason and ZERO
- * observations — NEVER a throw — so the ingest pipeline degrades gracefully and
- * keeps the last good quote.
+ * Parse a logam-mulia-api gold payload (from ANY of the fallback-chain sources —
+ * `bankbsi`, `anekalogam`, `pegadaian`; PER-235c) into a single canonical metal
+ * observation (per TROY OUNCE — see the unit decision above). The sources share
+ * the `{ success, data: [ { weight, weightUnit, buybackPrice, ... } ] }` envelope
+ * but differ in shape (bankbsi: one `1 gr` row; anekalogam: many rows; pegadaian:
+ * one `0.01 gram` row); `chooseGoldEntry` + `perGramBuybackDecimal` normalize any
+ * of them to a per-gram buyback, then to per-troy-ounce. The observation always
+ * carries the SAME `XAU-BSI` symbol (all sources price the one gold series) — the
+ * winning source is recorded as the quote `source`/provenance by the caller.
+ *
+ * Defensive: any shape problem (`success !== true`, empty/absent `data`, no
+ * usable priced gram row, an unparseable date) yields `status: "error"` with a
+ * reason and ZERO observations — NEVER a throw — so the ingest pipeline degrades
+ * gracefully and keeps the last good quote.
  *
  * Pure: no DB, no network, no secrets.
  */
 export function parseLogamMuliaGoldResponse(
   payload: unknown,
-  opts?: { priceField?: GoldPriceField; fallbackAsOf?: Date }
+  opts?: {
+    priceField?: GoldPriceField
+    fallbackAsOf?: Date
+    /** Provenance fallback for `providerRef` when the row omits its own source. */
+    sourceLabel?: string
+  }
 ): LogamMuliaParseResult {
   const priceField = opts?.priceField ?? BSI_GOLD_PRICE_FIELD
   const err = (reason: string): LogamMuliaParseResult => ({
@@ -573,19 +700,13 @@ export function parseLogamMuliaGoldResponse(
     return err("payload data is empty")
   }
 
-  // BSI publishes several weights; we price per gram, so take the 1-gram row.
-  const row = data.find(
-    (candidate) =>
-      isRecord(candidate) &&
-      Number(candidate.weight) === 1 &&
-      String(candidate.weightUnit).toLowerCase() === "gr"
-  )
-  if (!isRecord(row)) return err("no 1-gram (weightUnit=gr) row in payload")
-
-  const perGram = Number(row[priceField])
-  if (!Number.isFinite(perGram) || perGram <= 0) {
-    return err(`invalid ${priceField} ${String(row[priceField])}`)
+  const chosen = chooseGoldEntry(data, priceField)
+  if (chosen === null) {
+    return err(
+      `no usable ${priceField} row (need a positive price on a gram-weighted row)`
+    )
   }
+  const { row } = chosen
 
   const currency = typeof row.currency === "string" ? row.currency.trim() : ""
   if (currency.length === 0) return err("row is missing a currency")
@@ -599,7 +720,8 @@ export function parseLogamMuliaGoldResponse(
 
   let priceDecimal: string
   try {
-    priceDecimal = goldPerGramMajorToPerOunceDecimal(perGram)
+    const perGram = perGramBuybackDecimal(chosen.priceMajor, chosen.weightGrams)
+    priceDecimal = goldPerGramDecimalToPerOunceDecimal(perGram)
   } catch (error) {
     return err(error instanceof Error ? error.message : "unconvertible price")
   }
@@ -614,7 +736,9 @@ export function parseLogamMuliaGoldResponse(
         asOf,
         priceDecimal,
         providerRef:
-          typeof row.source === "string" ? row.source : BSI_GOLD_SOURCE,
+          typeof row.source === "string"
+            ? row.source
+            : (opts?.sourceLabel ?? BSI_GOLD_SOURCE),
       },
     ],
   }

--- a/src/server/market-data.server.ts
+++ b/src/server/market-data.server.ts
@@ -32,7 +32,6 @@
 import type { Prisma, PrismaClient } from "@prisma/client"
 import {
   BSI_GOLD_QUOTE_CURRENCY,
-  BSI_GOLD_SOURCE,
   BSI_GOLD_SYMBOL,
   normalizeObservations,
   parseLogamMuliaGoldResponse,
@@ -427,14 +426,35 @@ function toJson(value: unknown): Prisma.InputJsonValue {
 // Gold feed adapter — self-hosted logam-mulia-api (PER-235 / ADR-0050 slice 3)
 // -----------------------------------------------------------------------------
 //
-// The ONLY code that knows the gold vendor exists. It fetches the worker's
-// `GET {base}/api/prices/bankbsi` endpoint, stages the raw JSON verbatim, and
-// hands the pure parser (`parseLogamMuliaGoldResponse`, @/lib/market-data) a
-// single per-troy-ounce metal observation. Secrets/config (`LOGAM_MULIA_API_URL`)
-// are read ONLY here, at CALL time (never module scope). Graceful degradation is
-// total: a worker outage, a non-2xx status, non-JSON, `success:false`, or a
-// malformed shape all return `status:"error"` with the raw payload captured —
-// never a throw, never a bad quote (ADR-0050 §4).
+// The ONLY code that knows the gold vendor exists. It tries the worker's gold
+// endpoints in a priority FALLBACK CHAIN (PER-235c) — `GET {base}/api/prices/
+// {source}` for each source in `GOLD_SOURCE_CHAIN` — and uses the FIRST that
+// returns `success:true`, so gold ALWAYS gets a number as close to the user's BSI
+// Gold as is currently available. It stages the winning source's JSON verbatim
+// and hands the pure parser (`parseLogamMuliaGoldResponse`, @/lib/market-data) a
+// single per-troy-ounce metal observation (all sources price the ONE `XAU-BSI`
+// series). Secrets/config (`LOGAM_MULIA_API_URL`) are read ONLY here, at CALL
+// time (never module scope). Graceful degradation is total: if EVERY source fails
+// (worker outage, non-2xx such as the persistent BSI 429, non-JSON,
+// `success:false`, or a malformed shape) the chain returns `status:"error"` with
+// the aggregated reasons captured — never a throw, never a bad quote (ADR-0050 §4).
+
+/**
+ * The gold source fallback chain, in PRIORITY order — the FIRST source that
+ * returns `success:true` wins (PER-235c). Each label is BOTH the worker endpoint
+ * path segment (`/api/prices/{source}`) AND the quote `source`/provenance tag.
+ *
+ *   1. `bankbsi`    — the creator's exact BSI Gold price (when the source is up).
+ *   2. `anekalogam` — Antam LM; BSI sells Antam gold, so this is the CLOSEST
+ *                     reliable proxy (~1% below BSI's mark — flagged as a known
+ *                     approximation on fallback).
+ *   3. `pegadaian`  — the final reliable fallback.
+ *
+ * A small, readable constant so re-ordering the priority is a one-line change.
+ */
+export const GOLD_SOURCE_CHAIN = ["bankbsi", "anekalogam", "pegadaian"] as const
+
+export type GoldSource = (typeof GOLD_SOURCE_CHAIN)[number]
 
 /**
  * Minimal fetch surface the gold adapter needs (typed, no `any`). Tests inject a
@@ -489,11 +509,22 @@ export interface LogamMuliaGoldProviderOptions {
  * errors on this provider).
  */
 export class LogamMuliaGoldProvider implements MarketDataProvider {
-  readonly name = BSI_GOLD_SOURCE
   private readonly baseUrl: string
   private readonly fetchImpl: FetchLike
   private readonly priceField: GoldPriceField | undefined
   private readonly now: () => Date
+  /**
+   * The source that actually returned a usable quote this run (set during
+   * `fetchGold`). The pipeline reads `provider.name` AFTER the fetch resolves to
+   * stamp the quote `source`/provenance, so it reflects the WINNING source (or
+   * the primary `bankbsi` when every source failed and no quote is written).
+   */
+  private succeededSource: GoldSource | undefined
+
+  /** Provenance the ingest pipeline stamps on the raw fetch + canonical quote. */
+  get name(): string {
+    return this.succeededSource ?? GOLD_SOURCE_CHAIN[0]
+  }
 
   constructor(options?: LogamMuliaGoldProviderOptions) {
     this.baseUrl = options?.baseUrl ?? requireLogamMuliaApiUrl()
@@ -519,8 +550,39 @@ export class LogamMuliaGoldProvider implements MarketDataProvider {
     return this.fetchGold()
   }
 
+  /**
+   * Try each source in `GOLD_SOURCE_CHAIN` in priority order and return the FIRST
+   * that yields a usable quote. `succeededSource` is set to the winner so the
+   * pipeline stamps the correct provenance. If EVERY source fails, the aggregated
+   * per-source reasons are returned as one graceful error (no throw, no quote).
+   */
   private async fetchGold(): Promise<MarketFetchResult> {
-    const url = `${this.baseUrl}/api/prices/bankbsi`
+    this.succeededSource = undefined
+    const failures: string[] = []
+    let lastHttpStatus: number | undefined
+
+    for (const source of GOLD_SOURCE_CHAIN) {
+      const outcome = await this.fetchOneSource(source)
+      if (outcome.status === "ok") {
+        this.succeededSource = source
+        return outcome
+      }
+      failures.push(`${source}: ${outcome.error ?? "failed"}`)
+      lastHttpStatus = outcome.httpStatus ?? lastHttpStatus
+    }
+
+    return {
+      status: "error",
+      httpStatus: lastHttpStatus,
+      error: `all gold sources failed — ${failures.join("; ")}`,
+      observations: [],
+      rawPayload: { errors: failures },
+    }
+  }
+
+  /** Fetch + parse ONE source endpoint. Never throws; returns a staged result. */
+  private async fetchOneSource(source: GoldSource): Promise<MarketFetchResult> {
+    const url = `${this.baseUrl}/api/prices/${source}`
 
     let response: Response
     try {
@@ -563,6 +625,7 @@ export class LogamMuliaGoldProvider implements MarketDataProvider {
     const parsed = parseLogamMuliaGoldResponse(json, {
       priceField: this.priceField,
       fallbackAsOf: this.now(),
+      sourceLabel: source,
     })
     if (parsed.status !== "ok") {
       return {

--- a/tests/integration/gold-price-feed.integration.ts
+++ b/tests/integration/gold-price-feed.integration.ts
@@ -7,7 +7,10 @@ import {
   test,
 } from "vite-plus/test"
 import type { AccountType } from "@/lib/accounts"
-import { encodeSpotPrice } from "@/lib/market-data"
+import {
+  encodeSpotPrice,
+  goldPerGramMajorToPerOunceDecimal,
+} from "@/lib/market-data"
 import { createAccountForFamily } from "@/server/accounts"
 import {
   getAccountHoldingsForFamily,
@@ -91,6 +94,110 @@ const successFalseFetch: FetchLike = () =>
       headers: { "content-type": "application/json" },
     })
   )
+
+// ---------------------------------------------------------------------------
+// PER-235c fallback-chain fixtures: anekalogam (Antam LM, many bars) + pegadaian
+// (0.01-gram row). Each has a DIFFERENT shape; the parser normalizes all three
+// to a per-gram IDR buyback -> per troy ounce (the ONE XAU-BSI series).
+// ---------------------------------------------------------------------------
+const ANEKALOGAM_BUYBACK_PER_GRAM = 2_620_000
+const ANEKALOGAM_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "anekalogam",
+      material: "gold",
+      materialType: "LM",
+      weight: 0.5,
+      weightUnit: "gr",
+      sellPrice: 1_360_000,
+      buybackPrice: 1_310_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+    {
+      source: "anekalogam",
+      material: "gold",
+      materialType: "LM",
+      weight: 1,
+      weightUnit: "gr",
+      sellPrice: 2_680_000,
+      buybackPrice: ANEKALOGAM_BUYBACK_PER_GRAM,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+    {
+      source: "anekalogam",
+      material: "gold",
+      materialType: "LM",
+      weight: 2,
+      weightUnit: "gr",
+      sellPrice: 5_300_000,
+      buybackPrice: 5_240_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 3,
+  timestamp: "2026-05-16T05:06:58.888Z",
+}
+// pegadaian publishes the price of 0.01 gram -> per gram = buyback x 100.
+const PEGADAIAN_BUYBACK_PER_GRAM = 2_590_000
+const PEGADAIAN_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "pegadaian",
+      material: "gold",
+      materialType: "LM",
+      weight: 0.01,
+      weightUnit: "gram",
+      sellPrice: 27_000,
+      buybackPrice: PEGADAIAN_BUYBACK_PER_GRAM / 100,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 1,
+  timestamp: "2026-05-16T05:06:58.888Z",
+}
+
+const jsonResponse = (payload: unknown): Response =>
+  new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+
+/** How a single endpoint should respond in a chain test. */
+type SourceBehavior =
+  | { kind: "ok"; payload: unknown }
+  | { kind: "http"; status: number }
+  | { kind: "throw" }
+
+/**
+ * A URL-routing fetch fixture: dispatches on `/api/prices/{source}` so a test can
+ * make bankbsi 429 while anekalogam succeeds, exercising the real fallback chain
+ * with NO live network. An unconfigured endpoint 404s (treated as a failure).
+ */
+const chainFetch =
+  (behaviors: Partial<Record<string, SourceBehavior>>): FetchLike =>
+  (url) => {
+    for (const [source, behavior] of Object.entries(behaviors)) {
+      if (!url.includes(`/api/prices/${source}`)) continue
+      if (behavior?.kind === "throw") {
+        return Promise.reject(new Error(`ECONNREFUSED ${source}`))
+      }
+      if (behavior?.kind === "http") {
+        return Promise.resolve(
+          new Response(`error ${behavior.status}`, { status: behavior.status })
+        )
+      }
+      if (behavior?.kind === "ok") {
+        return Promise.resolve(jsonResponse(behavior.payload))
+      }
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }))
+  }
 
 describe("gold price feed (PER-235 — logam-mulia-api adapter, fixture-injected)", () => {
   let harness: IntegrationHarness
@@ -311,6 +418,143 @@ describe("gold price feed (PER-235 — logam-mulia-api adapter, fixture-injected
       tx.account.findUniqueOrThrow({ where: { id: account.id } })
     )
     expect(row.balance).toBe(795_000_000n)
+  })
+
+  // ===========================================================================
+  // PER-235c — gold source fallback chain (bankbsi -> anekalogam -> pegadaian).
+  // The FIRST source that returns success:true wins; the winning source is
+  // stamped as the quote `source` (provenance). All sources feed the ONE
+  // XAU-BSI series, so idempotency stays UNIQUE (marketInstrumentId, asOf,
+  // source). Nested here to reuse the one integration harness for this file.
+  // ===========================================================================
+  describe("gold source fallback chain (PER-235c, fixture-injected, no network)", () => {
+    const onlyQuote = () => harness.prisma.marketQuote.findFirstOrThrow({})
+
+    test("bankbsi up -> uses bankbsi (exact BSI price, source=bankbsi)", async () => {
+      const summary = await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl: chainFetch({
+          bankbsi: { kind: "ok", payload: GOLD_PAYLOAD },
+        }),
+        db: harness.prisma,
+      })
+      expect(summary.status).toBe("ok")
+      expect(summary.quotesUpserted).toBe(1)
+
+      const quote = await onlyQuote()
+      expect(quote.source).toBe("bankbsi")
+      expect(quote.price).toBe(EXPECTED_PER_OUNCE) // Rp 2,650,000/gram buyback
+
+      const raw = await harness.prisma.rawMarketDataFetch.findUniqueOrThrow({
+        where: { id: summary.rawFetchId },
+      })
+      expect(raw.provider).toBe("bankbsi")
+    })
+
+    test("bankbsi 429 -> falls back to anekalogam (source=anekalogam, ~Antam LM)", async () => {
+      const summary = await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl: chainFetch({
+          bankbsi: { kind: "http", status: 429 },
+          anekalogam: { kind: "ok", payload: ANEKALOGAM_PAYLOAD },
+        }),
+        db: harness.prisma,
+      })
+      expect(summary.status).toBe("ok")
+      expect(summary.quotesUpserted).toBe(1)
+
+      const quote = await onlyQuote()
+      // The winning source is recorded (provenance), not the primary.
+      expect(quote.source).toBe("anekalogam")
+      // The 1-gram Antam bar's buyback, normalized per troy ounce.
+      expect(quote.price).toBe(
+        encodeSpotPrice(
+          goldPerGramMajorToPerOunceDecimal(ANEKALOGAM_BUYBACK_PER_GRAM)
+        )
+      )
+      expect(quote.providerRef).toBe("anekalogam")
+
+      const raw = await harness.prisma.rawMarketDataFetch.findUniqueOrThrow({
+        where: { id: summary.rawFetchId },
+      })
+      expect(raw.provider).toBe("anekalogam")
+    })
+
+    test("bankbsi 429 + anekalogam unreachable -> falls back to pegadaian", async () => {
+      const summary = await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl: chainFetch({
+          bankbsi: { kind: "http", status: 429 },
+          anekalogam: { kind: "throw" },
+          pegadaian: { kind: "ok", payload: PEGADAIAN_PAYLOAD },
+        }),
+        db: harness.prisma,
+      })
+      expect(summary.status).toBe("ok")
+      expect(summary.quotesUpserted).toBe(1)
+
+      const quote = await onlyQuote()
+      expect(quote.source).toBe("pegadaian")
+      // 0.01-gram row -> per-gram = buyback x 100, normalized per troy ounce (exact).
+      expect(quote.price).toBe(
+        encodeSpotPrice(
+          goldPerGramMajorToPerOunceDecimal(PEGADAIAN_BUYBACK_PER_GRAM)
+        )
+      )
+    })
+
+    test("ALL sources fail -> graceful { ingested: 0, error }, no quote written", async () => {
+      const summary = await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl: chainFetch({
+          bankbsi: { kind: "http", status: 429 },
+          anekalogam: { kind: "throw" },
+          pegadaian: { kind: "http", status: 503 },
+        }),
+        db: harness.prisma,
+      })
+      expect(summary.status).toBe("error")
+      expect(summary.quotesUpserted).toBe(0)
+      expect(summary.error).toBeTruthy()
+      // The instrument is still ensured (linkable), but no bad quote was written.
+      const instrument = await goldInstrument()
+      expect(instrument.id).toBeTruthy()
+      expect(await harness.prisma.marketQuote.count()).toBe(0)
+      // The failure is staged (provenance).
+      const raw = await harness.prisma.rawMarketDataFetch.findUniqueOrThrow({
+        where: { id: summary.rawFetchId },
+      })
+      expect(raw.status).toBe("error")
+    })
+
+    test("a fallback win is idempotent + leaves the ledger untouched", async () => {
+      const owner =
+        await createTestFactories(harness).createAuthenticatedOnboardedUser()
+      const before = await ledgerSnapshot(harness, owner.family.id)
+
+      const fetchImpl = chainFetch({
+        bankbsi: { kind: "http", status: 429 },
+        anekalogam: { kind: "ok", payload: ANEKALOGAM_PAYLOAD },
+      })
+      await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl,
+        db: harness.prisma,
+      })
+      const second = await ingestGoldPricesOnce({
+        baseUrl: BASE_URL,
+        fetchImpl,
+        db: harness.prisma,
+      })
+
+      expect(second.status).toBe("ok")
+      // Same (instrument, asOf, source) -> re-ingest upserts in place, no duplicate.
+      expect(await harness.prisma.marketInstrument.count()).toBe(1)
+      expect(await harness.prisma.marketQuote.count()).toBe(1)
+
+      const after = await ledgerSnapshot(harness, owner.family.id)
+      expect(after).toEqual(before)
+    })
   })
 })
 


### PR DESCRIPTION
## The bug (verified on prod)
`LogamMuliaGoldProvider` hardcoded ONE endpoint: `${baseUrl}/api/prices/bankbsi`. That source scrapes BSI via a Google-Translate proxy that is **persistently HTTP 429**, so `syncMarketPricesFn` returned `{ ingested: 0, error }` and the user's "Refresh prices" showed *"Couldn't reach the price source"* — even though egress is fine and the OTHER worker endpoints (`/api/prices/anekalogam`, `/api/prices/pegadaian`) return `success:true`.

## The fix — source fallback chain
The provider now tries sources in priority order and uses the FIRST that returns `success:true`, so gold ALWAYS gets a number as close to the user's BSI Gold as available. A small, reorderable constant:

```
GOLD_SOURCE_CHAIN = ["bankbsi", "anekalogam", "pegadaian"]
```

1. **bankbsi** — exact BSI price (when up).
2. **anekalogam** — Antam LM (BSI *sells* Antam gold, so ≈1% of BSI; the closest reliable proxy).
3. **pegadaian** — final fallback.

## Per-source per-gram normalization (shapes differ)
The three feeds share the `{ success, data:[ { weight, weightUnit, buybackPrice, ... } ] }` envelope but not the shape. The generalized pure parser normalizes each to a **per-gram IDR buyback** using **exact BigInt rational math** (no float — `26500 / 0.01` in IEEE-754 is *not* 2_650_000), then to the canonical **per-troy-ounce** quote (PER-238 holding refresh untouched):

- `bankbsi` — single `weight:1, weightUnit:"gr"` → perGram = buyback.
- `anekalogam` — many bars → pick the `weight==1 && unit=="gr"` plain-LM row → perGram = buyback.
- `pegadaian` — single `weight:0.01, weightUnit:"gram"` → perGram = buyback / 0.01 (= ×100).
- GENERAL rule: `perGramBuyback = buyback / weightInGrams` (prefer a 1-gram bar; else the smallest-weight gram row). Still uses **buybackPrice** (PER-235 decision).

## Provenance / source tagging
All sources price the ONE `XAU-BSI` `MarketInstrument`; the quote `source` (and staged `RawMarketDataFetch` provider) is the source that actually **succeeded** — `LogamMuliaGoldProvider.name` became a getter returning the winner. Idempotency stays `UNIQUE (marketInstrumentId, asOf, source)`; the apply path already reads the latest quote by `asOf` regardless of source. No schema, `syncMarketPricesFn`/refresh wiring, or `XAU-BSI` identity change.

## Graceful all-fail
If EVERY source fails (429 / unreachable / non-JSON / `success:false`), the chain returns one aggregated `status:"error"` with the per-source reasons staged — never a throw, zero quotes written, last-good quote intact.

## ⚠️ Known approximation (flag for creator)
On fallback, `anekalogam`/`pegadaian` are NOT the exact BSI mark. BSI sells Antam gold, so Antam buyback is ≈1% below BSI's — the value is the closest reliable proxy until `bankbsi` recovers, not an exact BSI position value. If exactness on fallback matters, a per-source calibration factor is a future slice.

## Validation
- `vp check` — clean (no warnings / lint / type errors, 279 files).
- **`vp build` — ✓ built in 5.63s** (no server/client import-protection leak; the module is client-reachable).
- `vp test run` — 646 unit tests pass (34 in `market-data.test.ts`, incl. new anekalogam/pegadaian shape + fallback tests).
- Integration (real Postgres :5433): `gold-price-feed` + `market-price-sync` = 23 pass (incl. bankbsi-up, bankbsi-429→anekalogam, +anekalogam-fail→pegadaian, all-fail-graceful, idempotent + ledger-untouched); `market-data` + `holding-market-prices` = 17 pass.

## Files
- `src/lib/market-data.ts` — generalized parser + exact per-gram normalization.
- `src/server/market-data.server.ts` — `GOLD_SOURCE_CHAIN`, chained `LogamMuliaGoldProvider` (injectable baseUrl/fetchImpl unchanged).
- `src/lib/market-data.test.ts`, `tests/integration/gold-price-feed.integration.ts` — tests.
- `docs/adr/0050-market-data-ingestion.md` — PER-235c note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1