### PR TITLE
fix(market-data): PER-258 — reconcile reksadana worker to the real Bareksa ajax NAV endpoint

### DIFF
--- a/docs/adr/0053-reksadana-nav-source-and-worker.md
+++ b/docs/adr/0053-reksadana-nav-source-and-worker.md
@@ -24,18 +24,23 @@ worker. This ADR locks it.
   _statistics_ portal (APERD registry, aggregate NAB statistics), **not** a
   daily/historical per-fund NAV feed. Wrong tool; do not use it as the price
   source.
-- **Bibit internal (`api.bibit.id/products/list`) — REJECTED as primary.** Its
-  payload is **AES-CBC encrypted** and reverse-engineered; the only community
-  reference (`risan/bibit-reksadana`) is unmaintained since 2021 and returns a
-  paginated product _list_, not a clean per-fund NAV lookup. Fragile,
-  ToS-gray, and the cipher can change without notice.
-- **Bareksa internal public JSON / Pasardana — CHOSEN (primary).** Bareksa
-  exposes a **clean, un-encrypted JSON** endpoint keyed by its numeric product
-  id (`https://www.bareksa.com/api/v1/reksadana/product/<code>/nav`); Pasardana
-  offers an equivalent clean-JSON feed. Either returns NAV + date directly with
-  no decryption step — the durable, low-friction primary. (Community clean-JSON
-  mirrors such as Piramida exist as further cross-references but are not part of
-  the locked chain.)
+- **Bibit (`api.bibit.id/products/<code>/related`) — REJECTED, and dropped from
+  the chain entirely (PER-258).** It exposes **no per-fund NAV JSON** — the
+  `related` path returns _related products_ only. (The earlier community
+  reference `risan/bibit-reksadana` reads an AES-CBC-encrypted product _list_,
+  unmaintained since 2021 — fragile, ToS-gray, and not a NAV lookup.) There is no
+  Bibit path in the worker.
+- **Bareksa ajax NAV — CHOSEN (primary).** Bareksa serves clean, **un-encrypted
+  JSON** from `https://www.bareksa.com/ajax/mutualfund/nav/product1/?id=<pid>&…`
+  keyed by its numeric product id. **It is not unauthenticated** (the original
+  guess): the endpoint is gated by an anti-CSRF `x-ajax-token` **and** a
+  `ba_session` cookie, both of which are **bootstrapped from the product page**
+  (`/id/data/reksadana/<pid>/` sets `Set-Cookie: ba_session=…` and embeds
+  `$.ajaxSetup({ headers: { "X-Ajax-Token": '…' } })` inline). Once authed the
+  response is clean JSON with **no decryption step** — the durable, low-friction
+  primary. Verified live in PER-258 (a plain server-side `fetch` with a browser
+  `user-agent` reached both the product page and the ajax JSON — a CF Worker can
+  reach it, no headless browser needed).
 
 ## Decision
 
@@ -43,12 +48,22 @@ worker. This ADR locks it.
 
 Mirror the gold worker's graceful-degradation chain (ADR-0050 §4 / PER-235c):
 
-1. **Primary — Bareksa/Pasardana JSON API.** Clean JSON → normalized directly.
-2. **Fallback — Bareksa HTML scraper.** When the JSON API is unavailable / shape
-   drifts, parse the public product page for the NAV + date.
+1. **Primary — Bareksa ajax NAV JSON (two-step token bootstrap).** Step 1: `GET`
+   the product page (`/id/data/reksadana/<pid>/`) to obtain a fresh `ba_session`
+   cookie and extract the inline `x-ajax-token`. Step 2: `GET` the ajax endpoint
+   (`/ajax/mutualfund/nav/product1/?id=<pid>&cperiod=…`) with that token, the
+   cookie, `x-requested-with: XMLHttpRequest`, and a product-page `referer` →
+   clean JSON (`data.datas[0].nav[]`, `unitY`), normalized directly.
+   `status:false` / `data.auth:false` is a failed attempt → fall through.
+2. **Fallback — Bareksa product-page HTML scrape.** When the bootstrap can't
+   yield a token, salvage any NAV JSON embedded in the product HTML already
+   fetched in step 1.
 3. **Last resort — D1 stale cache (LKGP, "Last Known Good Price").** Serve the
    most recent cached quote, flagged stale, so a total upstream outage degrades
    to last-good rather than an error.
+
+The worker's `fund` param is the Bareksa numeric product id (`pid`); Permoney
+sets a reksadana instrument's `symbol` to that pid.
 
 Each step is tried in order; the first success wins. A step failing is recorded,
 never fatal — the worker always returns _something usable or an explicit,

--- a/workers/reksadana-nav/README.md
+++ b/workers/reksadana-nav/README.md
@@ -1,7 +1,7 @@
 # reksadana-nav worker
 
 Self-hosted Cloudflare Worker that serves Indonesian **reksadana (mutual-fund)
-NAV** as clean JSON for Permoney (PER-250 Slice B / [ADR-0053](../../docs/adr/0053-reksadana-nav-source-and-worker.md)).
+NAV** as clean JSON for Permoney (PER-250 Slice B / PER-258 / [ADR-0053](../../docs/adr/0053-reksadana-nav-source-and-worker.md)).
 
 It mirrors the gold worker's isolation: the fragile scrape + fallback chain live
 here, entirely outside the ledger app. Permoney's `ReksadanaNavProvider` calls
@@ -15,19 +15,23 @@ this worker behind `REKSADANA_API_URL` and never sees a vendor.
 
 ## Contract (ADR-0053 §2)
 
-- `GET /nav?fund=<code>` → latest quote (+ a short trailing window):
-- `GET /nav/history?fund=<code>&from=YYYY-MM-DD` → the dated series for a backfill.
+- `GET /nav?fund=<pid>` → latest quote (+ a short trailing window).
+- `GET /nav/history?fund=<pid>&from=YYYY-MM-DD` → the dated series for a backfill.
 
-Both emit exactly:
+`fund` is the **Bareksa numeric product id (pid)** — e.g. `3035` for _Majoris
+Pasar Uang Syariah Indonesia_. Permoney sets a reksadana instrument's `symbol` to
+that pid, and the worker passes it straight through as `?id=<pid>`.
+
+Both routes emit exactly:
 
 ```json
 {
-  "fundCode": "sucorinvest-money-market-fund",
+  "fundCode": "3035",
   "currency": "IDR",
-  "latest": { "nav": 1643.45, "asOf": "2026-08-14" },
+  "latest": { "nav": 1485.7881, "asOf": "2026-08-14" },
   "quotes": [
-    { "date": "2026-08-13", "nav": 1643.19 },
-    { "date": "2026-08-14", "nav": 1643.45 }
+    { "date": "2026-08-13", "nav": 1485.5894 },
+    { "date": "2026-08-14", "nav": 1485.7881 }
   ]
 }
 ```
@@ -35,30 +39,77 @@ Both emit exactly:
 `stale: true` is added when the payload was served from the D1 last-known-good
 cache (a total upstream outage degrades to last-good, never a 500).
 
+## The real Bareksa upstream (verified — PER-258)
+
+Bareksa's NAV lives behind an ajax endpoint gated by an **anti-CSRF token +
+session cookie** that are **bootstrapped from the product page**. It is clean
+JSON once authed — **no AES** (that was the OLD, guessed Bibit path; Bibit
+exposes no NAV JSON and is dropped from the chain).
+
+**Two-step primary flow (inside the worker):**
+
+1. **Bootstrap** — `GET https://www.bareksa.com/id/data/reksadana/<pid>/` with a
+   browser-like `user-agent`. It 302-redirects to the canonical product page; the
+   response sets `Set-Cookie: ba_session=…` (+ `clang=id`), and the HTML embeds,
+   in an inline `<script>`:
+
+   ```js
+   $.ajaxSetup({ headers: { "X-Ajax-Token": "<token>" } })
+   ```
+
+   The worker extracts `ba_session` from `Set-Cookie` (`extractCookie`) and the
+   token from that script (`extractAjaxToken`).
+
+2. **Fetch NAV** — `GET https://www.bareksa.com/ajax/mutualfund/nav/product1/?id=<pid>&cperiod=<period>&requested_page=profile.graph`
+   (history mode adds `startdate`/`enddate` in `DD-MM-YYYY`), with headers:
+
+   - `x-ajax-token: <token>`
+   - `x-requested-with: XMLHttpRequest`
+   - `cookie: ba_session=<session>; clang=id`
+   - `referer: https://www.bareksa.com/id/data/reksadana/<pid>/`
+   - a browser `user-agent`
+
+   → clean JSON:
+
+   ```json
+   {
+     "status": true,
+     "data": {
+       "auth": true,
+       "unitY": "IDR",
+       "datas": [
+         {
+           "pid": "3035",
+           "pname": "…",
+           "nav": [{ "date": "2026-08-14", "value": "1485.788100" }]
+         }
+       ]
+     }
+   }
+   ```
+
+   Field mapping: currency = `data.unitY`; series = `data.datas[0].nav[]`
+   (`{ date, value }` → `{ date, nav: Number(value) }`); **latest = the LAST
+   element** of `nav[]`. The array is **trading-days-only** (weekends/holidays are
+   absent), so the weekend invariant holds by construction. `status:false` or
+   `data.auth:false` is a failed attempt → fall through.
+
 ## Source fallback chain (ADR-0053 §1)
 
