### PR TITLE
feat(market-data): PER-250 — reksadana NAV auto-price feed (Bareksa/Pasardana worker + ReksadanaNavProvider)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,21 @@ DATABASE_URL="postgres://permoney:permoney@localhost:5433/permoney"
 # LOGAM_MULIA_API_URL="https://logam-mulia-api.example.workers.dev"
 
 # -----------------------------------------------------------------------------
+# Market data — reksadana NAV feed (PER-250 Slice B / ADR-0053)
+# -----------------------------------------------------------------------------
+# Base URL of the SELF-HOSTED `workers/reksadana-nav/` Cloudflare Worker (in this
+# repo). It scrapes Indonesian mutual-fund (reksadana) NAV from Bareksa/Pasardana,
+# caches in D1, and degrades gracefully — Permoney consumes ONLY its clean JSON,
+# so the scrape fragility stays in the worker. Read ONLY inside the `.server.ts`
+# adapter (`ReksadanaNavProvider`), at call time.
+#
+# The adapter fetches `{REKSADANA_API_URL}/nav?fund=<code>` (latest) and
+# `{REKSADANA_API_URL}/nav/history?fund=<code>&from=<YYYY-MM-DD>` (backfill).
+# Unset = the reksadana group degrades to `{ ingested: 0, error }` (gold + other
+# sources still refresh); it never throws at module scope. No trailing slash.
+# REKSADANA_API_URL="https://reksadana-nav.example.workers.dev"
+
+# -----------------------------------------------------------------------------
 # Auth (FUTURE — not yet wired, see ADRs)
 # -----------------------------------------------------------------------------
 # AUTH_SECRET="<openssl rand -base64 32>"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,6 +67,11 @@ services:
       # adapter reads it at call time and fails gracefully when unset, so the app
       # still boots without it. See docs/adr/0050-market-data-ingestion.md.
       LOGAM_MULIA_API_URL: ${LOGAM_MULIA_API_URL:-}
+      # PER-250 market-data: base URL of the self-hosted reksadana-nav worker
+      # (workers/reksadana-nav, a Cloudflare Worker). Optional — the reksadana
+      # ReksadanaNavProvider adapter reads it at call time and fails gracefully
+      # when unset, so the app still boots without it. See ADR-0053.
+      REKSADANA_API_URL: ${REKSADANA_API_URL:-}
     ports:
       - "127.0.0.1:3005:3005"
     networks:

--- a/docs/adr/0052-financial-ingestion-service-provider-routing.md
+++ b/docs/adr/0052-financial-ingestion-service-provider-routing.md
@@ -109,10 +109,12 @@ structured skip result, never a throw.
 
 Gold routes **through** the registry (its behaviour is unchanged but is now
 proven behind the router before fragile sources plug in). `syncMarketPricesFn`
-(PER-235b) calls `ingestAllLinkedInstrumentsOnce`; `refreshHoldingPricesFn`
+(PER-235b) calls `ingestAllInstrumentsOnce`; `refreshHoldingPricesFn`
 (PER-238) applies the fresh quotes anchor-safely — both contracts unchanged.
 
 ### 4. Reksadana NAV worker (the new source)
