### PR TITLE
feat(transactions): PER-247 — contextual money movement (transfer purpose + fees + per-account clarity)

### DIFF
--- a/prisma/migrations/20260809120000_transfer_purpose_and_fee/migration.sql
+++ b/prisma/migrations/20260809120000_transfer_purpose_and_fee/migration.sql
@@ -1,0 +1,249 @@
+-- PER-247: contextual money movement — Transfer.purpose + generalized
+-- transfer fee leg (kind "transfer_fee").
+--
+--   1. Transfer.purpose: constrained, nullable label describing WHY a
+--      funds_movement transfer happened (top_up / investment_contribution /
+--      investment_withdrawal / savings / cash_withdrawal). NULL means "plain
+--      transfer". Liability transfer kinds (cc_payment / loan_payment /
+--      liability_draw) already carry their meaning via `kind`, so purpose is
+--      forbidden there (trigger guard below).
+--   2. New transaction kind "transfer_fee": a standalone expense row posted
+--      on the fee-bearing account (default: the transfer source account),
+--      linked via Transfer.feeTransactionId — the same slot ADR-0035 §6 uses
+--      for fx_fee. One fee leg max per transfer; the kind distinguishes an FX
+--      conversion fee (cross-currency transfer) from a general transfer fee.
+--   3. Backstops: the fee leg link is now trigger-checked to point only at an
+--      fx_fee/transfer_fee expense row, and purpose is trigger-checked to
+--      appear only on funds_movement transfers. Both guards live in the
+--      existing enforce_transfer_liability_kind_invariant() choke point.
+
+-- 1. Transfer.purpose ----------------------------------------------------------
+
+ALTER TABLE "Transfer" ADD COLUMN "purpose" TEXT;
+
+ALTER TABLE "Transfer"
+  ADD CONSTRAINT transfer_purpose_domain CHECK (
+    purpose IS NULL
+    OR purpose IN (
+      'top_up',
+      'investment_contribution',
+      'investment_withdrawal',
+      'savings',
+      'cash_withdrawal'
+    )
+  );
+
+-- 2. `transfer_fee` transaction kind -------------------------------------------
+-- Drop + recreate the kind domain and type/kind shape CHECKs to add
+-- 'transfer_fee' (established pattern: 20260602043000, 20260617131419,
+-- 20260618120000). Like fx_fee it is an EXPENSE kind (a finance cost), never a
+-- transfer, and is naturally exempt from
+-- enforce_liability_cost_transaction_target() (which early-returns unless
+-- kind IN ('liability_interest','liability_fee')), so no toAccountId or
+-- liability-target requirement applies.
+
+ALTER TABLE "Transaction" DROP CONSTRAINT IF EXISTS transaction_kind_type_shape;
+ALTER TABLE "Transaction" DROP CONSTRAINT IF EXISTS transaction_kind_domain;
+
+ALTER TABLE "Transaction"
+  ADD CONSTRAINT transaction_kind_domain CHECK (
+    kind IN (
+      'standard',
+      'funds_movement',
+      'cc_payment',
+      'loan_payment',
+      'liability_draw',
+      'liability_interest',
+      'liability_fee',
+      'balance_adjustment',
+      'fx_fee',
+      'transfer_fee'
+    )
+  );
+
+ALTER TABLE "Transaction"
+  ADD CONSTRAINT transaction_kind_type_shape CHECK (
+    ("type" = 'transfer'
+      AND kind IN (
+        'funds_movement',
+        'cc_payment',
+        'loan_payment',
+        'liability_draw'
+      ))
+    OR ("type" = 'expense'
+      AND kind IN (
+        'standard',
+        'liability_interest',
+        'liability_fee',
+        'balance_adjustment',
+        'fx_fee',
+        'transfer_fee'
+      ))
+    OR ("type" = 'income' AND kind IN ('standard', 'balance_adjustment'))
+  );
+
+-- 3. Trigger guards: purpose only on funds_movement + fee leg kind -------------
+
+CREATE OR REPLACE FUNCTION enforce_transfer_liability_kind_invariant()
+RETURNS TRIGGER AS $$
+DECLARE
+  expected_kind TEXT;
+  cash_kind TEXT;
+  outflow_account_class TEXT;
+  outflow_account_type TEXT;
+  inflow_account_class TEXT;
+  inflow_account_type TEXT;
+  outflow_kind TEXT;
+  inflow_kind TEXT;
+  fee_kind TEXT;
+  fee_type TEXT;
+BEGIN
+  -- PER-247: a linked fee leg must be a fee expense row. Guarded here (the
+  -- single choke point every Transfer write passes) so raw SQL / future
+  -- workers cannot link an arbitrary transaction as a transfer's fee.
+  IF NEW."feeTransactionId" IS NOT NULL THEN
+    SELECT t.kind, t.type INTO fee_kind, fee_type
+      FROM "Transaction" t WHERE t.id = NEW."feeTransactionId";
+    IF fee_kind NOT IN ('fx_fee', 'transfer_fee') OR fee_type <> 'expense' THEN
+      PERFORM _per104_raise_check_violation(format(
+        'PER-247 malformed transfer fee leg (Transfer %s): fee Transaction %s must be an expense of kind fx_fee/transfer_fee, got type=%s kind=%s',
+        NEW.id, NEW."feeTransactionId", fee_type, fee_kind));
+    END IF;
+  END IF;
+
+  IF NEW."valuationId" IS NOT NULL THEN
+    IF NEW."outflowTransactionId" IS NOT NULL THEN
+      SELECT tx.kind, a."accountClass", a."accountType"
+        INTO cash_kind, outflow_account_class, outflow_account_type
+        FROM "Transaction" tx
+        JOIN "Account" a ON a.id = tx."accountId" AND a."familyId" = tx."familyId"
+       WHERE tx.id = NEW."outflowTransactionId";
+
+      SELECT a."accountClass", a."accountType"
+        INTO inflow_account_class, inflow_account_type
+        FROM "Valuation" v
+        JOIN "Account" a ON a.id = v."accountId" AND a."familyId" = v."familyId"
+       WHERE v.id = NEW."valuationId";
+    ELSE
+      SELECT tx.kind, a."accountClass", a."accountType"
+        INTO cash_kind, inflow_account_class, inflow_account_type
+        FROM "Transaction" tx
+        JOIN "Account" a ON a.id = tx."accountId" AND a."familyId" = tx."familyId"
+       WHERE tx.id = NEW."inflowTransactionId";
+
+      SELECT a."accountClass", a."accountType"
+        INTO outflow_account_class, outflow_account_type
+        FROM "Valuation" v
+        JOIN "Account" a ON a.id = v."accountId" AND a."familyId" = v."familyId"
+       WHERE v.id = NEW."valuationId";
+    END IF;
+
+    IF inflow_account_type = 'CREDIT' THEN
+      expected_kind := 'cc_payment';
+    ELSIF inflow_account_type = 'LOAN' THEN
+      expected_kind := 'loan_payment';
+    ELSIF outflow_account_class = 'LIABILITY' AND inflow_account_class = 'ASSET' THEN
+      expected_kind := 'liability_draw';
+    ELSIF outflow_account_class = 'ASSET' AND inflow_account_class = 'ASSET' THEN
+      expected_kind := 'funds_movement';
+    ELSE
+      PERFORM _per104_raise_check_violation(format(
+        'PER-196 unsupported valuation-linked transfer direction (Transfer %s): outflow %s/%s, inflow %s/%s',
+        NEW.id, outflow_account_class, outflow_account_type, inflow_account_class, inflow_account_type));
+    END IF;
+
+    IF cash_kind IS DISTINCT FROM expected_kind THEN
+      PERFORM _per104_raise_check_violation(format(
+        'PER-196 malformed valuation-linked transfer kind (Transfer %s): expected %s for outflow %s/%s -> inflow %s/%s, got %s',
+        NEW.id, expected_kind, outflow_account_class, outflow_account_type, inflow_account_class, inflow_account_type, cash_kind));
+    END IF;
+
+    -- PER-247: purpose is a funds_movement-only label.
+    IF NEW.purpose IS NOT NULL AND expected_kind <> 'funds_movement' THEN
+      PERFORM _per104_raise_check_violation(format(
+        'PER-247 transfer purpose %s rejected (Transfer %s): purpose requires kind funds_movement, got %s',
+        NEW.purpose, NEW.id, expected_kind));
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  SELECT
+      outflow_tx.kind,
+      outflow_account."accountClass",
+      outflow_account."accountType"
+    INTO outflow_kind, outflow_account_class, outflow_account_type
+    FROM "Transaction" outflow_tx
+    JOIN "Account" outflow_account
+      ON outflow_account.id = outflow_tx."accountId"
+     AND outflow_account."familyId" = outflow_tx."familyId"
+   WHERE outflow_tx.id = NEW."outflowTransactionId";
+
+  SELECT
+      inflow_tx.kind,
+      inflow_account."accountClass",
+      inflow_account."accountType"
+    INTO inflow_kind, inflow_account_class, inflow_account_type
+    FROM "Transaction" inflow_tx
+    JOIN "Account" inflow_account
+      ON inflow_account.id = inflow_tx."accountId"
+     AND inflow_account."familyId" = inflow_tx."familyId"
+   WHERE inflow_tx.id = NEW."inflowTransactionId";
+
+  IF outflow_kind IS DISTINCT FROM inflow_kind THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-74 malformed transfer kind pair (Transfer %s): outflow kind=%s, inflow kind=%s; both legs must share kind',
+      NEW.id, outflow_kind, inflow_kind));
+  END IF;
+
+  IF inflow_account_type = 'CREDIT' THEN
+    expected_kind := 'cc_payment';
+  ELSIF inflow_account_type = 'LOAN' THEN
+    expected_kind := 'loan_payment';
+  ELSIF outflow_account_class = 'LIABILITY'
+     AND inflow_account_class = 'ASSET' THEN
+    expected_kind := 'liability_draw';
+  ELSIF outflow_account_class = 'ASSET'
+     AND inflow_account_class = 'ASSET' THEN
+    expected_kind := 'funds_movement';
+  ELSE
+    PERFORM _per104_raise_check_violation(format(
+      'PER-74 unsupported transfer liability direction (Transfer %s): outflow %s/%s, inflow %s/%s',
+      NEW.id,
+      outflow_account_class,
+      outflow_account_type,
+      inflow_account_class,
+      inflow_account_type));
+  END IF;
+
+  IF outflow_kind IS DISTINCT FROM expected_kind THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-74 malformed transfer kind (Transfer %s): expected %s for outflow %s/%s -> inflow %s/%s, got %s',
+      NEW.id,
+      expected_kind,
+      outflow_account_class,
+      outflow_account_type,
+      inflow_account_class,
+      inflow_account_type,
+      outflow_kind));
+
+  END IF;
+
+  -- PER-247: purpose is a funds_movement-only label.
+  IF NEW.purpose IS NOT NULL AND expected_kind <> 'funds_movement' THEN
+    PERFORM _per104_raise_check_violation(format(
+      'PER-247 transfer purpose %s rejected (Transfer %s): purpose requires kind funds_movement, got %s',
+      NEW.purpose, NEW.id, expected_kind));
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Re-create the constraint trigger so purpose/fee-only UPDATEs re-fire the
+-- guard too (the previous OF-column list predates both columns).
+DROP TRIGGER IF EXISTS transfer_liability_kind_safe ON "Transfer";
+CREATE CONSTRAINT TRIGGER transfer_liability_kind_safe
+  AFTER INSERT OR UPDATE OF "outflowTransactionId", "inflowTransactionId", "valuationId", "purpose", "feeTransactionId" ON "Transfer"
+  DEFERRABLE INITIALLY IMMEDIATE
+  FOR EACH ROW EXECUTE FUNCTION enforce_transfer_liability_kind_invariant();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -409,7 +409,8 @@ model Transaction {
   // Relasi ke Transfer (Hanya terisi jika type == "transfer")
   transferOut Transfer? @relation("OutflowTransaction")
   transferIn  Transfer? @relation("InflowTransaction")
-  // This row is the FX fee leg of a transfer (kind == "fx_fee"); ADR-0035 §6.
+  // This row is the fee leg of a transfer (kind == "fx_fee" — ADR-0035 §6, or
+  // kind == "transfer_fee" — PER-247).
   feeForTransfer Transfer? @relation("FxFeeTransaction")
 
   createdAt DateTime @default(now())
@@ -501,7 +502,16 @@ model Transfer {
   fromCurrency String?
   toCurrency   String?
 
-  // Optional FX fee leg (kind == "fx_fee", a standalone expense row). ADR-0035 §6.
+  // PER-247: constrained, nullable purpose label for a funds_movement
+  // transfer (top_up / investment_contribution / investment_withdrawal /
+  // savings / cash_withdrawal). NULL for liability transfer kinds (cc_payment,
+  // loan_payment, liability_draw) whose kind already carries the meaning.
+  // Domain-CHECKed + trigger-guarded (purpose only on funds_movement).
+  purpose String?
+
+  // Optional fee leg (a standalone expense row; kind == "fx_fee" for a
+  // cross-currency transfer — ADR-0035 §6, or "transfer_fee" otherwise —
+  // PER-247). At most ONE fee leg per transfer.
   feeTransactionId String?      @unique
   feeTransaction   Transaction? @relation("FxFeeTransaction", fields: [feeTransactionId], references: [id], onDelete: Restrict)
 

--- a/src/components/transaction-form-modal.tsx
+++ b/src/components/transaction-form-modal.tsx
@@ -23,7 +23,22 @@ import { cn } from "@/lib/utils"
 import { getTransactionFormData } from "@/server/transactions"
 import { createMerchantFn } from "@/server/merchants"
 import { createCategoryFn } from "@/server/categories"
-import { toDisplayNumber, toMinorUnits, type Money } from "@/lib/money"
+import {
+  decodeMoney,
+  toDisplayNumber,
+  toMinorUnits,
+  type Money,
+} from "@/lib/money"
+import {
+  deriveTransferPurpose,
+  TRANSFER_PURPOSE_LABELS,
+  TRANSFER_PURPOSE_VALUES,
+  type TransferPurpose,
+} from "@/lib/money-movement"
+import {
+  deriveTransferKindForAccounts,
+  parseAccountType,
+} from "@/lib/liability-semantics"
 import { CURRENCIES, type CurrencyCode } from "@/lib/data/currencies"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import {
@@ -97,11 +112,19 @@ const transactionSchema = z.object({
   // Enterprise: Multi-Currency Transfer (Implied Rate Architecture)
   // destinationAmount hanya diisi saat transfer antar akun dengan mata uang berbeda
   destinationAmount: z.number().positive().optional(),
-  // PER-147 / ADR-0035 §6: optional FX fee charged on a cross-currency transfer.
-  // Denominated in the SOURCE account currency; posts a separate `fx_fee`
-  // expense row server-side. Optional category for that expense.
-  fxFeeAmount: z.number().nonnegative().optional(),
-  fxFeeCategoryId: z.string().optional(),
+  // PER-247 (generalizing PER-147 / ADR-0035 §6): optional fee on ANY
+  // transfer (top-up/e-wallet/bank charge, or FX spread on cross-currency).
+  // Denominated in the fee-bearing account's currency; posts a separate
+  // `transfer_fee`/`fx_fee` expense row server-side, linked to the Transfer.
+  feeAmount: z.number().nonnegative().optional(),
+  feeCategoryId: z.string().optional(),
+  // Which side bears the fee (default: the source account). Constrained to
+  // the two transfer accounts in this form; the server accepts any
+  // tenant-owned account via feeAccountId.
+  feeBearerAccountId: z.string().optional(),
+  // Optional override of the taxonomy-derived transfer purpose. Empty/undefined
+  // = derive server-side (→ E_WALLET = top_up, → INVESTMENT = invest, etc.).
+  transferPurpose: z.enum(TRANSFER_PURPOSE_VALUES).optional(),
   // PER-196 / ADR-0048 §1: valuation-linked transfer. Only meaningful when
   // either transfer side is a balanceSource="valuation" account — prefilled
   // client-side as latest ∓ amount (see NewValuationValueField), editable.
@@ -133,11 +156,23 @@ type EditAmount = number | bigint | Money
 
 interface TransactionFormModalProps {
   editData?:
-    | (Omit<TransactionFormValues, "amount" | "destinationAmount"> & {
+    | (Omit<
+        TransactionFormValues,
+        "amount" | "destinationAmount" | "transferPurpose"
+      > & {
         id: string
         amount: EditAmount
         destinationAmount?: EditAmount
         currency?: string
+        // PER-247: hydrated from the canonical Transfer row on the ledger
+        // record (see findLedgerTransactionsForFamily).
+        transferPurpose?: string | null
+        transferFee?: {
+          accountId: string
+          amount: string
+          categoryId: string | null
+          currency: string
+        } | null
         isSplit?: boolean
         splitEntries?: Array<
           Omit<SplitEntryValue, "amount"> & { amount: EditAmount }
@@ -668,7 +703,12 @@ function DestinationAmountField({
   )
 }
 
-function FxFeeField({
+// PER-247 — contextual money movement fields: a purpose label (derived from
+// the account taxonomy, overridable) and a fee leg on ANY transfer (not only
+// cross-currency), with an explicit bearer (default: the source account).
+// Both are pure derived-value renders via form.Subscribe (no-use-effect Rule
+// 1) — no state sync, everything recomputes from the selected accounts.
+function TransferContextFields({
   activeTab,
   form,
   formData,
@@ -680,88 +720,192 @@ function FxFeeField({
       selector={(state) => ({
         accountId: state.values.accountId,
         toAccountId: state.values.toAccountId,
+        feeBearerAccountId: state.values.feeBearerAccountId,
       })}
     >
-      {({ accountId, toAccountId }) => {
+      {({ accountId, toAccountId, feeBearerAccountId }) => {
         const srcAccount = formData?.accounts.find((a) => a.id === accountId)
         const dstAccount = formData?.accounts.find((a) => a.id === toAccountId)
-        const isCrossCurrency =
-          srcAccount &&
-          dstAccount &&
-          srcAccount.currency !== dstAccount.currency
+        if (!srcAccount || !dstAccount) return null
 
-        // The fx_fee contract (ADR-0035 §6) is scoped to cross-currency
-        // transfers: the bank/exchange spread is a real, separate cost.
-        if (!isCrossCurrency) return null
+        const isCrossCurrency = srcAccount.currency !== dstAccount.currency
+        const transferKind = deriveTransferKindForAccounts({
+          fromAccountType: parseAccountType(srcAccount.accountType),
+          toAccountType: parseAccountType(dstAccount.accountType),
+        })
+        // Purpose only applies to funds_movement (cc_payment / loan_payment /
+        // liability_draw already carry their meaning via kind — the server
+        // rejects a purpose override for them).
+        const isFundsMovement = transferKind === "funds_movement"
+        const derivedPurpose = isFundsMovement
+          ? deriveTransferPurpose({
+              fromAccountType: parseAccountType(srcAccount.accountType),
+              toAccountType: parseAccountType(dstAccount.accountType),
+              toAccountSubtype: dstAccount.accountSubtype,
+            })
+          : null
+
+        // The fee is an expense row: it can only post on a transaction_flow
+        // account (a valuation-tracked account has no expense deltas).
+        const bearerOptions = [srcAccount, dstAccount].filter(
+          (account) => account.balanceSource !== "valuation"
+        )
+        const bearerAccount =
+          bearerOptions.find((a) => a.id === feeBearerAccountId) ??
+          bearerOptions.find((a) => a.id === srcAccount.id) ??
+          bearerOptions[0]
 
         return (
-          <form.Field name="fxFeeAmount">
-            {(field) => (
-              <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50/40 p-3 dark:border-amber-800 dark:bg-amber-950/20">
-                <Label
-                  htmlFor="fx-fee-amount"
-                  className="flex items-center gap-1.5 text-sm font-semibold text-amber-700 dark:text-amber-400"
-                >
-                  <IconArrowsExchange className="size-4" />
-                  FX / transfer fee ({srcAccount.currency})
-                  <span className="text-xs font-normal text-muted-foreground">
-                    (Optional)
-                  </span>
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  The bank or exchange spread charged on this conversion. Posted
-                  as a separate expense on the source account — it never
-                  distorts the transferred amounts.
-                </p>
-                <div className="relative">
-                  <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
-                    {getCurrencySymbol(srcAccount.currency)}
-                  </span>
-                  <Input
-                    id="fx-fee-amount"
-                    name="fx-fee-amount"
-                    type="number"
-                    className="pl-8 font-semibold"
-                    placeholder="0"
-                    value={field.state.value ?? ""}
-                    onBlur={field.handleBlur}
-                    onChange={(e) =>
-                      field.handleChange(
-                        e.target.value ? Number(e.target.value) : undefined
-                      )
-                    }
-                  />
-                </div>
-                <form.Field name="fxFeeCategoryId">
-                  {(categoryField) => (
-                    <div className="space-y-1.5">
-                      <Label
-                        htmlFor="fx-fee-category"
-                        className="text-xs text-muted-foreground"
-                      >
-                        Fee category (optional)
-                      </Label>
-                      <select
-                        id="fx-fee-category"
-                        name="fx-fee-category"
-                        className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
-                        value={categoryField.state.value ?? ""}
-                        onChange={(e) =>
-                          categoryField.handleChange(e.target.value)
-                        }
-                      >
-                        <option value="">-- No category --</option>
-                        <CategoryOptions
-                          categories={formData?.categories}
-                          type="expense"
-                        />
-                      </select>
-                    </div>
-                  )}
-                </form.Field>
-              </div>
+          <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50/40 p-3 dark:border-amber-800 dark:bg-amber-950/20">
+            {isFundsMovement && (
+              <form.Field name="transferPurpose">
+                {(field) => (
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor="transfer-purpose"
+                      className="flex items-center gap-1.5 text-sm font-semibold text-amber-700 dark:text-amber-400"
+                    >
+                      <IconArrowsExchange className="size-4" />
+                      Transfer purpose
+                      <span className="text-xs font-normal text-muted-foreground">
+                        (Optional)
+                      </span>
+                    </Label>
+                    <select
+                      id="transfer-purpose"
+                      name="transfer-purpose"
+                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                      value={field.state.value ?? ""}
+                      onBlur={field.handleBlur}
+                      onChange={(e) =>
+                        field.handleChange(
+                          e.target.value
+                            ? (e.target.value as TransferPurpose)
+                            : undefined
+                        )
+                      }
+                    >
+                      <option value="">
+                        {derivedPurpose
+                          ? `Automatic — ${TRANSFER_PURPOSE_LABELS[derivedPurpose]}`
+                          : "Automatic"}
+                      </option>
+                      {TRANSFER_PURPOSE_VALUES.map((purpose) => (
+                        <option key={purpose} value={purpose}>
+                          {TRANSFER_PURPOSE_LABELS[purpose]}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </form.Field>
             )}
-          </form.Field>
+
+            <form.Field name="feeAmount">
+              {(field) => (
+                <div className="space-y-3">
+                  <Label
+                    htmlFor="transfer-fee-amount"
+                    className="flex items-center gap-1.5 text-sm font-semibold text-amber-700 dark:text-amber-400"
+                  >
+                    <IconArrowsExchange className="size-4" />
+                    {isCrossCurrency
+                      ? `FX / transfer fee (${bearerAccount?.currency ?? srcAccount.currency})`
+                      : `Transfer fee (${bearerAccount?.currency ?? srcAccount.currency})`}
+                    <span className="text-xs font-normal text-muted-foreground">
+                      (Optional)
+                    </span>
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    {isCrossCurrency
+                      ? "The bank or exchange spread charged on this conversion."
+                      : "The fee charged on this movement (e.g. an e-wallet top-up charge)."}{" "}
+                    Posted as a separate expense — it never distorts the
+                    transferred amounts.
+                  </p>
+                  <div className="relative">
+                    <span className="absolute top-2.5 left-3 text-sm font-medium text-muted-foreground">
+                      {getCurrencySymbol(
+                        bearerAccount?.currency ?? srcAccount.currency
+                      )}
+                    </span>
+                    <Input
+                      id="transfer-fee-amount"
+                      name="transfer-fee-amount"
+                      type="number"
+                      className="pl-8 font-semibold"
+                      placeholder="0"
+                      value={field.state.value ?? ""}
+                      onBlur={field.handleBlur}
+                      onChange={(e) =>
+                        field.handleChange(
+                          e.target.value ? Number(e.target.value) : undefined
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </form.Field>
+
+            {bearerOptions.length > 1 && (
+              <form.Field name="feeBearerAccountId">
+                {(bearerField) => (
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor="fee-bearer-account"
+                      className="text-xs text-muted-foreground"
+                    >
+                      Fee paid by (default: source account)
+                    </Label>
+                    <select
+                      id="fee-bearer-account"
+                      name="fee-bearer-account"
+                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                      value={bearerField.state.value ?? ""}
+                      onBlur={bearerField.handleBlur}
+                      onChange={(e) =>
+                        bearerField.handleChange(e.target.value || undefined)
+                      }
+                    >
+                      <option value="">Source account</option>
+                      {bearerOptions.map((account) => (
+                        <option key={account.id} value={account.id}>
+                          {account.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </form.Field>
+            )}
+
+            <form.Field name="feeCategoryId">
+              {(categoryField) => (
+                <div className="space-y-1.5">
+                  <Label
+                    htmlFor="transfer-fee-category"
+                    className="text-xs text-muted-foreground"
+                  >
+                    Fee category (optional)
+                  </Label>
+                  <select
+                    id="transfer-fee-category"
+                    name="transfer-fee-category"
+                    className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                    value={categoryField.state.value ?? ""}
+                    onChange={(e) => categoryField.handleChange(e.target.value)}
+                  >
+                    <option value="">-- No category --</option>
+                    <CategoryOptions
+                      categories={formData?.categories}
+                      type="expense"
+                    />
+                  </select>
+                </div>
+              )}
+            </form.Field>
+          </div>
         )
       }}
     </form.Subscribe>
@@ -1555,8 +1699,20 @@ function useTransactionFormModalController({
         notes: editData.notes ?? "",
         status: "CLEARED" as const,
         destinationAmount: undefined,
-        fxFeeAmount: undefined,
-        fxFeeCategoryId: "",
+        // PER-247: prefill the fee + purpose from the edited transfer's
+        // canonical Transfer row (exposed on the ledger record as
+        // transferPurpose / transferFee).
+        feeAmount: editData.transferFee
+          ? editAmountToInputNumber(
+              decodeMoney(editData.transferFee.amount),
+              editData.transferFee.currency
+            )
+          : undefined,
+        feeCategoryId: editData.transferFee?.categoryId ?? "",
+        feeBearerAccountId: editData.transferFee?.accountId ?? undefined,
+        transferPurpose:
+          (editData.transferPurpose as TransferPurpose | null | undefined) ??
+          undefined,
         attachmentUrl: "",
       }
     : {
@@ -1572,8 +1728,10 @@ function useTransactionFormModalController({
         notes: "",
         status: "CLEARED" as const,
         destinationAmount: undefined,
-        fxFeeAmount: undefined,
-        fxFeeCategoryId: "",
+        feeAmount: undefined,
+        feeCategoryId: "",
+        feeBearerAccountId: undefined,
+        transferPurpose: undefined,
         attachmentUrl: "",
       }
 
@@ -1660,16 +1818,25 @@ function useTransactionFormModalController({
           value.destinationAmount != null && destCurrency
             ? toMoney(value.destinationAmount, destCurrency)
             : null
-        // FX fee (ADR-0035 §6): only meaningful on a cross-currency transfer.
-        // Denominated in the source account currency; the server posts it as a
-        // separate fx_fee expense leg linked to the Transfer.
-        const fxFeeMoney: Money | null =
+        // Transfer fee (PER-247): ANY transfer can carry a fee (top-up /
+        // e-wallet / bank charge, or FX spread cross-currency). Denominated
+        // in the fee bearer's currency (default: the source account); the
+        // server posts it as a separate expense leg linked to the Transfer
+        // (fx_fee when cross-currency, transfer_fee otherwise).
+        const feeBearerAccount =
+          value.type === "transfer"
+            ? (formData?.accounts.find(
+                (a) => a.id === (value.feeBearerAccountId || value.accountId)
+              ) ?? null)
+            : null
+        const feeMoney: Money | null =
           value.type === "transfer" &&
-          destCurrency != null &&
-          destCurrency !== sourceCurrency &&
-          value.fxFeeAmount != null &&
-          value.fxFeeAmount > 0
-            ? toMoney(value.fxFeeAmount, sourceCurrency)
+          value.feeAmount != null &&
+          value.feeAmount > 0
+            ? toMoney(
+                value.feeAmount,
+                feeBearerAccount?.currency ?? sourceCurrency
+              )
             : null
         // PER-196 / ADR-0048 §1: only sent when the user manually edited the
         // prefill (NewValuationValueField leaves the field undefined until
@@ -1696,6 +1863,19 @@ function useTransactionFormModalController({
         const selectedToAccount =
           value.toAccountId && value.type === "transfer"
             ? formData?.accounts.find((a) => a.id === value.toAccountId)
+            : null
+        // Purpose override: only funds_movement transfers carry a purpose
+        // (liability kinds already mean something via `kind`; the server
+        // rejects an override there). Recomputed here — the user may have
+        // changed the destination AFTER picking a purpose.
+        const transferPurposePayload: TransferPurpose | null =
+          value.type === "transfer" && selectedAccount && selectedToAccount
+            ? deriveTransferKindForAccounts({
+                fromAccountType: parseAccountType(selectedAccount.accountType),
+                toAccountType: parseAccountType(selectedToAccount.accountType),
+              }) === "funds_movement"
+              ? (value.transferPurpose ?? null)
+              : null
             : null
         const accountRelation = selectedAccount
           ? {
@@ -1771,13 +1951,15 @@ function useTransactionFormModalController({
             }
             return null
           })(),
-          // FX-fee inputs are write-only ledger inputs (not collection columns).
-          // They ride along on the optimistic insert so `onInsert` can forward
-          // them to the server; the post-mutation refetch then surfaces the
-          // server-posted fx_fee expense as its own ledger row.
-          fxFeeAmount: fxFeeMoney,
-          fxFeeAccountId: fxFeeMoney ? value.accountId : null,
-          fxFeeCategoryId: fxFeeMoney ? value.fxFeeCategoryId || null : null,
+          // Transfer fee + purpose inputs are write-only ledger inputs (not
+          // collection columns). They ride along on the optimistic insert so
+          // `onInsert` can forward them to the server; the post-mutation
+          // refetch then surfaces the server-posted fee expense as its own
+          // ledger row and the resolved purpose on the movement.
+          feeAmount: feeMoney,
+          feeAccountId: feeMoney ? (feeBearerAccount?.id ?? null) : null,
+          feeCategoryId: feeMoney ? value.feeCategoryId || null : null,
+          transferPurpose: transferPurposePayload,
           newValuationValue: newValuationValueString,
           accountBalanceAfter: null, // Computed server-side
           attachmentUrl: value.attachmentUrl || null,
@@ -1824,6 +2006,16 @@ function useTransactionFormModalController({
               payload.destinationCurrency
             ;(draft as Record<string, unknown>)["attachmentUrl"] =
               payload.attachmentUrl
+            // PER-247: ephemeral fee + purpose inputs must ride on the draft
+            // so collections.onUpdate can forward them to updateTransactionFn
+            // (they are write-only, not collection columns).
+            ;(draft as Record<string, unknown>)["transferPurpose"] =
+              payload.transferPurpose
+            ;(draft as Record<string, unknown>)["feeAmount"] = payload.feeAmount
+            ;(draft as Record<string, unknown>)["feeAccountId"] =
+              payload.feeAccountId
+            ;(draft as Record<string, unknown>)["feeCategoryId"] =
+              payload.feeCategoryId
             draft.updatedAt = payload.updatedAt
             // Immer draft hanya mengenal scalar fields di schema collection-nya.
             // Relasi dan field baru (account, isSplit, splitEntries) di-cast secara eksplisit.
@@ -1862,6 +2054,15 @@ function useTransactionFormModalController({
             // transactions never carry one.
             externalProvider: null,
             externalId: null,
+            // PER-247: the fee leg is posted server-side as its own row; the
+            // post-mutation refetch surfaces it + the resolved purpose.
+            transferFee: null,
+            // PER-247: `transferIncoming` orients the account arrow for a
+            // valuation-linked redemption's cash leg (server-only). A
+            // form-authored transfer is always the outflow-authored leg, so the
+            // optimistic row is `false`; the post-mutation refetch replaces it
+            // with the authoritative server value.
+            transferIncoming: false,
             // splitEntries di optimistic payload adalah versi ringkas (tanpa relasi Prisma)
             splitEntries:
               payload.splitEntries as TransactionRecord["splitEntries"],
@@ -2035,7 +2236,11 @@ export function TransactionFormModal({
             form={form}
             formData={formData}
           />
-          <FxFeeField activeTab={activeTab} form={form} formData={formData} />
+          <TransferContextFields
+            activeTab={activeTab}
+            form={form}
+            formData={formData}
+          />
           <DateTimeFields form={form} />
           <MerchantField
             activeTab={activeTab}

--- a/src/lib/account-analytics.test.ts
+++ b/src/lib/account-analytics.test.ts
@@ -4,6 +4,7 @@ import {
   buildBalanceSeries,
   buildStatementCsv,
   matchesQuery,
+  orderStatementRows,
   rangeCutoff,
   signedDeltaForAccount,
   summarizeCategories,
@@ -137,6 +138,64 @@ describe("summarizeCategories", () => {
     const inn = summarizeCategories(txns, ID, { direction: "in" })
     expect(inn).toEqual([{ name: "Salary", color: null, total: 100_000n }])
   })
+
+  // PER-247 — transfers are bucketed by their CONTEXTUAL money-movement label
+  // (derived from kind + purpose), never lumped under one meaningless
+  // "Transfer". Different purposes/kinds must NOT collapse into one bucket.
+  it("buckets transfers by contextual money-movement label", () => {
+    const transferTxns: AnalyticsTxn[] = [
+      // Liability payment kinds read from `kind` (no purpose).
+      txn({
+        type: "transfer",
+        amount: 40_000n,
+        toAccountId: "cc",
+        kind: "cc_payment",
+      }),
+      // Investment contribution reads from `purpose`.
+      txn({
+        type: "transfer",
+        amount: 25_000n,
+        toAccountId: "bibit",
+        kind: "funds_movement",
+        transferPurpose: "investment_contribution",
+      }),
+      // A plain movement (no purpose) falls back to "Transfer".
+      txn({
+        type: "transfer",
+        amount: 15_000n,
+        toAccountId: "other",
+        kind: "funds_movement",
+      }),
+    ]
+    const out = summarizeCategories(transferTxns, ID, { direction: "out" })
+    expect(out.map((s) => [s.name, s.total])).toEqual([
+      ["Pay credit card", 40_000n],
+      ["Invest", 25_000n],
+      ["Transfer", 15_000n],
+    ])
+  })
+
+  it("does not merge two different-purpose transfers into one bucket", () => {
+    const transferTxns: AnalyticsTxn[] = [
+      txn({
+        type: "transfer",
+        amount: 30_000n,
+        toAccountId: "bibit",
+        kind: "funds_movement",
+        transferPurpose: "investment_contribution",
+      }),
+      txn({
+        type: "transfer",
+        amount: 20_000n,
+        toAccountId: "gopay",
+        kind: "funds_movement",
+        transferPurpose: "top_up",
+      }),
+    ]
+    const out = summarizeCategories(transferTxns, ID, { direction: "out" })
+    expect(out).toHaveLength(2)
+    expect(out.map((s) => s.name).sort()).toEqual(["Invest", "Top-up"])
+  })
 })
 
 describe("buildStatementCsv", () => {
@@ -185,6 +244,49 @@ describe("buildStatementCsv", () => {
     expect(buildStatementCsv([], ID)).toBe(
       "Date,Description,Category,Type,Amount,Currency"
     )
+  })
+})
+
+describe("orderStatementRows", () => {
+  // PER-247 — the per-account live query is unordered (TanStack DB is
+  // non-deterministic without orderBy), so the statement must sort explicitly:
+  // newest date first, most-recently-created first within the same date.
+  it("orders newest date first", () => {
+    const rows = [
+      txn({ date: "2026-01-01" }),
+      txn({ date: "2026-03-01" }),
+      txn({ date: "2026-02-01" }),
+    ]
+    expect(orderStatementRows(rows).map((r) => r.date)).toEqual([
+      "2026-03-01",
+      "2026-02-01",
+      "2026-01-01",
+    ])
+  })
+
+  it("surfaces a just-added backdated entry above same-date older rows", () => {
+    // Both dated the same day; the one CREATED later (recorded today for a
+    // past posting day) must sort first so reconciliation sees it immediately.
+    // `amount` is the per-row discriminator here.
+    const olderlyRecorded = txn({
+      date: "2026-02-10",
+      createdAt: "2026-02-10T09:00:00Z",
+      amount: 111n,
+    })
+    const justAdded = txn({
+      date: "2026-02-10",
+      createdAt: "2026-08-12T09:00:00Z",
+      amount: 222n,
+    })
+    const ordered = orderStatementRows([olderlyRecorded, justAdded])
+    expect(ordered.map((r) => r.amount)).toEqual([222n, 111n])
+  })
+
+  it("does not mutate the input array", () => {
+    const rows = [txn({ date: "2026-01-01" }), txn({ date: "2026-02-01" })]
+    const snapshot = rows.map((r) => r.date)
+    orderStatementRows(rows)
+    expect(rows.map((r) => r.date)).toEqual(snapshot)
   })
 })
 

--- a/src/lib/account-analytics.ts
+++ b/src/lib/account-analytics.ts
@@ -1,4 +1,5 @@
 import { toDisplayNumber } from "./money"
+import { moneyMovementLabel } from "./money-movement"
 import { type CurrencyCode } from "@/lib/data/currencies"
 
 // =============================================================================
@@ -30,6 +31,11 @@ export interface AnalyticsTxn {
   createdAt?: Date | string
   amount: bigint // absolute magnitude (sign lives in `type`)
   type: string // "income" | "expense" | "transfer"
+  // PER-247: the transaction kind (funds_movement / cc_payment / loan_payment /
+  // liability_draw / …) and the funds_movement purpose. Together they give a
+  // transfer its contextual bucket label instead of a lump "Transfer".
+  kind?: string | null
+  transferPurpose?: string | null
   accountId: string
   toAccountId?: string | null
   category?: { name: string; color?: string | null } | null
@@ -83,13 +89,34 @@ function localIsoDay(date: Date): string {
   return `${y}-${m}-${d}`
 }
 
-function chronological(a: AnalyticsTxn, b: AnalyticsTxn): number {
+function chronological(
+  a: Pick<AnalyticsTxn, "date" | "createdAt">,
+  b: Pick<AnalyticsTxn, "date" | "createdAt">
+): number {
   const ta = new Date(a.date).getTime()
   const tb = new Date(b.date).getTime()
   if (ta !== tb) return ta - tb
   const ca = a.createdAt ? new Date(a.createdAt).getTime() : 0
   const cb = b.createdAt ? new Date(b.createdAt).getTime() : 0
   return ca - cb
+}
+
+/**
+ * Order statement rows for display: newest DATE first, and within the same date
+ * the most-recently-CREATED first. A per-account `useLiveQuery(from(...))` has
+ * NO intrinsic order — TanStack DB's differential dataflow is explicitly
+ * non-deterministic without an `orderBy` (see db-core/live-queries skill) — so
+ * the account statement must sort explicitly, exactly like the /transactions
+ * ledger does. The createdAt tiebreak surfaces a just-added BACKDATED entry at
+ * the top of its day, which is what reconciling against a bank statement needs
+ * (record today, date it to the posting day, still see it immediately). Pure +
+ * unit-tested; the route only calls it.
+ */
+export function orderStatementRows<
+  T extends Pick<AnalyticsTxn, "date" | "createdAt">,
+>(rows: ReadonlyArray<T>): T[] {
+  // chronological() is ascending (date asc, createdAt asc); negate for desc.
+  return [...rows].sort((a, b) => -chronological(a, b))
 }
 
 export interface BalancePoint {
@@ -184,9 +211,13 @@ export function summarizeCategories(
     const isOut = delta < 0n
     if (direction === "out" && !isOut) continue
     if (direction === "in" && isOut) continue
+    // PER-247: a transfer is bucketed by its CONTEXTUAL money-movement label
+    // (Invest / Withdraw / Top-up / Pay credit card / Pay loan / Borrow / …),
+    // not lumped under one meaningless "Transfer". One source of truth shared
+    // with the ledger list and the per-account statement rows.
     const name =
       t.type === "transfer"
-        ? "Transfer"
+        ? moneyMovementLabel({ kind: t.kind, purpose: t.transferPurpose })
         : (t.category?.name ??
           t.merchant?.name ??
           (t.isSplit ? "Split" : "Uncategorized"))

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,6 +1,7 @@
 import { createCollection } from "@tanstack/react-db"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import type { TransactionKind } from "./liability-semantics"
+import type { TransferPurpose } from "./money-movement"
 import { decodeMoney, encodeMoney, type Money } from "./money"
 import { getQueryClient } from "./query-client"
 import { createUuidV7 } from "./uuid-v7"
@@ -134,11 +135,12 @@ export const transactionCollection = createCollection(
     onInsert: async ({ transaction }) => {
       try {
         const payload = transaction.mutations[0].changes
-        // FX-fee inputs ride along as write-only ephemeral fields (see the
-        // transaction form modal); they are not collection columns, so read them
-        // off the raw change set and forward to the server (ADR-0035 §6).
+        // Transfer-fee inputs ride along as write-only ephemeral fields (see
+        // the transaction form modal); they are not collection columns, so
+        // read them off the raw change set and forward to the server
+        // (PER-247, generalized from ADR-0035 §6's fxFee* fields).
         const feeFields = payload as Record<string, unknown>
-        const fxFeeAmount = feeFields.fxFeeAmount as Money | null | undefined
+        const feeAmount = feeFields.feeAmount as Money | null | undefined
         // PER-196 / ADR-0048 §1: valuation-linked transfer value override —
         // also a write-only ephemeral field, not a collection column (see
         // the transaction form modal's NewValuationValueField).
@@ -188,11 +190,16 @@ export const transactionCollection = createCollection(
             destinationCurrency:
               (payload.destinationCurrency as string | null | undefined) ??
               null,
-            fxFeeAmount: fxFeeAmount ? encodeMoney(fxFeeAmount) : null,
-            fxFeeAccountId:
-              (feeFields.fxFeeAccountId as string | null | undefined) ?? null,
-            fxFeeCategoryId:
-              (feeFields.fxFeeCategoryId as string | null | undefined) ?? null,
+            feeAmount: feeAmount ? encodeMoney(feeAmount) : null,
+            feeAccountId:
+              (feeFields.feeAccountId as string | null | undefined) ?? null,
+            feeCategoryId:
+              (feeFields.feeCategoryId as string | null | undefined) ?? null,
+            transferPurpose:
+              (feeFields.transferPurpose as
+                | TransferPurpose
+                | null
+                | undefined) ?? null,
             newValuationValue: newValuationValue ?? undefined,
             attachmentUrl:
               (payload.attachmentUrl as string | null | undefined) ?? null,
@@ -209,6 +216,12 @@ export const transactionCollection = createCollection(
     onUpdate: async ({ transaction }) => {
       try {
         const payload = transaction.mutations[0].modified
+
+        // PER-247: transfer fee + purpose are write-only ephemeral fields
+        // (not collection columns) — forward them like onInsert does so an
+        // edit can change/clear a transfer's fee and purpose.
+        const ephemeral = payload as Record<string, unknown>
+        const feeAmount = ephemeral.feeAmount as Money | null | undefined
 
         await updateTransactionFn({
           data: {
@@ -227,6 +240,16 @@ export const transactionCollection = createCollection(
             merchantId: payload.merchantId as string | null,
             date: payload.date as Date,
             notes: payload.notes as string | null,
+            feeAmount: feeAmount ? encodeMoney(feeAmount) : null,
+            feeAccountId:
+              (ephemeral.feeAccountId as string | null | undefined) ?? null,
+            feeCategoryId:
+              (ephemeral.feeCategoryId as string | null | undefined) ?? null,
+            transferPurpose:
+              (ephemeral.transferPurpose as
+                | TransferPurpose
+                | null
+                | undefined) ?? null,
             // Split Transaction Engine: kirim ke server (re-encode each entry)
             isSplit: (payload.isSplit as boolean | undefined) ?? false,
             splitEntries: (

--- a/src/lib/liability-semantics.test.ts
+++ b/src/lib/liability-semantics.test.ts
@@ -20,6 +20,7 @@ describe("liability semantics", () => {
       "liability_fee",
       "balance_adjustment",
       "fx_fee",
+      "transfer_fee",
     ])
   })
 

--- a/src/lib/liability-semantics.ts
+++ b/src/lib/liability-semantics.ts
@@ -19,6 +19,12 @@ export const TRANSACTION_KIND_VALUES = [
   // expense finance-cost row created alongside the transfer; never ordinary
   // spending. Naturally exempt from the liability cost-target trigger.
   "fx_fee",
+  // General transfer fee on any transfer (PER-247): top-up/e-wallet/bank
+  // charges. Same shape as fx_fee (standalone expense row linked via
+  // Transfer.feeTransactionId); the kind distinguishes it from an FX
+  // conversion fee. Never client-settable — synthesized by the transfer
+  // mutation path only.
+  "transfer_fee",
 ] as const
 
 export type TransactionKind = (typeof TRANSACTION_KIND_VALUES)[number]

--- a/src/lib/money-movement.ts
+++ b/src/lib/money-movement.ts
@@ -1,0 +1,108 @@
+import type { AccountType } from "./accounts"
+
+/**
+ * PER-247 — Contextual money movement.
+ *
+ * A `funds_movement` transfer carries a constrained, nullable `purpose` label
+ * describing WHY the money moved (top-up to an e-wallet, an investment
+ * contribution/withdrawal, savings, cash withdrawal). The purpose lives on
+ * the canonical `Transfer` pairing record (one value shared by both legs) and
+ * is derived from the account taxonomy by default; the user may override it.
+ * Liability transfer kinds (cc_payment / loan_payment / liability_draw) do
+ * NOT take a purpose — their `kind` already carries the meaning (enforced by
+ * the transfer_liability_kind_safe constraint trigger).
+ */
+export const TRANSFER_PURPOSE_VALUES = [
+  "top_up",
+  "investment_contribution",
+  "investment_withdrawal",
+  "savings",
+  "cash_withdrawal",
+] as const
+
+export type TransferPurpose = (typeof TRANSFER_PURPOSE_VALUES)[number]
+
+/** Short human labels for each purpose (UI select + list rendering). */
+export const TRANSFER_PURPOSE_LABELS: Record<TransferPurpose, string> = {
+  top_up: "Top-up",
+  investment_contribution: "Invest",
+  investment_withdrawal: "Withdraw",
+  savings: "Savings",
+  cash_withdrawal: "Cash withdrawal",
+}
+
+/**
+ * The contextual noun for a money movement in a transaction list row
+ * (PER-247 scope 3). A funds_movement transfer with a resolved purpose reads
+ * as that purpose ("Top-up", "Invest", "Withdraw", …) instead of the generic
+ * "Transfer"; everything else (a plain transfer, a liability kind) falls back
+ * to "Transfer". Direction ("from"/"to"), the counterparty account name, and
+ * the fee are formatted by the call site — they differ per list — so this
+ * stays a pure, reusable label. Accepts the raw persisted string (the DB
+ * CHECK guarantees it is a valid purpose) and defends against an unknown one.
+ */
+export function transferMovementNoun(
+  purpose: string | null | undefined
+): string {
+  if (purpose && purpose in TRANSFER_PURPOSE_LABELS) {
+    return TRANSFER_PURPOSE_LABELS[purpose as TransferPurpose]
+  }
+  return "Transfer"
+}
+
+/**
+ * The single human label for a money movement, contextual on BOTH the transfer
+ * `kind` and its `purpose` (PER-247). This is the ONE source of truth for the
+ * label shown wherever a transfer is summarized — the ledger list, the
+ * per-account statement, and the per-account "spend by category" breakdown.
+ *
+ * Liability transfer kinds already carry their meaning in `kind` and never take
+ * a purpose, so they map directly:
+ *   cc_payment → "Pay credit card", loan_payment → "Pay loan",
+ *   liability_draw → "Borrow".
+ * A plain `funds_movement` (or any other kind, e.g. an unclassified transfer)
+ * falls back to the purpose noun ("Top-up"/"Invest"/"Withdraw"/"Savings"/
+ * "Cash withdrawal"/"Transfer"). Accepts the raw persisted strings; the DB
+ * CHECK constraints guarantee valid domains and this defends against unknowns.
+ */
+export function moneyMovementLabel({
+  kind,
+  purpose,
+}: {
+  kind?: string | null
+  purpose?: string | null
+}): string {
+  if (kind === "cc_payment") return "Pay credit card"
+  if (kind === "loan_payment") return "Pay loan"
+  if (kind === "liability_draw") return "Borrow"
+  return transferMovementNoun(purpose)
+}
+
+/**
+ * Derive the default purpose for a funds_movement transfer from the account
+ * taxonomy (class/type/subtype — never ad-hoc product strings, AGENTS.md §5).
+ * Returns null when no rule matches (a plain transfer). An INVESTMENT →
+ * INVESTMENT move is ambiguous (both "contribution" and "withdrawal" apply),
+ * so it deliberately derives null; the user may still override explicitly.
+ */
+export function deriveTransferPurpose({
+  fromAccountType,
+  toAccountType,
+  toAccountSubtype,
+}: {
+  fromAccountType: AccountType
+  toAccountType: AccountType
+  toAccountSubtype?: string | null
+}): TransferPurpose | null {
+  if (fromAccountType === "INVESTMENT" && toAccountType === "INVESTMENT") {
+    return null
+  }
+  if (toAccountType === "E_WALLET") return "top_up"
+  if (toAccountType === "INVESTMENT") return "investment_contribution"
+  if (fromAccountType === "INVESTMENT") return "investment_withdrawal"
+  if (toAccountType === "CASH") return "cash_withdrawal"
+  if (toAccountType === "DEPOSITORY" && toAccountSubtype === "savings") {
+    return "savings"
+  }
+  return null
+}

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -92,6 +92,7 @@ import {
   buildBalanceSeries,
   buildStatementCsv,
   matchesQuery,
+  orderStatementRows,
   rangeCutoff,
   signedDeltaForAccount,
   summarizeCategories,
@@ -99,7 +100,8 @@ import {
 } from "@/lib/account-analytics"
 import { ACCOUNT_TYPE_LABEL } from "./-account-card"
 import { formatCurrency } from "@/lib/currency"
-import { toMoney, ZERO_MONEY, type Money } from "@/lib/money"
+import { decodeMoney, toMoney, ZERO_MONEY, type Money } from "@/lib/money"
+import { moneyMovementLabel } from "@/lib/money-movement"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
@@ -401,12 +403,20 @@ function AccountDetailPage() {
     return { inflow, outflow }
   }, [rangedLedger, accountId])
 
+  // A per-account live query has no intrinsic order (TanStack DB differential
+  // dataflow is non-deterministic without an orderBy), so sort explicitly —
+  // newest date first, most-recently-added first within a day — matching the
+  // /transactions ledger. Without this a just-added backdated entry can land
+  // anywhere in the list, so "All" appears not to surface recent work (PER-247
+  // reconciliation fix).
   const statement = React.useMemo(
     () =>
-      rangedLedger.filter(
-        (t) =>
-          matchesQuery(t, query) &&
-          (types.length === 0 || types.includes(t.type))
+      orderStatementRows(
+        rangedLedger.filter(
+          (t) =>
+            matchesQuery(t, query) &&
+            (types.length === 0 || types.includes(t.type))
+        )
       ),
     [rangedLedger, query, types]
   )
@@ -670,11 +680,38 @@ function AccountDetailPage() {
                 {statement.map((trx) => {
                   const dir =
                     signedDeltaForAccount(trx, accountId) >= 0n ? 1 : -1
+                  // PER-247: contextual money-movement label — a nabung/invest
+                  // reads "Invest to Bibit", a withdrawal "Withdraw from Bibit",
+                  // an e-wallet top-up "Top-up to GoPay" — instead of a bare
+                  // "Transfer" — with the fee (if any) annotated inline.
+                  const transferNoun = moneyMovementLabel({
+                    kind: trx.kind,
+                    purpose: trx.transferPurpose,
+                  })
+                  const feeSuffix =
+                    trx.transferFee != null
+                      ? ` · ${formatCurrency(
+                          decodeMoney(trx.transferFee.amount),
+                          trx.transferFee.currency
+                        )} fee`
+                      : ""
+                  // The counterparty is always the OTHER account, never the one
+                  // being viewed — never assume accountId is the source. A
+                  // valuation-linked reksadana redemption stores the cash leg
+                  // as accountId=BankJago (dest), toAccountId=HasilJualan
+                  // (source); reading `dir` (money direction from the viewed
+                  // account) picks "from"/"to" and this picks the counterparty,
+                  // so it reads "Withdraw from Hasil Jualan" — not the reversed
+                  // "Withdraw from Bank Jago".
+                  const counterpartyName =
+                    (trx.accountId === accountId
+                      ? trx.toAccount?.name
+                      : trx.account?.name) ?? "account"
                   const secondary =
                     trx.type === "transfer"
                       ? dir === 1
-                        ? `Transfer from ${trx.account?.name ?? "account"}`
-                        : `Transfer to ${trx.toAccount?.name ?? "account"}`
+                        ? `${transferNoun} from ${counterpartyName}${feeSuffix}`
+                        : `${transferNoun} to ${counterpartyName}${feeSuffix}`
                       : (trx.category?.name ??
                         trx.merchant?.name ??
                         (trx.isSplit ? "Split" : "Uncategorized"))

--- a/src/routes/_protected/transactions.tsx
+++ b/src/routes/_protected/transactions.tsx
@@ -46,7 +46,8 @@ import {
   getTransactionFormData,
 } from "@/server/transactions"
 import { formatCurrency } from "@/lib/currency"
-import { ZERO_MONEY, type Money } from "@/lib/money"
+import { decodeMoney, ZERO_MONEY, type Money } from "@/lib/money"
+import { moneyMovementLabel } from "@/lib/money-movement"
 import {
   applyFilters,
   applySearch,
@@ -925,8 +926,11 @@ function TransactionRow({
             >
               <IconArrowsExchange size={15} />
               {isIncomingTransfer
-                ? `Transfer from ${trx.account.name}`
-                : "Transfer"}
+                ? `${moneyMovementLabel({ kind: trx.kind, purpose: trx.transferPurpose })} from ${trx.account.name}`
+                : moneyMovementLabel({
+                    kind: trx.kind,
+                    purpose: trx.transferPurpose,
+                  })}
             </span>
           ) : trx.isSplit ? (
             <span className="flex items-center gap-1 text-sm font-medium text-amber-600 dark:text-amber-400">
@@ -949,14 +953,22 @@ function TransactionRow({
         {/* Account column (hidden until xl) */}
         <div className="hidden w-52 shrink-0 px-4 pt-0.5 xl:block">
           <div className="flex flex-wrap items-center gap-1">
+            {/* PER-247: orient the source → dest chips by money flow. A
+                valuation-linked redemption RECEIVES into `account` (its cash
+                leg is the inflow), so the true source is `toAccount` — render
+                "Hasil Jualan → Bank Jago", not the reversed "Bank Jago → Hasil
+                Jualan". The stored data (accountId=cash, toAccountId=tracked)
+                is correct; only the display direction needed the flip. */}
             <span className="rounded-md border bg-zinc-100 px-2 py-0.5 text-xs dark:bg-zinc-800">
-              {trx.account.name}
+              {trx.type === "transfer" && trx.transferIncoming && trx.toAccount
+                ? trx.toAccount.name
+                : trx.account.name}
             </span>
             {trx.type === "transfer" && trx.toAccount && (
               <>
                 <IconArrowRight size={12} className="text-muted-foreground" />
                 <span className="rounded-md border bg-zinc-100 px-2 py-0.5 text-xs dark:bg-zinc-800">
-                  {trx.toAccount.name}
+                  {trx.transferIncoming ? trx.account.name : trx.toAccount.name}
                 </span>
               </>
             )}
@@ -992,6 +1004,20 @@ function TransactionRow({
                 {formatCurrency(trx.destinationAmount, trx.destinationCurrency)}
               </div>
             )}
+
+          {/* PER-247: fee carried by this transfer (e.g. an e-wallet top-up
+              charge). A muted annotation — the fee is also its own expense
+              row, this just makes the movement self-explanatory in context. */}
+          {trx.transferFee != null && (
+            <div className="mt-0.5 text-[10px] font-normal text-muted-foreground">
+              +
+              {formatCurrency(
+                decodeMoney(trx.transferFee.amount),
+                trx.transferFee.currency
+              )}{" "}
+              fee
+            </div>
+          )}
         </div>
 
         {/* Actions column */}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -1260,6 +1260,16 @@ export async function recordTradeForFamily({
         trackedAccount: investmentAccount,
         direction,
         kind,
+        // PER-247: a Buy IS an investment contribution (Sell a withdrawal) —
+        // label the canonical Transfer so per-account rendering is
+        // contextual. Only on funds_movement (a liability-funded trade keeps
+        // its liability_draw meaning; purpose is forbidden there).
+        purpose:
+          kind === "funds_movement"
+            ? isBuy
+              ? "investment_contribution"
+              : "investment_withdrawal"
+            : null,
         leg,
         familyId,
         user,

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -6,6 +6,7 @@ import {
   isLiabilityCostKind,
   parseAccountType,
   TRANSACTION_KIND_VALUES,
+  type TransferTransactionKind,
 } from "@/lib/liability-semantics"
 import {
   absMoney,
@@ -17,6 +18,11 @@ import {
   type Money,
 } from "@/lib/money"
 import { deriveTransferFx } from "@/lib/fx"
+import {
+  deriveTransferPurpose,
+  TRANSFER_PURPOSE_VALUES,
+  type TransferPurpose,
+} from "@/lib/money-movement"
 import { assertSplitParity } from "@/lib/split-parity"
 import { computeBaseProjectionForAmount, getFamilyBaseCurrency } from "./fx"
 import {
@@ -496,6 +502,54 @@ export async function findLedgerTransactionsForFamily(
     if (splitEntry.merchantId) merchantIds.add(splitEntry.merchantId)
   }
 
+  // PER-247: hydrate the contextual money-movement labels (Transfer.purpose)
+  // and fee legs so lists can render self-explanatory movements ("Top-up
+  // GoPay (+Rp1.000 fee)") without a second round-trip per row.
+  const transfers =
+    transactionIds.length > 0
+      ? await tx.transfer.findMany({
+          where: {
+            deletedAt: null,
+            OR: [
+              { outflowTransactionId: { in: transactionIds } },
+              { inflowTransactionId: { in: transactionIds } },
+            ],
+          },
+          select: {
+            outflowTransactionId: true,
+            inflowTransactionId: true,
+            purpose: true,
+            feeTransactionId: true,
+          },
+        })
+      : []
+  const feeTransactionIds = transfers
+    .map((transfer) => transfer.feeTransactionId)
+    .filter((id): id is string => id != null)
+  const transferFees =
+    feeTransactionIds.length > 0
+      ? await tx.transaction.findMany({
+          where: { id: { in: feeTransactionIds } },
+          select: {
+            id: true,
+            accountId: true,
+            amount: true,
+            categoryId: true,
+            currency: true,
+          },
+        })
+      : []
+  const transferFeesById = indexById(transferFees)
+  const transferByTransactionId = new Map<string, (typeof transfers)[number]>()
+  for (const transfer of transfers) {
+    if (transfer.outflowTransactionId) {
+      transferByTransactionId.set(transfer.outflowTransactionId, transfer)
+    }
+    if (transfer.inflowTransactionId) {
+      transferByTransactionId.set(transfer.inflowTransactionId, transfer)
+    }
+  }
+
   const [accounts, categories, merchants] =
     await runTenantTransactionQueriesInOrder([
       () =>
@@ -547,6 +601,37 @@ export async function findLedgerTransactionsForFamily(
 
     return {
       ...transaction,
+      // PER-247: contextual money-movement fields (null for non-transfers).
+      // The fee amount is wire-encoded as a positive magnitude string (the
+      // same boundary convention as serializeTransaction).
+      transferPurpose:
+        transferByTransactionId.get(transaction.id)?.purpose ?? null,
+      // PER-247: does this surfaced transfer leg RECEIVE money into its own
+      // `accountId` (money flows toAccount → account), rather than send it out
+      // (account → toAccount)? True only for a valuation-linked redemption —
+      // its single cash leg sits in the Transfer's inflow slot with no outflow
+      // twin (classic inflow legs are hidden from this list). The renderer uses
+      // this to orient the account arrow, otherwise a reksadana withdrawal
+      // ("Hasil Jualan → Bank Jago") displays reversed as "Bank Jago → Hasil
+      // Jualan" — the data (accountId=cash, toAccountId=tracked) is correct,
+      // only the direction label needs it. See docs/adr/0048.
+      transferIncoming:
+        transferByTransactionId.get(transaction.id)?.inflowTransactionId ===
+        transaction.id,
+      transferFee: (() => {
+        const transfer = transferByTransactionId.get(transaction.id)
+        const fee = transfer?.feeTransactionId
+          ? transferFeesById.get(transfer.feeTransactionId)
+          : null
+        return fee
+          ? {
+              accountId: fee.accountId,
+              amount: encodeMoney(absMoney(fee.amount)),
+              categoryId: fee.categoryId,
+              currency: fee.currency,
+            }
+          : null
+      })(),
       account: accountListRelation(account),
       toAccount: toAccount ? accountListRelation(toAccount) : null,
       category: category ? categoryListRelation(category) : null,
@@ -799,13 +884,21 @@ const transactionInputSchema = z.object({
   destinationAmount: positiveMoneyInputSchema.nullable().optional(),
   destinationCurrency: z.string().nullable().optional(),
   attachmentUrl: z.string().nullable().optional(),
-  // Optional FX fee on a cross-currency transfer (PER-147 / ADR-0035 §6). When
-  // present, a standalone `fx_fee` expense row is posted on `fxFeeAccountId`
-  // (default: the source account) in that account's currency, linked to the
-  // Transfer. Ignored for non-transfer transactions.
-  fxFeeAmount: positiveMoneyInputSchema.nullable().optional(),
-  fxFeeAccountId: z.string().nullable().optional(),
-  fxFeeCategoryId: z.string().nullable().optional(),
+  // Optional fee on ANY transfer (PER-247, generalizing ADR-0035 §6's
+  // cross-currency-only fxFee* inputs). When present, a standalone fee expense
+  // row is posted on `feeAccountId` (default: the source account) in that
+  // account's currency and linked to the Transfer via feeTransactionId (one
+  // fee leg max per transfer). The server derives the leg's kind: `fx_fee`
+  // for a cross-currency transfer, `transfer_fee` otherwise. Rejected for
+  // non-transfer transactions (assertManualTransactionKindShape).
+  feeAmount: positiveMoneyInputSchema.nullable().optional(),
+  feeAccountId: z.string().nullable().optional(),
+  feeCategoryId: z.string().nullable().optional(),
+  // PER-247: optional override of the derived funds_movement transfer purpose
+  // (see src/lib/money-movement.ts). Null/absent = derive from the account
+  // taxonomy. Rejected for liability transfer kinds (cc_payment /
+  // loan_payment / liability_draw) — their kind already carries the meaning.
+  transferPurpose: z.enum(TRANSFER_PURPOSE_VALUES).nullable().optional(),
   // PER-196 / ADR-0048 §1: valuation-linked transfer. When either transfer
   // side is a balanceSource="valuation" account, this is the new valuation
   // value for that account (prefilled client-side as latest ∓ amount,
@@ -944,12 +1037,23 @@ function assertManualTransactionKindShape(data: {
   kind: string
   toAccountId?: string | null
   type: "expense" | "income" | "transfer"
+  feeAmount?: bigint | null
+  transferPurpose?: string | null
 }): void {
   if (data.type === "transfer") {
     if (data.kind !== "standard") {
       throw new Error("Transfer kind is derived from account direction")
     }
     return
+  }
+
+  // PER-247: fee + purpose are transfer-only inputs. Never silently drop
+  // money-shaped client input — reject it loud instead.
+  if (data.feeAmount) {
+    throw new Error("A transfer fee can only be attached to a transfer")
+  }
+  if (data.transferPurpose) {
+    throw new Error("A transfer purpose can only be attached to a transfer")
   }
 
   if (
@@ -977,68 +1081,92 @@ function assertManualTransactionKindShape(data: {
 }
 
 /**
- * Create the optional FX-fee leg of a cross-currency transfer (PER-147 /
- * ADR-0035 §6). A standalone `fx_fee` expense posted on `fxFeeAccountId`
- * (default: the source account) in that account's native currency, with its own
- * atomic balance delta, base projection, and audit. Returns the new fee
- * transaction id, or null when no fee was requested. The caller links it onto
- * the `Transfer` row.
+ * Create the optional fee leg of a transfer (PER-247, generalized from the
+ * PER-147 / ADR-0035 §6 cross-currency-only fee). A standalone expense posted
+ * on `feeAccountId` (default: the source account) in that account's native
+ * currency, with its own atomic balance delta, base projection, and audit.
+ * `feeKind` is "fx_fee" for a cross-currency transfer (ADR-0035 §6) and
+ * "transfer_fee" otherwise (PER-247). Returns the new fee transaction id, or
+ * null when no fee was requested. The caller links it onto the `Transfer`
+ * row.
  */
-async function createFxFeeLegIfRequested(
+async function createTransferFeeLegIfRequested(
   tx: TenantTransactionClient,
   {
-    data,
     familyId,
     user,
     baseCurrency,
     auditCtx,
+    feeKind,
+    feeAmount: requestedFeeAmount,
+    feeAccountId: requestedFeeAccountId,
+    feeCategoryId,
+    defaultFeeAccountId,
+    date,
+    description,
+    notes,
+    status,
   }: {
-    data: CreateTransactionInput
     familyId: string
     user: { id: string }
     baseCurrency: string
     auditCtx: Awaited<ReturnType<typeof createAuditContext>>
+    feeKind: "fx_fee" | "transfer_fee"
+    feeAmount: bigint | null | undefined
+    feeAccountId: string | null | undefined
+    feeCategoryId: string | null | undefined
+    // The fee bearer when feeAccountId is not specified: the transfer's
+    // source/cash account (PER-247 locked decision: origin bears the fee by
+    // default, editable via feeAccountId).
+    defaultFeeAccountId: string
+    date: Date
+    description: string
+    notes?: string | null
+    status: string
   }
 ): Promise<string | null> {
-  if (!data.fxFeeAmount) return null
+  if (!requestedFeeAmount) return null
 
-  const feeAccountId = data.fxFeeAccountId ?? data.accountId
+  const feeAccountId = requestedFeeAccountId ?? defaultFeeAccountId
   await validateTenantReferences(tx, familyId, {
     accountId: feeAccountId,
-    categoryId: data.fxFeeCategoryId,
+    categoryId: feeCategoryId,
   })
 
   const oldFeeAccount = await tx.account.findUniqueOrThrow({
     where: { id: feeAccountId },
   })
-  const feeAmount = negateMoney(absMoney(data.fxFeeAmount))
+  const feeAmount = negateMoney(absMoney(requestedFeeAmount))
   const feeMutation = await applyAccountBalanceDelta(tx, {
     accountId: feeAccountId,
     delta: feeAmount,
     familyId,
-    notFoundMessage: "FX fee account not found or access denied!",
+    notFoundMessage: "Transfer fee account not found or access denied!",
   })
   const feeProjection = await computeBaseProjectionForAmount(tx, familyId, {
     amount: feeAmount,
     currency: oldFeeAccount.currency,
-    date: data.date,
+    date,
     baseCurrency,
   })
 
   const feeTx = await tx.transaction.create({
     data: {
       type: "expense",
-      kind: "fx_fee",
+      kind: feeKind,
       amount: feeAmount,
       currency: oldFeeAccount.currency,
-      description: `FX fee: ${data.description}`,
-      date: data.date,
-      notes: data.notes || null,
+      description:
+        feeKind === "fx_fee"
+          ? `FX fee: ${description}`
+          : `Transfer fee: ${description}`,
+      date,
+      notes: notes || null,
       accountId: feeAccountId,
-      categoryId: data.fxFeeCategoryId || null,
+      categoryId: feeCategoryId || null,
       userId: user.id,
       familyId,
-      status: data.status,
+      status,
       baseAmount: feeProjection.baseAmount,
       baseCurrency: feeProjection.baseCurrency,
       fxRateScaled: feeProjection.fxRateScaled,
@@ -1056,6 +1184,110 @@ async function createFxFeeLegIfRequested(
   ])
 
   return feeTx.id
+}
+
+/**
+ * PER-247: resolve the effective purpose for a transfer. The client may
+ * override the taxonomy-derived default, but a purpose is only meaningful on
+ * a funds_movement transfer — liability kinds (cc_payment / loan_payment /
+ * liability_draw) already carry their meaning via `kind` (also guarded by the
+ * transfer_liability_kind_safe constraint trigger at the DB layer).
+ */
+function resolveTransferPurpose({
+  kind,
+  override,
+  fromAccount,
+  toAccount,
+}: {
+  kind: string
+  override: TransferPurpose | null | undefined
+  fromAccount: Account
+  toAccount: Account
+}): TransferPurpose | null {
+  if (kind !== "funds_movement") {
+    if (override) {
+      throw new Error(
+        `A transfer purpose only applies to funds_movement transfers, not ${kind}`
+      )
+    }
+    return null
+  }
+  return (
+    override ??
+    deriveTransferPurpose({
+      fromAccountType: parseAccountType(fromAccount.accountType),
+      toAccountType: parseAccountType(toAccount.accountType),
+      toAccountSubtype: toAccount.accountSubtype,
+    })
+  )
+}
+
+/**
+ * PER-247: resolve everything about a transfer request that the ledger
+ * DERIVES rather than trusts from the client — the kind (from account
+ * direction), the purpose (override or taxonomy-derived default), and the
+ * default fee bearer. Runs BEFORE the idempotency replay check so the
+ * canonical request payload hashes the same resolved values the persisted
+ * side stores: a faithful replay matches, and the same idempotency key with
+ * a different purpose/fee fails with a conflict (ADR-0006).
+ */
+interface ResolvedTransferSemantics {
+  data: CreateTransactionInput
+  fromAccount: Account
+  toAccount: Account
+  kind: TransferTransactionKind
+  purpose: TransferPurpose | null
+}
+
+async function resolveTransferSemantics(
+  tx: TenantTransactionClient,
+  data: CreateTransactionInput
+): Promise<ResolvedTransferSemantics> {
+  if (!data.toAccountId) {
+    throw new Error("Transfer requires a destination account!")
+  }
+  const toAccountId = data.toAccountId
+
+  const [fromAccount, toAccount] = await runTenantTransactionQueriesInOrder([
+    () =>
+      tx.account.findUniqueOrThrow({
+        where: { id: data.accountId },
+      }),
+    () =>
+      tx.account.findUniqueOrThrow({
+        where: { id: toAccountId },
+      }),
+  ] as const)
+
+  const kind = deriveTransferKindForAccounts({
+    fromAccountType: parseAccountType(fromAccount.accountType),
+    toAccountType: parseAccountType(toAccount.accountType),
+  })
+  const purpose = resolveTransferPurpose({
+    kind,
+    override: data.transferPurpose,
+    fromAccount,
+    toAccount,
+  })
+
+  // Default fee bearer: the source account (locked PER-247 decision: origin
+  // bears the fee, editable via feeAccountId). A valuation-linked
+  // REDEMPTION's source is the tracked (valuation) account, which cannot
+  // post expense deltas (ADR-0048 §3) — the cash destination bears the fee.
+  const feeAccountId = data.feeAmount
+    ? (data.feeAccountId ??
+      (fromAccount.balanceSource === "valuation"
+        ? toAccountId
+        : data.accountId))
+    : data.feeAccountId
+
+  return {
+    data: { ...data, transferPurpose: purpose, feeAccountId },
+    fromAccount,
+    toAccount,
+    kind,
+    purpose,
+  }
 }
 
 async function assertLiabilityCostTarget(
@@ -1182,7 +1414,18 @@ interface PersistedSplitEntryForIdempotency {
   merchantId: string | null
 }
 
-interface PersistedTransferOutForIdempotency {
+interface PersistedTransferFeeForIdempotency {
+  accountId: string
+  amount: bigint
+  categoryId: string | null
+}
+
+interface PersistedTransferRelationForIdempotency {
+  purpose: string | null
+  feeTransaction: PersistedTransferFeeForIdempotency | null
+}
+
+interface PersistedTransferOutForIdempotency extends PersistedTransferRelationForIdempotency {
   inflowTransaction: {
     accountId: string
     amount: bigint
@@ -1224,7 +1467,7 @@ interface PersistedTransactionForIdempotency {
   splitEntries: PersistedSplitEntryForIdempotency[]
   status: string
   toAccountId: string | null
-  transferIn: unknown
+  transferIn: PersistedTransferRelationForIdempotency | null
   transferOut: PersistedTransferOutForIdempotency | null
   type: string
   updatedAt: Date
@@ -1271,6 +1514,15 @@ function canonicalRequestPayload(
     description: data.description,
     destinationAmount: canonicalMoney(data.destinationAmount),
     destinationCurrency: data.destinationCurrency ?? null,
+    // PER-247: the transfer fee + purpose are part of the canonical payload —
+    // replaying the same key with a different fee/purpose must conflict, and
+    // (create path only) the caller pre-normalizes derived purpose + default
+    // fee bearer so a faithful replay hashes the same values the persisted
+    // side stores (see resolveTransferSemantics).
+    feeAmount: canonicalMoney(data.feeAmount),
+    feeAccountId: data.feeAmount ? (data.feeAccountId ?? null) : null,
+    feeCategoryId: data.feeAmount ? (data.feeCategoryId ?? null) : null,
+    transferPurpose: data.transferPurpose ?? null,
     isSplit: data.isSplit,
     kind: data.type === "transfer" ? null : data.kind,
     // PER-210: a split parent keeps its single merchant (merchant = whole
@@ -1386,6 +1638,12 @@ function assertAllRequestedTransactionsLoaded(
 
 function canonicalPersistedPayload(tx: PersistedTransactionForIdempotency) {
   const transferPartner = tx.transferOut?.inflowTransaction ?? null
+  // PER-247: the persisted purpose + fee leg live on the Transfer row — in
+  // whichever FK slot the idempotency-key-carrying cash leg landed (outflow
+  // for a classic transfer / valuation-linked contribution, inflow for a
+  // valuation-linked redemption).
+  const transferRelation = tx.transferOut ?? tx.transferIn
+  const persistedFee = transferRelation?.feeTransaction ?? null
 
   return {
     accountId: tx.accountId,
@@ -1397,6 +1655,10 @@ function canonicalPersistedPayload(tx: PersistedTransactionForIdempotency) {
     description: tx.description,
     destinationAmount: canonicalMoney(tx.destinationAmount),
     destinationCurrency: tx.destinationCurrency,
+    feeAmount: persistedFee ? canonicalMoney(persistedFee.amount) : null,
+    feeAccountId: persistedFee?.accountId ?? null,
+    feeCategoryId: persistedFee?.categoryId ?? null,
+    transferPurpose: transferRelation?.purpose ?? null,
     isSplit: tx.isSplit,
     kind: tx.type === "transfer" ? null : tx.kind,
     // PER-210: split parent keeps its merchant. Symmetric twin of
@@ -1487,9 +1749,38 @@ async function findIdempotentTransaction(
         }),
     ] as const)
 
+  // PER-247: hydrate the fee leg (if any) linked from whichever Transfer row
+  // this transaction anchors, so the canonical persisted payload can compare
+  // fee + purpose against a replayed request.
+  const feeTransactionIds = [
+    transferIn?.feeTransactionId,
+    transferOut?.feeTransactionId,
+  ].filter((id): id is string => id != null)
+  const feeTransactions =
+    feeTransactionIds.length > 0
+      ? await tx.transaction.findMany({
+          where: { id: { in: feeTransactionIds } },
+          select: {
+            id: true,
+            accountId: true,
+            amount: true,
+            categoryId: true,
+          },
+        })
+      : []
+  const feeTransactionsById = indexById(feeTransactions)
+  const feeFor = (
+    feeTransactionId: string | null | undefined
+  ): PersistedTransferFeeForIdempotency | null =>
+    feeTransactionId
+      ? (feeTransactionsById.get(feeTransactionId) ?? null)
+      : null
+
   const transferOutWithInflowTransaction = transferOut
     ? {
         ...transferOut,
+        purpose: transferOut.purpose,
+        feeTransaction: feeFor(transferOut.feeTransactionId),
         // PER-196 / ADR-0048 §4: null for a valuation-linked transfer where
         // THIS transaction is the outflow (contribution) leg — there is no
         // inflow Transaction, only a linked Valuation.
@@ -1504,7 +1795,12 @@ async function findIdempotentTransaction(
   return {
     ...transaction,
     splitEntries,
-    transferIn,
+    transferIn: transferIn
+      ? {
+          purpose: transferIn.purpose,
+          feeTransaction: feeFor(transferIn.feeTransactionId),
+        }
+      : null,
     transferOut: transferOutWithInflowTransaction,
   }
 }
@@ -1695,6 +1991,8 @@ export async function postValuationLinkedTransferLegs(
     auditCtx,
     baseCurrency,
     resolveValuation,
+    purpose = null,
+    fee = null,
   }: {
     cashAccount: Account
     trackedAccount: Account
@@ -1708,6 +2006,15 @@ export async function postValuationLinkedTransferLegs(
     resolveValuation: (
       tx: TenantTransactionClient
     ) => Promise<{ valuation: Valuation }>
+    // PER-247: optional purpose label (funds_movement only — callers
+    // resolve/validate it) and optional transfer-fee request, both written
+    // onto the canonical Transfer row in the same transaction.
+    purpose?: TransferPurpose | null
+    fee?: {
+      amount: bigint | null | undefined
+      accountId?: string | null
+      categoryId?: string | null
+    } | null
   }
 ) {
   // v1 scope (ADR-0048 §1): the cash leg and the tracked account are both
@@ -1777,6 +2084,7 @@ export async function postValuationLinkedTransferLegs(
         ? { outflowTransactionId: cashTx.id }
         : { inflowTransactionId: cashTx.id }),
       valuationId: valuation.id,
+      purpose,
     },
   })
 
@@ -1789,6 +2097,31 @@ export async function postValuationLinkedTransferLegs(
     ...createdAuditEntries("Transaction", [cashTx]),
     ...createdAuditEntries("Transfer", [createdTransfer]),
   ])
+
+  // PER-247: optional transfer-fee leg on a valuation-linked move (e.g. the
+  // bank charge on a nabung/invest transfer into a tracked investment
+  // account). Single-currency path (enforced above) => always transfer_fee.
+  const feeTransactionId = await createTransferFeeLegIfRequested(tx, {
+    familyId,
+    user,
+    baseCurrency,
+    auditCtx,
+    feeKind: "transfer_fee",
+    feeAmount: fee?.amount,
+    feeAccountId: fee?.accountId,
+    feeCategoryId: fee?.categoryId,
+    defaultFeeAccountId: cashAccount.id,
+    date: leg.date,
+    description: leg.description,
+    notes: leg.notes,
+    status: leg.status,
+  })
+  if (feeTransactionId) {
+    await tx.transfer.update({
+      where: { id: createdTransfer.id },
+      data: { feeTransactionId },
+    })
+  }
 
   return serializeTransaction({
     ...cashTx,
@@ -1808,6 +2141,7 @@ async function createValuationLinkedTransferWithinTx(
     user,
     auditCtx,
     baseCurrency,
+    purpose = null,
   }: {
     cashAccount: Account
     trackedAccount: Account
@@ -1818,6 +2152,9 @@ async function createValuationLinkedTransferWithinTx(
     user: { id: string }
     auditCtx: AuditContext
     baseCurrency: string
+    // PER-247: resolved funds_movement purpose label (null for liability
+    // kinds and for plain transfers).
+    purpose?: TransferPurpose | null
   }
 ) {
   return postValuationLinkedTransferLegs(tx, {
@@ -1825,6 +2162,12 @@ async function createValuationLinkedTransferWithinTx(
     trackedAccount,
     direction,
     kind,
+    purpose,
+    fee: {
+      amount: data.feeAmount,
+      accountId: data.feeAccountId,
+      categoryId: data.feeCategoryId,
+    },
     leg: {
       amount: data.amount,
       date: data.date,
@@ -1882,10 +2225,10 @@ export async function createTransactionForFamily({
   runInTenantTransaction = scopedTenantTransaction,
   user,
 }: CreateTransactionForFamilyArgs) {
-  const data = createTransactionInputSchema.parse(rawData)
+  const parsedData = createTransactionInputSchema.parse(rawData)
   const auditCtx = await createAuditContext(
     { user: { id: user.id, familyId } },
-    data.idempotencyKey
+    parsedData.idempotencyKey
   )
 
   const createOrReplay = async () =>
@@ -1893,20 +2236,31 @@ export async function createTransactionForFamily({
       familyId,
       user.id,
       async (tx: TenantTransactionClient) => {
-        const replay = await replayIdempotentTransaction(tx, familyId, data)
-        if (replay) return replay
-
         // PER-94: tenant-owned foreign reference validation. Runs first so a
         // cross-tenant payload short-circuits with a typed
         // `TenantReferenceError` before any balance update or audit row is
         // written. PER-104 DB triggers remain the backstop for raw-SQL paths.
         await validateTenantReferences(tx, familyId, {
-          accountId: data.accountId,
-          toAccountId: data.toAccountId,
-          merchantId: data.merchantId,
-          categoryId: data.categoryId,
-          splitEntries: data.splitEntries,
+          accountId: parsedData.accountId,
+          toAccountId: parsedData.toAccountId,
+          merchantId: parsedData.merchantId,
+          categoryId: parsedData.categoryId,
+          splitEntries: parsedData.splitEntries,
         })
+
+        // PER-247: resolve the derived transfer semantics (kind, purpose,
+        // default fee bearer) BEFORE the replay check, so the canonical
+        // request payload hashes the same resolved values the persisted side
+        // stores — a faithful replay matches, and the same idempotency key
+        // with a different purpose/fee fails with a conflict.
+        const transferSemantics =
+          parsedData.type === "transfer" && parsedData.toAccountId
+            ? await resolveTransferSemantics(tx, parsedData)
+            : null
+        const data = transferSemantics?.data ?? parsedData
+
+        const replay = await replayIdempotentTransaction(tx, familyId, data)
+        if (replay) return replay
 
         // === SPLIT PARITY GUARD (GAAP Compliance) ===
         // Backend MUST validate that SplitEntries sum === parent.amount.
@@ -1923,23 +2277,20 @@ export async function createTransactionForFamily({
         if (data.type === "transfer") {
           if (!data.toAccountId)
             throw new Error("Transfer requires a destination account!")
+          if (!transferSemantics) {
+            // Unreachable: semantics resolve for every transfer that carries
+            // a destination account. Internal invariant, not a user error.
+            throw new Error(
+              "Invariant violated: transfer semantics unresolved for a transfer with a destination account"
+            )
+          }
           const toAccountId = data.toAccountId
-
-          const [oldSrcAcc, oldDstAcc] =
-            await runTenantTransactionQueriesInOrder([
-              () =>
-                tx.account.findUniqueOrThrow({
-                  where: { id: data.accountId },
-                }),
-              () =>
-                tx.account.findUniqueOrThrow({
-                  where: { id: toAccountId },
-                }),
-            ] as const)
-          const kind = deriveTransferKindForAccounts({
-            fromAccountType: parseAccountType(oldSrcAcc.accountType),
-            toAccountType: parseAccountType(oldDstAcc.accountType),
-          })
+          const {
+            fromAccount: oldSrcAcc,
+            toAccount: oldDstAcc,
+            kind,
+            purpose,
+          } = transferSemantics
 
           // PER-196 / ADR-0048 §1/§2: route to the valuation-linked path
           // whenever either side is balanceSource="valuation" — the classic
@@ -1963,6 +2314,7 @@ export async function createTransactionForFamily({
               user,
               auditCtx,
               baseCurrency,
+              purpose,
             })
           }
 
@@ -2093,6 +2445,7 @@ export async function createTransactionForFamily({
               fxRateScaled: transferFx.fxRateScaled,
               fromCurrency: transferFx.fromCurrency,
               toCurrency: transferFx.toCurrency,
+              purpose,
             },
           })
 
@@ -2120,15 +2473,26 @@ export async function createTransactionForFamily({
             ...createdAuditEntries("Transfer", [createdTransfer]),
           ])
 
-          // Optional FX fee leg (ADR-0035 §6): a standalone fx_fee expense on the
-          // fee account (default: source) in that account's native currency,
-          // linked back onto the Transfer. Fully audited inside the helper.
-          const feeTransactionId = await createFxFeeLegIfRequested(tx, {
-            data,
+          // Optional fee leg (PER-247, generalized from ADR-0035 §6): a
+          // standalone expense on the fee account (default: source) in that
+          // account's native currency, linked back onto the Transfer. Kind is
+          // fx_fee for a cross-currency transfer, transfer_fee otherwise.
+          // Fully audited inside the helper.
+          const feeTransactionId = await createTransferFeeLegIfRequested(tx, {
             familyId,
             user,
             baseCurrency,
             auditCtx,
+            feeKind:
+              transferFx.fxRateScaled !== null ? "fx_fee" : "transfer_fee",
+            feeAmount: data.feeAmount,
+            feeAccountId: data.feeAccountId,
+            feeCategoryId: data.feeCategoryId,
+            defaultFeeAccountId: data.accountId,
+            date: data.date,
+            description: data.description,
+            notes: data.notes,
+            status: data.status,
           })
           if (feeTransactionId) {
             await tx.transfer.update({
@@ -2262,8 +2626,19 @@ export async function createTransactionForFamily({
     const replay = await runInTenantTransaction(
       familyId,
       user.id,
-      async (tx: TenantTransactionClient) =>
-        await replayIdempotentTransaction(tx, familyId, data)
+      async (tx: TenantTransactionClient) => {
+        // PER-247: the replay hash must use the same resolved transfer
+        // semantics as the create attempt (see createOrReplay).
+        const transferSemantics =
+          parsedData.type === "transfer" && parsedData.toAccountId
+            ? await resolveTransferSemantics(tx, parsedData)
+            : null
+        return await replayIdempotentTransaction(
+          tx,
+          familyId,
+          transferSemantics?.data ?? parsedData
+        )
+      }
     )
     if (replay) return replay
 
@@ -2549,7 +2924,7 @@ export async function softDeleteTransactionWithinTenantTransaction(
         accountId: feeTx.accountId,
         delta: absMoney(feeTx.amount),
         familyId,
-        notFoundMessage: "FX fee account not found or access denied!",
+        notFoundMessage: "Transfer fee account not found or access denied!",
       })
     }
   } else {
@@ -2860,10 +3235,25 @@ async function replaceTransactionWithinTenantTransaction(
         )
       : null
 
+  // PER-247: the old transfer's fee leg (fx_fee / transfer_fee) must be
+  // reversed and soft-deleted symmetrically with the legs — previously the
+  // replace path silently left the fee expense active and orphaned. The new
+  // fee (if any) is re-created fresh below from the request payload.
+  const oldFeeTx = oldTransferGraph?.feeTransactionId
+    ? await findOptionalTransactionWithSplitEntries(
+        tx,
+        oldTransferGraph.feeTransactionId
+      )
+    : null
+
   // Kumpulkan semua akun yang terpengaruh (sebelum dan sesudah).
   const touchedAccountIds = new Set([oldTx.accountId, data.accountId])
   if (oldInflowTx) touchedAccountIds.add(oldInflowTx.accountId)
   if (data.toAccountId) touchedAccountIds.add(data.toAccountId)
+  if (oldFeeTx) touchedAccountIds.add(oldFeeTx.accountId)
+  if (data.type === "transfer" && data.feeAmount) {
+    touchedAccountIds.add(data.feeAccountId ?? data.accountId)
+  }
 
   const oldAccounts = await tx.account.findMany({
     where: { id: { in: Array.from(touchedAccountIds) } },
@@ -2886,6 +3276,15 @@ async function replaceTransactionWithinTenantTransaction(
       oldInflowTx.accountId,
       negateMoney(absMoney(oldInflowTx.amount))
     )
+    // PER-247: reverse the old fee expense (add back its magnitude on the fee
+    // account) in the same aggregate delta pass.
+    if (oldFeeTx && oldFeeTx.deletedAt === null) {
+      addAccountDelta(
+        accountDeltas,
+        oldFeeTx.accountId,
+        absMoney(oldFeeTx.amount)
+      )
+    }
   } else {
     addAccountDelta(accountDeltas, oldTx.accountId, negateMoney(oldTx.amount))
   }
@@ -2918,6 +3317,14 @@ async function replaceTransactionWithinTenantTransaction(
     const kind = deriveTransferKindForAccounts({
       fromAccountType: parseAccountType(fromAccount.accountType),
       toAccountType: parseAccountType(toAccount.accountType),
+    })
+    // PER-247: resolve the contextual purpose (client override or
+    // taxonomy-derived default) for the replacement transfer.
+    const purpose = resolveTransferPurpose({
+      kind,
+      override: data.transferPurpose,
+      fromAccount,
+      toAccount,
     })
 
     const inAmount = data.destinationAmount ?? data.amount
@@ -3049,8 +3456,34 @@ async function replaceTransactionWithinTenantTransaction(
         fxRateScaled: transferFx.fxRateScaled,
         fromCurrency: transferFx.fromCurrency,
         toCurrency: transferFx.toCurrency,
+        purpose,
       },
     })
+
+    // PER-247: create the replacement transfer's fee leg (if requested) and
+    // link it onto the new Transfer. The old fee leg was reversed in the
+    // aggregate delta pass above and is soft-deleted below.
+    const newFeeTransactionId = await createTransferFeeLegIfRequested(tx, {
+      familyId,
+      user,
+      baseCurrency,
+      auditCtx,
+      feeKind: transferFx.fxRateScaled !== null ? "fx_fee" : "transfer_fee",
+      feeAmount: data.feeAmount,
+      feeAccountId: data.feeAccountId,
+      feeCategoryId: data.feeCategoryId,
+      defaultFeeAccountId: data.accountId,
+      date: data.date,
+      description: data.description,
+      notes: data.notes,
+      status: data.status,
+    })
+    if (newFeeTransactionId) {
+      createdTransfer = await tx.transfer.update({
+        where: { id: createdTransfer.id },
+        data: { feeTransactionId: newFeeTransactionId },
+      })
+    }
 
     resultTransaction = outflowTx
     createdInflowTx = inflowTx
@@ -3164,6 +3597,15 @@ async function replaceTransactionWithinTenantTransaction(
     if (transferUpdate.count !== 1) throw new TransactionGoneError()
   }
 
+  // PER-247: tombstone the old fee leg symmetrically with the old legs.
+  if (oldFeeTx && oldFeeTx.deletedAt === null) {
+    const feeUpdate = await tx.transaction.updateMany({
+      where: { id: oldFeeTx.id, familyId, deletedAt: null },
+      data: { deletedAt },
+    })
+    if (feeUpdate.count !== 1) throw new TransactionGoneError()
+  }
+
   const [
     updatedOldOutflow,
     updatedOldInflow,
@@ -3172,6 +3614,7 @@ async function replaceTransactionWithinTenantTransaction(
     updatedOldTransfer,
     newTransferGraph,
     newAccounts,
+    updatedOldFee,
   ] = await runTenantTransactionQueriesInOrder([
     () => findTransactionWithSplitEntries(tx, oldTx.id),
     () =>
@@ -3195,6 +3638,10 @@ async function replaceTransactionWithinTenantTransaction(
       tx.account.findMany({
         where: { id: { in: Array.from(touchedAccountIds) } },
       }),
+    () =>
+      oldFeeTx
+        ? findTransactionWithSplitEntries(tx, oldFeeTx.id)
+        : Promise.resolve(null),
   ] as const)
 
   await auditLogs(tx, auditCtx, [
@@ -3225,6 +3672,17 @@ async function replaceTransactionWithinTenantTransaction(
             entityId: oldTransferGraph.id,
             before: oldTransferGraph,
             after: updatedOldTransfer,
+          },
+        ]
+      : []),
+    ...(oldFeeTx && updatedOldFee
+      ? [
+          {
+            action: "soft_delete" as const,
+            entityType: "Transaction",
+            entityId: oldFeeTx.id,
+            before: oldFeeTx,
+            after: updatedOldFee,
           },
         ]
       : []),

--- a/tests/integration/account-statement-completeness.integration.ts
+++ b/tests/integration/account-statement-completeness.integration.ts
@@ -1,0 +1,221 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  createTransactionForFamily,
+  findLedgerTransactionsForFamily,
+} from "@/server/transactions"
+import { applyFilters } from "@/lib/transaction-filters"
+import {
+  orderStatementRows,
+  rangeCutoff,
+  type AccountRange,
+} from "@/lib/account-analytics"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-247 (TASK B) — per-account statement COMPLETENESS under the real client
+// pipeline, on real Postgres. The creator reported that on an account detail
+// page the range defaults to "3M" and clicking "All" still doesn't surface the
+// most recent (heavily back-dated) entries during reconciliation. The lead
+// could not reproduce a data-loss defect from code (no server LIMIT, "All"
+// cutoff is null, applyFilters matches accountId OR toAccountId). This test
+// proves that against real data: every back-dated row and both transfer
+// directions ARE present once the range is "All". The actual surfaced problem
+// was ORDER, not completeness — the per-account live query is unordered
+// (TanStack DB is non-deterministic without orderBy), which is fixed by
+// orderStatementRows (unit-tested in account-analytics.test.ts) and asserted
+// here to confirm the pipeline yields a deterministic newest-first statement.
+describe("account statement completeness (PER-247 TASK B)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const makeAccount = (
+    owner: AuthenticatedOnboardedUser,
+    overrides: {
+      name?: string
+      accountType?: AccountType
+      openingBalance?: string
+    } = {}
+  ) =>
+    createAccountForFamily({
+      data: {
+        name: overrides.name ?? "Account",
+        accountType: overrides.accountType ?? "DEPOSITORY",
+        currency: "IDR",
+        openingBalance: overrides.openingBalance ?? "1000000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const post = (
+    owner: AuthenticatedOnboardedUser,
+    data: {
+      type: "expense" | "income" | "transfer"
+      amount: bigint
+      accountId: string
+      toAccountId?: string
+      description: string
+      date: Date
+    }
+  ) =>
+    createTransactionForFamily({
+      data: { ...data, idempotencyKey: factories.createIdempotencyKey() },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // The exact per-account client pipeline the detail page runs:
+  //   applyFilters({accounts:[id]}) → rangeCutoff/isSameOrAfter → orderStatement.
+  // isSameOrAfter mirrors the (route-local) helper in accounts.$accountId.tsx.
+  const isSameOrAfter = (date: Date | string, cutoff: Date | null) =>
+    !cutoff || new Date(date).getTime() >= cutoff.getTime()
+
+  const accountStatement = async (
+    owner: AuthenticatedOnboardedUser,
+    accountId: string,
+    range: AccountRange,
+    now: Date
+  ) => {
+    const ledger = await harness.withFamily(owner.family.id, (tx) =>
+      findLedgerTransactionsForFamily(tx, owner.family.id)
+    )
+    const perAccount = applyFilters(ledger, { accounts: [accountId] })
+    const cutoff = rangeCutoff(range, now)
+    const ranged = perAccount.filter((t) => isSameOrAfter(t.date, cutoff))
+    return orderStatementRows(ranged)
+  }
+
+  test("'All' surfaces every back-dated row and both transfer directions", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "5000000",
+    })
+    const wallet = await makeAccount(owner, {
+      name: "Wallet",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+    const now = new Date("2026-08-12T10:00:00Z")
+
+    // A heavily back-dated expense (dated ~6 months ago, recorded "today"),
+    // exactly the reconciliation workflow the creator described.
+    const backdated = await post(owner, {
+      type: "expense",
+      amount: 40_000n,
+      accountId: bank.id,
+      description: "Backdated groceries",
+      date: new Date("2026-02-15T00:00:00Z"),
+    })
+    // A recent expense inside the 3M default window.
+    const recent = await post(owner, {
+      type: "expense",
+      amount: 25_000n,
+      accountId: bank.id,
+      description: "Recent coffee",
+      date: new Date("2026-08-01T00:00:00Z"),
+    })
+    // Transfer OUT of Bank (Bank is the source leg's accountId).
+    const outgoing = await post(owner, {
+      type: "transfer",
+      amount: 100_000n,
+      accountId: bank.id,
+      toAccountId: wallet.id,
+      description: "Top up wallet",
+      date: new Date("2026-07-20T00:00:00Z"),
+    })
+    // Transfer INTO Bank (Bank is toAccountId; the surfaced outflow leg's
+    // accountId is Wallet — must still appear via the toAccountId clause).
+    const incoming = await post(owner, {
+      type: "transfer",
+      amount: 30_000n,
+      accountId: wallet.id,
+      toAccountId: bank.id,
+      description: "Wallet back to Bank",
+      date: new Date("2026-07-25T00:00:00Z"),
+    })
+
+    const all = await accountStatement(owner, bank.id, "ALL", now)
+    const ids = new Set(all.map((t) => t.id))
+
+    // Completeness: nothing is dropped by the pipeline under "All".
+    expect(ids.has(backdated.id)).toBe(true)
+    expect(ids.has(recent.id)).toBe(true)
+    expect(ids.has(outgoing.id)).toBe(true)
+    // The incoming transfer surfaces as its single outflow leg (PER-202).
+    expect(ids.has(incoming.id)).toBe(true)
+    expect(all).toHaveLength(4)
+
+    // Deterministic newest-date-first order (the fix for "doesn't surface
+    // recent"): Recent(Aug 1) → Wallet→Bank(Jul 25) → Bank→Wallet(Jul 20) →
+    // Backdated(Feb 15).
+    expect(all.map((t) => t.id)).toEqual([
+      recent.id,
+      incoming.id,
+      outgoing.id,
+      backdated.id,
+    ])
+  })
+
+  test("the back-dated row is hidden by the default 3M range, revealed by 'All'", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, { name: "Bank" })
+    const now = new Date("2026-08-12T10:00:00Z")
+
+    const backdated = await post(owner, {
+      type: "expense",
+      amount: 40_000n,
+      accountId: bank.id,
+      description: "Backdated (Feb)",
+      date: new Date("2026-02-15T00:00:00Z"),
+    })
+    const recent = await post(owner, {
+      type: "expense",
+      amount: 25_000n,
+      accountId: bank.id,
+      description: "Recent (Aug)",
+      date: new Date("2026-08-01T00:00:00Z"),
+    })
+
+    // 3M window (cutoff ~ 2026-05-12) excludes the Feb entry — expected, and
+    // the reason the creator must switch to "All" to reconcile old postings.
+    const threeMonths = await accountStatement(owner, bank.id, "3M", now)
+    expect(threeMonths.map((t) => t.id)).toEqual([recent.id])
+
+    // "All" reveals it — completeness holds, the range was the only filter.
+    const all = await accountStatement(owner, bank.id, "ALL", now)
+    expect(new Set(all.map((t) => t.id))).toEqual(
+      new Set([recent.id, backdated.id])
+    )
+  })
+})

--- a/tests/integration/fx-currency.integration.ts
+++ b/tests/integration/fx-currency.integration.ts
@@ -323,7 +323,7 @@ describe("currency + FX snapshots + cross-currency transfers (PER-147 / ADR-0035
         toAccountId: idr.id,
         destinationAmount: 162_500_000n,
         destinationCurrency: "IDR",
-        fxFeeAmount: 2_500n, // $25.00 fee on the source account
+        feeAmount: 2_500n, // $25.00 fee on the source account
         description: "transfer with fee",
         date: new Date("2026-06-01"),
         idempotencyKey: factories.createIdempotencyKey(),

--- a/tests/integration/transfer-purpose-fee.integration.ts
+++ b/tests/integration/transfer-purpose-fee.integration.ts
@@ -1,0 +1,671 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import {
+  createAccountForFamily,
+  enableHoldingsTrackingForFamily,
+} from "@/server/accounts"
+import {
+  createTransactionForFamily,
+  deleteTransactionForFamily,
+  findLedgerTransactionsForFamily,
+  IdempotencyConflictError,
+} from "@/server/transactions"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-247 — contextual money movement: transfer purpose + transfer fee.
+// Real-Postgres proof of the §5A ledger invariants for the new transfer_fee
+// leg (conservation, dual-leg, idempotent replay/conflict, delete reversal,
+// audit) and the additive Transfer.purpose dimension (taxonomy derivation +
+// client override + DB guard). The purpose lives on the canonical Transfer
+// row (one shared value), never on the leg Transactions — so every assertion
+// reads it off `tx.transfer`.
+describe("transfer purpose + fee (PER-247)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const makeAccount = (
+    owner: AuthenticatedOnboardedUser,
+    overrides: {
+      name?: string
+      accountType?: AccountType
+      accountSubtype?: string
+      currency?: string
+      openingBalance?: string
+    } = {}
+  ) =>
+    createAccountForFamily({
+      data: {
+        name: overrides.name ?? "Account",
+        accountType: overrides.accountType ?? "DEPOSITORY",
+        accountSubtype: overrides.accountSubtype,
+        currency: overrides.currency ?? "IDR",
+        openingBalance: overrides.openingBalance ?? "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const accountBalance = (owner: AuthenticatedOnboardedUser, id: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const acc = await tx.account.findUniqueOrThrow({ where: { id } })
+      return acc.balance
+    })
+
+  // Family net worth = signed sum of every (non-deleted) account balance.
+  const netWorth = (owner: AuthenticatedOnboardedUser) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const accounts = await tx.account.findMany({
+        where: { familyId: owner.family.id, deletedAt: null },
+      })
+      return accounts.reduce((sum, a) => sum + a.balance, 0n)
+    })
+
+  const readTx = (owner: AuthenticatedOnboardedUser, id: string | null) => {
+    if (!id) throw new Error("readTx: expected a non-null transaction id")
+    return harness.withFamily(owner.family.id, async (tx) =>
+      tx.transaction.findUniqueOrThrow({ where: { id } })
+    )
+  }
+
+  // The purpose + fee link live on the canonical Transfer row.
+  const readTransferByOutflow = (
+    owner: AuthenticatedOnboardedUser,
+    outflowId: string
+  ) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.transfer.findFirstOrThrow({
+        where: { outflowTransactionId: outflowId },
+      })
+    )
+
+  // ---- fee conservation -----------------------------------------------------
+
+  test("same-currency transfer with a fee: origin −(amount+fee), dest +amount, net worth −fee", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const ewallet = await makeAccount(owner, {
+      name: "GoPay",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+
+    const before = await netWorth(owner)
+
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 100_000n,
+        accountId: bank.id,
+        toAccountId: ewallet.id,
+        feeAmount: 1_000n,
+        description: "Top up GoPay",
+        date: new Date("2026-06-01"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Ledger effect: origin loses amount + fee, destination gains amount.
+    expect(await accountBalance(owner, bank.id)).toBe(899_000n)
+    expect(await accountBalance(owner, ewallet.id)).toBe(100_000n)
+
+    // The fee is a real, signed expense of kind transfer_fee on the origin,
+    // linked to the Transfer (not a transfer leg — no toAccountId).
+    const transfer = await readTransferByOutflow(owner, created.id)
+    expect(transfer.feeTransactionId).not.toBeNull()
+    expect(transfer.purpose).toBe("top_up") // dest E_WALLET
+    const fee = await readTx(owner, transfer.feeTransactionId)
+    expect(fee.kind).toBe("transfer_fee")
+    expect(fee.type).toBe("expense")
+    expect(fee.amount).toBe(-1_000n)
+    expect(fee.accountId).toBe(bank.id)
+    expect(fee.toAccountId).toBeNull()
+
+    // Conservation to the sen: net worth is down by exactly the fee.
+    expect(await netWorth(owner)).toBe(before - 1_000n)
+
+    // Every written row is audited in the same transaction.
+    const feeAudit = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.findFirst({
+        where: {
+          entityType: "Transaction",
+          entityId: fee.id,
+          action: "create",
+        },
+      })
+    )
+    expect(feeAudit).not.toBeNull()
+  })
+
+  test("the fee may be borne by the destination account (editable bearer)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const ewallet = await makeAccount(owner, {
+      name: "OVO",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 100_000n,
+        accountId: bank.id,
+        toAccountId: ewallet.id,
+        feeAmount: 500n,
+        feeAccountId: ewallet.id, // destination bears the fee
+        description: "Top up OVO (dest-borne fee)",
+        date: new Date("2026-06-02"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Origin loses only the moved amount; destination gains amount then pays
+    // the fee out of its own balance.
+    expect(await accountBalance(owner, bank.id)).toBe(900_000n)
+    expect(await accountBalance(owner, ewallet.id)).toBe(99_500n)
+
+    const transfer = await readTransferByOutflow(owner, created.id)
+    const fee = await readTx(owner, transfer.feeTransactionId)
+    expect(fee.accountId).toBe(ewallet.id)
+    expect(fee.amount).toBe(-500n)
+  })
+
+  test("zero/absent fee writes NO fee row and conserves net worth exactly", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "500000",
+    })
+    const savings = await makeAccount(owner, {
+      name: "Savings",
+      openingBalance: "0",
+    })
+
+    const before = await netWorth(owner)
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 50_000n,
+        accountId: bank.id,
+        toAccountId: savings.id,
+        description: "Move to savings",
+        date: new Date("2026-06-03"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const transfer = await readTransferByOutflow(owner, created.id)
+    expect(transfer.feeTransactionId).toBeNull()
+    // A pure funds movement conserves net worth exactly.
+    expect(await netWorth(owner)).toBe(before)
+  })
+
+  // ---- purpose derivation + override ----------------------------------------
+
+  test("derives the purpose from the account taxonomy (kimi semantics)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "10000000",
+    })
+    const invest = await makeAccount(owner, {
+      name: "Reksadana",
+      accountType: "INVESTMENT",
+      openingBalance: "0",
+    })
+    const invest2 = await makeAccount(owner, {
+      name: "Reksadana 2",
+      accountType: "INVESTMENT",
+      openingBalance: "0",
+    })
+    const cash = await makeAccount(owner, {
+      name: "Cash",
+      accountType: "CASH",
+      openingBalance: "0",
+    })
+
+    const derive = async (
+      from: string,
+      to: string,
+      amount: bigint,
+      date: string
+    ) => {
+      const created = await createTransactionForFamily({
+        data: {
+          type: "transfer",
+          amount,
+          accountId: from,
+          toAccountId: to,
+          description: "derive",
+          date: new Date(date),
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+      return (await readTransferByOutflow(owner, created.id)).purpose
+    }
+
+    // dest INVESTMENT → contribution
+    expect(await derive(bank.id, invest.id, 200_000n, "2026-06-04")).toBe(
+      "investment_contribution"
+    )
+    // source INVESTMENT (to a plain bank) → withdrawal
+    expect(await derive(invest.id, bank.id, 50_000n, "2026-06-05")).toBe(
+      "investment_withdrawal"
+    )
+    // dest CASH → cash_withdrawal
+    expect(await derive(bank.id, cash.id, 10_000n, "2026-06-06")).toBe(
+      "cash_withdrawal"
+    )
+    // INVESTMENT → INVESTMENT is ambiguous → no derived purpose (null)
+    expect(await derive(invest.id, invest2.id, 5_000n, "2026-06-07")).toBeNull()
+  })
+
+  test("a savings-subtype destination derives the savings purpose", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const savings = await makeAccount(owner, {
+      name: "Tabungan",
+      accountType: "DEPOSITORY",
+      accountSubtype: "savings",
+      openingBalance: "0",
+    })
+
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 100_000n,
+        accountId: bank.id,
+        toAccountId: savings.id,
+        description: "Nabung",
+        date: new Date("2026-06-08"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect((await readTransferByOutflow(owner, created.id)).purpose).toBe(
+      "savings"
+    )
+  })
+
+  test("a client purpose override wins over the derived default", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const ewallet = await makeAccount(owner, {
+      name: "GoPay",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+
+    // Derived default would be top_up; the user calls it savings instead.
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 100_000n,
+        accountId: bank.id,
+        toAccountId: ewallet.id,
+        transferPurpose: "savings",
+        description: "Set aside on GoPay",
+        date: new Date("2026-06-09"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect((await readTransferByOutflow(owner, created.id)).purpose).toBe(
+      "savings"
+    )
+  })
+
+  test("valuation-linked contribution carries the derived purpose on its Transfer", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "5000000",
+    })
+    const invest = await makeAccount(owner, {
+      name: "Bibit",
+      accountType: "INVESTMENT",
+      openingBalance: "0",
+    })
+    // Flip the INVESTMENT account to valuation-tracked so the transfer routes
+    // through the valuation-linked path (ADR-0048).
+    await enableHoldingsTrackingForFamily({
+      data: {
+        accountId: invest.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 300_000n,
+        accountId: bank.id,
+        toAccountId: invest.id,
+        feeAmount: 2_000n,
+        description: "Nabung Bibit",
+        date: new Date("2026-06-10"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const transfer = await readTransferByOutflow(owner, created.id)
+    expect(transfer.purpose).toBe("investment_contribution")
+    // The fee on a valuation-linked contribution posts on the cash source.
+    const fee = await readTx(owner, transfer.feeTransactionId)
+    expect(fee.kind).toBe("transfer_fee")
+    expect(fee.accountId).toBe(bank.id)
+    expect(await accountBalance(owner, bank.id)).toBe(4_698_000n)
+  })
+
+  // ---- redemption direction (prod bug: reversed arrow) ----------------------
+
+  test("a valuation-linked redemption exposes transferIncoming so the arrow reads tracked → cash", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank Jago",
+      openingBalance: "5000000",
+    })
+    const invest = await makeAccount(owner, {
+      name: "Hasil Jualan",
+      accountType: "INVESTMENT",
+      openingBalance: "0",
+    })
+    await enableHoldingsTrackingForFamily({
+      data: {
+        accountId: invest.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Fund the position first (contribution: Bank Jago → Hasil Jualan). Pass
+    // the new valuation explicitly so the test does not depend on the
+    // anchor/backdating prefill heuristic.
+    const contribution = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 1_000_000n,
+        accountId: bank.id,
+        toAccountId: invest.id,
+        newValuationValue: "1000000",
+        description: "Nabung",
+        date: new Date("2026-06-15"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // ...then redeem part of it (Hasil Jualan → Bank Jago). The cash leg lands
+    // on Bank Jago (accountId) with toAccountId = Hasil Jualan — correct data,
+    // but naively rendered "account → toAccount" it reads reversed.
+    const redemption = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 400_000n,
+        accountId: invest.id,
+        toAccountId: bank.id,
+        newValuationValue: "600000",
+        description: "Tarik hasil jualan",
+        date: new Date("2026-06-16"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const ledger = await harness.withFamily(owner.family.id, (tx) =>
+      findLedgerTransactionsForFamily(tx, owner.family.id)
+    )
+    const redemptionRow = ledger.find((r) => r.id === redemption.id)
+    const contributionRow = ledger.find((r) => r.id === contribution.id)
+
+    // The redemption cash leg is stored on Bank Jago pointing at Hasil Jualan,
+    // and is flagged incoming so the renderer flips the arrow to
+    // "Hasil Jualan → Bank Jago".
+    expect(redemptionRow?.accountId).toBe(bank.id)
+    expect(redemptionRow?.toAccountId).toBe(invest.id)
+    expect(redemptionRow?.transferIncoming).toBe(true)
+    expect(redemptionRow?.transferPurpose).toBe("investment_withdrawal")
+
+    // A contribution is outgoing from its cash account — arrow stays
+    // "Bank Jago → Hasil Jualan".
+    expect(contributionRow?.transferIncoming).toBe(false)
+  })
+
+  // ---- idempotent replay + conflict -----------------------------------------
+
+  test("replaying the same idempotency key does not duplicate legs or the fee", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const ewallet = await makeAccount(owner, {
+      name: "OVO",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      type: "transfer" as const,
+      amount: 100_000n,
+      accountId: bank.id,
+      toAccountId: ewallet.id,
+      feeAmount: 1_500n,
+      description: "Top up OVO",
+      date: new Date("2026-06-11"),
+      idempotencyKey: key,
+    }
+
+    const first = await createTransactionForFamily({
+      data: payload,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const second = await createTransactionForFamily({
+      data: payload,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(second.id).toBe(first.id)
+
+    // Balances reflect exactly ONE application (amount + fee).
+    expect(await accountBalance(owner, bank.id)).toBe(898_500n)
+    expect(await accountBalance(owner, ewallet.id)).toBe(100_000n)
+
+    const counts = await harness.withFamily(owner.family.id, async (tx) => ({
+      transfers: await tx.transfer.count({ where: { deletedAt: null } }),
+      feeRows: await tx.transaction.count({
+        where: { kind: "transfer_fee", deletedAt: null },
+      }),
+    }))
+    expect(counts.transfers).toBe(1)
+    expect(counts.feeRows).toBe(1)
+  })
+
+  test("the same key with a different fee is a conflict (not a silent replay)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const ewallet = await makeAccount(owner, {
+      name: "Dana",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+    const key = factories.createIdempotencyKey()
+    const base = {
+      type: "transfer" as const,
+      amount: 100_000n,
+      accountId: bank.id,
+      toAccountId: ewallet.id,
+      description: "Top up Dana",
+      date: new Date("2026-06-12"),
+      idempotencyKey: key,
+    }
+
+    await createTransactionForFamily({
+      data: { ...base, feeAmount: 1_000n },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    await expect(
+      createTransactionForFamily({
+        data: { ...base, feeAmount: 2_000n },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(IdempotencyConflictError)
+  })
+
+  // ---- delete reversal ------------------------------------------------------
+
+  test("delete reverses the fee exactly once and restores net worth", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const ewallet = await makeAccount(owner, {
+      name: "ShopeePay",
+      accountType: "E_WALLET",
+      openingBalance: "0",
+    })
+    const before = await netWorth(owner)
+    const created = await createTransactionForFamily({
+      data: {
+        type: "transfer",
+        amount: 100_000n,
+        accountId: bank.id,
+        toAccountId: ewallet.id,
+        feeAmount: 2_000n,
+        description: "Top up ShopeePay",
+        date: new Date("2026-06-13"),
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const transfer = await readTransferByOutflow(owner, created.id)
+    const feeId = transfer.feeTransactionId
+
+    const deleteKey = factories.createIdempotencyKey()
+    await deleteTransactionForFamily({
+      id: created.id,
+      idempotencyKey: deleteKey,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Net worth is fully restored (amount move + fee both reversed).
+    expect(await netWorth(owner)).toBe(before)
+    expect(await accountBalance(owner, bank.id)).toBe(1_000_000n)
+    expect(await accountBalance(owner, ewallet.id)).toBe(0n)
+
+    // The fee row is soft-deleted, not erased (ledger history preserved).
+    const fee = await readTx(owner, feeId)
+    expect(fee.deletedAt).not.toBeNull()
+
+    // A replayed delete does not reverse balances a second time.
+    await deleteTransactionForFamily({
+      id: created.id,
+      idempotencyKey: deleteKey,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(await netWorth(owner)).toBe(before)
+    expect(await accountBalance(owner, bank.id)).toBe(1_000_000n)
+  })
+
+  // ---- DB guard: purpose only on funds_movement -----------------------------
+
+  test("a purpose override on a non-funds_movement (cc_payment) transfer is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const bank = await makeAccount(owner, {
+      name: "Bank",
+      openingBalance: "1000000",
+    })
+    const card = await makeAccount(owner, {
+      name: "Credit Card",
+      accountType: "CREDIT",
+      openingBalance: "0",
+    })
+
+    // bank (ASSET) → CREDIT card = cc_payment; a purpose is meaningless there.
+    await expect(
+      createTransactionForFamily({
+        data: {
+          type: "transfer",
+          amount: 100_000n,
+          accountId: bank.id,
+          toAccountId: card.id,
+          transferPurpose: "savings",
+          description: "Pay card",
+          date: new Date("2026-06-14"),
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## PER-247 — Contextual money movement

Makes money-movements self-explanatory + fee-aware, and fixes the reversed direction + non-deterministic ordering surfaced by dogfooding prod. Modal capture is kept (creator likes detailed entry).

### Core (server + DB, §5A ledger-correct)
- **`Transfer.purpose`** — nullable, DB-CHECK domain (`top_up / investment_contribution / investment_withdrawal / savings / cash_withdrawal`), derived from account taxonomy, user-overridable, funds_movement-only (trigger-guarded).
- **`transfer_fee` kind** (generalizes `fx_fee`) — standalone signed expense linked via `Transfer.feeTransactionId`, default borne by origin (editable), routed to the cash side for a valuation redemption. Atomic delta, base projection, audit, idempotency-aware (resolve purpose + fee bearer **before** the replay check; same key + different fee/purpose → conflict). Replace path now reverses + tombstones + audits the old fee leg (fixes a pre-existing orphan).
- `findLedgerTransactionsForFamily` returns `transferPurpose`, `transferFee`, `transferIncoming`.

### Contextual rendering + insights
- One label source `moneyMovementLabel({kind, purpose})` used by the ledger list, per-account statement, and **spend-by-category** breakdown (no more single lump "Transfer").
- **Fix reversed arrow** for a valuation-linked redemption (`transferIncoming` flips "cash → tracked" to "tracked → cash", e.g. *Hasil Jualan → Bank Jago*). Display-only; balances untouched — **verified against the real prod row**.
- **`orderStatementRows`** — the per-account live query has no intrinsic order (TanStack DB is non-deterministic without `orderBy`); sort newest-date-first, most-recently-created first within a day so a just-recorded backdated entry surfaces at the top of its day (reconciliation).

### Tests
- `transfer-purpose-fee.integration.ts` (12 real-PG cases) + `account-statement-completeness.integration.ts` (2) + unit tests for `summarizeCategories` bucketing and `orderStatementRows`.

### Gates (verified locally)
- `vp check` ✅ · `vp build` ✅ (no client leak) · unit **651/651** ✅ · integration **459/459** ✅

### Deploy note
Migration-bearing (`Transfer.purpose` + `transfer_fee` kind + trigger changes). Deploy as a deliberate batch **with a fresh pre-deploy backup**; the redemption-direction fix auto-corrects existing rows (display-only, no data migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1