### PR TITLE
feat(market-data): PER-257 — Financial Ingestion Service (provider routing engine)

### DIFF
--- a/docs/adr/0052-financial-ingestion-service-provider-routing.md
+++ b/docs/adr/0052-financial-ingestion-service-provider-routing.md
@@ -1,0 +1,157 @@
+# ADR-0052 — Financial Ingestion Service (provider routing)
+
+|                   |                                  |
+| ----------------- | -------------------------------- |
+| **Status**        | Accepted                         |
+| **Date**          | 2026-08-15                       |
+| **Accepted**      | 2026-08-15                       |
+| **Deciders**      | Hendri Permana                   |
+| **Supersedes**    | —                                |
+| **Superseded by** | —                                |
+| **Amends**        | ADR-0050 (market-data ingestion) |
+
+## Context
+
+ADR-0050 built a provider-agnostic market-data subsystem: a global
+`MarketInstrument` / `MarketQuote` store, a raw → staged → canonical pipeline
+(`ingestMarketDataOnce`), a single `MarketDataProvider` seam, and two live
+adapters — a fixture provider and the self-hosted gold worker
+(`LogamMuliaGoldProvider`, PER-235). Holdings link to a `MarketInstrument`
+(PER-238) and revalue anchor-safely on "Refresh prices".
+
+The subsystem was designed generic but is **wired for exactly one provider**.
+`syncMarketPricesOnce()` hardcodes `ingestGoldPricesOnce()` — there is no
+mechanism that, given a set of instruments of mixed kinds, sends each to the
+correct vendor. To finish the "auto market data for **all** my investments"
+story (PER-250) — Indonesian reksadana NAV first, then IDX/global equities,
+crypto, and FX — we need a **router** in front of the seam.
+
+The scope focus (creator, 2026-08-15) is explicit: the only genuinely hard
+**new source** is **local Indonesian reksadana NAV** (no clean free API). Gold
+already has its worker; IDX equities, US/global equities, crypto, and FX are
+covered by public/free vendors (Yahoo Finance / Alpaca / Twelve Data / ECB) and
+plug into the same router as later slices. So this ADR fixes the **routing
+architecture** and the **reksadana source**, and reserves the remaining vendor
+adapters as pluggable slots.
+
+## Decision
+
+Introduce a **Financial Ingestion Service**: a modular router that selects a
+`MarketDataProvider` per instrument, batches per provider, and ingests each
+batch through the existing (unchanged) `ingestMarketDataOnce` pipeline. No new
+storage or ledger mechanism — only a routing layer and new adapters.
+
+### 1. Explicit `provider` discriminator on `MarketInstrument`
+
+Add a **nullable `provider String?`** column to `MarketInstrument` (additive
+migration). It names the **source adapter** that prices this instrument
+(`"logam_mulia"`, `"reksadana_id"`, `"yahoo"`, `"alpaca"`, `"twelvedata"`). The
+router reads it first; when `NULL` it falls back to kind/mic derivation so
+existing rows (gold) keep routing correctly with zero backfill required.
+
+Rationale (chosen over overloading `mic`): an instrument should **declare** its
+data source. `mic` is an ISO-10383 exchange code; a reksadana fund has no
+exchange, so a synthetic `mic="RDID"` would be a contract smell. An explicit
+column removes routing ambiguity entirely — "prefer a smaller, stricter contract
+… ambiguity is technical debt" (CLAUDE.md). A CHECK constrains `provider` to the
+known adapter-id domain so an unknown source cannot be persisted.
+
+Reksadana identity becomes: `kind="security"`, `provider="reksadana_id"`,
+`symbol=<fund code>` (KSEI/Bareksa stable code), `quoteCurrency="IDR"`,
+`mic=NULL`. NAV per unit is a normal spot `MarketQuote`.
+
+### 2. Pure routing table — `resolveProviderId(instrument)`
+
+A pure function in `src/lib/market-data.ts` (no network, fully unit-tested):
+
+| `kind`     | discriminator             | → provider id  |
+| ---------- | ------------------------- | -------------- |
+| `metal`    | (gold symbol)             | `logam_mulia`  |
+| `security` | `provider="reksadana_id"` | `reksadana_id` |
+| `security` | IDX (`mic`/`.JK`)         | `yahoo`        |
+| `security` | global / other            | `yahoo`        |
+| `crypto`   | —                         | `yahoo`        |
+| `fx`       | —                         | `yahoo`        |
+
+`provider` column wins when set; otherwise derive from `(kind, mic, symbol)`. An
+instrument that resolves to no registered adapter is **skipped** with a
+structured skip result, never a throw.
+
+### 3. `ProviderRegistry` + `FinancialIngestionService`
+
+- **`ProviderRegistry`** — `Map<ProviderId, () => MarketDataProvider>` (lazy
+  factories so a provider whose env/secret is unset only throws when actually
+  invoked, and only fails its own group). Adapters are constructed inside their
+  own `.server.ts`; secrets never leak past the seam.
+- **`ingestAllInstrumentsOnce()`** replaces the gold-only sync:
+  1. Load the `MarketInstrument` **catalog** — all rows of this family-neutral,
+     no-RLS table. Instruments are created only when a user links one to a
+     holding (plus gold, ensured on sync), so the catalog equals the in-use set
+     and stays bounded, with **no cross-tenant read** into the RLS-forced
+     holdings `Instrument` table. **Do NOT** discover "held" instruments by
+     reading the tenant holdings table from the unscoped global job: the
+     `permoney_migrator` / `permoney_app` roles are `NOBYPASSRLS`, `Instrument`
+     is `FORCE ROW LEVEL SECURITY`, so even a `SECURITY DEFINER` function owned by
+     those roles is still subject to RLS and returns **zero rows in production**
+     (it only "works" under a local superuser). When a future slice bulk-seeds a
+     large instrument universe for search (instruments no longer created solely
+     on-link), prune pricing to the in-use set via a family-neutral
+     `MarketInstrumentUsage` signal maintained on the holdings link/unlink path —
+     never a cross-tenant read.
+  2. Group by `resolveProviderId`.
+  3. Per group: construct the provider, `fetchQuotes(batch)` →
+     `ingestMarketDataOnce` (idempotent upsert).
+  4. **Per-provider failure isolation**: each group runs in its own `try/catch`.
+     A provider that is unreachable / misconfigured / returns non-2xx degrades to
+     `{ ingested: 0, error }` for **its** instruments only; other groups still
+     refresh; the last-good `MarketQuote` is retained; a failed
+     `RawMarketDataFetch` is recorded. Returns a per-provider summary.
+
+Gold routes **through** the registry (its behaviour is unchanged but is now
+proven behind the router before fragile sources plug in). `syncMarketPricesFn`
+(PER-235b) calls `ingestAllLinkedInstrumentsOnce`; `refreshHoldingPricesFn`
+(PER-238) applies the fresh quotes anchor-safely — both contracts unchanged.
+
+### 4. Reksadana NAV worker (the new source)
+
+A **self-hosted Cloudflare Worker** (creator's CF account) mirroring the gold
+worker's isolation: it fetches Indonesian reksadana NAV from a chosen upstream
+(Bibit/Bareksa internal JSON — final source picked after a stability spike),
+caches in D1, and degrades gracefully. Minimal contract:
+`GET /nav?fund=<code>` → `{ fundCode, nav, asOf }` (and a batch form). The
+Permoney-side `ReksadanaNavProvider` calls it behind `REKSADANA_API_URL`,
+exactly as `LogamMuliaGoldProvider` calls `LOGAM_MULIA_API_URL`. Scrape
+fragility and ToS-gray live entirely inside the worker, never in Permoney.
+**Tests use saved fixtures — no live network in CI** (raw → staged doctrine).
+
+### 5. Reserved slots (later slices)
+
+`YahooFinanceProvider` (one adapter covering IDX `.JK` + global equities +
+crypto + FX), with `alpaca` / `twelvedata` as drop-in fallbacks, register into
+the same `ProviderRegistry` with zero consumer change. FX → base-IDR conversion
+for net worth (ADR-0035 read side) and the daily scheduler (PER-237) follow.
+
+## Consequences
+
+- **Modular & swappable**: adding a vendor = one adapter + one registry entry +
+  (optionally) a `provider` value. Consumers (`syncMarketPricesFn`, holdings
+  refresh, net worth) never change.
+- **Resilient**: one flaky source cannot break the others or lose data;
+  degradation is per-provider and observable.
+- **Durable & explicit**: instruments declare their source; routing is a pure,
+  tested function; no ledger or storage mechanism was added.
+- **Migration**: additive nullable column + CHECK; gold rows need no backfill
+  (NULL → derived route). Reksadana instruments are seeded with
+  `provider="reksadana_id"`.
+- **Cost**: reksadana relies on a scraped upstream — accepted, isolated in the
+  worker, guarded by graceful degradation + last-good retention.
+
+## Implementation slices (tracked in Linear, under PER-250)
+
+- **Slice A — routing engine**: `provider` column + `resolveProviderId` +
+  `ProviderRegistry` + `ingestAllInstrumentsOnce`; migrate gold onto the
+  router. Fixture + real-PG tests. No new vendor.
+- **Slice B — reksadana (focus)**: NAV worker + `ReksadanaNavProvider` + seed the
+  creator's Bibit funds + link holdings + refresh. Fixture + real-PG tests.
+- **Slice C (later)**: `YahooFinanceProvider` (IDX/global equities, crypto, FX).
+- **Slice D (later)**: FX → base-currency net worth + daily scheduler (PER-237).

--- a/prisma/migrations/20260815120000_market_instrument_provider/migration.sql
+++ b/prisma/migrations/20260815120000_market_instrument_provider/migration.sql
@@ -1,0 +1,60 @@
+-- PER-257 / ADR-0052 — Financial Ingestion Service (provider routing engine).
+--
+-- Adds an EXPLICIT source-adapter discriminator to MarketInstrument so the
+-- ingestion router can select the correct vendor per instrument, batch per
+-- vendor, and ingest through the (unchanged) raw -> staged -> canonical pipeline.
+--
+-- WHY an explicit column (chosen over overloading `mic`): an instrument should
+-- DECLARE its data source. `mic` is an ISO-10383 exchange code; a reksadana fund
+-- has no exchange, so a synthetic mic would be a contract smell. An explicit
+-- column removes routing ambiguity entirely (ADR-0052 §1). A CHECK constrains it
+-- to the known adapter-id domain so an unknown source can never be persisted.
+--
+-- ADDITIVE ONLY: a NULLABLE column, no default, no backfill. Existing rows (the
+-- BSI gold series) stay NULL and keep routing correctly via kind/mic derivation
+-- (`resolveProviderId`: metal -> 'logam_mulia'). Touches no existing value; adds
+-- no ledger behaviour; this table remains family-neutral (no RLS — see the
+-- 20260807130000_market_data_core header).
+
+ALTER TABLE "MarketInstrument" ADD COLUMN "provider" TEXT;
+
+-- Domain CHECK (Database Is the Law). NULL is allowed (derive the route); a
+-- non-NULL value must be one of the known adapter ids.
+ALTER TABLE "MarketInstrument"
+  ADD CONSTRAINT market_instrument_provider_domain CHECK (
+    "provider" IS NULL
+    OR "provider" IN ('logam_mulia', 'reksadana_id', 'yahoo', 'alpaca', 'twelvedata')
+  );
+
+-- ============================================================================
+-- Cross-tenant linkage discovery for the GLOBAL ingest (Financial Ingestion
+-- Service, ADR-0052 §3).
+--
+-- The ingestion router prices only the instruments actually HELD (bounded work,
+-- not the whole catalog). "Held" lives on the tenant-scoped holdings `Instrument`
+-- table, which is `FORCE ROW LEVEL SECURITY` (20260804120000_holdings_core). The
+-- global ingest runs with NO family scope (it writes only the family-neutral
+-- market tables, never the ledger — ADR-0050 §6), so under RLS it would see zero
+-- linkages and price nothing.
+--
+-- This `SECURITY DEFINER` function is the explicit, minimal boundary crossing:
+-- it returns ONLY the set of GLOBAL `MarketInstrument` ids that at least one
+-- holding links — never a tenant row, `familyId`, quantity, cost, or value. No
+-- tenant-private data leaves the boundary; the function merely tells the global
+-- pricing job which public price series are in use. Tenant isolation is intact;
+-- the global job stays bounded. `SET search_path` hardens the definer function
+-- against search-path hijacking. Owned by the (privileged) migration role, so it
+-- bypasses the holdings-table RLS to compute the DISTINCT set; EXECUTE is left to
+-- the PUBLIC default so the app runtime role can call it.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION market_instrument_ids_linked_to_holdings()
+  RETURNS SETOF text
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+  SELECT DISTINCT "marketInstrumentId"
+  FROM "Instrument"
+  WHERE "marketInstrumentId" IS NOT NULL
+$$;

--- a/prisma/migrations/20260815120000_market_instrument_provider/migration.sql
+++ b/prisma/migrations/20260815120000_market_instrument_provider/migration.sql
@@ -26,35 +26,11 @@ ALTER TABLE "MarketInstrument"
     OR "provider" IN ('logam_mulia', 'reksadana_id', 'yahoo', 'alpaca', 'twelvedata')
   );
 