+
+> **Source + worker contract now locked in [ADR-0053](./0053-reksadana-nav-source-and-worker.md)**.
 
 A **self-hosted Cloudflare Worker** (creator's CF account) mirroring the gold
 worker's isolation: it fetches Indonesian reksadana NAV from a chosen upstream

--- a/docs/adr/0053-reksadana-nav-source-and-worker.md
+++ b/docs/adr/0053-reksadana-nav-source-and-worker.md
@@ -1,0 +1,132 @@
+# ADR-0053 — Reksadana NAV source & ingestion worker (PER-250 Slice B)
+
+|                   |                                                                  |
+| ----------------- | ---------------------------------------------------------------- |
+| **Status**        | Accepted                                                         |
+| **Date**          | 2026-08-15                                                       |
+| **Accepted**      | 2026-08-15                                                       |
+| **Deciders**      | Hendri Permana                                                   |
+| **Supersedes**    | —                                                                |
+| **Superseded by** | —                                                                |
+| **Amends**        | ADR-0052 §4 (reksadana worker), ADR-0050 (market-data ingestion) |
+
+## Context
+
+ADR-0052 stood up the provider router (Financial Ingestion Service, PER-257,
+merged). Slice B plugs in the first genuinely-new source: **local Indonesian
+mutual-fund (reksadana) NAV**, behind the `reksadana_id` adapter slot. The open
+question ADR-0052 §4 deferred was **which upstream** feeds the self-hosted
+worker. This ADR locks it.
+
+**Sources evaluated:**
+
+- **OJK (`reksadana.ojk.go.id`) — REJECTED.** It is a registration + monthly
+  _statistics_ portal (APERD registry, aggregate NAB statistics), **not** a
+  daily/historical per-fund NAV feed. Wrong tool; do not use it as the price
+  source.
+- **Bibit internal (`api.bibit.id/products/list`) — REJECTED as primary.** Its
+  payload is **AES-CBC encrypted** and reverse-engineered; the only community
+  reference (`risan/bibit-reksadana`) is unmaintained since 2021 and returns a
+  paginated product _list_, not a clean per-fund NAV lookup. Fragile,
+  ToS-gray, and the cipher can change without notice.
+- **Bareksa internal public JSON / Pasardana — CHOSEN (primary).** Bareksa
+  exposes a **clean, un-encrypted JSON** endpoint keyed by its numeric product
+  id (`https://www.bareksa.com/api/v1/reksadana/product/<code>/nav`); Pasardana
+  offers an equivalent clean-JSON feed. Either returns NAV + date directly with
+  no decryption step — the durable, low-friction primary. (Community clean-JSON
+  mirrors such as Piramida exist as further cross-references but are not part of
+  the locked chain.)
+
+## Decision
+
+### 1. Source fallback chain (inside the worker)
+
+Mirror the gold worker's graceful-degradation chain (ADR-0050 §4 / PER-235c):
+
+1. **Primary — Bareksa/Pasardana JSON API.** Clean JSON → normalized directly.
+2. **Fallback — Bareksa HTML scraper.** When the JSON API is unavailable / shape
+   drifts, parse the public product page for the NAV + date.
+3. **Last resort — D1 stale cache (LKGP, "Last Known Good Price").** Serve the
+   most recent cached quote, flagged stale, so a total upstream outage degrades
+   to last-good rather than an error.
+
+Each step is tried in order; the first success wins. A step failing is recorded,
+never fatal — the worker always returns _something usable or an explicit,
+structured degradation_, never a 500 that breaks Permoney's sync.
+
+### 2. Worker contract — two ingestion modes
+
+The worker exposes **two** modes so the ingestion engine supports both the daily
+tick and an initial historical backfill:
+
+- `GET /nav?fund=<code>` → the **latest** quote (today, or the last trading day).
+- `GET /nav/history?fund=<code>&from=<YYYY-MM-DD>` → an **array** of historical
+  quotes from `from` to today, for the one-time backfill of a newly-linked fund.
+
+**Payload contract (target — the worker normalizes every source to this):**
+
+```json
+{
+  "fundCode": "RD-SUCOR-MMF",
+  "currency": "IDR",
+  "latest": { "nav": 1643.45, "asOf": "2026-08-14" },
+  "quotes": [
+    { "date": "2026-08-13", "nav": 1643.19 },
+    { "date": "2026-08-14", "nav": 1643.45 }
+  ]
+}
+```
+
+`/nav` populates `latest` (and may omit/short `quotes`); `/nav/history` populates
+`quotes`. `nav` is a decimal number in `currency` per unit; the Permoney adapter
+scales it to the canonical spot integer (`SPOT_PRICE_SCALE`, ADR-0050) — the wire
+value stays a decimal, precision handled at the boundary.
+
+### 3. Weekend / market-holiday invariant
+
+KSEI/IDX publish **no new NAV on Saturday–Sunday** (and public holidays); the
+price is flat, carrying Friday's value. The ingestion engine **must not treat a
+flat weekend/holiday price (or an absent new NAV) as a failure**: it is the
+correct, expected state. Concretely — a repeated `asOf` with an unchanged `nav`
+is a no-op success (the append-only `MarketQuote` UNIQUE `(instrumentId, asOf,
+source)` already dedupes it), and the sync surfaces "up to date", not an error or
+a keep-last-good _degradation_. Backfill over a weekend range simply yields
+Friday's value on Sat/Sun rows (or omits them) — both are valid.
+
+### 4. Worker home + the Permoney boundary
+
+The worker is **scaffolded in-repo** at `workers/reksadana-nav/` (wrangler + TS +
+D1 binding), version-controlled and unit-tested (its normalizer + fallback logic
+is the fragile part that most needs review) — an improvement over the opaque
+external gold worker. The creator deploys it to their own Cloudflare account and
+sets **`REKSADANA_API_URL`** (compose + `.env.example`, mirroring
+`LOGAM_MULIA_API_URL`). Permoney's app depends only on that URL — the scrape
+fragility + ToS-gray live entirely in the worker, never in the ledger app.
+
+The Permoney-side **`ReksadanaNavProvider`** (in `market-data.server.ts`)
+implements `MarketDataProvider`, calls the worker behind `REKSADANA_API_URL`
+(same shape as `LogamMuliaGoldProvider`), and normalizes the payload into
+`MarketObservation`s for the unchanged raw → staged → canonical pipeline. It
+registers in the `ProviderRegistry` under `reksadana_id`. Reksadana instruments:
+`kind="security"`, `provider="reksadana_id"`, `symbol=<fund code>`,
+`quoteCurrency="IDR"`, `mic=NULL` (ADR-0052 §1). A linked holding revalues
+anchor-safely on "Refresh prices" (PER-238); value = units × NAV.
+
+### 5. Testing
+
+**No live network in CI.** The worker's normalizer and the `ReksadanaNavProvider`
+are tested against **saved fixtures** (record once from the real upstream during
+the build spike, then replay). Real-PG integration proves: latest ingest,
+historical backfill, weekend flat-price no-op, primary→fallback→LKGP degradation,
+idempotent replay, and holding revaluation from NAV.
+
+## Consequences
+
+- Completes the "auto market data for all my investments" story: gold (live) +
+  reksadana (this slice), both on one router.
+- Durable history: daily `/nav` appends a `MarketQuote`; `/nav/history` backfills
+  past quotes — Permoney owns the append-only per-fund NAV series (ADR-0050).
+- Fragility is real but isolated (worker + fallback chain + LKGP); a source drift
+  degrades, never corrupts or crashes.
+- The two-mode contract + weekend invariant are the non-obvious correctness edges
+  a naive "fetch today's price" worker would get wrong.

--- a/src/components/blocks/holding-form-dialog.tsx
+++ b/src/components/blocks/holding-form-dialog.tsx
@@ -30,7 +30,11 @@ import {
 import { parseMoneyInput, toDecimalString } from "@/lib/money"
 import { createUuidV7 } from "@/lib/uuid-v7"
 import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
-import { listMarketInstrumentsFn, upsertHoldingFn } from "@/server/holdings"
+import {
+  ensureReksadanaInstrumentFn,
+  listMarketInstrumentsFn,
+  upsertHoldingFn,
+} from "@/server/holdings"
 
 // Sentinel Select value for "no live price source" (manual pricing). Radix
 // Select forbids an empty-string item value, so null is modeled explicitly.
@@ -103,10 +107,51 @@ export function HoldingFormDialog({
   const [submitting, setSubmitting] = React.useState(false)
 
   // Same-currency series only (cross-currency auto-pricing is a later slice).
-  const { data: marketInstruments } = useQuery({
-    queryKey: ["market_instruments", currency],
-    queryFn: async () => await listMarketInstrumentsFn({ data: { currency } }),
-  })
+  const { data: marketInstruments, refetch: refetchMarketInstruments } =
+    useQuery({
+      queryKey: ["market_instruments", currency],
+      queryFn: async () =>
+        await listMarketInstrumentsFn({ data: { currency } }),
+    })
+
+  // PER-250 Slice B — register a reksadana (IDR mutual-fund) NAV series inline so
+  // it becomes linkable, without leaving the dialog. Reksadana is IDR-only.
+  const isIdr = currency.toUpperCase() === "IDR"
+  const [showAddFund, setShowAddFund] = React.useState(false)
+  const [fundCode, setFundCode] = React.useState("")
+  const [fundNickname, setFundNickname] = React.useState("")
+  const [addingFund, setAddingFund] = React.useState(false)
+  const [addFundError, setAddFundError] = React.useState<string | null>(null)
+
+  async function handleAddReksadanaFund() {
+    setAddFundError(null)
+    const code = fundCode.trim()
+    if (code.length < 2) {
+      setAddFundError("Enter the fund code (e.g. its Bareksa/KSEI code).")
+      return
+    }
+    setAddingFund(true)
+    try {
+      const created = await ensureReksadanaInstrumentFn({
+        data: {
+          code,
+          name: fundNickname.trim() === "" ? undefined : fundNickname.trim(),
+        },
+      })
+      await refetchMarketInstruments()
+      // Auto-select the freshly-registered series so the user can save at once.
+      setMarketInstrumentId(created.id)
+      setShowAddFund(false)
+      setFundCode("")
+      setFundNickname("")
+    } catch (caught) {
+      setAddFundError(
+        caught instanceof Error ? caught.message : "Could not add the fund."
+      )
+    } finally {
+      setAddingFund(false)
+    }
+  }
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -309,6 +354,74 @@ export function HoldingFormDialog({
               &ldquo;Refresh prices&rdquo;. Only same-currency ({currency})
               sources are shown.
             </p>
+
+            {isIdr ? (
+              showAddFund ? (
+                <div className="flex flex-col gap-2 rounded-md border border-dashed p-3">
+                  <Label htmlFor="reksadana-fund-code">
+                    Reksadana fund code
+                  </Label>
+                  <Input
+                    id="reksadana-fund-code"
+                    value={fundCode}
+                    onChange={(event) => setFundCode(event.target.value)}
+                    placeholder="e.g. sucorinvest-money-market-fund"
+                    autoComplete="off"
+                  />
+                  <Label htmlFor="reksadana-fund-nickname">
+                    Nickname (optional)
+                  </Label>
+                  <Input
+                    id="reksadana-fund-nickname"
+                    value={fundNickname}
+                    onChange={(event) => setFundNickname(event.target.value)}
+                    placeholder="e.g. Sucorinvest MMF"
+                    autoComplete="off"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Registers the fund&rsquo;s NAV series so it can be linked
+                    and auto-priced. Uses the fund&rsquo;s Bareksa/KSEI code.
+                  </p>
+                  {addFundError ? (
+                    <p className="text-sm text-destructive" role="alert">
+                      {addFundError}
+                    </p>
+                  ) : null}
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={handleAddReksadanaFund}
+                      disabled={addingFund}
+                    >
+                      {addingFund ? "Adding…" : "Add fund"}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        setShowAddFund(false)
+                        setAddFundError(null)
+                      }}
+                      disabled={addingFund}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  variant="link"
+                  size="sm"
+                  className="h-auto self-start p-0 text-xs"
+                  onClick={() => setShowAddFund(true)}
+                >
+                  + Add a reksadana fund
+                </Button>
+              )
+            ) : null}
           </div>
 
           {error ? (

--- a/src/lib/market-data.test.ts
+++ b/src/lib/market-data.test.ts
@@ -14,6 +14,7 @@ import {
   marketQuoteToHoldingPriceMinor,
   normalizeObservations,
   parseLogamMuliaGoldResponse,
+  parseReksadanaNavResponse,
   priceScaleForKind,
   PROVIDER_IDS,
   resolveProviderId,
@@ -657,5 +658,123 @@ describe("resolveProviderId — structured skip (never throws)", () => {
     if (result.status === "skipped") {
       expect(result.reason).toContain("commodity")
     }
+  })
+})
+
+describe("parseReksadanaNavResponse (PER-250 Slice B / ADR-0053)", () => {
+  const WORKER_PAYLOAD = {
+    fundCode: "RD-SUCOR-MMF",
+    currency: "IDR",
+    latest: { nav: 1643.45, asOf: "2026-08-14" },
+    quotes: [
+      { date: "2026-08-13", nav: 1643.19 },
+      { date: "2026-08-14", nav: 1643.45 },
+    ],
+  }
+
+  test("maps each dated quote to a security observation (IDR, per-unit NAV)", () => {
+    const result = parseReksadanaNavResponse(WORKER_PAYLOAD, {
+      fundCode: "RD-SUCOR-MMF",
+    })
+    expect(result.status).toBe("ok")
+    expect(result.observations).toHaveLength(2)
+    const [first, second] = result.observations
+    expect(first).toMatchObject({
+      kind: "security",
+      symbol: "RD-SUCOR-MMF",
+      quoteCurrency: "IDR",
+      priceDecimal: "1643.19",
+      providerRef: "reksadana_id",
+    })
+    expect(first?.asOf.toISOString()).toBe("2026-08-13T00:00:00.000Z")
+    expect(second?.priceDecimal).toBe("1643.45")
+    // The observation symbol is the REQUESTED fund code (identity stability),
+    // even if the payload echoed a different formatting.
+    expect(second?.symbol).toBe("RD-SUCOR-MMF")
+  })
+
+  test("uses the requested fundCode even when the payload echoes another", () => {
+    const result = parseReksadanaNavResponse(
+      { ...WORKER_PAYLOAD, fundCode: "SOMETHING-ELSE" },
+      { fundCode: "RD-REQUESTED" }
+    )
+    expect(result.observations.every((o) => o.symbol === "RD-REQUESTED")).toBe(
+      true
+    )
+  })
+
+  test("falls back to the single latest point when quotes is empty", () => {
+    const result = parseReksadanaNavResponse(
+      { ...WORKER_PAYLOAD, quotes: [] },
+      { fundCode: "RD-SUCOR-MMF" }
+    )
+    expect(result.observations).toHaveLength(1)
+    expect(result.observations[0]?.priceDecimal).toBe("1643.45")
+    expect(result.observations[0]?.asOf.toISOString()).toBe(
+      "2026-08-14T00:00:00.000Z"
+    )
+  })
+
+  test("the encoded price round-trips through the spot scale", () => {
+    const result = parseReksadanaNavResponse(WORKER_PAYLOAD, {
+      fundCode: "RD-SUCOR-MMF",
+    })
+    const encoded = encodeSpotPrice(result.observations[1]!.priceDecimal)
+    expect(decodeSpotPrice(encoded)).toBe("1643.45")
+  })
+
+  test("weekend flat repeat is NOT an error (dedup happens downstream)", () => {
+    const flat = {
+      fundCode: "RD",
+      currency: "IDR",
+      latest: { nav: 1643.45, asOf: "2026-08-14" },
+      quotes: [
+        { date: "2026-08-14", nav: 1643.45 },
+        { date: "2026-08-14", nav: 1643.45 },
+      ],
+    }
+    const result = parseReksadanaNavResponse(flat, { fundCode: "RD" })
+    expect(result.status).toBe("ok")
+    // The parser emits both; normalizeObservations dedups (identity, asOf).
+    const normalized = normalizeObservations(result.observations)
+    expect(normalized.quotes).toHaveLength(1)
+  })
+
+  test("drops a row with a non-positive / unparseable NAV, keeps the good ones", () => {
+    const mixed = {
+      fundCode: "RD",
+      currency: "IDR",
+      latest: null,
+      quotes: [
+        { date: "2026-08-13", nav: 0 },
+        { date: "bad-date", nav: 1643.19 },
+        { date: "2026-08-14", nav: 1643.45 },
+      ],
+    }
+    const result = parseReksadanaNavResponse(mixed, { fundCode: "RD" })
+    expect(result.status).toBe("ok")
+    expect(result.observations).toHaveLength(1)
+    expect(result.observations[0]?.priceDecimal).toBe("1643.45")
+  })
+
+  test("structurally unusable payloads error gracefully (no throw)", () => {
+    expect(parseReksadanaNavResponse(null, { fundCode: "RD" }).status).toBe(
+      "error"
+    )
+    expect(
+      parseReksadanaNavResponse(
+        { currency: "IDR", latest: null, quotes: [] },
+        { fundCode: "RD" }
+      ).status
+    ).toBe("error")
+    expect(
+      parseReksadanaNavResponse(
+        { currency: "", latest: { nav: 1, asOf: "2026-08-14" }, quotes: [] },
+        { fundCode: "RD" }
+      ).status
+    ).toBe("error")
+    expect(
+      parseReksadanaNavResponse(WORKER_PAYLOAD, { fundCode: "  " }).status
+    ).toBe("error")
   })
 })

--- a/src/lib/market-data.ts
+++ b/src/lib/market-data.ts
@@ -843,3 +843,159 @@ export function parseLogamMuliaGoldResponse(
     ],
   }
 }
+
+// =============================================================================
+// Reksadana (Indonesian mutual-fund) NAV feed — worker-payload parsing
+// (PER-250 Slice B / ADR-0053)
+// =============================================================================
+//
+// Symmetric to the gold section above, but for the reksadana source: the FRAGILE
+// scrape (Bareksa/Pasardana → the ADR-0053 §2 contract) lives entirely inside the
+// self-hosted Cloudflare Worker (`workers/reksadana-nav/`). Permoney consumes ONLY
+// the worker's clean, already-normalized JSON, so THIS parser's job is the small,
+// stable one: turn the worker's `{ fundCode, currency, latest, quotes }` payload
+// into canonical `security` `MarketObservation`s. Pure — no DB, no network, no
+// secrets — so it is fully unit-testable; the network adapter (`ReksadanaNavProvider`,
+// which reads `REKSADANA_API_URL`) lives in `market-data.server.ts`.
+//
+// A reksadana instrument's identity (ADR-0052 §1 / ADR-0053 §4):
+//   kind="security", provider="reksadana_id", symbol=<fund code>,
+//   quoteCurrency="IDR", mic=NULL. NAV is a normal PER-UNIT spot price (scale 1e8);
+//   a linked holding revalues at units × NAV, anchor-safe via PER-238.
+//
+// WEEKEND / MARKET-HOLIDAY INVARIANT (ADR-0053 §3): KSEI/IDX publish no new NAV on
+// Sat–Sun/holidays, so the freshest quote simply carries Friday's value. This
+// parser NEVER treats a flat/repeated `asOf`+`nav` (or an absent new-today price)
+// as a failure — the canonical UNIQUE (instrumentId, asOf, source) dedupes a
+// repeat into a no-op. It fails ONLY on a structurally unusable payload (not an
+// object, no currency, or zero parseable positive-priced quotes).
+
+/** The source-adapter id + quote `source`/provenance label for reksadana NAV. */
+export const REKSADANA_PROVIDER_ID = "reksadana_id" as const
+
+/** Reksadana NAV is always quoted per unit in Indonesian rupiah. */
+export const REKSADANA_QUOTE_CURRENCY = "IDR"
+
+/** One dated NAV point in the worker payload (ADR-0053 §2). */
+export interface ReksadanaNavQuote {
+  date: string
+  nav: number
+}
+
+/**
+ * The worker's normalized NAV payload (ADR-0053 §2 — the ONE shape the worker
+ * emits regardless of which upstream/fallback it used). `latest` is the freshest
+ * quote (`/nav`); `quotes` is the dated series (`/nav/history`, or a short tail on
+ * `/nav`). `stale` flags a last-known-good (D1 cache) degradation.
+ */
+export interface ReksadanaWorkerPayload {
+  fundCode: string
+  currency: string
+  latest: { nav: number; asOf: string } | null
+  quotes: ReksadanaNavQuote[]
+  /** True when served from the worker's stale D1 cache (LKGP) — informational. */
+  stale?: boolean
+}
+
+/** The outcome of parsing a worker NAV payload into observations. */
+export interface ReksadanaParseResult {
+  status: "ok" | "error"
+  /** Human-readable reason when `status` is "error" (graceful skip, no throw). */
+  error?: string
+  observations: MarketObservation[]
+}
+
+/**
+ * A finite, positive NAV number → a plain decimal string `encodeSpotPrice` accepts
+ * (`^\d+(\.\d+)?$`). Rejects non-finite, non-positive, and exponent-notation
+ * numbers (a NAV that small/large is a corrupt value — fail the row, never
+ * mis-mark money). `String(1643.45)` → "1643.45"; `Number`'s shortest round-trip
+ * form is exact for the 2–4 dp NAVs KSEI publishes.
+ */
+function navNumberToDecimal(nav: unknown): string | null {
+  if (typeof nav !== "number" || !Number.isFinite(nav) || nav <= 0) return null
+  const text = String(nav)
+  if (!/^\d+(\.\d+)?$/.test(text)) return null
+  return text
+}
+
+/** A `YYYY-MM-DD` (or ISO) date string → a UTC midnight Date, or null. */
+function parseNavDate(value: unknown): Date | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null
+  const trimmed = value.trim()
+  // Bare calendar date → pin to UTC midnight (the canonical NAV as-of convention,
+  // mirroring the gold feed's recordedDate handling).
+  const iso = /^\d{4}-\d{2}-\d{2}$/.test(trimmed)
+    ? `${trimmed}T00:00:00.000Z`
+    : trimmed
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+/**
+ * Parse a reksadana worker NAV payload (ADR-0053 §2) into canonical `security`
+ * observations — one per dated quote (deduped downstream by (instrument, asOf,
+ * source)). `quotes` is preferred (covers both the `/nav/history` backfill and a
+ * `/nav` tail); when `quotes` is empty the single `latest` point is used. The
+ * requested `fundCode` (NOT the echoed payload one) is used as the observation
+ * symbol so identity stays stable regardless of upstream formatting.
+ *
+ * A row with a non-positive/unencodable NAV or an unparseable date is DROPPED (a
+ * flat repeat is kept — the store dedupes it), never thrown. The payload is an
+ * error ONLY when it is structurally unusable (not an object, blank currency, or
+ * zero usable rows). Pure: no DB, no network, no secrets.
+ */
+export function parseReksadanaNavResponse(
+  payload: unknown,
+  opts: { fundCode: string; sourceLabel?: string }
+): ReksadanaParseResult {
+  const err = (reason: string): ReksadanaParseResult => ({
+    status: "error",
+    error: reason,
+    observations: [],
+  })
+
+  const fundCode = opts.fundCode.trim()
+  if (fundCode.length === 0) return err("missing fundCode")
+  if (!isRecord(payload)) return err("payload is not an object")
+
+  const currency =
+    typeof payload.currency === "string" ? payload.currency.trim() : ""
+  if (currency.length === 0) return err("payload is missing a currency")
+
+  // Prefer the dated series; fall back to the single `latest` point.
+  const rawQuotes: unknown[] = Array.isArray(payload.quotes)
+    ? payload.quotes
+    : []
+  const points: { date: unknown; nav: unknown }[] = []
+  for (const row of rawQuotes) {
+    if (!isRecord(row)) continue
+    points.push({ date: row.date, nav: row.nav })
+  }
+  if (points.length === 0 && isRecord(payload.latest)) {
+    points.push({ date: payload.latest.asOf, nav: payload.latest.nav })
+  }
+  if (points.length === 0) return err("payload has no NAV quotes")
+
+  const providerRef = opts.sourceLabel ?? REKSADANA_PROVIDER_ID
+  const observations: MarketObservation[] = []
+  for (const point of points) {
+    const asOf = parseNavDate(point.date)
+    if (asOf === null) continue
+    const priceDecimal = navNumberToDecimal(point.nav)
+    if (priceDecimal === null) continue
+    observations.push({
+      kind: "security",
+      symbol: fundCode,
+      quoteCurrency: currency,
+      asOf,
+      priceDecimal,
+      providerRef,
+    })
+  }
+
+  if (observations.length === 0) {
+    return err("payload has no usable (positive-priced, dated) NAV quotes")
+  }
+  return { status: "ok", observations }
+}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -1573,6 +1573,82 @@ export const listMarketInstrumentsFn = createServerFn({ method: "GET" })
   })
 
 // -----------------------------------------------------------------------------
+// POST — register a reksadana (Indonesian mutual-fund) NAV price series so it is
+// LINKABLE from the holding form (PER-250 Slice B / ADR-0053).
+// -----------------------------------------------------------------------------
+//
+// Reksadana funds have no exchange listing, so — unlike gold — Permoney cannot
+// pre-seed the universe. The creator registers their specific Bibit/Bareksa fund
+// by its code; this ensures the GLOBAL `MarketInstrument`
+// (kind="security", provider="reksadana_id", symbol=<code>, quoteCurrency="IDR",
+// mic=NULL), after which it appears in the same-currency "Live price source"
+// dropdown and the router prices it under the `reksadana_id` adapter on the next
+// "Refresh prices". Writes ONLY the global reference row (no ledger data, no RLS
+// dependency); capability-gated (`ledger:write`) to keep the trigger authorized.
+
+export const ensureReksadanaInstrumentInputSchema = z.object({
+  // Bareksa/KSEI stable fund code (the worker's `?fund=` key). Alphanumeric with
+  // dashes/dots/underscores; the exact string is used as the instrument symbol.
+  code: z
+    .string()
+    .trim()
+    .min(2)
+    .max(48)
+    .regex(
+      /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
+      "Fund code must be alphanumeric (dashes, dots, underscores allowed)"
+    ),
+  name: z.string().trim().max(120).optional(),
+})
+
+export async function ensureReksadanaInstrumentForFamily({
+  data,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.infer<typeof ensureReksadanaInstrumentInputSchema>
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<SerializedMarketInstrument> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    // DYNAMIC import keeps the `.server` hard-fence module out of the client graph.
+    const { ensureReksadanaInstrument } = await import("./market-data.server")
+    const id = await ensureReksadanaInstrument(
+      { symbol: data.code, name: data.name },
+      tx
+    )
+    return await tx.marketInstrument.findUniqueOrThrow({
+      where: { id },
+      select: {
+        id: true,
+        kind: true,
+        symbol: true,
+        name: true,
+        quoteCurrency: true,
+        baseCurrency: true,
+        mic: true,
+      },
+    })
+  })
+}
+
+export const ensureReksadanaInstrumentFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator(
+    (data: z.input<typeof ensureReksadanaInstrumentInputSchema>) =>
+      ensureReksadanaInstrumentInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await ensureReksadanaInstrumentForFamily({
+      data,
+      familyId: context.familyId,
+      userId: context.user.id,
+    })
+  })
+
+// -----------------------------------------------------------------------------
 // POST — trigger ONE on-demand market-price sync (PER-235b).
 // -----------------------------------------------------------------------------
 //

