### PR TITLE
fix(holdings): panel-level Sell + ADR-0054 (holdings-account operational coherence)

### DIFF
--- a/docs/adr/0054-holdings-account-operational-coherence.md
+++ b/docs/adr/0054-holdings-account-operational-coherence.md
@@ -1,0 +1,116 @@
+# ADR-0054 — Holdings-account operational coherence (money movement for investment accounts)
+
+|              |                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------- |
+| **Status**   | Accepted                                                                           |
+| **Date**     | 2026-08-16                                                                         |
+| **Deciders** | Hendri Permana                                                                     |
+| **Amends**   | ADR-0043 (valuations), ADR-0048 (valuation-linked cash moves), ADR-0051 (holdings) |
+
+## Context
+
+Reksadana NAV auto-pricing is now live (PER-250/257/258), so real holdings-tracked
+investment accounts exist and get used. Dogfooding surfaced that **money movement
+for a holdings account is not operationally coherent** — there are several
+entry points that do different, partly-conflicting things:
+
+- **Buy/Sell trades** (`recordTradeFn`, PER-198/ADR-0051) — the correct path:
+  cash leg on a funding (cash-like) account + units±quantity + cost basis + a new
+  valuation on the investment side (never a raw balance write — respects the
+  guard) + realized gain on sell. Atomic, audited, idempotent.
+- **Valuation-linked transfer** (ADR-0048) — cash leg + a new **valuation**
+  (value moves, **no units**). Correct for a valuation account that has **no
+  holdings** (property, a manually-valued asset).
+- **Plain transfer / "Add transaction"** — a classic dual-leg transfer. On a
+  valuation account this is BLOCKED by the guard (`assertIncrementalBalanceWriteAllowed`
+  - the `valuation_account_balance_write_safe` constraint trigger, ADR-0048 §3).
+- **"Update value"** — a manual valuation on the tracked account.
+
+The defect: on a **holdings** account, the valuation-linked-transfer and
+"Update value" paths set a **value** without changing **units**, so units × NAV
+(the real position) desyncs from the stored value. And Sell was only reachable
+per-holding-row, so the account header showed Buy but no Sell. The system was not
+"operationally ready" for the way an investor actually transacts.
+
+## Decision
+
+**A holdings-tracked account moves money ONLY through trades.** For an account
+that carries holdings, every money movement is a trade on the `recordTradeFn`
+family; the plain-transfer, valuation-linked-transfer, and manual "Update value"
+paths are not offered and are rejected server-side. Value on a holdings account
+is always Σ(units × price) — never set directly.
+
+Precisely, keyed on the account's state:
+
+| Account state                                          | Money-in / money-out mechanism                         |
+| ------------------------------------------------------ | ------------------------------------------------------ |
+| **cash-like** (`transaction_flow`)                     | normal transactions / transfers (unchanged)            |
+| **valuation, NO holdings** (property, manual asset)    | valuation-linked transfer (ADR-0048) + "Update value"  |
+| **valuation, WITH holdings** (reksadana, gold, stocks) | **trades only** — Buy / Sell / Dividend / Fee / Switch |
+
+### The cascade — "if we do this, we also need…"
+
+Making trades the sole path for holdings accounts implies a set of trade modes +
+guards that must ALL exist for the model to be coherent (not just Buy/Sell):
+
+1. **Sell must be first-class** — panel-level (not only per-row), a position
+   picker when unspecified, guard sell-qty ≤ held, sell-all closes/archives the
+   position, realized gain shown. _(Slice 1 — panel Sell shipped.)_
+2. **Buy must cover first + subsequent** — create the instrument inline on the
+   first buy; average-cost into an existing position on later buys. _(Exists.)_
+3. **Dividend / distribution** — income with **no units bought** (cash to the
+   funding account) OR **reinvested** (units up, no external cash). A distinct
+   trade mode; without it users mis-record income as a Buy or a plain transfer.
+4. **Fees** — purchase / redemption / management fees reduce cash or NAV value;
+   a fee that isn't modeled gets mis-booked as a mystery value drop.
+5. **Switch** (fund A → fund B) — an atomic sell-A + buy-B in one account, the
+   single most common reksadana action after buy/sell; without it users do two
+   trades that can half-fail.
+6. **Server + DB invariant** — reject a plain transfer / valuation-linked move /
+   manual value-set whose leg is a **holdings** account, fail-loud with "use
+   Buy/Sell" (the guard already blocks raw balance writes; this extends it to the
+   value-set paths and gives an actionable message). UI hides the paths;
+   **the server is the law** (single + bulk + import + future bank-sync).
+7. **Entry-point coherence (UI)** — on a holdings account the primary actions are
+   Buy/Sell (+ Dividend/Fee/Switch); "Add transaction" transfer and "Update
+   value" are removed or redirected so a user can't silently desync the position.
+8. **Edit / delete / correct a trade** — a mis-entered Buy/Sell must be
+   correctable (reverse + re-record, audited) — today edit of a valuation-linked
+   transfer is unsupported (ADR-0048 known limitation); trades need coherent
+   edit/delete too.
+9. **Funding-account selection** — every trade names the cash account the money
+   comes from / returns to; multi-account families need it explicit.
+10. **Multi-currency trade** — buying a USD fund from IDR cash needs FX; deferred
+    to the global-instruments slice (Slice C of ADR-0052) but the trade schema
+    must not assume same-currency forever.
+11. **Legacy rows** — plain transfers / manual income that predate holdings on an
+    account (e.g. the creator's Dana Darurat) are **grandfathered as history**; a
+    "holdings baseline" marks where holdings tracking begins. No destructive
+    migration (creator's call).
+12. **Precision + idempotency** — fractional units (scaled bigint) and an
+    idempotency key on every trade (retry-safe), same contract as the ledger.
+
+### Non-goals (this ADR)
+
+Options pricing, dividends tax lots, corporate actions (splits/mergers), and
+FIFO-vs-average election beyond the current average-cost model — later.
+
+## Consequences
+
+- One coherent mental model: _on a holdings account, you trade; value follows
+  units × price automatically._ No conflicting entry points, no desync.
+- More trade modes to build (dividend/fee/switch) — but each closes a real hole
+  a user would otherwise hit.
+- The guard + UI removal must land together with the modes, else a holdings
+  account temporarily can't record a legitimate movement (sequence carefully).
+
+## Implementation slices (Linear epic)
+
+- **Slice 1 — discoverability + entry-point coherence**: panel Sell (done);
+  hide/redirect "Add transaction" transfer + "Update value" on holdings accounts;
+  server + DB invariant with an actionable "use Buy/Sell" message; real-PG + e2e.
+- **Slice 2 — Dividend / distribution** trade mode (cash-out or reinvest).
+- **Slice 3 — Fees** (purchase / redemption / management).
+- **Slice 4 — Switch** (atomic sell-A + buy-B).
+- **Slice 5 — Edit/correct a trade** (reverse + re-record, audited).
+- Cross-cutting: multi-currency trade + FX rides ADR-0052 Slice C/D.

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -86,6 +86,7 @@ export function HoldingsPanel({
   onEdit,
   onDelete,
   onBuy,
+  onSell,
   onBuyHolding,
   onSellHolding,
   onRefreshPrices,
@@ -98,6 +99,7 @@ export function HoldingsPanel({
   onEdit: (holding: HoldingRecord) => void
   onDelete: (holding: HoldingRecord) => void
   onBuy: () => void
+  onSell: () => void
   onBuyHolding: (holding: HoldingRecord) => void
   onSellHolding: (holding: HoldingRecord) => void
   onRefreshPrices: () => void
@@ -135,6 +137,12 @@ export function HoldingsPanel({
             <ArrowDownLeft className="size-4" />
             Buy
           </Button>
+          {holdings.length > 0 ? (
+            <Button size="sm" variant="outline" onClick={onSell}>
+              <ArrowUpRight className="size-4" />
+              Sell
+            </Button>
+          ) : null}
           <Button size="sm" variant="outline" onClick={onAdd}>
             <Plus className="size-4" />
             Add holding

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -691,6 +691,7 @@ function AccountDetailPage() {
               onEdit={(holding) => setHoldingDialog({ mode: "edit", holding })}
               onDelete={handleDeleteHolding}
               onBuy={() => setTradeDialog({ side: "buy" })}
+              onSell={() => setTradeDialog({ side: "sell" })}
               onBuyHolding={(holding) =>
                 setTradeDialog({ side: "buy", holding })
               }


### PR DESCRIPTION
First slice of the holdings-account money-movement coherence work (surfaced dogfooding the live reksadana).

- **Panel-level Sell** button (symmetric with Buy; shown when positions exist; opens the trade dialog with a position picker). Sell was only per-row → not discoverable.
- **ADR-0054** — the design: a holdings-tracked account moves money ONLY via trades (Buy/Sell/Dividend/Fee/Switch); valuation-linked transfer (ADR-0048) stays for valuation accounts *without* holdings; server+DB invariant + UI entry-point coherence. Enumerates the full cascade (dividend, fee, switch, edit, legacy, multi-currency, precision) + slices.

UI + docs only. `vp check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)