### PR TITLE
fix(transactions): PER-251 — resync account balances after a transaction mutation

### DIFF
--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,5 +1,6 @@
 import { createCollection } from "@tanstack/react-db"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
+import { accountCollection } from "./account-collections"
 import type { TransactionKind } from "./liability-semantics"
 import type { TransferPurpose } from "./money-movement"
 import { decodeMoney, encodeMoney, type Money } from "./money"
@@ -104,6 +105,20 @@ export type TransactionRecord = ReturnType<
   typeof reviveTransaction<RawTransactionFromServer>
 >
 
+// A transaction mutation changes account balances (the server applies an atomic
+// signed delta), so resync the account collection too — not just the ledger.
+// Without it, the account-page hero balance + KPIs (which read `account.balance`
+// from `accountCollection`) stay stale until a manual page reload. Drift is not
+// refetched here: a normal transaction_flow mutation cannot change valuation
+// drift, and its own mutation paths already resync it. AGENTS.md §5.B: sync
+// client collections with the Postgres source of truth after every mutation.
+async function resyncLedgerAndBalances(): Promise<void> {
+  await Promise.all([
+    transactionCollection.utils.refetch(),
+    accountCollection.utils.refetch(),
+  ])
+}
+
 // 1. Definisikan Koleksi Transaksi kita
 export const transactionCollection = createCollection(
   queryCollectionOptions({
@@ -206,7 +221,7 @@ export const transactionCollection = createCollection(
           },
         })
         // WAJIB: Tunggu server untuk sync ulang agar optimistic state tetap valid
-        await transactionCollection.utils.refetch()
+        await resyncLedgerAndBalances()
       } catch (error) {
         console.error("Optimistic Insert Failed! Rolled back:", error)
         throw error
@@ -279,7 +294,7 @@ export const transactionCollection = createCollection(
           },
         })
         // WAJIB: Tunggu server sync ulang agar data edit tersinkron permanen
-        await transactionCollection.utils.refetch()
+        await resyncLedgerAndBalances()
       } catch (error) {
         console.error("Optimistic Update Failed! Rolled back:", error)
         throw error
@@ -293,7 +308,7 @@ export const transactionCollection = createCollection(
           data: { id: id as string, idempotencyKey: createUuidV7() },
         })
         // WAJIB: Sync ulang setelah hapus agar UI konsisten dengan server
-        await transactionCollection.utils.refetch()
+        await resyncLedgerAndBalances()
       } catch (error) {
         console.error("Optimistic Delete Failed! Rolled back:", error)
         throw error

--- a/tests/e2e/account-balance-reactive.e2e.ts
+++ b/tests/e2e/account-balance-reactive.e2e.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-247 follow-up — the account-detail hero balance must recalculate
+// REACTIVELY after adding a transaction from the same page, without a manual
+// reload. A transaction mutation applies an atomic signed delta to the account
+// balance server-side; the client must resync `accountCollection` (not only
+// `transactionCollection`) so the hero + KPIs update in place. This spec drives
+// the real browser -> server-fn -> Postgres path and asserts the new balance
+// appears WITHOUT page.reload() — it would fail (hero stuck on the old balance)
+// before the resync fix.
+test.describe("account balance reactivity (PER-247)", () => {
+  test("hero balance updates in place after adding a transaction — no reload", async ({
+    page,
+  }) => {
+    await onboard(page)
+
+    const suffix = Date.now().toString(36)
+    const accountName = `E2E Balance ${suffix}`
+
+    // Create an account with a distinctive opening balance (no reserve, so the
+    // only 2,000,000 on the page is the hero balance).
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(accountName)
+    await page.getByLabel("Opening balance").fill("2000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Open the detail page and confirm the starting hero balance.
+    await page.getByRole("button", { name: `Open ${accountName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+    await expect(page.getByText("Rp 2,000,000.00").first()).toBeVisible()
+
+    // Add a transaction from the account page itself (in-place modal). The
+    // account is pre-filled via defaultAccountId (PER-247 account-aware add).
+    const description = `E2E reactive expense ${suffix}`
+    const categoryName = `E2E Reactive ${suffix}`
+    await page.getByRole("button", { name: "Add transaction" }).click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await page.getByLabel("Description *").fill(description)
+    await page.getByLabel("Amount *").fill("250000")
+    // Expense requires a category — quick-create one so the spec is
+    // self-contained (does not depend on seeded categories).
+    await page.getByLabel("Category *").click()
+    await page.getByPlaceholder("Search categories...").fill(categoryName)
+    await page
+      .getByRole("option", { name: `Create category "${categoryName}"` })
+      .click()
+    await page.getByRole("button", { name: "Save Transaction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // THE ASSERTION: without any reload, the hero balance recalculates to
+    // 2,000,000 - 250,000 = 1,750,000. Before the accountCollection resync fix
+    // this stayed at 2,000,000 until a manual reload.
+    await expect(page.getByText("Rp 1,750,000.00").first()).toBeVisible()
+    await expect(page.getByText("Rp 2,000,000.00")).toHaveCount(0)
+
+    // The new transaction also shows in the statement (newest first).
+    await expect(page.getByText(description)).toBeVisible()
+  })
+})


### PR DESCRIPTION
## PER-251 — account balance now reactive (no reload)

**Bug (creator, dogfooding):** on the account detail page, adding/editing/deleting a transaction did NOT recalculate the hero balance + KPIs until a manual reload.

**Root cause:** `transactionCollection`'s `onInsert/onUpdate/onDelete` only called `transactionCollection.utils.refetch()`. The account-page hero reads `account.balance` from `accountCollection`, which was never resynced — so the server-applied atomic delta wasn't reflected client-side until reload.

**Fix:** `resyncLedgerAndBalances()` refetches both `transactionCollection` and `accountCollection` after every transaction mutation. Drift is intentionally not refetched per-save (a normal transaction_flow mutation can't change valuation drift; its own paths resync it) to keep saves snappy.

**Verification:** new `tests/e2e/account-balance-reactive.e2e.ts` adds a transaction from the account page and asserts the hero updates in place (2,000,000 → 1,750,000) **without a reload** (fails before this fix). `vp check` ✅ · `vp build` ✅ · e2e **1 passed**. App-only (no migration).

Follow-up to PER-247. Related list/UX gaps (per-account statement virtualization + display parity with /transactions) tracked under PER-241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1