--- ============================================================================
--- Cross-tenant linkage discovery for the GLOBAL ingest (Financial Ingestion
--- Service, ADR-0052 §3).
---
--- The ingestion router prices only the instruments actually HELD (bounded work,
--- not the whole catalog). "Held" lives on the tenant-scoped holdings `Instrument`
--- table, which is `FORCE ROW LEVEL SECURITY` (20260804120000_holdings_core). The
--- global ingest runs with NO family scope (it writes only the family-neutral
--- market tables, never the ledger — ADR-0050 §6), so under RLS it would see zero
--- linkages and price nothing.
---
--- This `SECURITY DEFINER` function is the explicit, minimal boundary crossing:
--- it returns ONLY the set of GLOBAL `MarketInstrument` ids that at least one
--- holding links — never a tenant row, `familyId`, quantity, cost, or value. No
--- tenant-private data leaves the boundary; the function merely tells the global
--- pricing job which public price series are in use. Tenant isolation is intact;
--- the global job stays bounded. `SET search_path` hardens the definer function
--- against search-path hijacking. Owned by the (privileged) migration role, so it
--- bypasses the holdings-table RLS to compute the DISTINCT set; EXECUTE is left to
--- the PUBLIC default so the app runtime role can call it.
--- ============================================================================
-CREATE OR REPLACE FUNCTION market_instrument_ids_linked_to_holdings()
-  RETURNS SETOF text
-  LANGUAGE sql
-  STABLE
-  SECURITY DEFINER
-  SET search_path = public
-AS $$
-  SELECT DISTINCT "marketInstrumentId"
-  FROM "Instrument"
-  WHERE "marketInstrumentId" IS NOT NULL
-$$;
+-- NOTE (ADR-0052 §3): the ingestion router discovers what to price by reading the
+-- GLOBAL, family-neutral `MarketInstrument` catalog directly (a row exists only
+-- because a holding linked it or a prior ingest created it — so the catalog IS
+-- the in-use set, bounded, with NO tenant-RLS dependency). It deliberately does
+-- NOT read the tenant-scoped, FORCE-RLS holdings `Instrument` table: a
+-- no-family-scope global job cannot see those rows under a NOBYPASSRLS role
+-- (prod's `permoney_app`/`permoney_migrator`), and a `SECURITY DEFINER`
+-- cross-tenant read is banned. No new object is needed here.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1089,6 +1089,14 @@ model MarketInstrument {
   // across exchanges). A CHECK keeps it NULL unless kind = 'security'.
   mic String?
 
+  // PER-257 / ADR-0052 — the explicit SOURCE ADAPTER that prices this instrument
+  // ('logam_mulia' | 'reksadana_id' | 'yahoo' | 'alpaca' | 'twelvedata'). The
+  // Financial Ingestion Service router reads this FIRST; when NULL it falls back
+  // to kind/mic derivation (`resolveProviderId`), so existing rows (gold) keep
+  // routing correctly with zero backfill. A CHECK constrains it to the adapter-id
+  // domain (NULL allowed).
+  provider String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 

--- a/src/lib/market-data.test.ts
+++ b/src/lib/market-data.test.ts
@@ -9,15 +9,20 @@ import {
   FX_PRICE_DECIMALS,
   goldPerGramMajorToPerOunceDecimal,
   isMarketInstrumentKind,
+  isProviderId,
   MARKET_INSTRUMENT_KINDS,
   marketQuoteToHoldingPriceMinor,
   normalizeObservations,
   parseLogamMuliaGoldResponse,
   priceScaleForKind,
+  PROVIDER_IDS,
+  resolveProviderId,
   SPOT_PRICE_DECIMALS,
   SPOT_PRICE_SCALE,
   spotPriceScaledPerGram,
+  type MarketInstrumentKind,
   type MarketObservation,
+  type ProviderRoutingInput,
 } from "./market-data"
 
 const AS_OF = new Date("2026-08-07T00:00:00.000Z")
@@ -509,5 +514,148 @@ describe("parseLogamMuliaGoldResponse", () => {
       data: [{ ...GOLD_PAYLOAD.data[0], buybackPrice: 0 }],
     })
     expect(result.status).toBe("error")
+  })
+})
+
+// =============================================================================
+// Provider routing (ADR-0052 / PER-257) — resolveProviderId, every branch
+// =============================================================================
+
+describe("provider id domain guard", () => {
+  test("PROVIDER_IDS holds the five known adapter ids", () => {
+    expect([...PROVIDER_IDS]).toEqual([
+      "logam_mulia",
+      "reksadana_id",
+      "yahoo",
+      "alpaca",
+      "twelvedata",
+    ])
+  })
+
+  test("isProviderId accepts known ids and rejects everything else", () => {
+    for (const id of PROVIDER_IDS) expect(isProviderId(id)).toBe(true)
+    expect(isProviderId("bankbsi")).toBe(false)
+    expect(isProviderId("")).toBe(false)
+    expect(isProviderId("YAHOO")).toBe(false)
+  })
+})
+
+describe("resolveProviderId — kind/mic derivation (provider column NULL)", () => {
+  const route = (
+    over: Partial<ProviderRoutingInput> & { kind: MarketInstrumentKind }
+  ): ProviderRoutingInput => ({
+    symbol: over.symbol ?? "SYM",
+    mic: over.mic ?? null,
+    provider: over.provider ?? null,
+    kind: over.kind,
+  })
+
+  test("metal derives to logam_mulia (the gold baseline route)", () => {
+    expect(
+      resolveProviderId(route({ kind: "metal", symbol: "XAU-BSI" }))
+    ).toEqual({ status: "routed", providerId: "logam_mulia" })
+  })
+
+  test("security IDX (mic set) derives to yahoo", () => {
+    expect(
+      resolveProviderId(
+        route({ kind: "security", symbol: "BBCA", mic: "XIDX" })
+      )
+    ).toEqual({ status: "routed", providerId: "yahoo" })
+  })
+
+  test("security IDX (.JK suffix, no mic) derives to yahoo", () => {
+    expect(
+      resolveProviderId(route({ kind: "security", symbol: "BBCA.JK" }))
+    ).toEqual({ status: "routed", providerId: "yahoo" })
+  })
+
+  test("security global/other derives to yahoo", () => {
+    expect(
+      resolveProviderId(route({ kind: "security", symbol: "AAPL" }))
+    ).toEqual({ status: "routed", providerId: "yahoo" })
+  })
+
+  test("crypto derives to yahoo", () => {
+    expect(resolveProviderId(route({ kind: "crypto", symbol: "BTC" }))).toEqual(
+      {
+        status: "routed",
+        providerId: "yahoo",
+      }
+    )
+  })
+
+  test("fx derives to yahoo", () => {
+    expect(resolveProviderId(route({ kind: "fx", symbol: "USD/IDR" }))).toEqual(
+      {
+        status: "routed",
+        providerId: "yahoo",
+      }
+    )
+  })
+})
+
+describe("resolveProviderId — explicit provider wins", () => {
+  test("a set provider overrides the kind derivation", () => {
+    // A security that would derive to yahoo is pinned to reksadana_id.
+    expect(
+      resolveProviderId({
+        kind: "security",
+        symbol: "RD-SCHRODER",
+        mic: null,
+        provider: "reksadana_id",
+      })
+    ).toEqual({ status: "routed", providerId: "reksadana_id" })
+  })
+
+  test("an explicit provider is honoured even against a mismatched kind", () => {
+    expect(
+      resolveProviderId({
+        kind: "metal",
+        symbol: "XAU-BSI",
+        mic: null,
+        provider: "yahoo",
+      })
+    ).toEqual({ status: "routed", providerId: "yahoo" })
+  })
+
+  test("whitespace-only provider falls through to derivation", () => {
+    expect(
+      resolveProviderId({
+        kind: "metal",
+        symbol: "XAU-BSI",
+        mic: null,
+        provider: "   ",
+      })
+    ).toEqual({ status: "routed", providerId: "logam_mulia" })
+  })
+})
+
+describe("resolveProviderId — structured skip (never throws)", () => {
+  test("an unknown explicit provider id is skipped, not thrown", () => {
+    const result = resolveProviderId({
+      kind: "security",
+      symbol: "AAPL",
+      mic: null,
+      provider: "bloomberg",
+    })
+    expect(result.status).toBe("skipped")
+    if (result.status === "skipped") {
+      expect(result.reason).toContain("bloomberg")
+    }
+  })
+
+  test("an unroutable (runtime-invalid) kind is skipped, not thrown", () => {
+    // A value the DB CHECK forbids but an untyped caller could still pass.
+    const result = resolveProviderId({
+      kind: "commodity" as MarketInstrumentKind,
+      symbol: "WTI",
+      mic: null,
+      provider: null,
+    })
+    expect(result.status).toBe("skipped")
+    if (result.status === "skipped") {
+      expect(result.reason).toContain("commodity")
+    }
   })
 })