--- a/src/server/market-data.server.ts
+++ b/src/server/market-data.server.ts
@@ -36,6 +36,9 @@ import {
   isMarketInstrumentKind,
   normalizeObservations,
   parseLogamMuliaGoldResponse,
+  parseReksadanaNavResponse,
+  REKSADANA_PROVIDER_ID,
+  REKSADANA_QUOTE_CURRENCY,
   resolveProviderId,
   type GoldPriceField,
   type MarketInstrumentIdentity,
@@ -737,6 +740,329 @@ export async function ingestGoldPricesOnce(
   })
 }
 
+// -----------------------------------------------------------------------------
+// Reksadana NAV feed adapter — self-hosted reksadana-nav worker (PER-250 Slice B
+// / ADR-0053)
+// -----------------------------------------------------------------------------
+//
+// The ONLY code that knows the reksadana vendor exists — the exact mirror of
+// `LogamMuliaGoldProvider`. It calls the self-hosted worker behind
+// `REKSADANA_API_URL` (the fragile Bareksa/Pasardana scrape + fallback chain live
+// ENTIRELY in the worker; ADR-0053 §4), and hands the pure parser
+// (`parseReksadanaNavResponse`, @/lib/market-data) the worker's clean JSON. It
+// prices `security`/IDR instruments (a fund's NAV per unit); FX/other spot are a
+// no-op empty-ok here so a mixed ingest never errors on this provider. Secrets/
+// config (`REKSADANA_API_URL`) are read ONLY here, at CALL time (never module
+// scope). Graceful degradation is total: an unreachable worker, a non-2xx, a
+// non-JSON body, or a structurally-unusable payload for a fund is recorded but
+// never throws; when EVERY requested fund fails the result is one graceful error
+// (no quote written, last-good retained).
+//
+// TWO MODES (ADR-0053 §2): the daily tick uses `latest` (`GET /nav?fund=`); an
+// initial backfill of a newly-linked fund uses `history` (`GET /nav/history?
+// fund=&from=`), which yields many dated observations → many dated MarketQuotes.
+
+/** Read the reksadana worker base URL at CALL time; a clear error if unset. */
+function requireReksadanaApiUrl(): string {
+  const raw = process.env.REKSADANA_API_URL
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new Error(
+      "REKSADANA_API_URL is not set — configure the self-hosted reksadana-nav worker base URL to ingest reksadana NAV (ADR-0053 / PER-250)."
+    )
+  }
+  return raw.trim().replace(/\/+$/, "")
+}
+
+export type ReksadanaFetchMode = "latest" | "history"
+
+export interface ReksadanaNavProviderOptions {
+  /** Base URL; defaults to reading `REKSADANA_API_URL` at call time. */
+  baseUrl?: string
+  /** Injectable fetch (tests pass a fixture; prod uses the global `fetch`). */
+  fetchImpl?: FetchLike
+  /** `latest` (daily tick, default) or `history` (one-time backfill). */
+  mode?: ReksadanaFetchMode
+  /** History mode only: inclusive backfill start (`YYYY-MM-DD`). */
+  from?: string
+}
+
+/**
+ * The self-hosted reksadana-nav worker adapter. Serves reksadana `security` NAV
+ * only. The quote `source`/provenance is the stable `reksadana_id` adapter id
+ * (the worker abstracts WHICH upstream/fallback produced the number).
+ */
+export class ReksadanaNavProvider implements MarketDataProvider {
+  private readonly baseUrl: string
+  private readonly fetchImpl: FetchLike
+  private readonly mode: ReksadanaFetchMode
+  private readonly from: string | undefined
+
+  /** Provenance the ingest pipeline stamps on the raw fetch + canonical quote. */
+  get name(): string {
+    return REKSADANA_PROVIDER_ID
+  }
+
+  constructor(options?: ReksadanaNavProviderOptions) {
+    this.baseUrl = options?.baseUrl ?? requireReksadanaApiUrl()
+    this.fetchImpl = options?.fetchImpl ?? ((url, init) => fetch(url, init))
+    this.mode = options?.mode ?? "latest"
+    this.from = options?.from
+  }
+
+  fetchFxRates(): Promise<MarketFetchResult> {
+    return Promise.resolve({
+      status: "ok",
+      httpStatus: 200,
+      observations: [],
+      rawPayload: null,
+    })
+  }
+
+  fetchSpot(requests: readonly SpotRequest[]): Promise<MarketFetchResult> {
+    return this.fetchNav(requests)
+  }
+
+  fetchQuotes(
+    instruments: readonly MarketInstrumentRequest[]
+  ): Promise<MarketFetchResult> {
+    // Only reksadana `security` instruments reach this adapter (the router groups
+    // by provider id); fx pairs are ignored defensively.
+    const spot = instruments.filter(
+      (instrument): instrument is SpotRequest => instrument.kind !== "fx"
+    )
+    return this.fetchNav(spot)
+  }
+
+  /**
+   * Fetch each requested fund from the worker, parse via the pure normalizer, and
+   * aggregate into ONE staged result. A single fund failing is recorded but never
+   * fatal — the good funds still ingest. Only when EVERY fund fails does the whole
+   * result degrade to `status: "error"` (no quote written, last-good retained).
+   */
+  private async fetchNav(
+    requests: readonly SpotRequest[]
+  ): Promise<MarketFetchResult> {
+    if (requests.length === 0) {
+      return {
+        status: "ok",
+        httpStatus: 200,
+        observations: [],
+        rawPayload: null,
+      }
+    }
+
+    const observations: MarketObservation[] = []
+    const failures: string[] = []
+    const rawByFund: Record<string, unknown> = {}
+    let anyOk = false
+    let lastHttpStatus: number | undefined
+
+    for (const request of requests) {
+      const outcome = await this.fetchOneFund(request.symbol)
+      lastHttpStatus = outcome.httpStatus ?? lastHttpStatus
+      rawByFund[request.symbol] = outcome.rawPayload
+      if (outcome.status === "ok") {
+        anyOk = true
+        observations.push(...outcome.observations)
+      } else {
+        failures.push(`${request.symbol}: ${outcome.error ?? "failed"}`)
+      }
+    }
+
+    if (!anyOk) {
+      return {
+        status: "error",
+        httpStatus: lastHttpStatus,
+        error: `all reksadana funds failed — ${failures.join("; ")}`,
+        observations: [],
+        rawPayload: { errors: failures, byFund: rawByFund },
+      }
+    }
+
+    return {
+      status: "ok",
+      httpStatus: lastHttpStatus ?? 200,
+      observations,
+      rawPayload: { byFund: rawByFund, failures },
+    }
+  }
+
+  /** Fetch + parse ONE fund's NAV. Never throws; returns a per-fund result. */
+  private async fetchOneFund(symbol: string): Promise<{
+    status: "ok" | "error"
+    httpStatus?: number
+    error?: string
+    observations: MarketObservation[]
+    rawPayload: unknown
+  }> {
+    const url = this.buildUrl(symbol)
+
+    let response: Response
+    try {
+      response = await this.fetchImpl(url, {
+        headers: { accept: "application/json" },
+      })
+    } catch (error) {
+      return {
+        status: "error",
+        error:
+          error instanceof Error ? error.message : "reksadana fetch failed",
+        observations: [],
+        rawPayload: { error: String(error) },
+      }
+    }
+
+    if (!response.ok) {
+      const body = await safeReadText(response)
+      return {
+        status: "error",
+        httpStatus: response.status,
+        error: `reksadana worker HTTP ${response.status}`,
+        observations: [],
+        rawPayload: { httpStatus: response.status, body },
+      }
+    }
+
+    let json: unknown
+    try {
+      json = await response.json()
+    } catch (error) {
+      return {
+        status: "error",
+        httpStatus: response.status,
+        error: "reksadana worker returned non-JSON",
+        observations: [],
+        rawPayload: { httpStatus: response.status, parseError: String(error) },
+      }
+    }
+
+    const parsed = parseReksadanaNavResponse(json, { fundCode: symbol })
+    if (parsed.status !== "ok") {
+      return {
+        status: "error",
+        httpStatus: response.status,
+        error: parsed.error,
+        observations: [],
+        rawPayload: json,
+      }
+    }
+    return {
+      status: "ok",
+      httpStatus: response.status,
+      observations: parsed.observations,
+      rawPayload: json,
+    }
+  }
+
+  private buildUrl(symbol: string): string {
+    const fund = encodeURIComponent(symbol)
+    if (this.mode === "history") {
+      const from = this.from ? `&from=${encodeURIComponent(this.from)}` : ""
+      return `${this.baseUrl}/nav/history?fund=${fund}${from}`
+    }
+    return `${this.baseUrl}/nav?fund=${fund}`
+  }
+}
+
+/**
+ * Idempotently ensure a reksadana `MarketInstrument` exists so a holding can be
+ * LINKED to it (PER-238) and the router prices it under the `reksadana_id`
+ * adapter. Identity: kind="security", provider="reksadana_id", symbol=<fund code>,
+ * quoteCurrency="IDR", mic=NULL (ADR-0052 §1 / ADR-0053 §4). Safe to call
+ * repeatedly; recovers from the unique-index race. Returns its id.
+ *
+ * The explicit `provider` column is what routes the instrument to this adapter —
+ * WITHOUT it a bare `security` derives to `yahoo` (ADR-0052 §2). Creating it here
+ * (on link) rather than on ingest guarantees the route is correct from the start.
+ */
+export async function ensureReksadanaInstrument(
+  params: { symbol: string; name?: string },
+  db: Pick<PrismaClient, "marketInstrument"> = prisma
+): Promise<string> {
+  const symbol = params.symbol.trim()
+  if (symbol.length === 0) {
+    throw new Error("ensureReksadanaInstrument: fund code (symbol) is required")
+  }
+  const where = {
+    kind: "security",
+    symbol,
+    baseCurrency: null,
+    quoteCurrency: REKSADANA_QUOTE_CURRENCY,
+    mic: null,
+  } as const
+
+  const existing = await db.marketInstrument.findFirst({
+    where,
+    select: { id: true },
+  })
+  if (existing) return existing.id
+
+  try {
+    const created = await db.marketInstrument.create({
+      data: {
+        kind: "security",
+        symbol,
+        name: params.name?.trim() || null,
+        quoteCurrency: REKSADANA_QUOTE_CURRENCY,
+        provider: REKSADANA_PROVIDER_ID,
+      },
+      select: { id: true },
+    })
+    return created.id
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      const raced = await db.marketInstrument.findFirst({
+        where,
+        select: { id: true },
+      })
+      if (raced) return raced.id
+    }
+    throw error
+  }
+}
+
+export interface IngestReksadanaOptions {
+  /** The funds to price (each `symbol` is the fund code / instrument symbol). */
+  funds: readonly { symbol: string }[]
+  /** Base URL; defaults to reading `REKSADANA_API_URL` at call time. */
+  baseUrl?: string
+  /** Injectable fetch (tests pass a fixture; prod uses the global `fetch`). */
+  fetchImpl?: FetchLike
+  /** `latest` (default) or `history` (backfill). */
+  mode?: ReksadanaFetchMode
+  /** History mode only: inclusive backfill start (`YYYY-MM-DD`). */
+  from?: string
+  db?: MarketDataDb
+}
+
+/**
+ * Run ONE reksadana NAV ingest cycle for the given funds through the shared raw →
+ * staged → canonical pipeline. Used for the one-time HISTORY backfill of a
+ * newly-linked fund (many dated MarketQuotes) and callable directly for a targeted
+ * latest refresh; the DAILY tick for all linked funds flows through
+ * `ingestAllInstrumentsOnce` (the router). Idempotent; safe to call repeatedly.
+ */
+export async function ingestReksadanaPricesOnce(
+  options: IngestReksadanaOptions
+): Promise<IngestSummary> {
+  const db = options.db ?? prisma
+  const provider = new ReksadanaNavProvider({
+    baseUrl: options.baseUrl,
+    fetchImpl: options.fetchImpl,
+    mode: options.mode,
+    from: options.from,
+  })
+  return await ingestMarketDataOnce({
+    provider,
+    requests: options.funds.map((fund) => ({
+      kind: "security" as const,
+      symbol: fund.symbol,
+      quoteCurrency: REKSADANA_QUOTE_CURRENCY,
+    })),
+    db,
+  })
+}
+
 // =============================================================================
 // Financial Ingestion Service — provider registry + routing engine (PER-257 /
 // ADR-0052)