-1. **Bareksa/Pasardana clean JSON** (primary).
-2. **Bareksa product-page HTML** — scrapes the embedded `__NEXT_DATA__` JSON.
+1. **Bareksa ajax JSON** (primary — the two-step token bootstrap above).
+2. **Bareksa product-page HTML scrape** — when the bootstrap can't yield a token,
+   salvage any NAV JSON embedded in the product HTML we already fetched.
 3. **D1 stale cache (LKGP)** — the last payload this worker served.
 
 First success wins; each failure is recorded, never fatal. All of this logic is
 the PURE, unit-tested `src/normalize.ts`; `src/index.ts` is a thin IO shell.
 
-### ⚠️ Confirm the primary endpoint on first deploy
-
-During the build spike the Bareksa clean-JSON host (`api.bareksa.com/v22/...`)
-was found to require an **access token**, and the `www.bareksa.com` paths return
-the Next.js app **HTML** (not JSON) to an unauthenticated client. So:
-
-- The recorded fixtures (`src/fixtures.ts`) reflect the **documented** Bareksa
-  shape, not a live capture — **re-record them from a live probe on deploy**.
-- Set the real endpoints via `BAREKSA_JSON_URL` / `BAREKSA_HTML_URL` vars
-  (`{fund}` placeholder) in `wrangler.jsonc`. If no unauthenticated JSON endpoint
-  is available, the **HTML `__NEXT_DATA__` fallback + LKGP** carry the worker; the
-  normalizer's deep search tolerates shape drift by design.
-
 The weekend/holiday invariant (ADR-0053 §3) is built in: a flat/absent NAV on
 Sat–Sun is the correct state — `latest` stays Friday's value, never an error.
+
+> A CF Worker's `fetch` reaches Bareksa fine — a plain server-side request with a
+> browser `user-agent` (no headless browser) got both the product page and the
+> ajax JSON during the PER-258 probe.
 
 ## Deploy
 
@@ -77,13 +128,16 @@ REKSADANA_API_URL="https://reksadana-nav.<your-subdomain>.workers.dev"
 ```
 
 Now a holding linked to a reksadana series (via the holding form's **Add a
-reksadana fund** → **Live price source**) auto-prices on **Refresh prices**
-(units × NAV, anchor-safe via PER-238).
+reksadana fund** → **Live price source**, whose `symbol` is the Bareksa pid)
+auto-prices on **Refresh prices** (units × NAV, anchor-safe via PER-238).
+
+The endpoints are overridable via `BAREKSA_PRODUCT_URL` (a `{fund}` product-page
+template) and `BAREKSA_AJAX_BASE` (the ajax endpoint base) in `wrangler.jsonc`.
 
 ## Local checks
 
 ```sh
-# Unit tests (pure normalizer) — from the repo root, via the app toolchain:
+# Unit tests (pure normalizer + token-bootstrap parsers) — from the repo root:
 vp test workers/reksadana-nav
 
 # Worker typecheck (needs the worker's own deps installed here first):

--- a/workers/reksadana-nav/src/fixtures.ts
+++ b/workers/reksadana-nav/src/fixtures.ts
@@ -2,113 +2,148 @@
  * Recorded upstream fixtures for the reksadana-nav worker's PURE normalizer.
  * =============================================================================
  *
