### PR TITLE
fix(reksadana-nav): live history backfill (cperiod=1y) + bind deployed D1 cache

### DIFF
--- a/workers/reksadana-nav/package.json
+++ b/workers/reksadana-nav/package.json
@@ -13,5 +13,12 @@
     "@cloudflare/workers-types": "^4.20240815.0",
     "typescript": "^5.6.0",
     "wrangler": "^3.114.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11.22.0",
+      "onFail": "download"
+    }
   }
 }

--- a/workers/reksadana-nav/src/index.ts
+++ b/workers/reksadana-nav/src/index.ts
@@ -44,7 +44,6 @@ import {
   normalizeBareksaJson,
   normalizeStaleCache,
   resolveSeries,
-  toBareksaDate,
   type NavPayload,
   type NormalizedSeries,
   type SourceAttempt,
@@ -133,25 +132,28 @@ async function fetchProductPage(env: Env, fund: string): Promise<ProductPage> {
   }
 }
 
-/** Build the ajax NAV URL for a mode (`1m` window for latest; a dated range). */
+/**
+ * Build the ajax NAV URL for a mode (`1m` window for latest; `5y` for history).
+ *
+ * Use a `cperiod` PRESET with empty startdate/enddate — the exact shape the live
+ * capture proved works. `buildPayload` filters history to `from` client-side, so
+ * the upstream only needs to return enough trailing history; it does not need the
+ * date range. (An earlier `cperiod=all` + startdate/enddate made Bareksa reject
+ * the request, degrading `/nav/history` to the stale cache.)
+ */
 function buildAjaxUrl(
   base: string,
   fund: string,
-  mode: "latest" | "history",
-  from: string | undefined
+  mode: "latest" | "history"
 ): string {
   const params = new URLSearchParams()
   params.set("id", fund)
   params.set("requested_page", "profile.graph")
-  if (mode === "history") {
-    params.set("cperiod", "all")
-    const start = from ? toBareksaDate(from) : null
-    if (start) params.set("startdate", start)
-    const end = toBareksaDate(new Date().toISOString().slice(0, 10))
-    if (end) params.set("enddate", end)
-  } else {
-    params.set("cperiod", "1m")
-  }
+  // `1y` is the exact window the live capture proved works for an anonymous
+  // session; longer windows (`5y`/`all`) appear gated behind a Bareksa login and
+  // fail for the anonymous bootstrap, degrading history to the stale cache. One
+  // year is ample for a holding's NAV-value backfill (cost basis is user-entered).
+  params.set("cperiod", mode === "history" ? "1y" : "1m")
   return `${base}?${params.toString()}`
 }
 
@@ -165,14 +167,13 @@ async function fetchBareksaJson(
   env: Env,
   fund: string,
   page: ProductPage,
-  mode: "latest" | "history",
-  from: string | undefined
+  mode: "latest" | "history"
 ): Promise<{ series: NormalizedSeries | null; error?: string }> {
   if (!page.token || !page.cookie) {
     return { series: null, error: page.error ?? "ajax token bootstrap failed" }
   }
   const base = env.BAREKSA_AJAX_BASE ?? DEFAULT_AJAX_BASE
-  const url = buildAjaxUrl(base, fund, mode, from)
+  const url = buildAjaxUrl(base, fund, mode)
   const referer = fillTemplate(
     env.BAREKSA_PRODUCT_URL ?? DEFAULT_PRODUCT_URL,
     fund
@@ -254,7 +255,7 @@ async function handleNav(
   // scrape fallback (no double fetch).
   const page = await fetchProductPage(env, fund)
   const [json_, stale] = await Promise.all([
-    fetchBareksaJson(env, fund, page, mode, from),
+    fetchBareksaJson(env, fund, page, mode),
     readStaleCache(env, fund),
   ])
   const html: { series: NormalizedSeries | null; error?: string } = {

--- a/workers/reksadana-nav/wrangler.jsonc
+++ b/workers/reksadana-nav/wrangler.jsonc
@@ -16,7 +16,7 @@
     {
       "binding": "NAV_CACHE",
       "database_name": "reksadana-nav-cache",
-      "database_id": "REPLACE_WITH_D1_DATABASE_ID",
+      "database_id": "49744818-bb82-4c4f-aa0c-38f8c3253622",
     },
   ],
   // Optional upstream overrides (defaults target the VERIFIED Bareksa endpoints;


### PR DESCRIPTION
Follow-up to PR #241, after deploying the worker to the creator's CF account and validating live.

## What
- **History backfill now works live.** `/nav/history` degraded to the stale D1 cache because `cperiod=all` + startdate/enddate was rejected by Bareksa (longer windows appear login-gated for an anonymous session). Switched to the **capture-proven `cperiod=1y`** with empty dates; `buildPayload` already filters to `?from=` client-side. **Verified live on the deployed worker**: `/nav/history?fund=3035&from=2026-06-01` → 53 real quotes, `stale:false`. `/nav` latest unchanged (live).
- **Bind the deployed D1 cache id** (`reksadana-nav-cache`) so redeploys are reproducible.

## Tests
Worker unit 25 ✅. App untouched (worker is an isolated package). Live-verified against the deployed worker at reksadana-nav.hendripermana13.workers.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)