@@ -768,9 +1094,20 @@ export interface DefaultRegistryGoldOptions {
   now?: () => Date
 }
 
+/** Reksadana-adapter construction knobs (tests inject a fixture fetch). */
+export interface DefaultRegistryReksadanaOptions {
+  baseUrl?: string
+  fetchImpl?: FetchLike
+  /** The router's daily tick prices the LATEST NAV; history is a separate call. */
+  mode?: ReksadanaFetchMode
+  from?: string
+}
+
 export interface DefaultRegistryOptions {
   /** Passthrough for the `logam_mulia` gold adapter (see LogamMuliaGoldProvider). */
   gold?: DefaultRegistryGoldOptions
+  /** Passthrough for the `reksadana_id` NAV adapter (see ReksadanaNavProvider). */
+  reksadana?: DefaultRegistryReksadanaOptions
 }
 
 /**
@@ -792,6 +1129,19 @@ export function createDefaultProviderRegistry(
         fetchImpl: options?.gold?.fetchImpl,
         priceField: options?.gold?.priceField,
         now: options?.gold?.now,
+      })
+  )
+  // PER-250 Slice B: the reksadana NAV adapter. Lazy — it reads
+  // `REKSADANA_API_URL` only when actually constructed, so an install without the
+  // worker configured degrades ONLY the reksadana group (gold still refreshes).
+  registry.set(
+    REKSADANA_PROVIDER_ID,
+    () =>
+      new ReksadanaNavProvider({
+        baseUrl: options?.reksadana?.baseUrl,
+        fetchImpl: options?.reksadana?.fetchImpl,
+        mode: options?.reksadana?.mode,
+        from: options?.reksadana?.from,
       })
   )
   return registry
@@ -844,10 +1194,12 @@ export interface IngestAllSummary {
 
 export interface IngestAllOptions {
   db?: MarketDataDb
-  /** Adapter registry; defaults to the production registry (gold only, Slice A). */
+  /** Adapter registry; defaults to the production registry (gold + reksadana). */
   registry?: ProviderRegistry
   /** Gold passthrough used only when building the DEFAULT registry. */
   gold?: DefaultRegistryGoldOptions
+  /** Reksadana passthrough used only when building the DEFAULT registry. */
+  reksadana?: DefaultRegistryReksadanaOptions
 }
 
 /**
@@ -875,7 +1227,11 @@ export async function ingestAllInstrumentsOnce(
 ): Promise<IngestAllSummary> {
   const db = options?.db ?? prisma
   const registry =
-    options?.registry ?? createDefaultProviderRegistry({ gold: options?.gold })
+    options?.registry ??
+    createDefaultProviderRegistry({
+      gold: options?.gold,
+      reksadana: options?.reksadana,
+    })
 
   const instruments = await loadRoutableInstruments(db)
 
@@ -1015,8 +1371,13 @@ export interface SyncMarketPricesResult {
  * BSI-gold instrument is still ensured on every attempt (linkable before any
  * fetch succeeds), and the last good quote is left intact on failure.
  */