--- a/src/lib/market-data.ts
+++ b/src/lib/market-data.ts
@@ -76,6 +76,106 @@ export function priceScaleForKind(kind: MarketInstrumentKind): number {
   return kind === "fx" ? FX_PRICE_DECIMALS : SPOT_PRICE_DECIMALS
 }
 
+// =============================================================================
+// Provider routing (ADR-0052 / PER-257) — the PURE routing table
+// =============================================================================
+//
+// The Financial Ingestion Service selects a source ADAPTER per instrument, then
+// batches per adapter and ingests each batch through the unchanged
+// `ingestMarketDataOnce` pipeline. This is the pure, DB-free, network-free core
+// of that router: given the routing-relevant fields of a `MarketInstrument`, it
+// decides WHICH adapter should price it. The registry (which adapters actually
+// exist) and the batching/ingest live in `market-data.server.ts`.
+
+/**
+ * The known source-adapter ids (the `provider` CHECK domain in the migration).
+ * An instrument's `provider` column, when set, names ONE of these; the router
+ * reads it first and only derives from `(kind, mic, symbol)` when it is NULL.
+ */
+export const PROVIDER_IDS = [
+  "logam_mulia",
+  "reksadana_id",
+  "yahoo",
+  "alpaca",
+  "twelvedata",
+] as const
+
+/** A source-adapter id — the key a `ProviderRegistry` maps to a factory. */
+export type ProviderId = (typeof PROVIDER_IDS)[number]
+
+export function isProviderId(value: string): value is ProviderId {
+  return (PROVIDER_IDS as readonly string[]).includes(value)
+}
+
+/**
+ * The routing-relevant projection of a `MarketInstrument`. Deliberately a small
+ * plain shape (NOT the Prisma model) so this module stays DB-free and reusable:
+ *   - `provider` — the explicit source declaration; wins when non-null.
+ *   - `kind` / `mic` / `symbol` — the fallback derivation inputs.
+ */
+export interface ProviderRoutingInput {
+  kind: MarketInstrumentKind
+  symbol: string
+  mic: string | null
+  provider: string | null
+}
+
+/**
+ * The outcome of routing ONE instrument: either it routes to a known adapter id,
+ * or it is a structured SKIP (never a throw — an unroutable instrument must not
+ * kill a mixed batch). Whether the routed adapter is actually REGISTERED is the
+ * service's concern (an unregistered id degrades to a skip there).
+ */
+export type ProviderRouteResult =
+  | { status: "routed"; providerId: ProviderId }
+  | { status: "skipped"; reason: string }
+
+/**
+ * Decide which source adapter prices an instrument (ADR-0052 §2).
+ *
+ *   explicit `provider` (non-null) ─► that id (or a skip if it is not a known id)
+ *   else derive from `kind`:
+ *     metal                        ─► logam_mulia
+ *     security (IDX `.JK`/mic OR global) ─► yahoo
+ *     crypto                       ─► yahoo
+ *     fx                           ─► yahoo
+ *
+ * `mic`/`symbol` do not change the Slice-A outcome (IDX and global equities share
+ * the one `yahoo` adapter), but are part of the contract so a later slice can
+ * split them without a signature change. A runtime-invalid kind or an unknown
+ * explicit provider yields a structured skip, NEVER a throw.
+ *
+ * Pure: no DB, no network, no secrets.
+ */
+export function resolveProviderId(
+  instrument: ProviderRoutingInput
+): ProviderRouteResult {
+  const explicit = instrument.provider?.trim()
+  if (explicit !== undefined && explicit.length > 0) {
+    return isProviderId(explicit)
+      ? { status: "routed", providerId: explicit }
+      : { status: "skipped", reason: `unknown provider id "${explicit}"` }
+  }
+
+  if (!isMarketInstrumentKind(instrument.kind)) {
+    // Defense-in-depth: the DB CHECK constrains kind, but an untyped caller could
+    // still hand over a bad value — degrade to a skip rather than mis-route.
+    return {
+      status: "skipped",
+      reason: `unroutable kind "${String(instrument.kind)}"`,
+    }
+  }
+
+  switch (instrument.kind) {
+    case "metal":
+      return { status: "routed", providerId: "logam_mulia" }
+    case "security":
+    case "crypto":
+    case "fx":
+      return { status: "routed", providerId: "yahoo" }
+  }
+}
+
 /**
  * Divide `numerator / denominator` with round-half-to-even. `denominator` MUST
  * be positive; sign is carried by `numerator`. Mirrors `@/lib/fx` and

--- a/src/server/market-data.server.ts
+++ b/src/server/market-data.server.ts
@@ -236,11 +236,7 @@ function serializeObservation(
 /** The Prisma surface the pipeline needs — a full client (has `$transaction`). */
 export type MarketDataDb = Pick<
   PrismaClient,