- * PROVENANCE (read before trusting these): during the ADR-0053 build spike the
- * Bareksa clean-JSON host (`api.bareksa.com/v22/...`) was found to require an
- * access token, and the `www.bareksa.com` product/API paths serve the Next.js app
- * shell (HTML), not JSON, to an unauthenticated client. So these fixtures reflect
- * the DOCUMENTED Bareksa response shape (a `data.nav` latest + `data.nav_history`
- * series; the product page's embedded `__NEXT_DATA__` JSON), NOT a byte-for-byte
- * live capture. They MUST be re-recorded from a live/authenticated probe when the
- * worker is first deployed (see README). The normalizer is deliberately
- * shape-tolerant + falls back (HTML → D1 stale) precisely so a shape drift
- * degrades instead of crashing; these fixtures pin that behaviour.
- *
- * The values are illustrative (Sucorinvest Money Market Fund, IDR MMF NAVs).
+ * PROVENANCE (PER-258): these are recorded from a LIVE probe of the real Bareksa
+ * ajax NAV endpoint (product id `3035` — Majoris Pasar Uang Syariah Indonesia).
+ * The envelope shape, field names (`status`, `data.auth`, `data.unitY`,
+ * `data.datas[].pid`/`pname`, `nav[].{id,date,value}`), the trading-days-only
+ * series, and the `X-Ajax-Token` embedding (`$.ajaxSetup({ headers: { … } })`) are
+ * all as captured live. The freshest point (`2026-08-14` → `1485.788100`) and the
+ * prior day (`2026-08-13` → `1485.589400`) are the REAL values; the earlier points
+ * are illustrative trading days on the same fund. Weekend rows (Sat/Sun) are absent
+ * by construction — Bareksa's `nav[]` is trading-days-only.
  */
 
-/** Primary — Bareksa/Pasardana clean JSON: a latest point + a short history. */
-export const BAREKSA_NAV_JSON_SAMPLE = {
-  status: "success",
-  data: {
-    id: 1742,
-    code: "sucorinvest-money-market-fund",
-    name: "Sucorinvest Money Market Fund",
-    currency: "IDR",
-    nav: { date: "2026-08-14", value: 1643.45 },
-    nav_history: [
-      { date: "2026-08-11", value: 1642.71 },
-      { date: "2026-08-12", value: 1642.98 },
-      { date: "2026-08-13", value: 1643.19 },
-      { date: "2026-08-14", value: 1643.45 },
-    ],
-  },
-} as const
+/** A `nav[]` row as Bareksa returns it (value is a decimal STRING). */
+interface RawNavRow {
+  id: string
+  date: string
+  value: string
+}
 
-/** Primary — the `/nav/history` clean-JSON form (a dated array under `data`). */
-export const BAREKSA_HISTORY_JSON_SAMPLE = {
-  status: "success",
-  data: [
-    { date: "2026-08-03", nav: 1641.02 },
-    { date: "2026-08-04", nav: 1641.29 },
-    { date: "2026-08-05", nav: 1641.55 },
-    { date: "2026-08-06", nav: 1641.83 },
-    { date: "2026-08-07", nav: 1642.1 },
-    { date: "2026-08-10", nav: 1642.44 },
-    { date: "2026-08-11", nav: 1642.71 },
-    { date: "2026-08-12", nav: 1642.98 },
-    { date: "2026-08-13", nav: 1643.19 },
-    { date: "2026-08-14", nav: 1643.45 },
-  ],
+/** Wrap a `nav[]` series in the real Bareksa ajax envelope. */
+function bareksaEnvelope(nav: RawNavRow[]) {
+  return {
+    status: true,
+    data: {
+      auth: true,
+      redirect_url: "",
+      startdate: nav[0]?.date.split("-").reverse().join("-") ?? "",
+      enddate: nav.at(-1)?.date.split("-").reverse().join("-") ?? "",
+      subtitle: "Grafik NAB/Unit",
+      unitY: "IDR",
+      datas: [
+        {
+          pid: "3035",
+          ptype: "1",
+          idate: "2018-01-09",
+          inav: "1000.0000",
+          pname: "Majoris Pasar Uang Syariah Indonesia",
+          nav,
+        },
+      ],
+    },
+  } as const
+}
+
+/** Trading-days-only NAV rows ending at the REAL latest (2026-08-14). */
+const NAV_ROWS_SHORT: RawNavRow[] = [
+  { id: "5170011", date: "2026-08-06", value: "1484.100000" },
+  { id: "5171422", date: "2026-08-07", value: "1484.320000" },
+  { id: "5173044", date: "2026-08-10", value: "1484.900000" },
+  { id: "5174511", date: "2026-08-11", value: "1485.110000" },
+  { id: "5175800", date: "2026-08-12", value: "1485.360000" },
+  { id: "5177112", date: "2026-08-13", value: "1485.589400" },
+  { id: "5178544", date: "2026-08-14", value: "1485.788100" },
+]
+
+/** A longer trading-days window, for the `/nav/history` backfill. */
+const NAV_ROWS_HISTORY: RawNavRow[] = [
+  { id: "5160010", date: "2026-08-03", value: "1482.900000" },
+  { id: "5161422", date: "2026-08-04", value: "1483.150000" },
+  { id: "5162844", date: "2026-08-05", value: "1483.470000" },
+  ...NAV_ROWS_SHORT,
+]
+
+/**
+ * Primary — the REAL Bareksa ajax NAV envelope (`GET /ajax/mutualfund/nav/
+ * product1/?id=3035&cperiod=1m…`). `data.datas[0].nav[]` is the series; the LAST
+ * element is the latest quote; `data.unitY` is the currency.
+ */
+export const BAREKSA_NAV_JSON_SAMPLE = bareksaEnvelope(NAV_ROWS_SHORT)
+
+/** Primary — the same envelope with a longer nav[] (history backfill window). */
+export const BAREKSA_HISTORY_JSON_SAMPLE = bareksaEnvelope(NAV_ROWS_HISTORY)
+
+/**
+ * A FAILED ajax attempt — Bareksa answers `status:false` / `data.auth:false` when
+ * the `x-ajax-token` / `ba_session` bootstrap did not authenticate. The normalizer
+ * must return null so the chain falls through to the HTML scrape, then D1 LKGP.
+ */
+export const UNUSABLE_JSON_SAMPLE = {
+  status: false,
+  data: { auth: false },
 } as const
 
 /**
- * Fallback — the Bareksa product page HTML, reduced to the load-bearing part: the
- * `__NEXT_DATA__` JSON blob the scraper extracts. A minimal but realistic Next.js
- * shell so the extractor + deep search are exercised against real structure.
+ * The fake `X-Ajax-Token` the product-page fixture embeds (NEVER a real token).
+ * Deliberately a non-hex, obviously-fake string so secret scanners don't flag it
+ * as a high-entropy credential — the extractor accepts any non-quote value.
  */
-export const BAREKSA_PRODUCT_HTML_SAMPLE = `<!DOCTYPE html><html lang="id"><head><title>Sucorinvest Money Market Fund | Bareksa</title></head><body><div id="__next"></div><script id="__NEXT_DATA__" type="application/json">${JSON.stringify(
-  {
-    props: {
-      pageProps: {
-        product: {
-          code: "sucorinvest-money-market-fund",
-          currency: "IDR",
-          nav: { date: "2026-08-14", value: 1643.45 },
-          navHistory: [
-            { date: "2026-08-12", value: 1642.98 },
-            { date: "2026-08-13", value: 1643.19 },
-            { date: "2026-08-14", value: 1643.45 },
-          ],
-        },
-      },
-    },
-    page: "/reksadana/[slug]",
-  }
-)}</script></body></html>`
+export const BAREKSA_TOKEN_SAMPLE = "EXAMPLE-fake-ajax-token-not-a-secret"
+
+/**
+ * A representative `Set-Cookie` header (as `Headers.getSetCookie()` would join it)
+ * the product-page response carries. `ba_session` is the session the ajax call
+ * needs; `clang=id` pins the Indonesian locale. Values are fake.
+ */
+export const BAREKSA_SET_COOKIE_SAMPLE = [
+  "ba_session=OLDSESSIONdiscarded; path=/; domain=.bareksa.com",
+  "ba_session=FAKEba_session_value_1234567890; expires=Sun, 16-Aug-2026 13:43:26 GMT; Max-Age=86400; path=/; domain=.bareksa.com",
+  "clang=id; Max-Age=2595000; path=/; domain=.bareksa.com",
+].join("\n")
+
+/** The freshest `ba_session` value `extractCookie` should return from the above. */
+export const BAREKSA_SESSION_SAMPLE = "FAKEba_session_value_1234567890"
+
+/**
+ * Fallback — the Bareksa product-page HTML, reduced to the two load-bearing parts:
+ * (1) the inline `$.ajaxSetup({ headers: { "X-Ajax-Token": '…' } })` the token
+ * bootstrap extracts, and (2) an embedded `<script type="application/json">` NAV
+ * blob the HTML scraper salvages when the token bootstrap fails.
+ */
+export const BAREKSA_PRODUCT_HTML_SAMPLE = `<!DOCTYPE html><html lang="id"><head><title>Majoris Pasar Uang Syariah Indonesia | Bareksa</title></head><body><div id="app"></div><script>
+      var LANG = 'id';
+      var ULOGIN = '';
+      $.ajaxSetup({
+        headers: { "X-Ajax-Token": '${BAREKSA_TOKEN_SAMPLE}' }
+      });
+    </script><script id="nav-data" type="application/json">${JSON.stringify(
+      bareksaEnvelope(NAV_ROWS_SHORT.slice(-3))
+    )}</script></body></html>`
+
+/** Product-page HTML with NO ajax token (a markup drift) — bootstrap must fail. */
+export const BAREKSA_HTML_NO_TOKEN_SAMPLE = `<!DOCTYPE html><html lang="id"><head><title>Bareksa</title></head><body><div id="app"></div></body></html>`
 
 /**
  * Last resort — a payload previously served by THIS worker and cached in D1
  * (already in the ADR-0053 §2 contract shape). Served as LKGP, flagged stale.
  */
 export const STALE_CACHE_SAMPLE = {
-  fundCode: "sucorinvest-money-market-fund",
+  fundCode: "RD-MAJORIS-MMF",
   currency: "IDR",
-  latest: { nav: 1643.19, asOf: "2026-08-13" },
+  latest: { nav: 1485.5894, asOf: "2026-08-13" },
   quotes: [
-    { date: "2026-08-12", nav: 1642.98 },
-    { date: "2026-08-13", nav: 1643.19 },
+    { date: "2026-08-12", nav: 1485.36 },
+    { date: "2026-08-13", nav: 1485.5894 },
   ],
 } as const
 
 /**
  * Weekend case — the freshest available NAV is Friday's (2026-08-14 is a Friday);
- * no Sat/Sun rows exist. Re-serving this on Sat/Sun must be a no-op success, not a
- * failure (ADR-0053 §3): `latest` stays Friday's value.
+ * Bareksa's trading-days-only `nav[]` carries no Sat/Sun rows. Re-serving this on
+ * Sat/Sun is a no-op success (ADR-0053 §3): `latest` stays Friday's value.
  */
-export const WEEKEND_FLAT_JSON_SAMPLE = {
-  status: "success",
-  data: {
-    currency: "IDR",
-    nav: { date: "2026-08-14", value: 1643.45 },
-    nav_history: [
-      { date: "2026-08-13", value: 1643.19 },
-      { date: "2026-08-14", value: 1643.45 },
-    ],
-  },
-} as const
-
-/** A malformed payload (no NAV-shaped data) — the JSON normalizer returns null. */
-export const UNUSABLE_JSON_SAMPLE = {
-  status: "error",
-  message: "product not found",
-} as const
+export const WEEKEND_FLAT_JSON_SAMPLE = bareksaEnvelope([
+  { id: "5177112", date: "2026-08-13", value: "1485.589400" },
+  { id: "5178544", date: "2026-08-14", value: "1485.788100" },
+])

--- a/workers/reksadana-nav/src/index.ts
+++ b/workers/reksadana-nav/src/index.ts
@@ -2,32 +2,49 @@
  * reksadana-nav — Cloudflare Worker entry (the thin IO SHELL).
  * =============================================================================
  *
- * ADR-0053. All the fragile logic (per-source normalization, fallback ordering,
- * the weekend rule, the target contract) lives in the PURE, CF-free `normalize.ts`
- * — unit-tested with `vp test`. This file only does what a shell must: parse the
- * request, fetch each upstream (browser-like headers), read/write the D1 stale
- * cache, and serialize the ADR-0053 §2 payload. It NEVER 500s on an upstream
- * outage — it degrades to the stale cache, then to a structured error.
+ * ADR-0053. All the fragile logic (per-source normalization, the token-bootstrap
+ * string parsing, fallback ordering, the weekend rule, the target contract) lives
+ * in the PURE, CF-free `normalize.ts` — unit-tested with `vp test`. This file only
+ * does what a shell must: parse the request, run the two-step Bareksa bootstrap
+ * (product page → `ba_session` + `x-ajax-token` → ajax NAV), scrape the HTML as a
+ * fallback, read/write the D1 stale cache, and serialize the ADR-0053 §2 payload.
+ * It NEVER 500s on an upstream outage — it degrades to the stale cache, then to a
+ * structured error.
+ *
+ * THE REAL BAREKSA UPSTREAM (verified by live probe — PER-258)
+ * -----------------------------------------------------------
+ *   1. GET https://www.bareksa.com/id/data/reksadana/<PID>/  (browser-like UA)
+ *        → 302 to the canonical product page; response sets `Set-Cookie:
+ *          ba_session=…` (+ `clang=id`), and the HTML embeds, inline,
+ *          `$.ajaxSetup({ headers: { "X-Ajax-Token": '…' } })`.
+ *   2. GET https://www.bareksa.com/ajax/mutualfund/nav/product1/?id=<PID>&cperiod=…
+ *        with `x-ajax-token`, `x-requested-with: XMLHttpRequest`,
+ *        `cookie: ba_session=…; clang=id`, and a product-page `referer`.
+ *        → CLEAN JSON: `{ status, data: { unitY, datas:[{ nav:[{date,value}] }] } }`.
+ *
+ * The worker's `fund` query param IS the Bareksa numeric product id (`<PID>`);
+ * Permoney sets a reksadana instrument's `symbol` to that pid.
  *
  * Routes:
- *   GET /nav?fund=<code>                         → latest quote (+ short tail)
- *   GET /nav/history?fund=<code>&from=YYYY-MM-DD  → dated series for a backfill
+ *   GET /nav?fund=<PID>                          → latest quote (+ short tail)
+ *   GET /nav/history?fund=<PID>&from=YYYY-MM-DD   → dated series for a backfill
  *
  * Bindings (wrangler.jsonc):
  *   NAV_CACHE (D1)          — last-known-good payload per fund (LKGP).
- *   Vars/secrets (optional) — BAREKSA_JSON_URL, BAREKSA_HTML_URL templates with
- *     `{fund}` / `{from}` placeholders. Defaults target Bareksa; CONFIRM + adjust
- *     against the live upstream on first deploy (see README — the exact public
- *     JSON endpoint must be recorded during deploy; the primary may be token-gated,
- *     in which case the HTML fallback + LKGP carry the worker).
+ *   Vars/secrets (optional) — BAREKSA_PRODUCT_URL (a `{fund}` product-page
+ *     template) + BAREKSA_AJAX_BASE (the ajax endpoint base). Defaults target the
+ *     verified Bareksa endpoints.
  */
 
 import {
   buildPayload,
+  extractAjaxToken,
+  extractCookie,
   normalizeBareksaHtml,
   normalizeBareksaJson,
   normalizeStaleCache,
   resolveSeries,
+  toBareksaDate,
   type NavPayload,
   type NormalizedSeries,
   type SourceAttempt,
@@ -36,22 +53,18 @@ import {
 export interface Env {
   /** D1 database holding the per-fund last-known-good payload (LKGP). */
   NAV_CACHE: D1Database
-  /** Primary clean-JSON URL template (`{fund}`). */
-  BAREKSA_JSON_URL?: string
-  /** Fallback product-page URL template (`{fund}`). */
-  BAREKSA_HTML_URL?: string
+  /** Product-page URL template (`{fund}` = the Bareksa numeric pid). */
+  BAREKSA_PRODUCT_URL?: string
+  /** Ajax NAV endpoint base (query is built by the worker). */
+  BAREKSA_AJAX_BASE?: string
 }
 
-const DEFAULT_JSON_URL =
-  "https://api.bareksa.com/v22/products/mutualfund/{fund}/nav"
-const DEFAULT_HTML_URL = "https://www.bareksa.com/reksadana/{fund}"
+const DEFAULT_PRODUCT_URL = "https://www.bareksa.com/id/data/reksadana/{fund}/"
+const DEFAULT_AJAX_BASE =
+  "https://www.bareksa.com/ajax/mutualfund/nav/product1/"
 
-const BROWSER_HEADERS: Record<string, string> = {
-  "user-agent":
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
-  accept: "application/json, text/plain, */*",
-  referer: "https://www.bareksa.com/",
-}
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -67,44 +80,126 @@ function fillTemplate(template: string, fund: string): string {
   return template.replaceAll("{fund}", encodeURIComponent(fund))
 }
 
-/** Fetch the primary clean-JSON source; null on any non-2xx / non-JSON / drift. */
+/** Join a response's Set-Cookie header(s) into one string `extractCookie` reads. */
+function readSetCookie(response: Response): string | null {
+  const headers = response.headers as Headers & {
+    getSetCookie?: () => string[]
+  }
+  if (typeof headers.getSetCookie === "function") {
+    const all = headers.getSetCookie()
+    if (all.length > 0) return all.join("\n")
+  }
+  return response.headers.get("set-cookie")
+}
+
+interface ProductPage {
+  html: string | null
+  cookie: string | null
+  token: string | null
+  error?: string
+}
+
+/**
+ * Step 1 of the bootstrap: fetch the product page (following its 302) to obtain a
+ * fresh `ba_session` cookie AND the `x-ajax-token` embedded in the HTML. The HTML
+ * is also returned so the fallback scraper can reuse it without a second fetch.
+ */
+async function fetchProductPage(env: Env, fund: string): Promise<ProductPage> {
+  const url = fillTemplate(env.BAREKSA_PRODUCT_URL ?? DEFAULT_PRODUCT_URL, fund)
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "user-agent": USER_AGENT,
+        accept: "text/html,application/xhtml+xml",
+        "accept-language": "id,en;q=0.9",
+      },
+      redirect: "follow",
+    })
+    const cookie = extractCookie(readSetCookie(res))
+    const html = res.ok ? await res.text() : null
+    return {
+      html,
+      cookie,
+      token: extractAjaxToken(html),
+      error: res.ok ? undefined : `product page HTTP ${res.status}`,
+    }
+  } catch (error) {
+    return {
+      html: null,
+      cookie: null,
+      token: null,
+      error: error instanceof Error ? error.message : "product fetch failed",
+    }
+  }
+}
+
+/** Build the ajax NAV URL for a mode (`1m` window for latest; a dated range). */
+function buildAjaxUrl(
+  base: string,
+  fund: string,
+  mode: "latest" | "history",
+  from: string | undefined
+): string {
+  const params = new URLSearchParams()
+  params.set("id", fund)
+  params.set("requested_page", "profile.graph")
+  if (mode === "history") {
+    params.set("cperiod", "all")
+    const start = from ? toBareksaDate(from) : null
+    if (start) params.set("startdate", start)
+    const end = toBareksaDate(new Date().toISOString().slice(0, 10))
+    if (end) params.set("enddate", end)
+  } else {
+    params.set("cperiod", "1m")
+  }
+  return `${base}?${params.toString()}`
+}
+
+/**
+ * Step 2 of the bootstrap: call the ajax NAV endpoint with the bootstrapped token
+ * + cookie + referer. Returns null (never throws) when the token/cookie is absent,
+ * the request is non-2xx / non-JSON, or the envelope reports a failed attempt — so
+ * the chain falls through to the HTML scrape, then D1 LKGP.
+ */
 async function fetchBareksaJson(
   env: Env,
-  fund: string
+  fund: string,
+  page: ProductPage,
+  mode: "latest" | "history",
+  from: string | undefined
 ): Promise<{ series: NormalizedSeries | null; error?: string }> {
-  const url = fillTemplate(env.BAREKSA_JSON_URL ?? DEFAULT_JSON_URL, fund)
+  if (!page.token || !page.cookie) {
+    return { series: null, error: page.error ?? "ajax token bootstrap failed" }
+  }
+  const base = env.BAREKSA_AJAX_BASE ?? DEFAULT_AJAX_BASE
+  const url = buildAjaxUrl(base, fund, mode, from)
+  const referer = fillTemplate(
+    env.BAREKSA_PRODUCT_URL ?? DEFAULT_PRODUCT_URL,
+    fund
+  )
   try {
-    const res = await fetch(url, { headers: BROWSER_HEADERS })
-    if (!res.ok) return { series: null, error: `json HTTP ${res.status}` }
+    const res = await fetch(url, {
+      headers: {
+        "user-agent": USER_AGENT,
+        accept: "application/json, text/javascript, */*; q=0.01",
+        "x-ajax-token": page.token,
+        "x-requested-with": "XMLHttpRequest",
+        cookie: `ba_session=${page.cookie}; clang=id`,
+        referer,
+      },
+    })
+    if (!res.ok) return { series: null, error: `ajax HTTP ${res.status}` }
     const contentType = res.headers.get("content-type") ?? ""
-    if (!contentType.includes("json")) {
-      return { series: null, error: "json endpoint returned non-JSON" }
+    if (!contentType.includes("json") && !contentType.includes("javascript")) {
+      const body = await res.json().catch(() => null)
+      return { series: normalizeBareksaJson(body) }
     }
     const body = await res.json()
     return { series: normalizeBareksaJson(body) }
   } catch (error) {
     return {
       series: null,
-      error: error instanceof Error ? error.message : "fetch failed",
-    }
-  }
-}
-
-/** Fetch the product-page HTML and scrape its embedded __NEXT_DATA__. */
-async function fetchBareksaHtml(
-  env: Env,
-  fund: string
-): Promise<{ series: NormalizedSeries | null; error?: string }> {
-  const url = fillTemplate(env.BAREKSA_HTML_URL ?? DEFAULT_HTML_URL, fund)
-  try {
-    const res = await fetch(url, { headers: BROWSER_HEADERS })
-    if (!res.ok) return { series: null, error: `html HTTP ${res.status}` }
-    const html = await res.text()
-    return { series: normalizeBareksaHtml(html) }
-  } catch (error) {
-    return {
-      series: null,
-      error: error instanceof Error ? error.message : "fetch failed",
+      error: error instanceof Error ? error.message : "ajax fetch failed",
     }
   }
 }
@@ -155,11 +250,17 @@ async function handleNav(
   mode: "latest" | "history",
   from: string | undefined
 ): Promise<Response> {
-  const [json_, html, stale] = await Promise.all([
-    fetchBareksaJson(env, fund),
-    fetchBareksaHtml(env, fund),
+  // One product-page fetch powers BOTH the token-gated ajax primary and the HTML
+  // scrape fallback (no double fetch).
+  const page = await fetchProductPage(env, fund)
+  const [json_, stale] = await Promise.all([
+    fetchBareksaJson(env, fund, page, mode, from),
     readStaleCache(env, fund),
   ])
+  const html: { series: NormalizedSeries | null; error?: string } = {
+    series: normalizeBareksaHtml(page.html),
+    error: page.html ? "no NAV in product HTML" : page.error,
+  }
 
   const attempts: SourceAttempt[] = [
     { source: "bareksa_json", series: json_.series, error: json_.error },
@@ -196,7 +297,7 @@ export default {
       return json({ error: "method not allowed" }, 405)
     }
     const fund = url.searchParams.get("fund")?.trim()
-    if (!fund) return json({ error: "missing ?fund=<code>" }, 400)
+    if (!fund) return json({ error: "missing ?fund=<pid>" }, 400)
 
     if (url.pathname === "/nav") {
       return handleNav(env, fund, "latest", undefined)

--- a/workers/reksadana-nav/src/normalize.test.ts
+++ b/workers/reksadana-nav/src/normalize.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "vite-plus/test"
 import {
   BAREKSA_HISTORY_JSON_SAMPLE,
+  BAREKSA_HTML_NO_TOKEN_SAMPLE,
   BAREKSA_NAV_JSON_SAMPLE,
   BAREKSA_PRODUCT_HTML_SAMPLE,
+  BAREKSA_SESSION_SAMPLE,
+  BAREKSA_SET_COOKIE_SAMPLE,
+  BAREKSA_TOKEN_SAMPLE,
   STALE_CACHE_SAMPLE,
   UNUSABLE_JSON_SAMPLE,
   WEEKEND_FLAT_JSON_SAMPLE,
@@ -10,6 +14,8 @@ import {
 import {
   buildPayload,
   cleanSeries,
+  extractAjaxToken,
+  extractCookie,
   isWeekendDate,
   normalizeBareksaHtml,
   normalizeBareksaJson,
@@ -17,15 +23,16 @@ import {
   normalizeNav,
   normalizeStaleCache,
   resolveSeries,
+  toBareksaDate,
   type ResolvedSeries,
   type SourceAttempt,
 } from "./normalize"
 
 // =============================================================================
-// PER-250 Slice B / ADR-0053 — the reksadana-nav worker's PURE normalizer +
-// fallback ordering + weekend rule, fixture-driven, NO live network. This is the
-// fragile part the ADR singles out for review; every source shape, the priority
-// chain, and the weekend invariant are pinned here.
+// PER-258 / ADR-0053 — the reksadana-nav worker's PURE normalizer + token
+// bootstrap parsers + fallback ordering + weekend rule, fixture-driven, NO live
+// network. Reconciled to the REAL Bareksa ajax NAV envelope + the two-step
+// `x-ajax-token` / `ba_session` product-page bootstrap.
 // =============================================================================
 
 describe("scalar normalizers", () => {
@@ -43,7 +50,7 @@ describe("scalar normalizers", () => {
 
   test("normalizeNav accepts positive numbers/strings, rejects the rest", () => {
     expect(normalizeNav(1643.45)).toBe(1643.45)
-    expect(normalizeNav("1643.45")).toBe(1643.45)
+    expect(normalizeNav("1485.788100")).toBe(1485.7881)
     expect(normalizeNav(0)).toBeNull()
     expect(normalizeNav(-1)).toBeNull()
     expect(normalizeNav("abc")).toBeNull()
@@ -51,14 +58,21 @@ describe("scalar normalizers", () => {
   })
 })
 
-describe("normalizeBareksaJson (primary clean JSON)", () => {
-  test("documented shape: data.nav latest + data.nav_history series", () => {
+describe("normalizeBareksaJson (REAL Bareksa ajax envelope)", () => {
+  test("parses data.datas[0].nav[]; currency from unitY; latest = LAST point", () => {
     const series = normalizeBareksaJson(BAREKSA_NAV_JSON_SAMPLE)
     expect(series).not.toBeNull()
     expect(series?.currency).toBe("IDR")
-    // Deduped + ascending; the latest is Friday's value.
-    expect(series?.points.at(-1)).toEqual({ date: "2026-08-14", nav: 1643.45 })
+    // The last element is the freshest quote (the real 2026-08-14 value).
+    expect(series?.points.at(-1)).toEqual({
+      date: "2026-08-14",
+      nav: 1485.7881,
+    })
+    // Deduped + ascending, trading-days-only (no Sat/Sun 08-08/08-09).
     expect(series?.points.map((p) => p.date)).toEqual([
+      "2026-08-06",
+      "2026-08-07",
+      "2026-08-10",
       "2026-08-11",
       "2026-08-12",
       "2026-08-13",
@@ -66,14 +80,22 @@ describe("normalizeBareksaJson (primary clean JSON)", () => {
     ])
   })
 
-  test("history array shape (data: [{date, nav}])", () => {
+  test("history envelope: a longer nav[] window normalizes in full", () => {
     const series = normalizeBareksaJson(BAREKSA_HISTORY_JSON_SAMPLE)
     expect(series?.points).toHaveLength(10)
-    expect(series?.points[0]).toEqual({ date: "2026-08-03", nav: 1641.02 })
+    expect(series?.points[0]).toEqual({ date: "2026-08-03", nav: 1482.9 })
+    expect(series?.points.at(-1)).toEqual({
+      date: "2026-08-14",
+      nav: 1485.7881,
+    })
   })
 
-  test("a malformed payload with no NAV data returns null (→ next source)", () => {
+  test("status:false / data.auth:false is a FAILED attempt → null (chain falls through)", () => {
     expect(normalizeBareksaJson(UNUSABLE_JSON_SAMPLE)).toBeNull()
+    expect(normalizeBareksaJson({ status: false })).toBeNull()
+    expect(
+      normalizeBareksaJson({ data: { auth: false, datas: [] } })
+    ).toBeNull()
     expect(normalizeBareksaJson(null)).toBeNull()
     expect(normalizeBareksaJson("nope")).toBeNull()
   })
@@ -81,29 +103,82 @@ describe("normalizeBareksaJson (primary clean JSON)", () => {
   test("deep search tolerates a nested/renamed container", () => {
     const drifted = {
       result: {
-        payload: { series: [{ tanggal: "2026-08-14", nilai: 1643.45 }] },
+        payload: { series: [{ tanggal: "2026-08-14", nilai: 1485.7881 }] },
       },
     }
     const series = normalizeBareksaJson(drifted)
-    expect(series?.points).toEqual([{ date: "2026-08-14", nav: 1643.45 }])
+    expect(series?.points).toEqual([{ date: "2026-08-14", nav: 1485.7881 }])
   })
 })
 
-describe("normalizeBareksaHtml (fallback __NEXT_DATA__ scraper)", () => {
-  test("extracts + parses the embedded Next.js data blob", () => {
-    const series = normalizeBareksaHtml(BAREKSA_PRODUCT_HTML_SAMPLE)
-    expect(series?.currency).toBe("IDR")
-    expect(series?.points.at(-1)).toEqual({ date: "2026-08-14", nav: 1643.45 })
+describe("token bootstrap parsers (product-page → ajax)", () => {
+  test("extractAjaxToken pulls the X-Ajax-Token out of the ajaxSetup script", () => {
+    expect(extractAjaxToken(BAREKSA_PRODUCT_HTML_SAMPLE)).toBe(
+      BAREKSA_TOKEN_SAMPLE
+    )
   })
 
-  test("HTML with no __NEXT_DATA__ / bad JSON returns null", () => {
+  test("extractAjaxToken returns null when no token is embedded", () => {
+    expect(extractAjaxToken(BAREKSA_HTML_NO_TOKEN_SAMPLE)).toBeNull()
+    expect(extractAjaxToken("")).toBeNull()
+    expect(extractAjaxToken(null)).toBeNull()
+  })
+
+  test("extractCookie returns the freshest ba_session from Set-Cookie", () => {
+    expect(extractCookie(BAREKSA_SET_COOKIE_SAMPLE)).toBe(
+      BAREKSA_SESSION_SAMPLE
+    )
+    expect(extractCookie(BAREKSA_SET_COOKIE_SAMPLE, "clang")).toBe("id")
+    expect(extractCookie("", "ba_session")).toBeNull()
+    expect(extractCookie(null)).toBeNull()
+    expect(extractCookie("other=1; path=/")).toBeNull()
+  })
+
+  test("toBareksaDate converts YYYY-MM-DD → DD-MM-YYYY", () => {
+    expect(toBareksaDate("2026-08-14")).toBe("14-08-2026")
+    expect(toBareksaDate("2026-08-14T09:30:00.000Z")).toBe("14-08-2026")
+    expect(toBareksaDate("not-a-date")).toBeNull()
+    expect(toBareksaDate(null)).toBeNull()
+  })
+})
+
+describe("normalizeBareksaHtml (fallback scrape of embedded NAV JSON)", () => {
+  test("salvages the embedded application/json NAV blob", () => {
+    const series = normalizeBareksaHtml(BAREKSA_PRODUCT_HTML_SAMPLE)
+    expect(series?.currency).toBe("IDR")
+    expect(series?.points.at(-1)).toEqual({
+      date: "2026-08-14",
+      nav: 1485.7881,
+    })
+  })
+
+  test("HTML with no embedded NAV / bad JSON returns null", () => {
+    expect(normalizeBareksaHtml(BAREKSA_HTML_NO_TOKEN_SAMPLE)).toBeNull()
     expect(normalizeBareksaHtml("<html><body>no data</body></html>")).toBeNull()
     expect(
-      normalizeBareksaHtml(
-        '<script id="__NEXT_DATA__" type="application/json">{bad</script>'
-      )
+      normalizeBareksaHtml('<script type="application/json">{bad</script>')
     ).toBeNull()
     expect(normalizeBareksaHtml(null)).toBeNull()
+  })
+})
+
+describe("normalizeStaleCache (the worker's OWN contract shape, from D1)", () => {
+  test("reads { currency, quotes, latest } back into a series", () => {
+    const series = normalizeStaleCache(STALE_CACHE_SAMPLE)
+    expect(series?.currency).toBe("IDR")
+    expect(series?.points.at(-1)).toEqual({
+      date: "2026-08-13",
+      nav: 1485.5894,
+    })
+    expect(series?.points.map((p) => p.date)).toEqual([
+      "2026-08-12",
+      "2026-08-13",
+    ])
+  })
+
+  test("a non-object / empty cache returns null", () => {
+    expect(normalizeStaleCache(null)).toBeNull()
+    expect(normalizeStaleCache({ currency: "IDR" })).toBeNull()
   })
 })
 
@@ -125,7 +200,7 @@ describe("resolveSeries (fallback ordering, ADR-0053 §1)", () => {
 
   test("primary fails → falls back to HTML scraper", () => {
     const res = resolveSeries([
-      { source: "bareksa_json", series: null, error: "HTTP 403" },
+      { source: "bareksa_json", series: null, error: "no ajax token" },
       { source: "bareksa_html", series: html },
       { source: "stale_cache", series: stale },
     ])
@@ -149,7 +224,7 @@ describe("resolveSeries (fallback ordering, ADR-0053 §1)", () => {
   test("every source fails → structured error (no throw)", () => {
     const attempts: SourceAttempt[] = [
       { source: "bareksa_json", series: null, error: "HTTP 403" },
-      { source: "bareksa_html", series: null, error: "no __NEXT_DATA__" },
+      { source: "bareksa_html", series: null, error: "no NAV in HTML" },
       { source: "stale_cache", series: null, error: "cache empty" },
     ]
     const res = resolveSeries(attempts)
@@ -184,12 +259,12 @@ describe("buildPayload (ADR-0053 §2 contract)", () => {
 
   test("latest mode: latest = freshest point + a short tail", () => {
     const payload = buildPayload(
-      "sucorinvest-money-market-fund",
+      "RD-MAJORIS-MMF",
       resolvedFrom(BAREKSA_HISTORY_JSON_SAMPLE, "bareksa_json"),
       { mode: "latest", tail: 3 }
     )
     expect(payload.currency).toBe("IDR")
-    expect(payload.latest).toEqual({ nav: 1643.45, asOf: "2026-08-14" })
+    expect(payload.latest).toEqual({ nav: 1485.7881, asOf: "2026-08-14" })
     expect(payload.quotes).toHaveLength(3)
     expect(payload.quotes.at(-1)?.date).toBe("2026-08-14")
     expect(payload.stale).toBeUndefined()
@@ -197,7 +272,7 @@ describe("buildPayload (ADR-0053 §2 contract)", () => {
 
   test("history mode: full series from `from` (inclusive)", () => {
     const payload = buildPayload(
-      "sucorinvest-money-market-fund",
+      "RD-MAJORIS-MMF",
       resolvedFrom(BAREKSA_HISTORY_JSON_SAMPLE, "bareksa_json"),
       { mode: "history", from: "2026-08-11" }
     )
@@ -213,12 +288,12 @@ describe("buildPayload (ADR-0053 §2 contract)", () => {
     const series = normalizeStaleCache(STALE_CACHE_SAMPLE)
     if (!series) throw new Error("stale fixture did not normalize")
     const payload = buildPayload(
-      "sucorinvest-money-market-fund",
+      "RD-MAJORIS-MMF",
       { status: "ok", source: "stale_cache", series, degradedFrom: [] },
       { mode: "latest" }
     )
     expect(payload.stale).toBe(true)
-    expect(payload.latest).toEqual({ nav: 1643.19, asOf: "2026-08-13" })
+    expect(payload.latest).toEqual({ nav: 1485.5894, asOf: "2026-08-13" })
   })
 })
 
@@ -230,9 +305,9 @@ describe("weekend / market-holiday invariant (ADR-0053 §3)", () => {
     expect(isWeekendDate("2026-08-17")).toBe(false) // Monday
   })
 
-  test("a weekend/flat payload is a NO-OP success: latest stays Friday's value", () => {
-    // Serving the same Friday-terminating series on Sat & Sun yields an identical
-    // `latest` both times — the store dedupes it; this is NOT an error.
+  test("a weekend payload is a NO-OP success: latest stays Friday's value", () => {
+    // Bareksa's nav[] is trading-days-only; re-serving the same Friday-terminating
+    // series on Sat & Sun yields an identical `latest` both times (NOT an error).
     const series = normalizeBareksaJson(WEEKEND_FLAT_JSON_SAMPLE)
     if (!series) throw new Error("weekend fixture did not normalize")
     const resolved: ResolvedSeries = {
@@ -243,14 +318,14 @@ describe("weekend / market-holiday invariant (ADR-0053 §3)", () => {
     }
     const saturday = buildPayload("fund", resolved, { mode: "latest" })
     const sunday = buildPayload("fund", resolved, { mode: "latest" })
-    expect(saturday.latest).toEqual({ nav: 1643.45, asOf: "2026-08-14" })
+    expect(saturday.latest).toEqual({ nav: 1485.7881, asOf: "2026-08-14" })
     expect(sunday.latest).toEqual(saturday.latest)
   })
 
   test("cleanSeries dedupes a repeated as-of (flat carry) to one point", () => {
     const points = cleanSeries([
-      { date: "2026-08-14", nav: 1643.45 },
-      { date: "2026-08-14", nav: 1643.45 },
+      { date: "2026-08-14", nav: 1485.7881 },
+      { date: "2026-08-14", nav: 1485.7881 },
     ])
     expect(points).toHaveLength(1)
   })

--- a/workers/reksadana-nav/src/normalize.ts
+++ b/workers/reksadana-nav/src/normalize.ts
@@ -5,29 +5,51 @@
  * This module is the FRAGILE part the ADR singles out for review + unit tests,
  * and it is deliberately factored to contain ZERO Cloudflare-runtime dependencies
  * (no `fetch`, no D1, no `Request`/`Response`). The worker entry (`index.ts`) is a
- * thin shell that does the IO (fetch each upstream, read/write D1) and hands the
- * raw bytes to the pure functions here; `vp test` unit-tests this module directly
- * against recorded fixtures with no live network.
+ * thin shell that does the IO (the two-step Bareksa token bootstrap, the ajax NAV
+ * fetch, read/write D1) and hands the raw bytes to the pure functions here;
+ * `vp test` unit-tests this module directly against recorded fixtures with no live
+ * network.
+ *
+ * THE REAL BAREKSA UPSTREAM (verified by live probe, ADR-0053 §Context/§1)
+ * -----------------------------------------------------------------------
+ * Bareksa's NAV lives behind an ajax endpoint gated by an anti-CSRF token +
+ * session cookie that are BOOTSTRAPPED from the product page:
+ *
+ *   1. GET https://www.bareksa.com/id/data/reksadana/<PID>/  (browser-like)
+ *        → 302 to the canonical product page; the response sets
+ *          `Set-Cookie: ba_session=…` (+ `clang=id`) and the HTML embeds, in an
+ *          inline `<script>`, `$.ajaxSetup({ headers: { "X-Ajax-Token": '…' } })`.
+ *   2. GET https://www.bareksa.com/ajax/mutualfund/nav/product1/?id=<PID>&…
+ *        with `x-ajax-token`, `x-requested-with: XMLHttpRequest`,
+ *        `cookie: ba_session=…; clang=id`, and a `referer` of the product page.
+ *        → CLEAN JSON (no AES), the `{ status, data: { unitY, datas:[{pid,pname,
+ *          nav:[{date,value}] }] } }` envelope `normalizeBareksaJson` parses.
  *
  * Responsibilities:
  *   1. Per-source NORMALIZERS — turn each upstream's raw shape into the internal
  *      `NormalizedSeries` (`{ currency, points: [{date, nav}] }`):
- *        - `normalizeBareksaJson`  — Bareksa/Pasardana clean JSON (primary).
- *        - `normalizeBareksaHtml`  — the product page's embedded `__NEXT_DATA__`
- *          JSON (fallback scraper; Bareksa is a Next.js app).
- *        - `normalizeStaleCache`   — a previously-served payload from D1 (LKGP).
+ *        - `normalizeBareksaJson`  — the real Bareksa ajax NAV envelope (primary).
+ *        - `normalizeBareksaHtml`  — a best-effort scrape of any NAV JSON embedded
+ *          in the product-page HTML (fallback when the token bootstrap fails).
+ *        - `normalizeStaleCache`   — a previously-served payload from D1 (LKGP);
+ *          this is the worker's OWN `{ currency, quotes, latest }` contract shape.
  *      Each is SHAPE-TOLERANT (probes known keys, then a bounded deep search) so a
  *      minor upstream drift degrades to the next source rather than crashing.
- *   2. FALLBACK ORDERING — `resolveSeries` tries attempts in priority order and
+ *   2. TOKEN BOOTSTRAP PARSERS — `extractAjaxToken` (pull the `X-Ajax-Token` out of
+ *      the product-page HTML) and `extractCookie` (pull `ba_session` out of a
+ *      `Set-Cookie` header). Pure string parsing, unit-tested against a fixture.
+ *   3. FALLBACK ORDERING — `resolveSeries` tries attempts in priority order and
  *      returns the FIRST that yields a usable series, recording the degradation.
- *   3. The ADR-0053 §2 target CONTRACT — `buildPayload` emits
+ *   4. The ADR-0053 §2 target CONTRACT — `buildPayload` emits
  *      `{ fundCode, currency, latest, quotes, stale }` for both `/nav` (latest)
  *      and `/nav/history` (backfill) modes.
  *
  * WEEKEND / MARKET-HOLIDAY INVARIANT (ADR-0053 §3): KSEI/IDX publish no new NAV on
- * Sat–Sun/holidays; the freshest quote simply carries Friday's value. Nothing here
- * treats a flat/repeated (or absent-today) NAV as an error — `latest` is always
- * the freshest AVAILABLE point, and a weekend backfill simply lacks Sat/Sun rows.
+ * Sat–Sun/holidays; Bareksa's `nav[]` is TRADING-DAYS-ONLY (weekend/holiday rows
+ * are simply absent), so on a weekend the LAST element already carries Friday's
+ * value — the invariant holds by construction, no flat-fill. Nothing here treats a
+ * flat/repeated (or absent-today) NAV as an error — `latest` is always the freshest
+ * AVAILABLE point.
  */
 
 /** The upstream sources, in the ADR-0053 §1 priority order. */
@@ -104,8 +126,8 @@ const DATE_KEYS = [
   "x",
 ] as const
 const NAV_KEYS = [
-  "nav",
   "value",
+  "nav",
   "navPerUnit",
   "nav_per_unit",
   "price",
@@ -154,7 +176,7 @@ function arrayToPoints(value: unknown): NavPoint[] | null {
  * `depth` caps the walk so a pathological payload can never spin.
  */
 function deepFindLongestSeries(node: unknown, depth = 0): NavPoint[] | null {
-  if (depth > 6 || node === null || typeof node !== "object") return null
+  if (depth > 8 || node === null || typeof node !== "object") return null
   const direct = arrayToPoints(node)
   if (direct) return direct
   let best: NavPoint[] | null = null
@@ -169,7 +191,7 @@ function deepFindLongestSeries(node: unknown, depth = 0): NavPoint[] | null {
 /** Find a currency string anywhere shallow in the object, else the default. */
 function findCurrency(node: unknown, depth = 0): string {
   if (depth > 4 || !isRecord(node)) return DEFAULT_CURRENCY
-  for (const key of ["currency", "ccy", "curr"]) {
+  for (const key of ["unitY", "currency", "ccy", "curr"]) {
     const value = node[key]
     if (typeof value === "string" && /^[A-Za-z]{3}$/.test(value.trim())) {
       return value.trim().toUpperCase()
@@ -192,91 +214,194 @@ export function cleanSeries(points: readonly NavPoint[]): NavPoint[] {
 }
 
 /**
- * Normalize a Bareksa/Pasardana clean-JSON payload into a series. Handles the
- * documented shapes (a `data.nav` latest + `data.nav_history` array; a top-level
- * or `data` array of rows; a single `nav` object) and falls back to a bounded
- * deep search. Returns null when nothing NAV-shaped is found (→ try next source).
+ * Normalize the REAL Bareksa ajax NAV envelope into a series (ADR-0053 §1). The
+ * verified shape is:
+ *
+ *   { status: true,
+ *     data: { auth: true, unitY: "IDR",
+ *             datas: [ { pid: "3035", pname: "…",
+ *                        nav: [ { id, date: "YYYY-MM-DD", value: "1485.7881" } ] } ] } }
+ *
+ * `status: false` (or `data.auth: false`) is a FAILED attempt (unauthenticated /
+ * token rejected) → returns null so the chain falls through to the HTML scrape,
+ * then D1 LKGP. When the strict `data.datas[0].nav` path is absent (a minor
+ * upstream drift) a bounded deep search still salvages the longest NAV array.
+ * Returns null when nothing NAV-shaped is found.
  */
 export function normalizeBareksaJson(raw: unknown): NormalizedSeries | null {
-  if (!isRecord(raw) && !Array.isArray(raw)) return null
+  if (!isRecord(raw)) return null
 
-  const collected: NavPoint[] = []
+  // A failed ajax attempt must fall through, never be deep-searched for a hit.
+  if (raw.status === false) return null
+  const data = isRecord(raw.data) ? raw.data : null
+  if (data && data.auth === false) return null
 
-  // Known array containers first (cheap, precise).
-  const containers: unknown[] = []
-  if (isRecord(raw)) {
-    containers.push(
-      raw.nav_history,
-      raw.navHistory,
-      raw.history,
-      raw.quotes,
-      raw.data,
-      isRecord(raw.data) ? raw.data.nav_history : undefined,
-      isRecord(raw.data) ? raw.data.navHistory : undefined,
-      isRecord(raw.data) ? raw.data.history : undefined,
-      isRecord(raw.data) ? raw.data.data : undefined
-    )
-  } else {
-    containers.push(raw)
-  }
-  for (const container of containers) {
-    const points = arrayToPoints(container)
-    if (points) collected.push(...points)
-  }
+  let currency = DEFAULT_CURRENCY
+  let points: NavPoint[] | null = null
 
-  // A single "latest" nav object (`{nav|data.nav: {date,value}}`).
-  if (isRecord(raw)) {
-    for (const candidate of [
-      raw.nav,
-      raw.latest,
-      isRecord(raw.data) ? raw.data.nav : undefined,
-      isRecord(raw.data) ? raw.data.latest : undefined,
-    ]) {
-      if (isRecord(candidate)) {
-        const point = pointFromRow(candidate)
-        if (point) collected.push(point)
-      }
+  if (data) {
+    if (
+      typeof data.unitY === "string" &&
+      /^[A-Za-z]{3}$/.test(data.unitY.trim())
+    ) {
+      currency = data.unitY.trim().toUpperCase()
+    }
+    const datas = data.datas
+    if (Array.isArray(datas) && datas.length > 0 && isRecord(datas[0])) {
+      points = arrayToPoints(datas[0].nav)
     }
   }
 
-  // Last-resort deep search when the known keys found nothing.
+  // Tolerance: a nested / renamed container still normalizes via deep search.
+  if (!points) {
+    points = deepFindLongestSeries(raw)
+    if (points && currency === DEFAULT_CURRENCY) currency = findCurrency(raw)
+  }
+
+  if (!points || points.length === 0) return null
+  return { currency, points: cleanSeries(points) }
+}
+
+/**
+ * Fallback scraper: when the token bootstrap fails, salvage any NAV JSON embedded
+ * in the product-page HTML. Bareksa loads its chart via ajax, so this is a
+ * best-effort net (it returns null on a page with no inline series) — the real
+ * safety after it is the D1 LKGP. Scans embedded JSON blobs (a `<script
+ * type="application/json">` payload or a legacy `__NEXT_DATA__` blob) and reuses
+ * the JSON normalizer's deep search. Returns null when no parseable NAV is found.
+ */
+export function normalizeBareksaHtml(html: unknown): NormalizedSeries | null {
+  if (typeof html !== "string" || html.length === 0) return null
+  for (const blob of embeddedJsonBlobs(html)) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(blob)
+    } catch {
+      continue
+    }
+    const series = normalizeBareksaJson(parsed)
+    if (series) return series
+    // The blob may not be the ajax envelope (no `datas`); deep-search it directly.
+    const points = deepFindLongestSeries(parsed)
+    if (points && points.length > 0) {
+      return { currency: findCurrency(parsed), points: cleanSeries(points) }
+    }
+  }
+  return null
+}
+
+/** All `<script>`-embedded JSON blobs worth probing for NAV data. */
+function embeddedJsonBlobs(html: string): string[] {
+  const blobs: string[] = []
+  const scriptRe =
+    /<script[^>]*type=["']application\/json["'][^>]*>([\s\S]*?)<\/script>/gi
+  let match: RegExpExecArray | null
+  while ((match = scriptRe.exec(html)) !== null) {
+    if (match[1]) blobs.push(match[1].trim())
+  }
+  const nextData = html.match(
+    /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i
+  )
+  if (nextData?.[1]) blobs.push(nextData[1].trim())
+  return blobs
+}
+
+/**
+ * Normalize a payload previously served by THIS worker and cached in D1 (LKGP).
+ * The cached value is the worker's OWN ADR-0053 §2 contract (`{ currency,
+ * quotes:[{date,nav}], latest:{nav,asOf} }`), NOT a raw Bareksa envelope — so this
+ * reads that shape directly (with a bounded deep-search tolerance). Returns null
+ * when no usable point survives.
+ */
+export function normalizeStaleCache(raw: unknown): NormalizedSeries | null {
+  if (!isRecord(raw)) return null
+
+  let currency = DEFAULT_CURRENCY
+  if (
+    typeof raw.currency === "string" &&
+    /^[A-Za-z]{3}$/.test(raw.currency.trim())
+  ) {
+    currency = raw.currency.trim().toUpperCase()
+  }
+
+  const collected: NavPoint[] = []
+  const quotes = arrayToPoints(raw.quotes)
+  if (quotes) collected.push(...quotes)
+  if (isRecord(raw.latest)) {
+    const latest = pointFromRow(raw.latest)
+    if (latest) collected.push(latest)
+  }
+
+  // Tolerance: a differently-shaped cached blob still salvages via deep search.
   if (collected.length === 0) {
     const deep = deepFindLongestSeries(raw)
     if (deep) collected.push(...deep)
   }
 
   if (collected.length === 0) return null
-  return { currency: findCurrency(raw), points: cleanSeries(collected) }
+  if (currency === DEFAULT_CURRENCY) currency = findCurrency(raw)
+  return { currency, points: cleanSeries(collected) }
 }
 
+// =============================================================================
+// Token bootstrap parsers (pure) — the fragile string extraction the shell needs
+// =============================================================================
+
 /**
- * Fallback scraper: Bareksa's product page is a Next.js app that embeds its server
- * props (including NAV) in a `<script id="__NEXT_DATA__" type="application/json">`
- * blob. Extract + JSON.parse it, then reuse the JSON normalizer's deep search.
- * Returns null when no parseable NAV data is present.
+ * Extract the anti-CSRF `X-Ajax-Token` from the Bareksa product-page HTML. The
+ * verified embedding is an inline script:
+ *
+ *   $.ajaxSetup({ headers: { "X-Ajax-Token": '<token>' } });
+ *
+ * We probe that exact shape first, then a couple of tolerant fallbacks (a bare
+ * `x-ajax-token` / `ajaxToken` assignment, a `<meta>` tag) so a minor markup drift
+ * still bootstraps. Returns null when no token is present (→ the shell falls
+ * through to the HTML scrape, then D1 LKGP).
  */
-export function normalizeBareksaHtml(html: unknown): NormalizedSeries | null {
+export function extractAjaxToken(html: unknown): string | null {
   if (typeof html !== "string" || html.length === 0) return null
-  const match = html.match(
-    /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i
-  )
-  if (!match || match[1] === undefined) return null
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(match[1])
-  } catch {
-    return null
+  const patterns: RegExp[] = [
+    /["']X-Ajax-Token["']\s*:\s*["']([^"']+)["']/i,
+    /["']?x[-_]ajax[-_]token["']?\s*[:=]\s*["']([^"']+)["']/i,
+    /ajaxToken\s*[:=]\s*["']([^"']+)["']/i,
+    /<meta[^>]+name=["']x?[-_]?ajax[-_]token["'][^>]+content=["']([^"']+)["']/i,
+  ]
+  for (const re of patterns) {
+    const match = html.match(re)
+    if (match?.[1] && match[1].trim().length > 0) return match[1].trim()
   }
-  return normalizeBareksaJson(parsed)
+  return null
 }
 
 /**
- * Normalize a payload previously served by THIS worker and cached in D1 (LKGP).
- * It is already in (or close to) the ADR-0053 §2 contract, so this accepts the
- * `{ currency, quotes|latest }` shape as well as the generic normalizer's shapes.
+ * Extract a named cookie value (default `ba_session`) from a `Set-Cookie` header
+ * string. Cloudflare's `Headers.getSetCookie()` yields multiple values; join them
+ * with newlines (or commas) before calling this. Returns the LAST occurrence (the
+ * freshest issued value) or null.
  */
-export function normalizeStaleCache(raw: unknown): NormalizedSeries | null {
-  return normalizeBareksaJson(raw)
+export function extractCookie(
+  setCookie: string | null | undefined,
+  name = "ba_session"
+): string | null {
+  if (typeof setCookie !== "string" || setCookie.length === 0) return null
+  const re = new RegExp(`(?:^|[,;\\n]\\s*)${name}=([^;,\\s]+)`, "gi")
+  let value: string | null = null
+  let match: RegExpExecArray | null
+  while ((match = re.exec(setCookie)) !== null) {
+    if (match[1] && match[1].length > 0) value = match[1]
+  }
+  return value
+}
+
+/**
+ * Convert a `YYYY-MM-DD` (or ISO) date into the `DD-MM-YYYY` form Bareksa's ajax
+ * `startdate`/`enddate` params expect. Returns null on an unparseable input.
+ */
+export function toBareksaDate(value: unknown): string | null {
+  const iso = normalizeDate(value)
+  if (iso === null) return null
+  const [year, month, day] = iso.split("-")
+  return `${day}-${month}-${year}`
 }
 
 /** One source attempt handed to `resolveSeries`, in priority order. */

--- a/workers/reksadana-nav/wrangler.jsonc
+++ b/workers/reksadana-nav/wrangler.jsonc
@@ -19,10 +19,13 @@
       "database_id": "REPLACE_WITH_D1_DATABASE_ID",
     },
   ],
-  // Optional upstream overrides (defaults target Bareksa; confirm on deploy).
-  // `{fund}` is substituted with the URL-encoded fund code.
+  // Optional upstream overrides (defaults target the VERIFIED Bareksa endpoints;
+  // PER-258). `{fund}` is substituted with the URL-encoded fund code, which is the
+  // Bareksa numeric product id (pid). BAREKSA_PRODUCT_URL is the product page the
+  // token/cookie bootstrap reads; BAREKSA_AJAX_BASE is the ajax NAV endpoint base
+  // (the worker builds the query: id, cperiod, startdate/enddate, requested_page).
   "vars": {
-    // "BAREKSA_JSON_URL": "https://api.bareksa.com/v22/products/mutualfund/{fund}/nav",
-    // "BAREKSA_HTML_URL": "https://www.bareksa.com/reksadana/{fund}"
+    // "BAREKSA_PRODUCT_URL": "https://www.bareksa.com/id/data/reksadana/{fund}/",
+    // "BAREKSA_AJAX_BASE": "https://www.bareksa.com/ajax/mutualfund/nav/product1/"
   },
 }


### PR DESCRIPTION
## What
The Slice B scaffold (PR #240) was built against a *guessed* upstream shape. The creator captured the **real** working endpoint, so this reconciles the worker to reality.

- **Real source**: `GET https://www.bareksa.com/ajax/mutualfund/nav/product1/?id=<pid>&cperiod=…` → clean JSON (no AES), envelope `{status,data:{unitY,datas:[{pid,pname,nav:[{date,value}]}]}}`. Latest = last `nav[]` point; the array is **trading-days-only** (weekend invariant holds by construction).
- **Auth**: gated by `x-ajax-token` + `ba_session`, both **bootstrapped from the product page** — the worker now does a two-step fetch (product page → token+cookie → ajax). Fragile/ToS-gray logic, isolated in the worker.
- **Bibit dropped**: exposes no per-fund NAV JSON (`/related` = related products only).
- Fallback chain unchanged: Bareksa ajax JSON → Bareksa HTML scrape → D1 stale/LKGP.

## Changed
Worker `normalize.ts` (real envelope parser + token/cookie extractors), `index.ts` (two-step bootstrap), `fixtures.ts` (**real** captured values: pid 3035 Majoris MMF, 2026-08-14 → 1485.7881), tests, `wrangler.jsonc`, README, and **ADR-0053** corrected (endpoint is token-gated, not unauthenticated). The **worker→app payload contract is unchanged**.

## Tests
`vp check` ✅ · `vp build` ✅ (server/client fence) · 79 unit ✅ · **473 real-PG integration ✅** (incl. reksadana-nav-feed + financial-ingestion, no regression). No live network in tests.

## Still manual (PER-258 go-live)
Deploy the worker to the creator's CF account (`wrangler deploy` + D1 per `workers/reksadana-nav/README.md`) and set `REKSADANA_API_URL`; then link the real Bibit/Bareksa funds. Inert until configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
