### PR TITLE
fix(holdings): account Performance uses holdings cost basis (fixes conflicting gain figures)

### DIFF
--- a/src/lib/account-performance.test.ts
+++ b/src/lib/account-performance.test.ts
@@ -98,4 +98,28 @@ describe("computeAccountPerformance", () => {
     expect(p.hasBasis).toBe(false)
     expect(p.returnPct).toBeNull()
   })
+
+  test("holdings cost basis OVERRIDES the ledger heuristic when passed", () => {
+    // The ledger heuristic would give cost = opening 207,792 (+ no contributions),
+    // but the account tracks a holding whose real position cost is 209,210.64.
+    // The holdings basis wins, so the header matches the per-holding Performance.
+    // (Real Majoris case: 142.4345 units, value 211,627.76, +1.16%.)
+    const p = computeAccountPerformance(
+      [],
+      20_779_200n, // ledger opening = pre-holdings balance anchor (would mislead)
+      21_162_776n, // current market value (units × NAV)
+      ACC,
+      20_921_064n // Σ holdings cost — authoritative
+    )
+    expect(p.costBasisMinor).toBe(20_921_064n)
+    expect(p.gainMinor).toBe(241_712n)
+    expect(p.hasBasis).toBe(true)
+    expect(p.returnPct).toBeCloseTo(0.0116, 4)
+  })
+
+  test("null holdings basis falls back to the ledger heuristic (no holdings)", () => {
+    const p = computeAccountPerformance([], 20_000_000n, 25_000_000n, ACC, null)
+    expect(p.costBasisMinor).toBe(20_000_000n)
+    expect(p.gainMinor).toBe(5_000_000n)
+  })
 })

--- a/src/lib/account-performance.ts
+++ b/src/lib/account-performance.ts
@@ -42,13 +42,23 @@ export function computeAccountPerformance(
   txns: ReadonlyArray<AnalyticsTxn>,
   openingValueMinor: bigint,
   currentValueMinor: bigint,
-  accountId: string
+  accountId: string,
+  // When the account tracks explicit holdings (PER-232), the summed position
+  // cost (Σ units × avg cost) is the AUTHORITATIVE basis — it matches the
+  // per-holding Performance and the broker/fund app. Pass it here to OVERRIDE the
+  // ledger-contribution heuristic below, which only estimates net deposits and
+  // legitimately drifts from real lot cost (e.g. a pre-holdings balance anchor).
+  // Pass null (no holdings) to fall back to opening + net contributions (v1).
+  holdingsCostBasisMinor?: bigint | null
 ): AccountPerformance {
   const contributions = txns.reduce(
     (sum, t) => sum + signedDeltaForAccount(t, accountId),
     0n
   )
-  const costBasis = openingValueMinor + contributions
+  const costBasis =
+    holdingsCostBasisMinor != null
+      ? holdingsCostBasisMinor
+      : openingValueMinor + contributions
   const gain = currentValueMinor - costBasis
   const hasBasis = costBasis > 0n
   const returnPct = hasBasis ? Number(gain) / Number(costBasis) : null

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -361,13 +361,22 @@ function AccountDetailPage() {
   // value → unrealized gain/loss + return %. Reuses the proven ledger lens.
   const performance = React.useMemo(() => {
     if (!tracked || !openingData) return null
+    // When this account tracks holdings, their summed position cost is the
+    // authoritative basis (matches the per-holding Performance + the fund app),
+    // so it overrides the ledger-contribution heuristic — otherwise the account
+    // header and the holdings panel show two conflicting gain figures.
+    const holdingsCostBasis =
+      holdingsView && holdingsView.holdings.length > 0
+        ? BigInt(holdingsView.totalCostMinor)
+        : null
     return computeAccountPerformance(
       ledger,
       openingData.openingValue ? BigInt(openingData.openingValue) : 0n,
       currentBalance,
-      accountId
+      accountId,
+      holdingsCostBasis
     )
-  }, [tracked, openingData, ledger, currentBalance, accountId])
+  }, [tracked, openingData, ledger, currentBalance, accountId, holdingsView])
 
   // Time-scoped subset (range drives KPI + breakdown + statement).
   const rangedLedger = React.useMemo(() => {


### PR DESCRIPTION
Surfaced during the creator's live reksadana link-test on prod.

## Problem
The account **Performance header** and the **holdings panel** showed **two different gain figures** for the same position — the header derived cost from the ledger heuristic (opening valuation + net contributions = Rp 207,792 → +1.85%), while the holding used the real position cost (Σ units × avg cost = Rp 209,210.64 → +1.16%, matching the Bibit app).

## Fix
When an account tracks holdings, their **summed cost is authoritative** and overrides the ledger heuristic (`computeAccountPerformance` gets an optional `holdingsCostBasisMinor`). Header, holdings panel, and the fund app now agree. Falls back to opening + contributions for valuation accounts with **no** holdings (PER-229 v1 unchanged).

Pure lib change + account-page wiring + 2 unit tests. `vp check` + 9 unit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)