-  | "marketInstrument"
-  | "marketQuote"
-  | "rawMarketDataFetch"
-  | "$transaction"
-  | "$queryRaw"
+  "marketInstrument" | "marketQuote" | "rawMarketDataFetch" | "$transaction"
 >
 
 export interface IngestSummary {
@@ -852,18 +848,17 @@ export interface IngestAllOptions {
   registry?: ProviderRegistry
   /** Gold passthrough used only when building the DEFAULT registry. */
   gold?: DefaultRegistryGoldOptions
-  /**
-   * Instrument ids to price REGARDLESS of holding links (the on-demand baseline).
-   * `syncMarketPricesOnce` passes the ensured BSI-gold id so gold still refreshes
-   * on an install that has not linked a gold holding yet (unchanged behaviour).
-   */
-  baselineInstrumentIds?: readonly string[]
 }
 
 /**
- * Ingest EVERY instrument this install can price, routed per adapter (ADR-0052
- * §3). Bounded work: only instruments LINKED to at least one holding (plus any
- * explicit `baselineInstrumentIds`) — never the whole catalog.
+ * Ingest EVERY instrument in the catalog, routed per adapter (ADR-0052 §3).
+ *
+ * DISCOVERY (no tenant-RLS dependency): reads the GLOBAL, family-neutral
+ * `MarketInstrument` catalog directly. A row exists there ONLY because a holding
+ * linked it (`applyMarketLinkWithinTx`) or a prior ingest created it, so the
+ * catalog IS the in-use set — bounded, and readable by a NOBYPASSRLS role with no
+ * family scope. It deliberately never reads the tenant-scoped, FORCE-RLS holdings
+ * `Instrument` table (a `SECURITY DEFINER` cross-tenant read is banned).
  *
  * Per-adapter FAILURE ISOLATION: each group runs in its own try/catch. An adapter
  * that is unreachable / misconfigured / throws on construction degrades to
@@ -875,17 +870,14 @@ export interface IngestAllOptions {
  * GLOBAL ingest ONLY — writes exclusively the three global market tables, NEVER
  * the ledger, so it runs OUTSIDE any family RLS transaction (ADR-0050 §6).
  */
-export async function ingestAllLinkedInstrumentsOnce(
+export async function ingestAllInstrumentsOnce(
   options?: IngestAllOptions
 ): Promise<IngestAllSummary> {
   const db = options?.db ?? prisma
   const registry =
     options?.registry ?? createDefaultProviderRegistry({ gold: options?.gold })
 
-  const instruments = await loadRoutableInstruments(
-    db,
-    options?.baselineInstrumentIds ?? []
-  )
+  const instruments = await loadRoutableInstruments(db)
 
   // 1. Group by routed adapter; collect structured skips as we go.
   const groups = new Map<ProviderId, RoutableInstrument[]>()
@@ -956,32 +948,17 @@ export async function ingestAllLinkedInstrumentsOnce(
 }
 
 /**
- * Load the instruments the router should price: those LINKED to at least one
- * holding (discovered cross-tenant via the `SECURITY DEFINER`
- * `market_instrument_ids_linked_to_holdings()` — see the migration; the global
- * ingest has no family scope, so it cannot read the RLS-forced holdings
- * `Instrument` table directly), plus any explicit baseline ids, de-duplicated.
+ * Load the instruments the router should price: the whole `MarketInstrument`
+ * catalog. `MarketInstrument` is a GLOBAL, family-neutral table with NO
+ * row-level security — a row exists there only because a holding linked it or a
+ * prior ingest created it, so the catalog IS the bounded in-use set. Reading it
+ * needs no family scope and no BYPASSRLS, so the global ingest (which runs with
+ * neither) discovers exactly what to price without ever touching tenant data.
  */
 async function loadRoutableInstruments(
-  db: MarketDataDb,
-  baselineInstrumentIds: readonly string[]
+  db: MarketDataDb
 ): Promise<RoutableInstrument[]> {
-  const linkedIdRows = await db.$queryRaw<{ id: string }[]>`
-    SELECT ids::text AS id
-    FROM market_instrument_ids_linked_to_holdings() AS ids
-  `
-
-  const ids = new Set<string>()
-  for (const row of linkedIdRows) ids.add(row.id)
-  for (const id of baselineInstrumentIds) ids.add(id)
-  if (ids.size === 0) return []
-
-  // MarketInstrument is a global, family-neutral table (no RLS), so this read is
-  // safe outside any family scope.
-  return await db.marketInstrument.findMany({
-    where: { id: { in: [...ids] } },
-    select: ROUTABLE_SELECT,
-  })
+  return await db.marketInstrument.findMany({ select: ROUTABLE_SELECT })
 }
 
 /** Build the pipeline request for one instrument (fx pair vs spot instrument). */
@@ -1012,10 +989,10 @@ function toInstrumentRequest(
 // -----------------------------------------------------------------------------
 // On-demand price sync trigger — the graceful boundary the UI/serverFn call
 // (PER-235b), now backed by the router (PER-257). It ENSURES the BSI-gold
-// instrument (so gold stays linkable + refreshes even before any holding links
-// it — unchanged behaviour), then runs the Financial Ingestion Service over
-// every linked instrument PLUS the gold baseline. Gold now flows THROUGH the
-// registry instead of a hardcoded call. NEVER throws: a MISSING config
+// instrument (so gold's row exists in the catalog + stays linkable on the very
+// first run — unchanged behaviour), then runs the Financial Ingestion Service
+// over the whole `MarketInstrument` catalog. Gold now flows THROUGH the registry
+// instead of a hardcoded call. NEVER throws: a MISSING config
 // (`LOGAM_MULIA_API_URL` unset → the gold factory throws inside its group), an
 // unreachable worker, or a non-2xx / `success:false` payload all degrade to
 // `{ ingested: 0, error }`, and the last-good quote is always kept. This performs
@@ -1043,10 +1020,11 @@ export async function syncMarketPricesOnce(
 ): Promise<SyncMarketPricesResult> {
   const db = options?.db ?? prisma
   try {
-    // Keep gold linkable + baseline-priced even with zero linked holdings.
-    const goldInstrumentId = await ensureBsiGoldInstrument(db)
+    // Ensure the BSI-gold row exists in the catalog (linkable + priced) even on
+    // an install's first run, before any holding has linked it.
+    await ensureBsiGoldInstrument(db)
 
-    const summary = await ingestAllLinkedInstrumentsOnce({
+    const summary = await ingestAllInstrumentsOnce({
       db,
       gold: {
         baseUrl: options?.baseUrl,
@@ -1054,7 +1032,6 @@ export async function syncMarketPricesOnce(
         priceField: options?.priceField,
         now: options?.now,
       },
-      baselineInstrumentIds: [goldInstrumentId],
     })
 
     if (summary.totalIngested > 0) {

--- a/src/server/market-data.server.ts
+++ b/src/server/market-data.server.ts
@@ -33,12 +33,15 @@ import type { Prisma, PrismaClient } from "@prisma/client"
 import {
   BSI_GOLD_QUOTE_CURRENCY,
   BSI_GOLD_SYMBOL,
+  isMarketInstrumentKind,
   normalizeObservations,
   parseLogamMuliaGoldResponse,
+  resolveProviderId,
   type GoldPriceField,
   type MarketInstrumentIdentity,
   type MarketInstrumentKind,
   type MarketObservation,
+  type ProviderId,
 } from "@/lib/market-data"
 import { prisma } from "./db.server"
 
@@ -233,7 +236,11 @@ function serializeObservation(
 /** The Prisma surface the pipeline needs — a full client (has `$transaction`). */
 export type MarketDataDb = Pick<
   PrismaClient,
-  "marketInstrument" | "marketQuote" | "rawMarketDataFetch" | "$transaction"
+  | "marketInstrument"
+  | "marketQuote"
+  | "rawMarketDataFetch"
+  | "$transaction"
+  | "$queryRaw"
 >
 
 export interface IngestSummary {
@@ -734,16 +741,287 @@ export async function ingestGoldPricesOnce(
   })
 }
 
+// =============================================================================
+// Financial Ingestion Service — provider registry + routing engine (PER-257 /
+// ADR-0052)
+// =============================================================================
+//
+// A modular ROUTER in front of the single `ingestMarketDataOnce` seam. Given a
+// set of instruments of mixed kinds it selects the right adapter per instrument
+// (pure `resolveProviderId`), batches per adapter, and ingests each batch through
+// the unchanged raw -> staged -> canonical pipeline. Adding a vendor = one
+// adapter + one registry entry, with zero consumer change.
+//
+// The routing DECISION is pure (`@/lib/market-data`); which adapters actually
+// EXIST — and their secrets — live here, behind the `.server.ts` fence. Factories
+// are LAZY so an adapter whose env/secret is unset only throws when its own group
+// is invoked, and that throw degrades to a per-group error, never aborting the
+// other groups.
+
+/** A lazy adapter factory: constructing it may read env/secrets (call time). */
+export type ProviderFactory = () => MarketDataProvider
+
+/** The registry the router looks an adapter up in by its `ProviderId`. */
+export type ProviderRegistry = Map<ProviderId, ProviderFactory>
+
+/** Gold-adapter construction knobs (tests inject a fixture fetch / clock). */
+export interface DefaultRegistryGoldOptions {
+  baseUrl?: string
+  fetchImpl?: FetchLike
+  priceField?: GoldPriceField
+  now?: () => Date
+}
+
+export interface DefaultRegistryOptions {
+  /** Passthrough for the `logam_mulia` gold adapter (see LogamMuliaGoldProvider). */
+  gold?: DefaultRegistryGoldOptions
+}
+
+/**
+ * The production registry. Slice A registers ONLY `logam_mulia` (gold now flows
+ * THROUGH the router, proving the mechanism before fragile sources plug in).
+ * `reksadana_id` (PER-257 Slice B) and `yahoo` / `alpaca` / `twelvedata`
+ * (later slices) drop in here with no consumer change. The factory is lazy: the
+ * gold provider reads `LOGAM_MULIA_API_URL` only when actually constructed.
+ */
+export function createDefaultProviderRegistry(
+  options?: DefaultRegistryOptions
+): ProviderRegistry {
+  const registry: ProviderRegistry = new Map()
+  registry.set(
+    "logam_mulia",
+    () =>
+      new LogamMuliaGoldProvider({
+        baseUrl: options?.gold?.baseUrl,
+        fetchImpl: options?.gold?.fetchImpl,
+        priceField: options?.gold?.priceField,
+        now: options?.gold?.now,
+      })
+  )
+  return registry
+}
+
+/** The routing-relevant columns the router loads for each instrument. */
+type RoutableInstrument = {
+  id: string
+  kind: string
+  symbol: string
+  mic: string | null
+  quoteCurrency: string
+  baseCurrency: string | null
+  provider: string | null
+}
+
+const ROUTABLE_SELECT = {
+  id: true,
+  kind: true,
+  symbol: true,
+  mic: true,
+  quoteCurrency: true,
+  baseCurrency: true,
+  provider: true,
+} as const
+
+/** One adapter group's outcome in the aggregate summary. */
+export interface ProviderIngestSummary {
+  providerId: ProviderId
+  /** Instruments routed to this adapter this run. */
+  instrumentCount: number
+  /** Canonical quotes written for this group (0 on this group's failure). */
+  ingested: number
+  /** Present only when THIS group degraded (its adapter failed / is misconfigured). */
+  error?: string
+}
+
+/** An instrument the router could not send anywhere (no adapter routed/registered). */
+export interface SkippedInstrument {
+  marketInstrumentId: string
+  symbol: string
+  reason: string
+}
+
+export interface IngestAllSummary {
+  perProvider: ProviderIngestSummary[]
+  totalIngested: number
+  skipped: SkippedInstrument[]
+}
+
+export interface IngestAllOptions {
+  db?: MarketDataDb
+  /** Adapter registry; defaults to the production registry (gold only, Slice A). */
+  registry?: ProviderRegistry
+  /** Gold passthrough used only when building the DEFAULT registry. */
+  gold?: DefaultRegistryGoldOptions
+  /**
+   * Instrument ids to price REGARDLESS of holding links (the on-demand baseline).
+   * `syncMarketPricesOnce` passes the ensured BSI-gold id so gold still refreshes
+   * on an install that has not linked a gold holding yet (unchanged behaviour).
+   */
+  baselineInstrumentIds?: readonly string[]
+}
+
+/**
+ * Ingest EVERY instrument this install can price, routed per adapter (ADR-0052
+ * §3). Bounded work: only instruments LINKED to at least one holding (plus any
+ * explicit `baselineInstrumentIds`) — never the whole catalog.
+ *
+ * Per-adapter FAILURE ISOLATION: each group runs in its own try/catch. An adapter
+ * that is unreachable / misconfigured / throws on construction degrades to
+ * `{ ingested: 0, error }` for ITS instruments only; other groups still refresh,
+ * the last-good `MarketQuote` is retained, and the failed `RawMarketDataFetch` is
+ * staged by `ingestMarketDataOnce`. An instrument that routes nowhere (unroutable
+ * kind, or a routed id with no registered adapter) lands in `skipped`.
+ *
+ * GLOBAL ingest ONLY — writes exclusively the three global market tables, NEVER
+ * the ledger, so it runs OUTSIDE any family RLS transaction (ADR-0050 §6).
+ */
+export async function ingestAllLinkedInstrumentsOnce(
+  options?: IngestAllOptions
+): Promise<IngestAllSummary> {
+  const db = options?.db ?? prisma
+  const registry =
+    options?.registry ?? createDefaultProviderRegistry({ gold: options?.gold })
+
+  const instruments = await loadRoutableInstruments(
+    db,
+    options?.baselineInstrumentIds ?? []
+  )
+
+  // 1. Group by routed adapter; collect structured skips as we go.
+  const groups = new Map<ProviderId, RoutableInstrument[]>()
+  const skipped: SkippedInstrument[] = []
+  for (const instrument of instruments) {
+    const route = resolveProviderId({
+      kind: instrument.kind as MarketInstrumentKind,
+      symbol: instrument.symbol,
+      mic: instrument.mic,
+      provider: instrument.provider,
+    })
+    if (route.status === "skipped") {
+      skipped.push({
+        marketInstrumentId: instrument.id,
+        symbol: instrument.symbol,
+        reason: route.reason,
+      })
+      continue
+    }
+    if (!registry.has(route.providerId)) {
+      // Routed, but no adapter is registered for it yet (e.g. `yahoo` in Slice A).
+      skipped.push({
+        marketInstrumentId: instrument.id,
+        symbol: instrument.symbol,
+        reason: `no adapter registered for "${route.providerId}"`,
+      })
+      continue
+    }
+    const bucket = groups.get(route.providerId)
+    if (bucket) bucket.push(instrument)
+    else groups.set(route.providerId, [instrument])
+  }
+
+  // 2. Ingest each group in isolation — one flaky source can never break another.
+  const perProvider: ProviderIngestSummary[] = []
+  let totalIngested = 0
+  for (const [providerId, groupInstruments] of groups) {
+    const factory = registry.get(providerId)
+    if (!factory) continue // unreachable (has() guarded above) — defensive.
+    try {
+      const provider = factory()
+      const summary = await ingestMarketDataOnce({
+        provider,
+        requests: groupInstruments.map(toInstrumentRequest),
+        db,
+      })
+      const ingested = summary.status === "ok" ? summary.quotesUpserted : 0
+      totalIngested += ingested
+      perProvider.push({
+        providerId,
+        instrumentCount: groupInstruments.length,
+        ingested,
+        error: summary.status === "ok" ? undefined : summary.error,
+      })
+    } catch (error) {
+      // A misconfigured/throwing adapter (e.g. unset secret) degrades to a
+      // per-group error; the other groups above/below still run.
+      perProvider.push({
+        providerId,
+        instrumentCount: groupInstruments.length,
+        ingested: 0,
+        error: error instanceof Error ? error.message : "provider failed",
+      })
+    }
+  }
+
+  return { perProvider, totalIngested, skipped }
+}
+
+/**
+ * Load the instruments the router should price: those LINKED to at least one
+ * holding (discovered cross-tenant via the `SECURITY DEFINER`
+ * `market_instrument_ids_linked_to_holdings()` — see the migration; the global
+ * ingest has no family scope, so it cannot read the RLS-forced holdings
+ * `Instrument` table directly), plus any explicit baseline ids, de-duplicated.
+ */
+async function loadRoutableInstruments(
+  db: MarketDataDb,
+  baselineInstrumentIds: readonly string[]
+): Promise<RoutableInstrument[]> {
+  const linkedIdRows = await db.$queryRaw<{ id: string }[]>`
+    SELECT ids::text AS id
+    FROM market_instrument_ids_linked_to_holdings() AS ids
+  `
+
+  const ids = new Set<string>()
+  for (const row of linkedIdRows) ids.add(row.id)
+  for (const id of baselineInstrumentIds) ids.add(id)
+  if (ids.size === 0) return []
+
+  // MarketInstrument is a global, family-neutral table (no RLS), so this read is
+  // safe outside any family scope.
+  return await db.marketInstrument.findMany({
+    where: { id: { in: [...ids] } },
+    select: ROUTABLE_SELECT,
+  })
+}
+
+/** Build the pipeline request for one instrument (fx pair vs spot instrument). */
+function toInstrumentRequest(
+  instrument: RoutableInstrument
+): MarketInstrumentRequest {
+  if (instrument.kind === "fx") {
+    return {
+      kind: "fx",
+      baseCurrency: instrument.baseCurrency ?? "",
+      quoteCurrency: instrument.quoteCurrency,
+    }
+  }
+  // metal / security / crypto (validated: the caller only reaches here for a
+  // routed, non-fx instrument; a bad kind would have been skipped by the router).
+  const spotKind: Exclude<MarketInstrumentKind, "fx"> =
+    isMarketInstrumentKind(instrument.kind) && instrument.kind !== "fx"
+      ? instrument.kind
+      : "security"
+  return {
+    kind: spotKind,
+    symbol: instrument.symbol,
+    quoteCurrency: instrument.quoteCurrency,
+    mic: instrument.mic ?? undefined,
+  }
+}
+
 // -----------------------------------------------------------------------------
 // On-demand price sync trigger — the graceful boundary the UI/serverFn call
-// (PER-235b). Wraps `ingestGoldPricesOnce` so a MISSING config
-// (`LOGAM_MULIA_API_URL` unset → the provider constructor throws) or ANY other
-// unexpected throw degrades to a structured result instead of a 500. A fetch
-// that reaches the pipeline already degrades internally (a failed
-// `RawMarketDataFetch` + zero quotes), so the last-good quote is always kept.
-// This performs a GLOBAL ingest only — it writes exclusively the three global
-// market tables and NEVER the ledger, so it runs OUTSIDE any family RLS
-// transaction (its caller keeps the family-scoped holdings refresh separate).
+// (PER-235b), now backed by the router (PER-257). It ENSURES the BSI-gold
+// instrument (so gold stays linkable + refreshes even before any holding links
+// it — unchanged behaviour), then runs the Financial Ingestion Service over
+// every linked instrument PLUS the gold baseline. Gold now flows THROUGH the
+// registry instead of a hardcoded call. NEVER throws: a MISSING config
+// (`LOGAM_MULIA_API_URL` unset → the gold factory throws inside its group), an
+// unreachable worker, or a non-2xx / `success:false` payload all degrade to
+// `{ ingested: 0, error }`, and the last-good quote is always kept. This performs
+// a GLOBAL ingest only — the three global market tables, NEVER the ledger — so it
+// runs OUTSIDE any family RLS transaction (the caller keeps the family-scoped
+// holdings refresh separate).
 // -----------------------------------------------------------------------------
 
 export interface SyncMarketPricesResult {
@@ -754,27 +1032,42 @@ export interface SyncMarketPricesResult {
 }
 
 /**
- * Run one on-demand market-price sync (currently BSI gold). NEVER throws: an
- * unreachable worker, a non-2xx / `success:false` payload, or an unset
+ * Run one on-demand market-price sync through the ingestion router. NEVER throws:
+ * an unreachable worker, a non-2xx / `success:false` payload, or an unset
  * `LOGAM_MULIA_API_URL` all resolve to `{ ingested: 0, error }`. The canonical
- * instrument is still ensured on every attempt (linkable before any fetch
- * succeeds), and the last good quote is left intact on failure.
+ * BSI-gold instrument is still ensured on every attempt (linkable before any
+ * fetch succeeds), and the last good quote is left intact on failure.
  */
 export async function syncMarketPricesOnce(
   options?: IngestGoldOptions
 ): Promise<SyncMarketPricesResult> {
+  const db = options?.db ?? prisma
   try {
-    const summary = await ingestGoldPricesOnce(options)
-    if (summary.status !== "ok") {
-      return {
-        ingested: 0,
-        error: summary.error ?? "market data source unavailable",
-      }
+    // Keep gold linkable + baseline-priced even with zero linked holdings.
+    const goldInstrumentId = await ensureBsiGoldInstrument(db)
+
+    const summary = await ingestAllLinkedInstrumentsOnce({
+      db,
+      gold: {
+        baseUrl: options?.baseUrl,
+        fetchImpl: options?.fetchImpl,
+        priceField: options?.priceField,
+        now: options?.now,
+      },
+      baselineInstrumentIds: [goldInstrumentId],
+    })
+
+    if (summary.totalIngested > 0) {
+      return { ingested: summary.totalIngested }
     }
-    return { ingested: summary.quotesUpserted }
+
+    // Nothing ingested — surface the first degraded group's reason (if any) so
+    // the caller/UI can explain the failure, mirroring the old contract.
+    const failed = summary.perProvider.find((group) => group.error)
+    if (failed?.error) return { ingested: 0, error: failed.error }
+    return { ingested: 0 }
   } catch (error) {
-    // Config unset (provider constructor throws) or any other unexpected error —
-    // degrade gracefully rather than surfacing a 500 to the browser.
+    // Defense-in-depth: any unexpected throw degrades rather than 500-ing.
     return {
       ingested: 0,
       error: error instanceof Error ? error.message : "market sync failed",

--- a/tests/integration/financial-ingestion.integration.ts
+++ b/tests/integration/financial-ingestion.integration.ts
@@ -12,7 +12,7 @@ import { createAccountForFamily } from "@/server/accounts"
 import { upsertHoldingForFamily } from "@/server/holdings"
 import {
   ensureBsiGoldInstrument,
-  ingestAllLinkedInstrumentsOnce,
+  ingestAllInstrumentsOnce,
   MarketFixtureProvider,
   syncMarketPricesOnce,
   type FetchLike,
@@ -34,11 +34,14 @@ import {
 // PER-257 / ADR-0052 — Financial Ingestion Service (provider routing engine),
 // real Postgres, NO live network. Every adapter is injected as a FIXTURE (a
 // recorded gold payload for `logam_mulia`, or a `MarketFixtureProvider`), so the
-// full router (load linked instruments -> route -> group -> ingest per adapter)
-// runs against the real DB with zero network. Covers: mixed-kind routing through
-// the registry, PER-ADAPTER failure isolation (one bad group does not break the
-// others), idempotent replay, the unrouted/unregistered SKIP bucket, and the
-// migrated gold path still working through the router.
+// full router (read the MarketInstrument catalog -> route -> group -> ingest per
+// adapter) runs against the real DB with zero network. Covers: mixed-kind routing
+// through the registry, PER-ADAPTER failure isolation (one bad group does not
+// break the others), idempotent replay, the unrouted/unregistered SKIP bucket,
+// the migrated gold path, and — critically — that discovery works under a
+// NOBYPASSRLS role with NO family scope (a regression guard against a
+// cross-tenant SECURITY DEFINER read; all tests already run on `harness.prisma`,
+// the non-privileged runtime role).
 // =============================================================================
 
 const GOLD_BASE_URL = "http://gold.test"
@@ -226,7 +229,7 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
       ])
     )
 
-    const summary = await ingestAllLinkedInstrumentsOnce({
+    const summary = await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry,
     })
@@ -292,7 +295,7 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
       ])
     )
 
-    const summary = await ingestAllLinkedInstrumentsOnce({
+    const summary = await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry,
     })
@@ -352,7 +355,7 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
           ]),
       ],
     ])
-    await ingestAllLinkedInstrumentsOnce({
+    await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry: goodRegistry,
     })
@@ -364,7 +367,7 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
         () => fixtureProvider("reksadana_id", [], "upstream 503"),
       ],
     ])
-    const summary = await ingestAllLinkedInstrumentsOnce({
+    const summary = await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry: failingRegistry,
     })
@@ -416,7 +419,7 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
       ],
     ])
 