+export interface SyncMarketPricesOptions extends IngestGoldOptions {
+  /** Reksadana adapter passthrough (tests inject a fixture fetch / base URL). */
+  reksadana?: DefaultRegistryReksadanaOptions
+}
+
 export async function syncMarketPricesOnce(
-  options?: IngestGoldOptions
+  options?: SyncMarketPricesOptions
 ): Promise<SyncMarketPricesResult> {
   const db = options?.db ?? prisma
   try {
@@ -1032,6 +1393,7 @@ export async function syncMarketPricesOnce(
         priceField: options?.priceField,
         now: options?.now,
       },
+      reksadana: options?.reksadana,
     })
 
     if (summary.totalIngested > 0) {

--- a/tests/integration/reksadana-nav-feed.integration.ts
+++ b/tests/integration/reksadana-nav-feed.integration.ts
@@ -1,0 +1,383 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  refreshHoldingPricesForFamily,
+  upsertHoldingForFamily,
+} from "@/server/holdings"
+import {
+  ensureBsiGoldInstrument,
+  ensureReksadanaInstrument,
+  ingestAllInstrumentsOnce,
+  ingestReksadanaPricesOnce,
+  type FetchLike,
+} from "@/server/market-data.server"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// =============================================================================
+// PER-250 Slice B / ADR-0053 — reksadana NAV feed (real Postgres, NO network).
+//
+// The self-hosted reksadana-nav worker is injected as a FIXTURE `fetchImpl`
+// returning the ADR-0053 §2 payload — no live network is ever touched. Covers:
+// (a) latest /nav ingest → one canonical security MarketQuote; (b) /nav/history
+// backfill → multiple dated quotes; (c) weekend flat-price = no-op success
+// (repeated asOf/nav dedupes); (d) worker-total-failure keeps the last-good quote
+// (LKGP-equivalent degradation from Permoney's side); (e) idempotent replay;
+// (f) a linked reksadana holding revalues at units × NAV, anchor-safe (PER-238);
+// (g) a reksadana_id group failure is isolated from gold (per-provider isolation).
+// =============================================================================
+
+const BASE_URL = "http://reksadana.test"
+const FUND = "RD-SUCOR-MMF"
+
+function navPayload(quotes: { date: string; nav: number }[]) {
+  const latest = quotes.at(-1) ?? null
+  return {
+    fundCode: FUND,
+    currency: "IDR",
+    latest: latest ? { nav: latest.nav, asOf: latest.date } : null,
+    quotes,
+  }
+}
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+
+// A fixture worker returning a fixed payload for any /nav[/history] request.
+const okNavFetch =
+  (quotes: { date: string; nav: number }[]): FetchLike =>
+  () =>
+    Promise.resolve(jsonResponse(navPayload(quotes)))
+
+const http503Fetch: FetchLike = () =>
+  Promise.resolve(new Response("upstream down", { status: 503 }))
+
+const GOLD_PAYLOAD = {
+  success: true,
+  data: [
+    {
+      source: "bankbsi",
+      material: "gold",
+      materialType: "BSI",
+      weight: 1,
+      weightUnit: "gr",
+      sellPrice: 2_700_000,
+      buybackPrice: 2_650_000,
+      currency: "IDR",
+      recordedDate: "2026-05-16",
+    },
+  ],
+  count: 1,
+  timestamp: "2026-05-16T05:06:58.888Z",
+}
+const okGoldFetch: FetchLike = () => Promise.resolve(jsonResponse(GOLD_PAYLOAD))
+
+describe("reksadana NAV feed (PER-250 Slice B — worker adapter, fixture-injected)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const reksadanaInstrument = () =>
+    harness.prisma.marketInstrument.findFirstOrThrow({
+      where: { kind: "security", symbol: FUND, quoteCurrency: "IDR" },
+    })
+
+  async function investmentAccount(owner: AuthenticatedOnboardedUser) {
+    return await createAccountForFamily({
+      data: {
+        name: "Bibit",
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // (a) latest /nav ingest → one canonical security MarketQuote
+  // ---------------------------------------------------------------------------
+  test("latest ingest creates a security MarketQuote (IDR, per-unit NAV)", async () => {
+    await ensureReksadanaInstrument(
+      { symbol: FUND, name: "Sucor MMF" },
+      harness.prisma
+    )
+
+    const summary = await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: okNavFetch([{ date: "2026-08-14", nav: 1643.45 }]),
+      db: harness.prisma,
+    })
+
+    expect(summary.status).toBe("ok")
+    expect(summary.quotesUpserted).toBe(1)
+
+    const instrument = await reksadanaInstrument()
+    expect(instrument.provider).toBe("reksadana_id")
+    const quote = await harness.prisma.marketQuote.findFirstOrThrow({
+      where: { marketInstrumentId: instrument.id },
+    })
+    expect(quote.priceScale).toBe(8)
+    expect(quote.quoteCurrency).toBe("IDR")
+    expect(quote.source).toBe("reksadana_id")
+    expect(quote.asOf.toISOString()).toBe("2026-08-14T00:00:00.000Z")
+  })
+
+  // ---------------------------------------------------------------------------
+  // (b) /nav/history backfill writes multiple dated quotes
+  // ---------------------------------------------------------------------------
+  test("history backfill writes one MarketQuote per dated NAV point", async () => {
+    await ensureReksadanaInstrument({ symbol: FUND }, harness.prisma)
+    const history = [
+      { date: "2026-08-12", nav: 1642.98 },
+      { date: "2026-08-13", nav: 1643.19 },
+      { date: "2026-08-14", nav: 1643.45 },
+    ]
+
+    const summary = await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      mode: "history",
+      from: "2026-08-12",
+      baseUrl: BASE_URL,
+      fetchImpl: okNavFetch(history),
+      db: harness.prisma,
+    })
+
+    expect(summary.status).toBe("ok")
+    expect(summary.quotesUpserted).toBe(3)
+    const instrument = await reksadanaInstrument()
+    const quotes = await harness.prisma.marketQuote.findMany({
+      where: { marketInstrumentId: instrument.id },
+      orderBy: { asOf: "asc" },
+    })
+    expect(quotes.map((q) => q.asOf.toISOString())).toEqual([
+      "2026-08-12T00:00:00.000Z",
+      "2026-08-13T00:00:00.000Z",
+      "2026-08-14T00:00:00.000Z",
+    ])
+  })
+
+  // ---------------------------------------------------------------------------
+  // (c) weekend flat-price = no-op success (repeated asOf/nav dedupes)
+  // ---------------------------------------------------------------------------
+  test("re-ingesting the same Friday NAV over a weekend is a no-op success", async () => {
+    await ensureReksadanaInstrument({ symbol: FUND }, harness.prisma)
+    const friday = okNavFetch([{ date: "2026-08-14", nav: 1643.45 }])
+
+    // Friday's tick, then Saturday + Sunday re-serve the SAME asOf/nav.
+    const first = await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: friday,
+      db: harness.prisma,
+    })
+    const saturday = await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: friday,
+      db: harness.prisma,
+    })
+    const sunday = await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: friday,
+      db: harness.prisma,
+    })
+
+    // Every attempt is a SUCCESS (not an error / degradation) ...
+    expect([first.status, saturday.status, sunday.status]).toEqual([
+      "ok",
+      "ok",
+      "ok",
+    ])
+    // ... but the UNIQUE (instrument, asOf, source) dedupes to ONE canonical quote.
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    // Three fetches were staged (provenance of each attempt).
+    expect(await harness.prisma.rawMarketDataFetch.count()).toBe(3)
+  })
+
+  // ---------------------------------------------------------------------------
+  // (d) worker total failure keeps the last-good quote (degradation)
+  // ---------------------------------------------------------------------------
+  test("a worker outage keeps the last good quote and records the failure", async () => {
+    await ensureReksadanaInstrument({ symbol: FUND }, harness.prisma)
+    await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: okNavFetch([{ date: "2026-08-14", nav: 1643.45 }]),
+      db: harness.prisma,
+    })
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+
+    const failed = await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: http503Fetch,
+      db: harness.prisma,
+    })
+    expect(failed.status).toBe("error")
+    expect(failed.quotesUpserted).toBe(0)
+    // Last good quote untouched; the failure is staged (provenance).
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    const raw = await harness.prisma.rawMarketDataFetch.findUniqueOrThrow({
+      where: { id: failed.rawFetchId },
+    })
+    expect(raw.status).toBe("error")
+    expect(raw.provider).toBe("reksadana_id")
+  })
+
+  // ---------------------------------------------------------------------------
+  // (e) idempotent replay
+  // ---------------------------------------------------------------------------
+  test("replaying the same latest ingest is idempotent", async () => {
+    await ensureReksadanaInstrument({ symbol: FUND }, harness.prisma)
+    const fetchImpl = okNavFetch([{ date: "2026-08-14", nav: 1643.45 }])
+    await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl,
+      db: harness.prisma,
+    })
+    await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl,
+      db: harness.prisma,
+    })
+    expect(await harness.prisma.marketInstrument.count()).toBe(1)
+    expect(await harness.prisma.marketQuote.count()).toBe(1)
+    expect(await harness.prisma.rawMarketDataFetch.count()).toBe(2)
+  })
+
+  // ---------------------------------------------------------------------------
+  // (f) a linked reksadana holding revalues at units × NAV, anchor-safe
+  // ---------------------------------------------------------------------------
+  test("END-TO-END: a linked reksadana holding marks at units × NAV after refresh", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const account = await investmentAccount(owner)
+
+    const marketInstrumentId = await ensureReksadanaInstrument(
+      { symbol: FUND, name: "Sucor MMF" },
+      harness.prisma
+    )
+    await ingestReksadanaPricesOnce({
+      funds: [{ symbol: FUND }],
+      baseUrl: BASE_URL,
+      fetchImpl: okNavFetch([{ date: "2026-08-14", nav: 1643.45 }]),
+      db: harness.prisma,
+    })
+
+    // 10 units, no manual price, linked to the NAV series.
+    const holding = await upsertHoldingForFamily({
+      data: {
+        accountId: account.id,
+        instrument: { kind: "mutual_fund", name: "Sucor MMF", symbol: FUND },
+        quantity: "10",
+        avgUnitCost: "1600",
+        marketInstrumentId,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(holding.lastPriceMinor).toBeNull()
+
+    const result = await refreshHoldingPricesForFamily({
+      data: {
+        accountId: account.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(result.updatedHoldings).toBe(1)
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: account.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    const marked = view.holdings[0]
+    // NAV Rp 1643.45/unit → lastPriceMinor 164345 sen; 10 units → 1,643,450 sen.
+    expect(marked?.lastPriceMinor).toBe("164345")
+    expect(marked?.valueMinor).toBe("1643450")
+    expect(marked?.latestMarketQuoteAsOf).toBe("2026-08-14T00:00:00.000Z")
+
+    const row = await harness.withFamily(owner.family.id, (tx) =>
+      tx.account.findUniqueOrThrow({ where: { id: account.id } })
+    )
+    expect(row.balance).toBe(1_643_450n)
+  })
+
+  // ---------------------------------------------------------------------------
+  // (g) a reksadana_id group failure is isolated from gold
+  // ---------------------------------------------------------------------------
+  test("a failing reksadana group does not break the gold group (isolation)", async () => {
+    const goldId = await ensureBsiGoldInstrument(harness.prisma)
+    const fundId = await ensureReksadanaInstrument(
+      { symbol: FUND },
+      harness.prisma
+    )
+
+    const summary = await ingestAllInstrumentsOnce({
+      db: harness.prisma,
+      gold: { baseUrl: "http://gold.test", fetchImpl: okGoldFetch },
+      reksadana: { baseUrl: BASE_URL, fetchImpl: http503Fetch },
+    })
+
+    const gold = summary.perProvider.find((g) => g.providerId === "logam_mulia")
+    const reksadana = summary.perProvider.find(
+      (g) => g.providerId === "reksadana_id"
+    )
+    // Gold ingested; reksadana degraded — its failure was isolated.
+    expect(gold?.ingested).toBe(1)
+    expect(gold?.error).toBeUndefined()
+    expect(reksadana?.ingested).toBe(0)
+    expect(reksadana?.error).toBeTruthy()
+
+    expect(
+      await harness.prisma.marketQuote.count({
+        where: { marketInstrumentId: goldId },
+      })
+    ).toBe(1)
+    expect(
+      await harness.prisma.marketQuote.count({
+        where: { marketInstrumentId: fundId },
+      })
+    ).toBe(0)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 
   "exclude": [
     "node_modules",
+    "workers",
     ".agents",
     ".claude",
     ".windsurf",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,7 +48,16 @@ const config = defineConfig({
       "tests/e2e/**",
       "tests/integration/**",
     ],
-    include: ["scripts/**/*.test.mjs", "src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: [
+      "scripts/**/*.test.mjs",
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      // PER-250 Slice B — the reksadana-nav worker's PURE normalizer unit tests.
+      // The worker package is otherwise isolated (own tsconfig, excluded from the
+      // app typecheck); only its CF-free `*.test.ts` + the module it imports run
+      // here, fixture-driven with no live network.
+      "workers/**/*.test.ts",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary", "lcov"],
@@ -107,6 +116,10 @@ const config = defineConfig({
       // inference produces false positives on Object.entries destructures.
       // Script is idempotent and not part of the runtime bundle.
       "scripts/**",
+      // PER-250 — the reksadana-nav worker is an ISOLATED package (own tsconfig +
+      // CF-runtime types not in the app tsconfig); it self-lints/typechecks. The
+      // app's type-aware lint would error on its Cloudflare types, so ignore it.
+      "workers/**",
     ],
     // =========================================================
   },

--- a/workers/reksadana-nav/README.md
+++ b/workers/reksadana-nav/README.md
@@ -1,0 +1,91 @@
+# reksadana-nav worker
+
+Self-hosted Cloudflare Worker that serves Indonesian **reksadana (mutual-fund)
+NAV** as clean JSON for Permoney (PER-250 Slice B / [ADR-0053](../../docs/adr/0053-reksadana-nav-source-and-worker.md)).
+
+It mirrors the gold worker's isolation: the fragile scrape + fallback chain live
+here, entirely outside the ledger app. Permoney's `ReksadanaNavProvider` calls
+this worker behind `REKSADANA_API_URL` and never sees a vendor.
+
+> **Isolated package.** This directory has its own `package.json`, `tsconfig.json`,
+> and Cloudflare deps — it is **not** part of the Permoney app build (`vp install`
+> / `vp build` ignore it). Only its PURE normalizer's unit tests
+> (`src/normalize.test.ts`) run under the app's `vp test` (they import no
+> Cloudflare runtime).
+
+## Contract (ADR-0053 §2)
+
+- `GET /nav?fund=<code>` → latest quote (+ a short trailing window):
+- `GET /nav/history?fund=<code>&from=YYYY-MM-DD` → the dated series for a backfill.
+
+Both emit exactly:
+
+```json
+{
+  "fundCode": "sucorinvest-money-market-fund",
+  "currency": "IDR",
+  "latest": { "nav": 1643.45, "asOf": "2026-08-14" },
+  "quotes": [
+    { "date": "2026-08-13", "nav": 1643.19 },
+    { "date": "2026-08-14", "nav": 1643.45 }
+  ]
+}
+```
+
+`stale: true` is added when the payload was served from the D1 last-known-good
+cache (a total upstream outage degrades to last-good, never a 500).
+
+## Source fallback chain (ADR-0053 §1)
+
+1. **Bareksa/Pasardana clean JSON** (primary).
+2. **Bareksa product-page HTML** — scrapes the embedded `__NEXT_DATA__` JSON.
+3. **D1 stale cache (LKGP)** — the last payload this worker served.
+
+First success wins; each failure is recorded, never fatal. All of this logic is
+the PURE, unit-tested `src/normalize.ts`; `src/index.ts` is a thin IO shell.
+
+### ⚠️ Confirm the primary endpoint on first deploy
+
+During the build spike the Bareksa clean-JSON host (`api.bareksa.com/v22/...`)
+was found to require an **access token**, and the `www.bareksa.com` paths return
+the Next.js app **HTML** (not JSON) to an unauthenticated client. So:
+
+- The recorded fixtures (`src/fixtures.ts`) reflect the **documented** Bareksa
+  shape, not a live capture — **re-record them from a live probe on deploy**.
+- Set the real endpoints via `BAREKSA_JSON_URL` / `BAREKSA_HTML_URL` vars
+  (`{fund}` placeholder) in `wrangler.jsonc`. If no unauthenticated JSON endpoint
+  is available, the **HTML `__NEXT_DATA__` fallback + LKGP** carry the worker; the
+  normalizer's deep search tolerates shape drift by design.
+
+The weekend/holiday invariant (ADR-0053 §3) is built in: a flat/absent NAV on
+Sat–Sun is the correct state — `latest` stays Friday's value, never an error.
+
+## Deploy
+
+```sh
+cd workers/reksadana-nav
+vp dlx wrangler d1 create reksadana-nav-cache          # → copy database_id
+# paste database_id into wrangler.jsonc, then create the table:
+vp dlx wrangler d1 execute reksadana-nav-cache --remote --file=./schema.sql
+vp dlx wrangler deploy                                  # → prints the worker URL
+```
+
+Then point Permoney at it (server-side `.env` / compose):
+
+```sh
+REKSADANA_API_URL="https://reksadana-nav.<your-subdomain>.workers.dev"
+```
+
+Now a holding linked to a reksadana series (via the holding form's **Add a
+reksadana fund** → **Live price source**) auto-prices on **Refresh prices**
+(units × NAV, anchor-safe via PER-238).
+
+## Local checks
+
+```sh
+# Unit tests (pure normalizer) — from the repo root, via the app toolchain:
+vp test workers/reksadana-nav
+
+# Worker typecheck (needs the worker's own deps installed here first):
+cd workers/reksadana-nav && pnpm install && pnpm run typecheck
+```

--- a/workers/reksadana-nav/package.json
+++ b/workers/reksadana-nav/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "reksadana-nav-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Self-hosted Cloudflare Worker: Indonesian reksadana (mutual-fund) NAV feed for Permoney (PER-250 / ADR-0053). Isolated package — NOT part of the app build.",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240815.0",
+    "typescript": "^5.6.0",
+    "wrangler": "^3.114.0"
+  }
+}

--- a/workers/reksadana-nav/schema.sql
+++ b/workers/reksadana-nav/schema.sql
@@ -1,0 +1,7 @@
+-- reksadana-nav D1 stale cache (LKGP). Apply after creating the D1 database:
+--   wrangler d1 execute reksadana-nav-cache --remote --file=./schema.sql
+CREATE TABLE IF NOT EXISTS nav_cache (
+  fund       TEXT PRIMARY KEY,
+  payload    TEXT NOT NULL,   -- the last-known-good ADR-0053 §2 JSON payload
+  updated_at TEXT NOT NULL    -- ISO-8601 UTC timestamp of the last live refresh
+);

--- a/workers/reksadana-nav/src/fixtures.ts
+++ b/workers/reksadana-nav/src/fixtures.ts
@@ -1,0 +1,114 @@
+/**
+ * Recorded upstream fixtures for the reksadana-nav worker's PURE normalizer.
+ * =============================================================================
+ *
+ * PROVENANCE (read before trusting these): during the ADR-0053 build spike the
+ * Bareksa clean-JSON host (`api.bareksa.com/v22/...`) was found to require an
+ * access token, and the `www.bareksa.com` product/API paths serve the Next.js app
+ * shell (HTML), not JSON, to an unauthenticated client. So these fixtures reflect
+ * the DOCUMENTED Bareksa response shape (a `data.nav` latest + `data.nav_history`
+ * series; the product page's embedded `__NEXT_DATA__` JSON), NOT a byte-for-byte
+ * live capture. They MUST be re-recorded from a live/authenticated probe when the
+ * worker is first deployed (see README). The normalizer is deliberately
+ * shape-tolerant + falls back (HTML → D1 stale) precisely so a shape drift
+ * degrades instead of crashing; these fixtures pin that behaviour.
+ *
+ * The values are illustrative (Sucorinvest Money Market Fund, IDR MMF NAVs).
+ */
+
+/** Primary — Bareksa/Pasardana clean JSON: a latest point + a short history. */
+export const BAREKSA_NAV_JSON_SAMPLE = {
+  status: "success",
+  data: {
+    id: 1742,
+    code: "sucorinvest-money-market-fund",
+    name: "Sucorinvest Money Market Fund",
+    currency: "IDR",
+    nav: { date: "2026-08-14", value: 1643.45 },
+    nav_history: [
+      { date: "2026-08-11", value: 1642.71 },
+      { date: "2026-08-12", value: 1642.98 },
+      { date: "2026-08-13", value: 1643.19 },
+      { date: "2026-08-14", value: 1643.45 },
+    ],
+  },
+} as const
+
+/** Primary — the `/nav/history` clean-JSON form (a dated array under `data`). */
+export const BAREKSA_HISTORY_JSON_SAMPLE = {
+  status: "success",
+  data: [
+    { date: "2026-08-03", nav: 1641.02 },
+    { date: "2026-08-04", nav: 1641.29 },
+    { date: "2026-08-05", nav: 1641.55 },
+    { date: "2026-08-06", nav: 1641.83 },
+    { date: "2026-08-07", nav: 1642.1 },
+    { date: "2026-08-10", nav: 1642.44 },
+    { date: "2026-08-11", nav: 1642.71 },
+    { date: "2026-08-12", nav: 1642.98 },
+    { date: "2026-08-13", nav: 1643.19 },
+    { date: "2026-08-14", nav: 1643.45 },
+  ],
+} as const
+
+/**
+ * Fallback — the Bareksa product page HTML, reduced to the load-bearing part: the
+ * `__NEXT_DATA__` JSON blob the scraper extracts. A minimal but realistic Next.js
+ * shell so the extractor + deep search are exercised against real structure.
+ */
+export const BAREKSA_PRODUCT_HTML_SAMPLE = `<!DOCTYPE html><html lang="id"><head><title>Sucorinvest Money Market Fund | Bareksa</title></head><body><div id="__next"></div><script id="__NEXT_DATA__" type="application/json">${JSON.stringify(
+  {
+    props: {
+      pageProps: {
+        product: {
+          code: "sucorinvest-money-market-fund",
+          currency: "IDR",
+          nav: { date: "2026-08-14", value: 1643.45 },
+          navHistory: [
+            { date: "2026-08-12", value: 1642.98 },
+            { date: "2026-08-13", value: 1643.19 },
+            { date: "2026-08-14", value: 1643.45 },
+          ],
+        },
+      },
+    },
+    page: "/reksadana/[slug]",
+  }
+)}</script></body></html>`
+
+/**
+ * Last resort — a payload previously served by THIS worker and cached in D1
+ * (already in the ADR-0053 §2 contract shape). Served as LKGP, flagged stale.
+ */
+export const STALE_CACHE_SAMPLE = {
+  fundCode: "sucorinvest-money-market-fund",
+  currency: "IDR",
+  latest: { nav: 1643.19, asOf: "2026-08-13" },
+  quotes: [
+    { date: "2026-08-12", nav: 1642.98 },
+    { date: "2026-08-13", nav: 1643.19 },
+  ],
+} as const
+
+/**
+ * Weekend case — the freshest available NAV is Friday's (2026-08-14 is a Friday);
+ * no Sat/Sun rows exist. Re-serving this on Sat/Sun must be a no-op success, not a
+ * failure (ADR-0053 §3): `latest` stays Friday's value.
+ */
+export const WEEKEND_FLAT_JSON_SAMPLE = {
+  status: "success",
+  data: {
+    currency: "IDR",
+    nav: { date: "2026-08-14", value: 1643.45 },
+    nav_history: [
+      { date: "2026-08-13", value: 1643.19 },
+      { date: "2026-08-14", value: 1643.45 },
+    ],
+  },
+} as const
+
+/** A malformed payload (no NAV-shaped data) — the JSON normalizer returns null. */
+export const UNUSABLE_JSON_SAMPLE = {
+  status: "error",
+  message: "product not found",
+} as const

--- a/workers/reksadana-nav/src/index.ts
+++ b/workers/reksadana-nav/src/index.ts
@@ -1,0 +1,210 @@
+/**
+ * reksadana-nav — Cloudflare Worker entry (the thin IO SHELL).
+ * =============================================================================
+ *
+ * ADR-0053. All the fragile logic (per-source normalization, fallback ordering,
+ * the weekend rule, the target contract) lives in the PURE, CF-free `normalize.ts`
+ * — unit-tested with `vp test`. This file only does what a shell must: parse the
+ * request, fetch each upstream (browser-like headers), read/write the D1 stale
+ * cache, and serialize the ADR-0053 §2 payload. It NEVER 500s on an upstream
+ * outage — it degrades to the stale cache, then to a structured error.
+ *
+ * Routes:
+ *   GET /nav?fund=<code>                         → latest quote (+ short tail)
+ *   GET /nav/history?fund=<code>&from=YYYY-MM-DD  → dated series for a backfill
+ *
+ * Bindings (wrangler.jsonc):
+ *   NAV_CACHE (D1)          — last-known-good payload per fund (LKGP).
+ *   Vars/secrets (optional) — BAREKSA_JSON_URL, BAREKSA_HTML_URL templates with
+ *     `{fund}` / `{from}` placeholders. Defaults target Bareksa; CONFIRM + adjust
+ *     against the live upstream on first deploy (see README — the exact public
+ *     JSON endpoint must be recorded during deploy; the primary may be token-gated,
+ *     in which case the HTML fallback + LKGP carry the worker).
+ */
+
+import {
+  buildPayload,
+  normalizeBareksaHtml,
+  normalizeBareksaJson,
+  normalizeStaleCache,
+  resolveSeries,
+  type NavPayload,
+  type NormalizedSeries,
+  type SourceAttempt,
+} from "./normalize"
+
+export interface Env {
+  /** D1 database holding the per-fund last-known-good payload (LKGP). */
+  NAV_CACHE: D1Database
+  /** Primary clean-JSON URL template (`{fund}`). */
+  BAREKSA_JSON_URL?: string
+  /** Fallback product-page URL template (`{fund}`). */
+  BAREKSA_HTML_URL?: string
+}
+
+const DEFAULT_JSON_URL =
+  "https://api.bareksa.com/v22/products/mutualfund/{fund}/nav"
+const DEFAULT_HTML_URL = "https://www.bareksa.com/reksadana/{fund}"
+
+const BROWSER_HEADERS: Record<string, string> = {
+  "user-agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+  accept: "application/json, text/plain, */*",
+  referer: "https://www.bareksa.com/",
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  })
+}
+
+function fillTemplate(template: string, fund: string): string {
+  return template.replaceAll("{fund}", encodeURIComponent(fund))
+}
+
+/** Fetch the primary clean-JSON source; null on any non-2xx / non-JSON / drift. */
+async function fetchBareksaJson(
+  env: Env,
+  fund: string
+): Promise<{ series: NormalizedSeries | null; error?: string }> {
+  const url = fillTemplate(env.BAREKSA_JSON_URL ?? DEFAULT_JSON_URL, fund)
+  try {
+    const res = await fetch(url, { headers: BROWSER_HEADERS })
+    if (!res.ok) return { series: null, error: `json HTTP ${res.status}` }
+    const contentType = res.headers.get("content-type") ?? ""
+    if (!contentType.includes("json")) {
+      return { series: null, error: "json endpoint returned non-JSON" }
+    }
+    const body = await res.json()
+    return { series: normalizeBareksaJson(body) }
+  } catch (error) {
+    return {
+      series: null,
+      error: error instanceof Error ? error.message : "fetch failed",
+    }
+  }
+}
+
+/** Fetch the product-page HTML and scrape its embedded __NEXT_DATA__. */
+async function fetchBareksaHtml(
+  env: Env,
+  fund: string
+): Promise<{ series: NormalizedSeries | null; error?: string }> {
+  const url = fillTemplate(env.BAREKSA_HTML_URL ?? DEFAULT_HTML_URL, fund)
+  try {
+    const res = await fetch(url, { headers: BROWSER_HEADERS })
+    if (!res.ok) return { series: null, error: `html HTTP ${res.status}` }
+    const html = await res.text()
+    return { series: normalizeBareksaHtml(html) }
+  } catch (error) {
+    return {
+      series: null,
+      error: error instanceof Error ? error.message : "fetch failed",
+    }
+  }
+}
+
+/** Read the last-known-good payload for a fund from D1 (LKGP). */
+async function readStaleCache(
+  env: Env,
+  fund: string
+): Promise<{ series: NormalizedSeries | null; error?: string }> {
+  try {
+    const row = await env.NAV_CACHE.prepare(
+      "SELECT payload FROM nav_cache WHERE fund = ?"
+    )
+      .bind(fund)
+      .first<{ payload: string }>()
+    if (!row?.payload) return { series: null, error: "cache empty" }
+    return { series: normalizeStaleCache(JSON.parse(row.payload)) }
+  } catch (error) {
+    return {
+      series: null,
+      error: error instanceof Error ? error.message : "cache read failed",
+    }
+  }
+}
+
+/** Persist the freshest successful payload as the new LKGP (best-effort). */
+async function writeStaleCache(
+  env: Env,
+  fund: string,
+  payload: NavPayload
+): Promise<void> {
+  try {
+    await env.NAV_CACHE.prepare(
+      `INSERT INTO nav_cache (fund, payload, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(fund) DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at`
+    )
+      .bind(fund, JSON.stringify(payload), new Date().toISOString())
+      .run()
+  } catch {
+    // Cache write failures never affect the response — LKGP is best-effort.
+  }
+}
+
+async function handleNav(
+  env: Env,
+  fund: string,
+  mode: "latest" | "history",
+  from: string | undefined
+): Promise<Response> {
+  const [json_, html, stale] = await Promise.all([
+    fetchBareksaJson(env, fund),
+    fetchBareksaHtml(env, fund),
+    readStaleCache(env, fund),
+  ])
+
+  const attempts: SourceAttempt[] = [
+    { source: "bareksa_json", series: json_.series, error: json_.error },
+    { source: "bareksa_html", series: html.series, error: html.error },
+    { source: "stale_cache", series: stale.series, error: stale.error },
+  ]
+
+  const resolution = resolveSeries(attempts)
+  if (resolution.status === "error") {
+    return json(
+      {
+        error: "all reksadana sources failed",
+        fund,
+        failures: resolution.failures,
+      },
+      502
+    )
+  }
+
+  const payload = buildPayload(fund, resolution, { mode, from })
+
+  // Refresh the LKGP only from a LIVE source (never re-persist stale over itself).
+  if (resolution.source !== "stale_cache") {
+    await writeStaleCache(env, fund, payload)
+  }
+
+  return json(payload)
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    if (request.method !== "GET") {
+      return json({ error: "method not allowed" }, 405)
+    }
+    const fund = url.searchParams.get("fund")?.trim()
+    if (!fund) return json({ error: "missing ?fund=<code>" }, 400)
+
+    if (url.pathname === "/nav") {
+      return handleNav(env, fund, "latest", undefined)
+    }
+    if (url.pathname === "/nav/history") {
+      const from = url.searchParams.get("from")?.trim() || undefined
+      return handleNav(env, fund, "history", from)
+    }
+    return json({ error: "not found" }, 404)
+  },
+} satisfies ExportedHandler<Env>

--- a/workers/reksadana-nav/src/normalize.test.ts
+++ b/workers/reksadana-nav/src/normalize.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from "vite-plus/test"
+import {
+  BAREKSA_HISTORY_JSON_SAMPLE,
+  BAREKSA_NAV_JSON_SAMPLE,
+  BAREKSA_PRODUCT_HTML_SAMPLE,
+  STALE_CACHE_SAMPLE,
+  UNUSABLE_JSON_SAMPLE,
+  WEEKEND_FLAT_JSON_SAMPLE,
+} from "./fixtures"
+import {
+  buildPayload,
+  cleanSeries,
+  isWeekendDate,
+  normalizeBareksaHtml,
+  normalizeBareksaJson,
+  normalizeDate,
+  normalizeNav,
+  normalizeStaleCache,
+  resolveSeries,
+  type ResolvedSeries,
+  type SourceAttempt,
+} from "./normalize"
+
+// =============================================================================
+// PER-250 Slice B / ADR-0053 — the reksadana-nav worker's PURE normalizer +
+// fallback ordering + weekend rule, fixture-driven, NO live network. This is the
+// fragile part the ADR singles out for review; every source shape, the priority
+// chain, and the weekend invariant are pinned here.
+// =============================================================================
+
+describe("scalar normalizers", () => {
+  test("normalizeDate accepts YYYY-MM-DD, ISO, and epochs", () => {
+    expect(normalizeDate("2026-08-14")).toBe("2026-08-14")
+    expect(normalizeDate("2026-08-14T09:30:00.000Z")).toBe("2026-08-14")
+    expect(normalizeDate(Date.UTC(2026, 7, 11))).toBe("2026-08-11") // ms epoch
+    expect(normalizeDate(Math.floor(Date.UTC(2026, 7, 11) / 1000))).toBe(
+      "2026-08-11"
+    ) // s epoch
+    expect(normalizeDate("not-a-date")).toBeNull()
+    expect(normalizeDate("")).toBeNull()
+    expect(normalizeDate(null)).toBeNull()
+  })
+
+  test("normalizeNav accepts positive numbers/strings, rejects the rest", () => {
+    expect(normalizeNav(1643.45)).toBe(1643.45)
+    expect(normalizeNav("1643.45")).toBe(1643.45)
+    expect(normalizeNav(0)).toBeNull()
+    expect(normalizeNav(-1)).toBeNull()
+    expect(normalizeNav("abc")).toBeNull()
+    expect(normalizeNav(null)).toBeNull()
+  })
+})
+
+describe("normalizeBareksaJson (primary clean JSON)", () => {
+  test("documented shape: data.nav latest + data.nav_history series", () => {
+    const series = normalizeBareksaJson(BAREKSA_NAV_JSON_SAMPLE)
+    expect(series).not.toBeNull()
+    expect(series?.currency).toBe("IDR")
+    // Deduped + ascending; the latest is Friday's value.
+    expect(series?.points.at(-1)).toEqual({ date: "2026-08-14", nav: 1643.45 })
+    expect(series?.points.map((p) => p.date)).toEqual([
+      "2026-08-11",
+      "2026-08-12",
+      "2026-08-13",
+      "2026-08-14",
+    ])
+  })
+
+  test("history array shape (data: [{date, nav}])", () => {
+    const series = normalizeBareksaJson(BAREKSA_HISTORY_JSON_SAMPLE)
+    expect(series?.points).toHaveLength(10)
+    expect(series?.points[0]).toEqual({ date: "2026-08-03", nav: 1641.02 })
+  })
+
+  test("a malformed payload with no NAV data returns null (→ next source)", () => {
+    expect(normalizeBareksaJson(UNUSABLE_JSON_SAMPLE)).toBeNull()
+    expect(normalizeBareksaJson(null)).toBeNull()
+    expect(normalizeBareksaJson("nope")).toBeNull()
+  })
+
+  test("deep search tolerates a nested/renamed container", () => {
+    const drifted = {
+      result: {
+        payload: { series: [{ tanggal: "2026-08-14", nilai: 1643.45 }] },
+      },
+    }
+    const series = normalizeBareksaJson(drifted)
+    expect(series?.points).toEqual([{ date: "2026-08-14", nav: 1643.45 }])
+  })
+})
+
+describe("normalizeBareksaHtml (fallback __NEXT_DATA__ scraper)", () => {
+  test("extracts + parses the embedded Next.js data blob", () => {
+    const series = normalizeBareksaHtml(BAREKSA_PRODUCT_HTML_SAMPLE)
+    expect(series?.currency).toBe("IDR")
+    expect(series?.points.at(-1)).toEqual({ date: "2026-08-14", nav: 1643.45 })
+  })
+
+  test("HTML with no __NEXT_DATA__ / bad JSON returns null", () => {
+    expect(normalizeBareksaHtml("<html><body>no data</body></html>")).toBeNull()
+    expect(
+      normalizeBareksaHtml(
+        '<script id="__NEXT_DATA__" type="application/json">{bad</script>'
+      )
+    ).toBeNull()
+    expect(normalizeBareksaHtml(null)).toBeNull()
+  })
+})
+
+describe("resolveSeries (fallback ordering, ADR-0053 §1)", () => {
+  const good = normalizeBareksaJson(BAREKSA_NAV_JSON_SAMPLE)
+  const html = normalizeBareksaHtml(BAREKSA_PRODUCT_HTML_SAMPLE)
+  const stale = normalizeStaleCache(STALE_CACHE_SAMPLE)
+
+  test("primary wins when available (no degradation)", () => {
+    const res = resolveSeries([
+      { source: "bareksa_json", series: good },
+      { source: "bareksa_html", series: html },
+      { source: "stale_cache", series: stale },
+    ])
+    expect(res.status).toBe("ok")
+    expect((res as ResolvedSeries).source).toBe("bareksa_json")
+    expect((res as ResolvedSeries).degradedFrom).toEqual([])
+  })
+
+  test("primary fails → falls back to HTML scraper", () => {
+    const res = resolveSeries([
+      { source: "bareksa_json", series: null, error: "HTTP 403" },
+      { source: "bareksa_html", series: html },
+      { source: "stale_cache", series: stale },
+    ])
+    expect((res as ResolvedSeries).source).toBe("bareksa_html")
+    expect((res as ResolvedSeries).degradedFrom).toEqual(["bareksa_json"])
+  })
+
+  test("primary + fallback fail → serves stale D1 cache (LKGP)", () => {
+    const res = resolveSeries([
+      { source: "bareksa_json", series: null },
+      { source: "bareksa_html", series: null },
+      { source: "stale_cache", series: stale },
+    ])
+    expect((res as ResolvedSeries).source).toBe("stale_cache")
+    expect((res as ResolvedSeries).degradedFrom).toEqual([
+      "bareksa_json",
+      "bareksa_html",
+    ])
+  })
+
+  test("every source fails → structured error (no throw)", () => {
+    const attempts: SourceAttempt[] = [
+      { source: "bareksa_json", series: null, error: "HTTP 403" },
+      { source: "bareksa_html", series: null, error: "no __NEXT_DATA__" },
+      { source: "stale_cache", series: null, error: "cache empty" },
+    ]
+    const res = resolveSeries(attempts)
+    expect(res.status).toBe("error")
+    if (res.status === "error") {
+      expect(res.failures.map((f) => f.source)).toEqual([
+        "bareksa_json",
+        "bareksa_html",
+        "stale_cache",
+      ])
+    }
+  })
+
+  test("an empty series is treated as a failure, not a win", () => {
+    const res = resolveSeries([
+      { source: "bareksa_json", series: { currency: "IDR", points: [] } },
+      {
+        source: "stale_cache",
+        series: normalizeStaleCache(STALE_CACHE_SAMPLE),
+      },
+    ])
+    expect((res as ResolvedSeries).source).toBe("stale_cache")
+  })
+})
+
+describe("buildPayload (ADR-0053 §2 contract)", () => {
+  function resolvedFrom(sample: unknown, source: ResolvedSeries["source"]) {
+    const series = normalizeBareksaJson(sample)
+    if (!series) throw new Error("fixture did not normalize")
+    return { status: "ok", source, series, degradedFrom: [] } as ResolvedSeries
+  }
+
+  test("latest mode: latest = freshest point + a short tail", () => {
+    const payload = buildPayload(
+      "sucorinvest-money-market-fund",
+      resolvedFrom(BAREKSA_HISTORY_JSON_SAMPLE, "bareksa_json"),
+      { mode: "latest", tail: 3 }
+    )
+    expect(payload.currency).toBe("IDR")
+    expect(payload.latest).toEqual({ nav: 1643.45, asOf: "2026-08-14" })
+    expect(payload.quotes).toHaveLength(3)
+    expect(payload.quotes.at(-1)?.date).toBe("2026-08-14")
+    expect(payload.stale).toBeUndefined()
+  })
+
+  test("history mode: full series from `from` (inclusive)", () => {
+    const payload = buildPayload(
+      "sucorinvest-money-market-fund",
+      resolvedFrom(BAREKSA_HISTORY_JSON_SAMPLE, "bareksa_json"),
+      { mode: "history", from: "2026-08-11" }
+    )
+    expect(payload.quotes.map((q) => q.date)).toEqual([
+      "2026-08-11",
+      "2026-08-12",
+      "2026-08-13",
+      "2026-08-14",
+    ])
+  })
+
+  test("stale source sets the stale flag", () => {
+    const series = normalizeStaleCache(STALE_CACHE_SAMPLE)
+    if (!series) throw new Error("stale fixture did not normalize")
+    const payload = buildPayload(
+      "sucorinvest-money-market-fund",
+      { status: "ok", source: "stale_cache", series, degradedFrom: [] },
+      { mode: "latest" }
+    )
+    expect(payload.stale).toBe(true)
+    expect(payload.latest).toEqual({ nav: 1643.19, asOf: "2026-08-13" })
+  })
+})
+
+describe("weekend / market-holiday invariant (ADR-0053 §3)", () => {
+  test("isWeekendDate flags Sat/Sun only", () => {
+    expect(isWeekendDate("2026-08-14")).toBe(false) // Friday
+    expect(isWeekendDate("2026-08-15")).toBe(true) // Saturday
+    expect(isWeekendDate("2026-08-16")).toBe(true) // Sunday
+    expect(isWeekendDate("2026-08-17")).toBe(false) // Monday
+  })
+
+  test("a weekend/flat payload is a NO-OP success: latest stays Friday's value", () => {
+    // Serving the same Friday-terminating series on Sat & Sun yields an identical
+    // `latest` both times — the store dedupes it; this is NOT an error.
+    const series = normalizeBareksaJson(WEEKEND_FLAT_JSON_SAMPLE)
+    if (!series) throw new Error("weekend fixture did not normalize")
+    const resolved: ResolvedSeries = {
+      status: "ok",
+      source: "bareksa_json",
+      series,
+      degradedFrom: [],
+    }
+    const saturday = buildPayload("fund", resolved, { mode: "latest" })
+    const sunday = buildPayload("fund", resolved, { mode: "latest" })
+    expect(saturday.latest).toEqual({ nav: 1643.45, asOf: "2026-08-14" })
+    expect(sunday.latest).toEqual(saturday.latest)
+  })
+
+  test("cleanSeries dedupes a repeated as-of (flat carry) to one point", () => {
+    const points = cleanSeries([
+      { date: "2026-08-14", nav: 1643.45 },
+      { date: "2026-08-14", nav: 1643.45 },
+    ])
+    expect(points).toHaveLength(1)
+  })
+})

--- a/workers/reksadana-nav/src/normalize.ts
+++ b/workers/reksadana-nav/src/normalize.ts
@@ -1,0 +1,383 @@
+/**
+ * Reksadana NAV — PURE normalization + source-selection core (ADR-0053).
+ * =============================================================================
+ *
+ * This module is the FRAGILE part the ADR singles out for review + unit tests,
+ * and it is deliberately factored to contain ZERO Cloudflare-runtime dependencies
+ * (no `fetch`, no D1, no `Request`/`Response`). The worker entry (`index.ts`) is a
+ * thin shell that does the IO (fetch each upstream, read/write D1) and hands the
+ * raw bytes to the pure functions here; `vp test` unit-tests this module directly
+ * against recorded fixtures with no live network.
+ *
+ * Responsibilities:
+ *   1. Per-source NORMALIZERS — turn each upstream's raw shape into the internal
+ *      `NormalizedSeries` (`{ currency, points: [{date, nav}] }`):
+ *        - `normalizeBareksaJson`  — Bareksa/Pasardana clean JSON (primary).
+ *        - `normalizeBareksaHtml`  — the product page's embedded `__NEXT_DATA__`
+ *          JSON (fallback scraper; Bareksa is a Next.js app).
+ *        - `normalizeStaleCache`   — a previously-served payload from D1 (LKGP).
+ *      Each is SHAPE-TOLERANT (probes known keys, then a bounded deep search) so a
+ *      minor upstream drift degrades to the next source rather than crashing.
+ *   2. FALLBACK ORDERING — `resolveSeries` tries attempts in priority order and
+ *      returns the FIRST that yields a usable series, recording the degradation.
+ *   3. The ADR-0053 §2 target CONTRACT — `buildPayload` emits
+ *      `{ fundCode, currency, latest, quotes, stale }` for both `/nav` (latest)
+ *      and `/nav/history` (backfill) modes.
+ *
+ * WEEKEND / MARKET-HOLIDAY INVARIANT (ADR-0053 §3): KSEI/IDX publish no new NAV on
+ * Sat–Sun/holidays; the freshest quote simply carries Friday's value. Nothing here
+ * treats a flat/repeated (or absent-today) NAV as an error — `latest` is always
+ * the freshest AVAILABLE point, and a weekend backfill simply lacks Sat/Sun rows.
+ */
+
+/** The upstream sources, in the ADR-0053 §1 priority order. */
+export type SourceKind = "bareksa_json" | "bareksa_html" | "stale_cache"
+
+/** One dated NAV point (`nav` per unit, in `currency`). */
+export interface NavPoint {
+  date: string
+  nav: number
+}
+
+/** A source's raw shape reduced to the internal per-fund series. */
+export interface NormalizedSeries {
+  currency: string
+  points: NavPoint[]
+}
+
+/** The ADR-0053 §2 worker payload — the ONE shape every route emits. */
+export interface NavPayload {
+  fundCode: string
+  currency: string
+  latest: { nav: number; asOf: string } | null
+  quotes: NavPoint[]
+  /** True when served from the D1 stale cache (LKGP) — informational. */
+  stale?: boolean
+}
+
+/** Default quote currency for Indonesian reksadana. */
+export const DEFAULT_CURRENCY = "IDR"
+
+/** How many trailing points `/nav` includes alongside `latest` for context. */
+export const LATEST_TAIL = 5
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+/** A `YYYY-MM-DD` normalization of a date-ish value, or null. */
+export function normalizeDate(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    // Epoch — accept ms (13-digit) and s (10-digit).
+    const ms = value > 1e11 ? value : value * 1000
+    const d = new Date(ms)
+    return Number.isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10)
+  }
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed
+  const d = new Date(trimmed)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10)
+}
+
+/** A positive finite NAV number from a number-or-numeric-string, or null. */
+export function normalizeNav(value: unknown): number | null {
+  const n =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value.trim())
+        : NaN
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}
+
+const DATE_KEYS = [
+  "date",
+  "navDate",
+  "nav_date",
+  "recordedDate",
+  "asOf",
+  "as_of",
+  "tanggal",
+  "x",
+] as const
+const NAV_KEYS = [
+  "nav",
+  "value",
+  "navPerUnit",
+  "nav_per_unit",
+  "price",
+  "nilai",
+  "y",
+] as const
+
+/** Extract a `{date, nav}` from a row-like object, probing known keys. */
+function pointFromRow(row: Record<string, unknown>): NavPoint | null {
+  let date: string | null = null
+  for (const key of DATE_KEYS) {
+    if (key in row) {
+      date = normalizeDate(row[key])
+      if (date !== null) break
+    }
+  }
+  let nav: number | null = null
+  for (const key of NAV_KEYS) {
+    if (key in row) {
+      nav = normalizeNav(row[key])
+      if (nav !== null) break
+    }
+  }
+  if (date === null || nav === null) return null
+  return { date, nav }
+}
+
+/** An array is a NAV series when a majority of its rows parse to a NavPoint. */
+function arrayToPoints(value: unknown): NavPoint[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null
+  const points: NavPoint[] = []
+  for (const row of value) {
+    if (!isRecord(row)) continue
+    const point = pointFromRow(row)
+    if (point) points.push(point)
+  }
+  if (points.length === 0) return null
+  // Guard against false positives: require most rows to have been NAV-shaped.
+  if (points.length * 2 < value.length) return null
+  return points
+}
+
+/**
+ * Bounded recursive search for the LONGEST NAV-point array anywhere in the object
+ * graph. The last-resort tolerance so a nested/renamed container still normalizes;
+ * `depth` caps the walk so a pathological payload can never spin.
+ */
+function deepFindLongestSeries(node: unknown, depth = 0): NavPoint[] | null {
+  if (depth > 6 || node === null || typeof node !== "object") return null
+  const direct = arrayToPoints(node)
+  if (direct) return direct
+  let best: NavPoint[] | null = null
+  const children = Array.isArray(node) ? node : Object.values(node)
+  for (const child of children) {
+    const found = deepFindLongestSeries(child, depth + 1)
+    if (found && (!best || found.length > best.length)) best = found
+  }
+  return best
+}
+
+/** Find a currency string anywhere shallow in the object, else the default. */
+function findCurrency(node: unknown, depth = 0): string {
+  if (depth > 4 || !isRecord(node)) return DEFAULT_CURRENCY
+  for (const key of ["currency", "ccy", "curr"]) {
+    const value = node[key]
+    if (typeof value === "string" && /^[A-Za-z]{3}$/.test(value.trim())) {
+      return value.trim().toUpperCase()
+    }
+  }
+  for (const child of Object.values(node)) {
+    if (isRecord(child)) {
+      const found = findCurrency(child, depth + 1)
+      if (found !== DEFAULT_CURRENCY) return found
+    }
+  }
+  return DEFAULT_CURRENCY
+}
+
+/** Dedupe by date (last wins) and sort ascending — the canonical series order. */
+export function cleanSeries(points: readonly NavPoint[]): NavPoint[] {
+  const byDate = new Map<string, NavPoint>()
+  for (const point of points) byDate.set(point.date, point)
+  return [...byDate.values()].sort((a, b) => (a.date < b.date ? -1 : 1))
+}
+
+/**
+ * Normalize a Bareksa/Pasardana clean-JSON payload into a series. Handles the
+ * documented shapes (a `data.nav` latest + `data.nav_history` array; a top-level
+ * or `data` array of rows; a single `nav` object) and falls back to a bounded
+ * deep search. Returns null when nothing NAV-shaped is found (→ try next source).
+ */
+export function normalizeBareksaJson(raw: unknown): NormalizedSeries | null {
+  if (!isRecord(raw) && !Array.isArray(raw)) return null
+
+  const collected: NavPoint[] = []
+
+  // Known array containers first (cheap, precise).
+  const containers: unknown[] = []
+  if (isRecord(raw)) {
+    containers.push(
+      raw.nav_history,
+      raw.navHistory,
+      raw.history,
+      raw.quotes,
+      raw.data,
+      isRecord(raw.data) ? raw.data.nav_history : undefined,
+      isRecord(raw.data) ? raw.data.navHistory : undefined,
+      isRecord(raw.data) ? raw.data.history : undefined,
+      isRecord(raw.data) ? raw.data.data : undefined
+    )
+  } else {
+    containers.push(raw)
+  }
+  for (const container of containers) {
+    const points = arrayToPoints(container)
+    if (points) collected.push(...points)
+  }
+
+  // A single "latest" nav object (`{nav|data.nav: {date,value}}`).
+  if (isRecord(raw)) {
+    for (const candidate of [
+      raw.nav,
+      raw.latest,
+      isRecord(raw.data) ? raw.data.nav : undefined,
+      isRecord(raw.data) ? raw.data.latest : undefined,
+    ]) {
+      if (isRecord(candidate)) {
+        const point = pointFromRow(candidate)
+        if (point) collected.push(point)
+      }
+    }
+  }
+
+  // Last-resort deep search when the known keys found nothing.
+  if (collected.length === 0) {
+    const deep = deepFindLongestSeries(raw)
+    if (deep) collected.push(...deep)
+  }
+
+  if (collected.length === 0) return null
+  return { currency: findCurrency(raw), points: cleanSeries(collected) }
+}
+
+/**
+ * Fallback scraper: Bareksa's product page is a Next.js app that embeds its server
+ * props (including NAV) in a `<script id="__NEXT_DATA__" type="application/json">`
+ * blob. Extract + JSON.parse it, then reuse the JSON normalizer's deep search.
+ * Returns null when no parseable NAV data is present.
+ */
+export function normalizeBareksaHtml(html: unknown): NormalizedSeries | null {
+  if (typeof html !== "string" || html.length === 0) return null
+  const match = html.match(
+    /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i
+  )
+  if (!match || match[1] === undefined) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(match[1])
+  } catch {
+    return null
+  }
+  return normalizeBareksaJson(parsed)
+}
+
+/**
+ * Normalize a payload previously served by THIS worker and cached in D1 (LKGP).
+ * It is already in (or close to) the ADR-0053 §2 contract, so this accepts the
+ * `{ currency, quotes|latest }` shape as well as the generic normalizer's shapes.
+ */
+export function normalizeStaleCache(raw: unknown): NormalizedSeries | null {
+  return normalizeBareksaJson(raw)
+}
+
+/** One source attempt handed to `resolveSeries`, in priority order. */
+export interface SourceAttempt {
+  source: SourceKind
+  series: NormalizedSeries | null
+  /** Optional reason the attempt yielded no series (recorded for observability). */
+  error?: string
+}
+
+export interface ResolvedSeries {
+  status: "ok"
+  source: SourceKind
+  series: NormalizedSeries
+  /** Sources tried before the winner (each failed). */
+  degradedFrom: SourceKind[]
+}
+
+export interface UnresolvedSeries {
+  status: "error"
+  /** Per-source failure reasons, in priority order. */
+  failures: { source: SourceKind; error: string }[]
+}
+
+export type SeriesResolution = ResolvedSeries | UnresolvedSeries
+
+/**
+ * Try the attempts in priority order; the FIRST with a non-empty series wins
+ * (ADR-0053 §1). A failing source is recorded, never fatal. Pure — the shell does
+ * the IO and passes already-normalized results here.
+ */
+export function resolveSeries(
+  attempts: readonly SourceAttempt[]
+): SeriesResolution {
+  const degradedFrom: SourceKind[] = []
+  const failures: { source: SourceKind; error: string }[] = []
+  for (const attempt of attempts) {
+    if (attempt.series && attempt.series.points.length > 0) {
+      return {
+        status: "ok",
+        source: attempt.source,
+        series: attempt.series,
+        degradedFrom,
+      }
+    }
+    degradedFrom.push(attempt.source)
+    failures.push({
+      source: attempt.source,
+      error: attempt.error ?? "no usable NAV data",
+    })
+  }
+  return { status: "error", failures }
+}
+
+export interface BuildPayloadOptions {
+  mode: "latest" | "history"
+  /** History mode: inclusive lower bound (`YYYY-MM-DD`). */
+  from?: string
+  /** `/nav` tail length (defaults to `LATEST_TAIL`). */
+  tail?: number
+}
+
+/**
+ * Build the ADR-0053 §2 payload from a resolved series. `latest` is the freshest
+ * point (Friday's value on a weekend — the correct, expected state). `/nav`
+ * returns a short trailing window; `/nav/history` returns the full series from
+ * `from`. `stale` is set when the winning source was the D1 cache.
+ */
+export function buildPayload(
+  fundCode: string,
+  resolution: ResolvedSeries,
+  options: BuildPayloadOptions
+): NavPayload {
+  const currency = resolution.series.currency
+  const sorted = cleanSeries(resolution.series.points)
+
+  let quotes: NavPoint[]
+  if (options.mode === "history") {
+    quotes = options.from
+      ? sorted.filter((point) => point.date >= options.from!)
+      : sorted
+  } else {
+    const tail = options.tail ?? LATEST_TAIL
+    quotes = sorted.slice(-tail)
+  }
+
+  const freshest = sorted.at(-1) ?? null
+  const stale = resolution.source === "stale_cache"
+
+  return {
+    fundCode,
+    currency,
+    latest: freshest ? { nav: freshest.nav, asOf: freshest.date } : null,
+    quotes,
+    ...(stale ? { stale: true } : {}),
+  }
+}
+
+/** Is a `YYYY-MM-DD` date a Saturday/Sunday (UTC)? Documents the weekend rule. */
+export function isWeekendDate(date: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false
+  const day = new Date(`${date}T00:00:00.000Z`).getUTCDay()
+  return day === 0 || day === 6
+}

--- a/workers/reksadana-nav/tsconfig.json
+++ b/workers/reksadana-nav/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/workers/reksadana-nav/wrangler.jsonc
+++ b/workers/reksadana-nav/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  // reksadana-nav — self-hosted NAV feed worker (PER-250 / ADR-0053).
+  // Deploy to the creator's Cloudflare account; then set REKSADANA_API_URL in the
+  // Permoney app to this worker's URL. See README.md.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "reksadana-nav",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-15",
+  "observability": {
+    "enabled": true,
+  },
+  // D1 stale cache (LKGP): the last-known-good payload per fund. Create it with
+  //   wrangler d1 create reksadana-nav-cache
+  // then paste the returned database_id below and apply schema.sql (see README).
+  "d1_databases": [
+    {
+      "binding": "NAV_CACHE",
+      "database_name": "reksadana-nav-cache",
+      "database_id": "REPLACE_WITH_D1_DATABASE_ID",
+    },
+  ],
+  // Optional upstream overrides (defaults target Bareksa; confirm on deploy).
+  // `{fund}` is substituted with the URL-encoded fund code.
+  "vars": {
+    // "BAREKSA_JSON_URL": "https://api.bareksa.com/v22/products/mutualfund/{fund}/nav",
+    // "BAREKSA_HTML_URL": "https://www.bareksa.com/reksadana/{fund}"
+  },
+}


### PR DESCRIPTION
## Scope (PER-250 Slice B / ADR-0053)

Plugs the **`reksadana_id`** adapter into the PER-257 provider router so Indonesian mutual-fund (reksadana) NAV auto-prices alongside gold — the second live source on the one router.

### Part 1 — the worker (`workers/reksadana-nav/`, isolated in-repo package)
- Two routes emitting the exact ADR-0053 §2 contract: `GET /nav?fund=<code>` (latest) and `GET /nav/history?fund=<code>&from=YYYY-MM-DD` (backfill).
- **Pure, CF-free `normalize.ts`** (the fragile part): per-source normalization + fallback ordering + weekend rule — Bareksa clean JSON → Bareksa product-page `__NEXT_DATA__` HTML scrape → **D1 stale cache (LKGP)**. Thin `index.ts` shell does the IO (fetch + D1).
- Own `package.json` / `tsconfig.json` / `wrangler.jsonc` / `schema.sql` / `README.md` so it does **not** entangle the app build (`vp install`/`vp build` ignore it; only its pure `*.test.ts` runs under `vp test`).

### Part 2 — Permoney-side adapter + wiring
- Pure `parseReksadanaNavResponse` (`src/lib/market-data.ts`) + **`ReksadanaNavProvider`** (`market-data.server.ts`): reads `REKSADANA_API_URL` at call time, injectable `fetchImpl`, `latest` + `history` modes, `security`/IDR per-unit NAV scaled at the boundary. Registered as `reksadana_id` in `createDefaultProviderRegistry`; threaded through `ingestAllInstrumentsOnce` / `syncMarketPricesOnce`.
- `ensureReksadanaInstrument` + `ensureReksadanaInstrumentFn` (capability-gated) so a fund is registered (`kind=security`, `provider=reksadana_id`, `IDR`, `mic=null`) and shows in the holding form's **Live price source** dropdown; inline **"Add a reksadana fund"** affordance (IDR accounts).
- `REKSADANA_API_URL` added to `.env.example` + `docker-compose.prod.yml`.
- Docs: ADR-0053 added; ADR-0052 §3 (`ingestAllInstrumentsOnce`) + §4 (locked-source blockquote) fixes.

## Test evidence (no live network anywhere)
- `vp check` ✅ · `vp build` ✅ (no server/client leak) · `vp fmt` ✅
- `vp test` (unit) ✅ **706 passed** — includes the worker's pure normalizer/fallback/weekend tests + the app-side parser tests.
- Real-PG integration ✅ **reksadana 7/7** + related market-data **30/30**: latest ingest, history backfill (multiple dated quotes), weekend flat-price no-op (dedupe, not an error), worker-outage degradation (last-good kept), idempotent replay, linked-holding revaluation (units × NAV, anchor-safe via PER-238), and reksadana↔gold per-provider isolation.

## ⚠️ Deploy note (manual, creator's CF account)
The worker is **not** deployed here (needs the creator's Cloudflare account). It requires a manual `wrangler deploy` + D1 setup, then `REKSADANA_API_URL` set in the app — steps in `workers/reksadana-nav/README.md`.

During the build spike the Bareksa clean-JSON host (`api.bareksa.com/v22/...`) was found to **require an access token**, and `www.bareksa.com` paths return the Next.js **HTML** (not JSON) unauthenticated. So the recorded fixtures reflect the **documented** Bareksa shape (not a byte-for-byte live capture) and must be **re-recorded from a live probe on deploy**; the normalizer is deliberately shape-tolerant and the HTML `__NEXT_DATA__` fallback + LKGP carry the worker if the JSON endpoint stays gated. Endpoints are overridable via `BAREKSA_JSON_URL` / `BAREKSA_HTML_URL` vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
