### PR TITLE
feat(holdings): PER-259 Slice 1 — holdings accounts move money via trades only (guard + UI coherence)

### DIFF
--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -256,6 +256,15 @@ function AccountDetailPage() {
     enabled: tracked,
   })
 
+  // PER-259 / ADR-0054 — a tracked account that carries ≥1 holding moves money
+  // ONLY through trades (Buy/Sell in the HoldingsPanel). Its value is always
+  // Σ(units × price); the generic "Add transaction" transfer and "Update value"
+  // entry points would silently desync the position, so they are hidden here —
+  // and rejected server-side (the server is the law; UI hiding is coherence
+  // only). A tracked account with NO holdings yet keeps both paths (it may use
+  // Update value / a valuation-linked transfer, or add a holding).
+  const hasHoldings = tracked && (holdingsView?.holdings.length ?? 0) > 0
+
   // After any holding mutation the account balance changes (the holdings anchor
   // re-materialized it), so resync BOTH the holdings query and the account
   // collections the hero/KPIs read from.
@@ -615,15 +624,24 @@ function AccountDetailPage() {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <BackLink />
         <div className="flex flex-wrap items-center gap-2">
-          <TransactionFormModal
-            defaultAccountId={accountId}
-            customTrigger={
-              <Button size="sm">
-                <Plus className="size-4" />
-                Add transaction
-              </Button>
-            }
-          />
+          {/* PER-259 / ADR-0054 — a holdings account moves money via Buy/Sell
+              only (HoldingsPanel), so the generic transfer + value-set entry
+              points are hidden; a one-line hint points to the trade actions. */}
+          {hasHoldings ? (
+            <span className="text-xs text-muted-foreground">
+              Move money with Buy / Sell below
+            </span>
+          ) : (
+            <TransactionFormModal
+              defaultAccountId={accountId}
+              customTrigger={
+                <Button size="sm">
+                  <Plus className="size-4" />
+                  Add transaction
+                </Button>
+              }
+            />
+          )}
           <Button
             variant="outline"
             size="sm"
@@ -632,14 +650,16 @@ function AccountDetailPage() {
             <Pencil className="size-4" />
             Edit
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setDetailDialog("valuation")}
-          >
-            <Scale className="size-4" />
-            {cashLike ? "Reconcile" : "Update value"}
-          </Button>
+          {hasHoldings ? null : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setDetailDialog("valuation")}
+            >
+              <Scale className="size-4" />
+              {cashLike ? "Reconcile" : "Update value"}
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -54,9 +54,11 @@ import {
   type RunInTenantTransaction,
 } from "./mutation-kit"
 import {
+  accountHasHoldings,
   createValuationWithinTx,
   fetchAccountFacts,
   HOLDINGS_VALUATION_SOURCE,
+  HoldingsAccountLedgerError,
   latestValuation,
   rebuildWithinTx,
   valueMagnitudeSchema,
@@ -2157,6 +2159,19 @@ async function createValuationLinkedTransferWithinTx(
     purpose?: TransferPurpose | null
   }
 ) {
+  // PER-259 / ADR-0054 — a holdings-tracked account moves money ONLY through
+  // trades (Buy/Sell), which post via `postValuationLinkedTransferLegs`
+  // directly (bypassing this function). A plain or valuation-linked transfer
+  // whose tracked leg carries holdings would set a value without moving units,
+  // desyncing units × price. Reject fail-loud BEFORE the cash leg posts so the
+  // user gets an actionable "use Buy/Sell" message (createValuationWithinTx is
+  // the backstop law for any other value-set path). This never fires for a
+  // holdings-free valuation account (property, manual asset), so ADR-0048 is
+  // unchanged.
+  if (await accountHasHoldings(tx, trackedAccount.id, familyId)) {
+    throw new HoldingsAccountLedgerError(trackedAccount.id)
+  }
+
   return postValuationLinkedTransferLegs(tx, {
     cashAccount,
     trackedAccount,

--- a/src/server/valuations.ts
+++ b/src/server/valuations.ts
@@ -104,6 +104,43 @@ export class ValuationError extends Error {
   }
 }
 
+// PER-259 / ADR-0054 — a holdings-tracked account moves money ONLY through
+// trades (Buy/Sell). Its value is always Σ(units × price), written back as the
+// holdings anchor (source === HOLDINGS_VALUATION_SOURCE). Any OTHER value-set
+// path — a plain/valuation-linked transfer leg, or a manual "Update value" —
+// sets a value WITHOUT moving units, desyncing units × price from the stored
+// balance. Those paths are rejected fail-loud with an actionable message; the
+// trade path (source="holdings") is unaffected. This extends the ADR-0048
+// balance-write guard: ValuationAccountLedgerError blocks the incremental
+// delta path, and a holdings account IS a valuation account so that path is
+// already blocked — this covers the remaining VALUE-SET paths.
+export class HoldingsAccountLedgerError extends Error {
+  override readonly name = "HoldingsAccountLedgerError"
+  readonly statusCode = 422
+  constructor(accountId: string) {
+    super(
+      `Account ${accountId} carries holdings (ADR-0054): move money with a ` +
+        `Buy/Sell trade, not a transfer or a manual value edit. Its value is ` +
+        `always Σ(units × price) and follows your trades automatically.`
+    )
+  }
+}
+
+// PER-259 / ADR-0054 — does this account carry ≥1 holdings position? Tenant-
+// scoped (familyId + RLS). The single predicate the holdings-account value-set
+// guards key off; a `true` result means "money moves via trades only".
+export async function accountHasHoldings(
+  tx: TenantTransactionClient,
+  accountId: string,
+  familyId: string
+): Promise<boolean> {
+  const holding = await tx.holding.findFirst({
+    where: { accountId, familyId },
+    select: { id: true },
+  })
+  return holding !== null
+}
+
 const currencySchema = z
   .string()
   .trim()
@@ -518,6 +555,23 @@ export async function createValuationWithinTx(
   const account = await fetchAccountFacts(tx, familyId, data.accountId)
   if (!account) {
     throw new ValuationError(`Account ${data.accountId} not found`)
+  }
+
+  // PER-259 / ADR-0054 — the single choke point for EVERY valuation write, so
+  // gating it here covers the single, bulk, import, and future bank-sync paths
+  // at once. A holdings-tracked account's value is Σ(units × price), written
+  // ONLY by the holdings anchor (source === HOLDINGS_VALUATION_SOURCE); the
+  // trade path and holdings CRUD both use that source and pass through. Any
+  // other source — a manual "Update value" (source="manual") or a valuation-
+  // linked transfer's tracked-side valuation (source="transfer") — would set a
+  // value without moving units and is rejected fail-loud. Grandfathering holds:
+  // rebuild recomputes from existing rows via setAccountBalanceTo, never this
+  // path, so legacy transfer/income rows are never re-rejected.
+  if (
+    data.source !== HOLDINGS_VALUATION_SOURCE &&
+    (await accountHasHoldings(tx, account.id, familyId))
+  ) {
+    throw new HoldingsAccountLedgerError(account.id)
   }
 
   const currency = data.currency ?? account.currency

--- a/tests/integration/holdings-move-coherence.integration.ts
+++ b/tests/integration/holdings-move-coherence.integration.ts
@@ -1,0 +1,470 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import { recordTradeForFamily } from "@/server/holdings"
+import {
+  bulkCreateTransactionsForFamily,
+  createTransactionForFamily,
+  findLedgerTransactionsForFamily,
+} from "@/server/transactions"
+import {
+  createValuationForFamily,
+  detectBalanceDriftForFamily,
+  HoldingsAccountLedgerError,
+  rebuildFamilyBalances,
+} from "@/server/valuations"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-259 / ADR-0054 — holdings-account operational coherence.
+//
+// A holdings-tracked account (a valuation account carrying ≥1 Holding) moves
+// money ONLY through trades (Buy/Sell). Its value is always Σ(units × price),
+// written back as the holdings anchor (source="holdings"). Every OTHER value-set
+// path — a plain/valuation-linked transfer leg, or a manual "Update value" — is
+// rejected fail-loud (HoldingsAccountLedgerError). The SAME operations on a
+// valuation account WITHOUT holdings still succeed (ADR-0048 unchanged), and
+// recordTradeFn's own valuation writes (source="holdings") are unaffected.
+// Legacy rows that predate holdings are grandfathered: rebuild/drift never
+// re-reject them.
+
+const TEST_DATE = new Date("2026-08-16T00:00:00.000Z")
+
+describe("PER-259 / ADR-0054 — holdings-account money-movement coherence", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const fundInline = { kind: "mutual_fund" as const, name: "Fund A" }
+
+  // A valuation-tracked investment account (TRACKED_ASSET → balanceSource
+  // "valuation"). Real account-create, so it carries a genuine opening
+  // valuation (ADR-0034 §3) — the realistic production shape.
+  const makeInvestmentAccount = async (owner: AuthenticatedOnboardedUser) =>
+    await createAccountForFamily({
+      data: {
+        name: "Bibit",
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // A cash-like funding account (DEPOSITORY → balanceSource "transaction_flow").
+  const makeCashAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    opening = "150000"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name: "Checking",
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance: opening,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // Give the investment account a real holding via a Buy (the coherent path).
+  const buyInto = async (
+    owner: AuthenticatedOnboardedUser,
+    investmentId: string,
+    fundingId: string
+  ) =>
+    await recordTradeForFamily({
+      data: {
+        investmentAccountId: investmentId,
+        fundingAccountId: fundingId,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000", // 100 units × 10,000 sen
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const balanceOf = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const row = await tx.account.findUniqueOrThrow({
+        where: { id: accountId },
+        select: { balance: true },
+      })
+      return row.balance
+    })
+
+  // --------------------------------------------------------------------------
+  // REJECTED on a WITH-HOLDINGS account
+  // --------------------------------------------------------------------------
+
+  test("a plain transfer INTO a with-holdings account is rejected fail-loud", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    await buyInto(owner, investment.id, cash.id)
+
+    const investBefore = await balanceOf(owner, investment.id)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    await expect(
+      createTransactionForFamily({
+        data: {
+          accountId: cash.id,
+          amount: 250_000n,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Top up reksadana (should be a Buy)",
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: investment.id,
+          type: "transfer",
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(HoldingsAccountLedgerError)
+
+    // Fully rolled back — neither leg moved.
+    expect(await balanceOf(owner, investment.id)).toBe(investBefore)
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore)
+  })
+
+  test("a transfer OUT of a with-holdings account is rejected fail-loud", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    await buyInto(owner, investment.id, cash.id)
+
+    await expect(
+      createTransactionForFamily({
+        data: {
+          accountId: investment.id,
+          amount: 100_000n,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "Withdraw (should be a Sell)",
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: cash.id,
+          type: "transfer",
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(HoldingsAccountLedgerError)
+  })
+
+  test("a manual 'Update value' on a with-holdings account is rejected fail-loud", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    await buyInto(owner, investment.id, cash.id)
+
+    const investBefore = await balanceOf(owner, investment.id)
+
+    await expect(
+      createValuationForFamily({
+        data: {
+          accountId: investment.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+          type: "manual",
+          value: "9999999",
+          valuationDate: TEST_DATE,
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(HoldingsAccountLedgerError)
+
+    // Value untouched — Σ(units × price) still governs.
+    expect(await balanceOf(owner, investment.id)).toBe(investBefore)
+  })
+
+  test("the bulk-create path targeting a with-holdings account is rejected (single/bulk parity)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    await buyInto(owner, investment.id, cash.id)
+
+    const investBefore = await balanceOf(owner, investment.id)
+
+    // Bulk create only posts income/expense (single accountId) — a valuation
+    // account is already blocked at the incremental-delta guard, so a bulk
+    // value-set on a holdings account is impossible from this endpoint too.
+    await expect(
+      bulkCreateTransactionsForFamily({
+        data: {
+          idempotencyKey: factories.createIdempotencyKey(),
+          transactions: [
+            {
+              id: factories.createIdempotencyKey(),
+              accountId: investment.id,
+              amount: 5_000n,
+              date: TEST_DATE,
+              description: "Bulk income (should be a trade)",
+              idempotencyKey: factories.createIdempotencyKey(),
+              status: "CLEARED",
+              type: "income",
+            },
+          ],
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow()
+
+    expect(await balanceOf(owner, investment.id)).toBe(investBefore)
+  })
+
+  // --------------------------------------------------------------------------
+  // ALLOWED on a valuation account WITHOUT holdings (ADR-0048 unbroken)
+  // --------------------------------------------------------------------------
+
+  test("valuation-linked transfer INTO a holdings-FREE valuation account still succeeds", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    // Tracked asset with NO holdings — a property / manually-valued asset.
+    const property = await createAccountForFamily({
+      data: {
+        name: "Rumah",
+        accountType: "TRACKED_ASSET" as AccountType,
+        openingBalance: "1000000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const cash = await makeCashAccount(owner, "5000000")
+
+    const result = await createTransactionForFamily({
+      data: {
+        accountId: cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: TEST_DATE,
+        description: "Add to property value",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: property.id,
+        type: "transfer",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result).toBeDefined()
+    expect(await balanceOf(owner, property.id)).toBe(1_000_000n + 250_000n)
+  })
+
+  test("manual 'Update value' on a holdings-FREE valuation account still succeeds", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const property = await createAccountForFamily({
+      data: {
+        name: "Rumah",
+        accountType: "TRACKED_ASSET" as AccountType,
+        openingBalance: "1000000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const result = await createValuationForFamily({
+      data: {
+        accountId: property.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+        type: "manual",
+        value: "1250000",
+        valuationDate: TEST_DATE,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result).toBeDefined()
+    expect(await balanceOf(owner, property.id)).toBe(1_250_000n)
+  })
+
+  // --------------------------------------------------------------------------
+  // TRADES on a with-holdings account are UNAFFECTED (source="holdings")
+  // --------------------------------------------------------------------------
+
+  test("Buy then Sell on a with-holdings account still works (cash + units + valuation + realized gain)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner, "5000000")
+
+    const buy = await buyInto(owner, investment.id, cash.id)
+    expect(buy.holding?.quantity).toBe("100.00000000")
+    const instrumentId = buy.holding?.instrumentId
+    expect(instrumentId).toBeTruthy()
+
+    // Sell 40 units at 12,000 sen/unit = 480,000 sen; cost removed = 40×10,000
+    // = 400,000; realized gain = 80,000.
+    const sell = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "sell",
+        cashAmount: "480000",
+        quantity: "40",
+        unitPrice: "12000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(sell.side).toBe("sell")
+    expect(sell.realizedGainMinor).toBe("80000")
+    expect(sell.holding?.quantity).toBe("60.00000000")
+    // Investment value = Σ holdings = 60 × 10,000 = 600,000 (carried at cost).
+    expect(await balanceOf(owner, investment.id)).toBe(600_000n)
+
+    // Audit rows were written for the trade (Holding + Transaction + Valuation).
+    const holdingAudits = await harness.withFamily(owner.family.id, (tx) =>
+      tx.auditLog.count({ where: { entityType: "Holding" } })
+    )
+    expect(holdingAudits).toBeGreaterThan(0)
+  })
+
+  test("recording a trade is idempotent — replaying the same key does not double the position", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner, "5000000")
+
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      investmentAccountId: investment.id,
+      fundingAccountId: cash.id,
+      instrument: fundInline,
+      side: "buy" as const,
+      cashAmount: "1000000",
+      quantity: "100",
+      unitPrice: "10000",
+      idempotencyKey: key,
+    }
+    const first = await recordTradeForFamily({
+      data: payload,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const replay = await recordTradeForFamily({
+      data: payload,
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(replay.holding?.quantity).toBe(first.holding?.quantity)
+    expect(await balanceOf(owner, investment.id)).toBe(1_000_000n)
+    const holdingCount = await harness.withFamily(owner.family.id, (tx) =>
+      tx.holding.count({ where: { accountId: investment.id } })
+    )
+    expect(holdingCount).toBe(1)
+  })
+
+  // --------------------------------------------------------------------------
+  // LEGACY rows grandfathered — rebuild/drift never re-reject them
+  // --------------------------------------------------------------------------
+
+  test("a legacy valuation-linked transfer written BEFORE holdings survives; later trades add holdings and rebuild/drift stay clean", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner, "5000000")
+
+    // (1) Legacy money movement BEFORE the account has holdings — allowed.
+    const legacy = await createTransactionForFamily({
+      data: {
+        accountId: cash.id,
+        amount: 250_000n,
+        currency: "IDR",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+        description: "Legacy top-up (pre-holdings)",
+        idempotencyKey: factories.createIdempotencyKey(),
+        isSplit: false,
+        status: "CLEARED",
+        toAccountId: investment.id,
+        type: "transfer",
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(legacy).toBeDefined()
+
+    // (2) The account gains holdings via a Buy.
+    await buyInto(owner, investment.id, cash.id)
+
+    // (3) A NEW transfer is now rejected (guard is on new writes only)...
+    await expect(
+      createTransactionForFamily({
+        data: {
+          accountId: cash.id,
+          amount: 10_000n,
+          currency: "IDR",
+          date: TEST_DATE,
+          description: "New transfer after holdings",
+          idempotencyKey: factories.createIdempotencyKey(),
+          isSplit: false,
+          status: "CLEARED",
+          toAccountId: investment.id,
+          type: "transfer",
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(HoldingsAccountLedgerError)
+
+    // (4) ...but the legacy row is still visible history.
+    const ledger = await harness.withFamily(owner.family.id, (tx) =>
+      findLedgerTransactionsForFamily(tx, owner.family.id)
+    )
+    expect(ledger.some((row) => row.id === legacy.id)).toBe(true)
+
+    // (5) Rebuild does not throw on the grandfathered rows, and no
+    // materialization drift is introduced.
+    await expect(
+      rebuildFamilyBalances({ familyId: owner.family.id, user: owner.user })
+    ).resolves.toBeDefined()
+
+    const drift = await detectBalanceDriftForFamily({
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(drift.filter((d) => d.kind === "MATERIALIZATION")).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## The model (ADR-0054)

A **holdings-tracked account** — a valuation account carrying **≥1 `Holding`** — moves money **ONLY through trades** (Buy/Sell). Its value is always **Σ(units × price)**, written back as the holdings anchor (`source="holdings"`). Every other value-set path would set a value **without** moving units, silently desyncing units × price from the stored balance.

| Account state | Money-in / money-out |
| --- | --- |
| cash-like (`transaction_flow`) | normal transactions / transfers (unchanged) |
| valuation, **NO** holdings (property, manual asset) | valuation-linked transfer (ADR-0048) + "Update value" — **unchanged** |
| valuation, **WITH** holdings (reksadana, gold, stocks) | **trades only** — Buy / Sell |

## What is guarded (server is the law)

- New `accountHasHoldings(tx, accountId, familyId)` helper + `HoldingsAccountLedgerError` (422, actionable "use Buy/Sell" message), tenant-scoped, in `valuations.ts`.
- **`createValuationWithinTx`** — the single choke point every valuation write funnels through (single + bulk + import + future bank-sync). Rejects when the account has holdings **and** `source !== "holdings"`. Covers manual "Update value" (`source="manual"`) and the valuation-linked transfer's tracked-side valuation (`source="transfer"`). The trade path and holdings CRUD write `source="holdings"` and pass through unaffected.
- **`createValuationLinkedTransferWithinTx`** — early reject before the cash leg posts, so a plain/valuation-linked transfer targeting a holdings account fails fast with the actionable message. (A plain transfer whose leg is a valuation account already routes here.)
- **Bulk** income/expense on a holdings (valuation) account remains blocked by the existing ADR-0048 incremental-delta guard (`ValuationAccountLedgerError`).
- `recordTradeFn`'s own valuation writes are **unaffected** (they use `source="holdings"` via `createValuationWithinTx`, bypassing `createValuationLinkedTransferWithinTx`).

## UI coherence (`accounts.$accountId.tsx`)

On a tracked account **with holdings**, the generic "Add transaction" transfer trigger and the "Update value" button are **hidden**; a one-line hint points to Buy/Sell in the Holdings panel. Tracked accounts with **no holdings yet** keep the current behavior (Update value / valuation-linked transfer / add a holding). UI hiding is coherence only — the server rejects regardless.

## Grandfathering (legacy rows)

The invariant applies to **NEW writes only**. `rebuildFamilyBalances`/drift recompute from existing rows via `setAccountBalanceTo` (never the guarded valuation-create path), so legacy transfer/income rows on an account that later gains holdings are never re-rejected or mutated (the creator's Dana Darurat history stays visible).

## ADR-0048 is unchanged

The guard keys **strictly on "has holdings"**. A holdings-free valuation account (property, manual asset) still uses valuation-linked transfer + manual "Update value" exactly as before — verified by dedicated passing tests.

## Test evidence (real Postgres, PER-86 harness)

New `tests/integration/holdings-move-coherence.integration.ts` — **9 passed**:
- plain transfer in/out, valuation-linked transfer, manual "Update value", and bulk-create targeting a **with-holdings** account are all **rejected** (fully rolled back);
- the same transfer + manual valuation on a **holdings-free** valuation account still **succeed** (ADR-0048 unbroken);
- Buy then Sell on a with-holdings account still works (cash + units + valuation + realized gain), and a trade replay is idempotent (no duplicate position);
- a legacy pre-holdings transfer survives, a new transfer after holdings is rejected, and `rebuildFamilyBalances` + drift stay clean.

```
Test Files  1 passed (1)
     Tests  9 passed (9)
```

Adjacent suites green (trades, valuation-linked-transfer, valuation-account-balance-guard, holdings, enable-holdings-tracking):
```
Test Files  5 passed (5)
     Tests  53 passed (53)
```

Gates: `vp check`, `vp build` (server/client fence), `vp fmt`, `vp test` (714 unit) all green.

## Notes / deviations

- Scope is ADR-0054 **Slice 1 remainder** only (guard + entry-point coherence). Trade modes Dividend/Fee/Switch and trade edit/delete (Slices 2–5) are out of scope.
- No deviation from ADR-0054. Design choice worth a reviewer eyeball: the primary server law is a single guard in `createValuationWithinTx` keyed on `source !== "holdings"`, with the transfer-path early guard as defense-in-depth + a cleaner message. This keeps the invariant at the one choke point every value-set path (single/bulk/import) already funnels through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