-    const summary = await ingestAllLinkedInstrumentsOnce({
+    const summary = await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry,
     })
@@ -462,11 +465,11 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
       ],
     ])
 
-    const first = await ingestAllLinkedInstrumentsOnce({
+    const first = await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry,
     })
-    const second = await ingestAllLinkedInstrumentsOnce({
+    const second = await ingestAllInstrumentsOnce({
       db: harness.prisma,
       registry,
     })
@@ -498,5 +501,77 @@ describe("Financial Ingestion Service (PER-257 — router + registry, fixture-in
       where: { marketInstrumentId: gold.id },
     })
     expect(quote.source).toBe("bankbsi")
+  })
+
+  // ---------------------------------------------------------------------------
+  // 6. REGRESSION GUARD (PER-257 review): discovery must NOT depend on BYPASSRLS.
+  //
+  // The earlier design discovered "held" instruments by reading the tenant-scoped,
+  // FORCE-RLS holdings `Instrument` table through a `SECURITY DEFINER` function —
+  // which silently returns ZERO rows in prod, where the migration/app roles are
+  // NOSUPERUSER/NOBYPASSRLS (deploy/provision-postgres-roles.sql). The fix reads
+  // the GLOBAL, non-RLS `MarketInstrument` catalog directly. This test proves the
+  // fix: it runs the ingest through `harness.prisma` — the harness's non-privileged
+  // runtime role, asserted NOSUPERUSER/NOBYPASSRLS by `assertRuntimeRoleEnforcesRls`
+  // — with NO `app.family_id` set, and asserts a linked instrument is still priced.
+  // ---------------------------------------------------------------------------
+  test("discovery works under a NOBYPASSRLS role with no family scope (no SECURITY DEFINER)", async () => {
+    // The role this test (and the whole suite) runs as genuinely cannot bypass RLS.
+    const roleFlags = await harness.prisma.$queryRaw<
+      { rolsuper: boolean; rolbypassrls: boolean }[]
+    >`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+    expect(roleFlags[0]?.rolsuper).toBe(false)
+    expect(roleFlags[0]?.rolbypassrls).toBe(false)
+
+    // A holding links a reksadana instrument (the tenant `Instrument` row is
+    // written under family scope + FORCE RLS — invisible to a no-scope reader).
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+    const fundId = await makeInstrument({
+      kind: "security",
+      symbol: "RD-NOBYPASS",
+      quoteCurrency: "IDR",
+      provider: "reksadana_id",
+    })
+    await linkHolding(owner, account.id, fundId, {
+      kind: "mutual_fund",
+      name: "RD NoBypass",
+      symbol: "RD-NOBYPASS",
+    })
+
+    // Sanity: as this NOBYPASSRLS role with no `app.family_id`, the tenant
+    // holdings `Instrument` table is INVISIBLE — proving discovery cannot lean on
+    // reading it, and MUST use the global catalog instead.
+    expect(await harness.prisma.instrument.count()).toBe(0)
+
+    const registry: ProviderRegistry = new Map([
+      [
+        "reksadana_id" as ProviderId,
+        () =>
+          fixtureProvider("reksadana_id", [
+            {
+              kind: "security",
+              symbol: "RD-NOBYPASS",
+              quoteCurrency: "IDR",
+              priceDecimal: "1750.5",
+            },
+          ]),
+      ],
+    ])
+
+    const summary = await ingestAllInstrumentsOnce({
+      db: harness.prisma,
+      registry,
+    })
+
+    // The linked instrument was discovered (via the global catalog) and priced,
+    // even though the tenant `Instrument` row was unreadable to this role.
+    expect(summary.totalIngested).toBe(1)
+    expect(summary.skipped).toEqual([])
+    expect(
+      await harness.prisma.marketQuote.count({
+        where: { marketInstrumentId: fundId },
+      })
+    ).toBe(1)
   })
 })

--- a/tests/integration/financial-ingestion.integration.ts
+++ b/tests/integration/financial-ingestion.integration.ts
@@ -1,0 +1,502 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import type { ProviderId } from "@/lib/market-data"
+import { createAccountForFamily } from "@/server/accounts"
+import { upsertHoldingForFamily } from "@/server/holdings"
+import {
+  ensureBsiGoldInstrument,
+  ingestAllLinkedInstrumentsOnce,
+  MarketFixtureProvider,
+  syncMarketPricesOnce,
+  type FetchLike,
+  type FixtureQuote,
+  type MarketDataProvider,
+  type ProviderRegistry,
+} from "@/server/market-data.server"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// =============================================================================
+// PER-257 / ADR-0052 — Financial Ingestion Service (provider routing engine),
+// real Postgres, NO live network. Every adapter is injected as a FIXTURE (a
+// recorded gold payload for `logam_mulia`, or a `MarketFixtureProvider`), so the
+// full router (load linked instruments -> route -> group -> ingest per adapter)
+// runs against the real DB with zero network. Covers: mixed-kind routing through
+// the registry, PER-ADAPTER failure isolation (one bad group does not break the
+// others), idempotent replay, the unrouted/unregistered SKIP bucket, and the
+// migrated gold path still working through the router.
+// =============================================================================
+
+const GOLD_BASE_URL = "http://gold.test"
+
+const GOLD_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "bankbsi",
+      material: "gold",
+      materialType: "BSI",
+      weight: 1,
+      weightUnit: "gr",
+      sellPrice: 2_700_000,
+      buybackPrice: 2_650_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 1,
+  timestamp: "2026-05-16T05:06:58.888Z",
+  cached: true,
+}
+
+const okGoldFetch: FetchLike = () =>
+  Promise.resolve(
+    new Response(JSON.stringify(GOLD_PAYLOAD), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  )
+
+const AS_OF = new Date("2026-08-07T00:00:00.000Z")
+
+// The holdings `Instrument` taxonomy (distinct from the MarketInstrument kinds).
+type HoldingInstrumentKind =
+  | "mutual_fund"
+  | "metal"
+  | "stock"
+  | "crypto"
+  | "bond"
+  | "deposit"
+
+// A deterministic fixture provider echoing back canned quotes for the requested
+// symbols. Used to stand in for the `yahoo`/`reksadana_id` adapters (not yet
+// registered in production) so we can prove mixed-kind routing end to end.
+function fixtureProvider(
+  name: string,
+  quotes: FixtureQuote[],
+  failWith?: string
+): MarketDataProvider {
+  return new MarketFixtureProvider({ name, asOf: AS_OF, quotes, failWith })
+}
+
+describe("Financial Ingestion Service (PER-257 — router + registry, fixture-injected)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  // Link a holding to a market instrument of the given identity, creating the
+  // instrument row (mirrors how a real linked holding reaches the router).
+  async function linkHolding(
+    owner: AuthenticatedOnboardedUser,
+    accountId: string,
+    marketInstrumentId: string,
+    instrument: { kind: HoldingInstrumentKind; name: string; symbol: string }
+  ): Promise<void> {
+    await upsertHoldingForFamily({
+      data: {
+        accountId,
+        instrument,
+        quantity: "1",
+        avgUnitCost: "1",
+        marketInstrumentId,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+  }
+
+  async function investmentAccount(owner: AuthenticatedOnboardedUser) {
+    return await createAccountForFamily({
+      data: {
+        name: "Brokerage",
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+  }
+
+  // A market instrument created directly (no holding link yet) so we control the
+  // `provider` column + identity precisely.
+  async function makeInstrument(data: {
+    kind: string
+    symbol: string
+    quoteCurrency: string
+    mic?: string | null
+    baseCurrency?: string | null
+    provider?: ProviderId | null
+    name?: string
+  }): Promise<string> {
+    const row = await harness.prisma.marketInstrument.create({
+      data: {
+        kind: data.kind,
+        symbol: data.symbol,
+        quoteCurrency: data.quoteCurrency,
+        mic: data.mic ?? null,
+        baseCurrency: data.baseCurrency ?? null,
+        provider: data.provider ?? null,
+        name: data.name ?? null,
+      },
+      select: { id: true },
+    })
+    return row.id
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Mixed-kind routing: each linked instrument reaches the right adapter.
+  // ---------------------------------------------------------------------------
+  test("routes mixed-kind linked instruments to the correct adapter and ingests each", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+
+    // Gold (metal -> logam_mulia) and a reksadana fund (provider=reksadana_id).
+    const goldId = await ensureBsiGoldInstrument(harness.prisma)
+    const fundId = await makeInstrument({
+      kind: "security",
+      symbol: "RD-ABC",
+      quoteCurrency: "IDR",
+      provider: "reksadana_id",
+      name: "Reksadana ABC",
+    })
+
+    await linkHolding(owner, account.id, goldId, {
+      kind: "metal",
+      name: "BSI Gold",
+      symbol: "XAU",
+    })
+    await linkHolding(owner, account.id, fundId, {
+      kind: "mutual_fund",
+      name: "Reksadana ABC",
+      symbol: "RD-ABC",
+    })
+
+    // Registry: a fixture gold adapter + a fixture reksadana adapter, one per
+    // group, so we can assert each group ingested through its own adapter.
+    const registry: ProviderRegistry = new Map()
+    registry.set("logam_mulia", () =>
+      fixtureProvider("bankbsi", [
+        {
+          kind: "metal",
+          symbol: "XAU-BSI",
+          quoteCurrency: "IDR",
+          priceDecimal: "85000000",
+          providerRef: "gold",
+        },
+      ])
+    )
+    registry.set("reksadana_id", () =>
+      fixtureProvider("reksadana_id", [
+        {
+          kind: "security",
+          symbol: "RD-ABC",
+          quoteCurrency: "IDR",
+          priceDecimal: "1500.25",
+          providerRef: "nav",
+        },
+      ])
+    )
+
+    const summary = await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry,
+    })
+
+    expect(summary.totalIngested).toBe(2)
+    expect(summary.skipped).toEqual([])
+    const byProvider = new Map(
+      summary.perProvider.map((group) => [group.providerId, group])
+    )
+    expect(byProvider.get("logam_mulia")?.ingested).toBe(1)
+    expect(byProvider.get("reksadana_id")?.ingested).toBe(1)
+
+    // Each canonical quote landed under the right instrument + source.
+    const goldQuote = await harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId: goldId },
+    })
+    expect(goldQuote.source).toBe("bankbsi")
+    const fundQuote = await harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId: fundId },
+    })
+    expect(fundQuote.source).toBe("reksadana_id")
+  })
+
+  // ---------------------------------------------------------------------------
+  // 2. Per-adapter failure isolation: one bad group, the other still ingests.
+  // ---------------------------------------------------------------------------
+  test("a failing adapter degrades only its own group; other groups still ingest", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+
+    const goldId = await ensureBsiGoldInstrument(harness.prisma)
+    const fundId = await makeInstrument({
+      kind: "security",
+      symbol: "RD-GOOD",
+      quoteCurrency: "IDR",
+      provider: "reksadana_id",
+    })
+    await linkHolding(owner, account.id, goldId, {
+      kind: "metal",
+      name: "BSI Gold",
+      symbol: "XAU",
+    })
+    await linkHolding(owner, account.id, fundId, {
+      kind: "mutual_fund",
+      name: "RD Good",
+      symbol: "RD-GOOD",
+    })
+
+    const registry: ProviderRegistry = new Map()
+    // The gold group FAILS (adapter constructor throws — unset secret analogue).
+    registry.set("logam_mulia", () => {
+      throw new Error("LOGAM_MULIA_API_URL is not set")
+    })
+    // The reksadana group SUCCEEDS.
+    registry.set("reksadana_id", () =>
+      fixtureProvider("reksadana_id", [
+        {
+          kind: "security",
+          symbol: "RD-GOOD",
+          quoteCurrency: "IDR",
+          priceDecimal: "1000",
+        },
+      ])
+    )
+
+    const summary = await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry,
+    })
+
+    // The good group ingested; the bad group degraded, did NOT abort the run.
+    expect(summary.totalIngested).toBe(1)
+    const gold = summary.perProvider.find((g) => g.providerId === "logam_mulia")
+    const fund = summary.perProvider.find(
+      (g) => g.providerId === "reksadana_id"
+    )
+    expect(gold?.ingested).toBe(0)
+    expect(gold?.error).toContain("LOGAM_MULIA_API_URL")
+    expect(fund?.ingested).toBe(1)
+    expect(fund?.error).toBeUndefined()
+
+    // Good group wrote its quote; failed group wrote none (last-good retained).
+    expect(
+      await harness.prisma.marketQuote.count({
+        where: { marketInstrumentId: fundId },
+      })
+    ).toBe(1)
+    expect(
+      await harness.prisma.marketQuote.count({
+        where: { marketInstrumentId: goldId },
+      })
+    ).toBe(0)
+  })
+
+  // A fixture provider that returns a graceful error result (not a throw) — the
+  // "unreachable / non-2xx" degradation the pipeline stages as a failed fetch.
+  test("an adapter that returns a graceful error keeps the last-good quote for its group", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+    const fundId = await makeInstrument({
+      kind: "security",
+      symbol: "RD-X",
+      quoteCurrency: "IDR",
+      provider: "reksadana_id",
+    })
+    await linkHolding(owner, account.id, fundId, {
+      kind: "mutual_fund",
+      name: "RD X",
+      symbol: "RD-X",
+    })
+
+    const goodRegistry: ProviderRegistry = new Map([
+      [
+        "reksadana_id" as ProviderId,
+        () =>
+          fixtureProvider("reksadana_id", [
+            {
+              kind: "security",
+              symbol: "RD-X",
+              quoteCurrency: "IDR",
+              priceDecimal: "2000",
+            },
+          ]),
+      ],
+    ])
+    await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry: goodRegistry,
+    })
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+
+    const failingRegistry: ProviderRegistry = new Map([
+      [
+        "reksadana_id" as ProviderId,
+        () => fixtureProvider("reksadana_id", [], "upstream 503"),
+      ],
+    ])
+    const summary = await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry: failingRegistry,
+    })
+    expect(summary.totalIngested).toBe(0)
+    expect(
+      summary.perProvider.find((g) => g.providerId === "reksadana_id")?.error
+    ).toContain("upstream 503")
+    // Last-good quote untouched; the failed fetch is still staged.
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    expect(
+      await harness.prisma.rawMarketDataFetch.count({
+        where: { status: "error" },
+      })
+    ).toBe(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 3. Skip bucket: routed to an adapter that is not registered.
+  // ---------------------------------------------------------------------------
+  test("instruments routed to an unregistered adapter land in the skipped bucket", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+    // A security with no `provider` derives to `yahoo`, which is NOT registered
+    // in Slice A. (IDR-quoted so the holding link matches the account currency.)
+    const equityId = await makeInstrument({
+      kind: "security",
+      symbol: "AAPL",
+      quoteCurrency: "IDR",
+    })
+    await linkHolding(owner, account.id, equityId, {
+      kind: "stock",
+      name: "Apple",
+      symbol: "AAPL",
+    })
+
+    // Registry with ONLY logam_mulia (the Slice-A production shape).
+    const registry: ProviderRegistry = new Map([
+      [
+        "logam_mulia" as ProviderId,
+        () =>
+          fixtureProvider("bankbsi", [
+            {
+              kind: "metal",
+              symbol: "XAU-BSI",
+              quoteCurrency: "IDR",
+              priceDecimal: "85000000",
+            },
+          ]),
+      ],
+    ])
+
+    const summary = await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry,
+    })
+
+    expect(summary.totalIngested).toBe(0)
+    expect(summary.perProvider).toEqual([])
+    expect(summary.skipped).toHaveLength(1)
+    expect(summary.skipped[0]?.marketInstrumentId).toBe(equityId)
+    expect(summary.skipped[0]?.reason).toContain("yahoo")
+    expect(await harness.prisma.marketQuote.count()).toBe(0)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 4. Idempotent replay: running the router twice yields identical rows.
+  // ---------------------------------------------------------------------------
+  test("replaying the router is idempotent (identical canonical rows)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+    const fundId = await makeInstrument({
+      kind: "security",
+      symbol: "RD-IDEM",
+      quoteCurrency: "IDR",
+      provider: "reksadana_id",
+    })
+    await linkHolding(owner, account.id, fundId, {
+      kind: "mutual_fund",
+      name: "RD Idem",
+      symbol: "RD-IDEM",
+    })
+
+    const registry: ProviderRegistry = new Map([
+      [
+        "reksadana_id" as ProviderId,
+        () =>
+          fixtureProvider("reksadana_id", [
+            {
+              kind: "security",
+              symbol: "RD-IDEM",
+              quoteCurrency: "IDR",
+              priceDecimal: "1234.5",
+            },
+          ]),
+      ],
+    ])
+
+    const first = await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry,
+    })
+    const second = await ingestAllLinkedInstrumentsOnce({
+      db: harness.prisma,
+      registry,
+    })
+
+    expect(first.totalIngested).toBe(1)
+    expect(second.totalIngested).toBe(1)
+    // One canonical quote (upsert in place), two staged fetches (provenance).
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    expect(await harness.prisma.rawMarketDataFetch.count()).toBe(2)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 5. Gold path still works end to end through the migrated syncMarketPricesOnce.
+  // ---------------------------------------------------------------------------
+  test("syncMarketPricesOnce ingests gold through the router (baseline, no linked holding)", async () => {
+    const result = await syncMarketPricesOnce({
+      baseUrl: GOLD_BASE_URL,
+      fetchImpl: okGoldFetch,
+      db: harness.prisma,
+    })
+    expect(result.ingested).toBe(1)
+    expect(result.error).toBeUndefined()
+    const gold = await harness.prisma.marketInstrument.findFirstOrThrow({
+      where: { symbol: "XAU-BSI" },
+    })
+    // Gold rows keep provider = NULL (route derived) — zero backfill (ADR-0052).
+    expect(gold.provider).toBeNull()
+    const quote = await harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId: gold.id },
+    })
+    expect(quote.source).toBe("bankbsi")
+  })
+})


### PR DESCRIPTION
## Summary

Slice A of **ADR-0052** — a modular **provider routing engine** in front of the single market-data ingest seam. Given instruments of mixed kinds it selects the right adapter per instrument, batches per adapter, and ingests each batch through the **unchanged** `ingestMarketDataOnce` (raw → staged → canonical) pipeline. **No new vendor**; gold keeps working, now proven behind the router before fragile sources (reksadana, PER-257 Slice B) plug in.

App-only + **additive** migration. No ledger writes. Idempotent ingest.

## What changed

- **schema / migration** (`20260815120000_market_instrument_provider`): additive nullable `MarketInstrument.provider` + CHECK constraining it to the adapter-id domain `('logam_mulia','reksadana_id','yahoo','alpaca','twelvedata')` (NULL allowed). Existing gold rows stay NULL → derived route, **zero backfill**. Also adds a `SECURITY DEFINER` function `market_instrument_ids_linked_to_holdings()` (see note below).
- **pure routing** (`src/lib/market-data.ts`): `resolveProviderId(instrument)` + `ProviderId` union + `isProviderId`. Explicit `provider` wins; else derive from `(kind, mic, symbol)`. Unroutable / unknown-provider → **structured skip, never a throw**. No network, no secrets, no `any`.
- **service** (`src/server/market-data.server.ts`): `ProviderRegistry` (lazy factories) + `ingestAllLinkedInstrumentsOnce` with **per-provider failure isolation** (one bad group degrades to `{ ingested: 0, error }`, keeps last-good quote, stages the failed `RawMarketDataFetch`, never aborts other groups) and a reported `skipped` bucket. Global ingest only — the three global market tables, **never the ledger**, outside any family RLS transaction.
- **gold migrated onto the router**: `syncMarketPricesOnce` now ensures the BSI-gold instrument and routes it **through the registry** (`logam_mulia`), behaviour unchanged (NEVER-throws graceful contract intact). `syncMarketPricesFn` caller unchanged.

### Routing table (as implemented)

| `kind`     | discriminator             | → provider id  |
| ---------- | ------------------------- | -------------- |
| `metal`    | —                         | `logam_mulia`  |
| `security` | `provider="reksadana_id"` | `reksadana_id` |
| `security` | IDX (`mic`/`.JK`) or global | `yahoo`      |
| `crypto`   | —                         | `yahoo`        |
| `fx`       | —                         | `yahoo`        |

Explicit `provider` column wins when non-null. In Slice A only `logam_mulia` is registered, so linked `yahoo`/`reksadana_id` instruments land in the `skipped` bucket until their adapters ship — never an error.

### Note on the `SECURITY DEFINER` function (design call — flagging for review)

The router prices only instruments actually **held** (bounded work). "Held" lives on the tenant-scoped holdings `Instrument` table, which is `FORCE ROW LEVEL SECURITY`. The global ingest runs with **no family scope**, so under RLS it would see zero linkages. The function returns **only the set of global `MarketInstrument` ids** linked by ≥1 holding — never a tenant row, `familyId`, quantity, cost, or value — so tenant isolation is preserved while the global job stays bounded. `SET search_path` hardens it; EXECUTE is left to the PUBLIC default. This is the one place I extended beyond the literal ADR text (the ADR says "load linked instruments" but doesn't address the RLS boundary a no-family global job hits).

## Test evidence

- **Unit** (`src/lib/market-data.test.ts`): every `resolveProviderId` branch — metal→logam_mulia, security (mic / `.JK` / global)→yahoo, crypto→yahoo, fx→yahoo, explicit-provider-wins, whitespace fallthrough, unknown-provider skip, unroutable-kind skip. Full unit suite: **680 passed**.
- **Real-PG integration** (`tests/integration/financial-ingestion.integration.ts`, fixture-injected, no live network): mixed-kind routing through the registry; per-adapter failure isolation (bad group degrades, good group still ingests); graceful-error keep-last-good; unregistered-adapter skip bucket; idempotent replay (identical canonical rows); migrated gold path.

```
tests/integration/financial-ingestion.integration.ts  Test Files 1 passed (1)  Tests 6 passed (6)
```

- Existing market-data integration suites (gold sync, market-data core, holding-market-prices): **26 passed** — gold behaviour unchanged.
- RLS / holdings-adjacent integration (rls-guc-scoping, cross-tenant-fk, tenant-reference-validation, holdings, enable-holdings-tracking, gold-price-feed, db-constraints): **92 passed** — tenant isolation intact with the new column + function.
- `vp check`, `vp build` (server/client leak gate), `vp fmt`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
