### PR TITLE
feat(holdings): PER-259 Slice 2 — dividend / distribution (cash payout + reinvest, broker-agnostic)

### DIFF
--- a/docs/adr/0054-holdings-account-operational-coherence.md
+++ b/docs/adr/0054-holdings-account-operational-coherence.md
@@ -34,6 +34,13 @@ per-holding-row, so the account header showed Buy but no Sell. The system was no
 
 ## Decision
 
+**Broker/country-agnostic principle.** Permoney serves users worldwide on any
+broker/fund app (Bibit, Ajaib, Vanguard, Fidelity, IBKR, …), any currency, any
+country. Every mechanism here is modelled on the UNIVERSAL concept (a
+"distribution", a "position move", a "trade"), never a single vendor's wording or
+behaviour. Vendor specifics (e.g. one app auto-reinvests, another pays cash) are
+just which generic option a user picks — never hardcoded.
+
 **A holdings-tracked account moves money ONLY through trades.** For an account
 that carries holdings, every money movement is a trade on the `recordTradeFn`
 family; the plain-transfer, valuation-linked-transfer, and manual "Update value"
@@ -58,9 +65,19 @@ guards that must ALL exist for the model to be coherent (not just Buy/Sell):
    position, realized gain shown. _(Slice 1 — panel Sell shipped.)_
 2. **Buy must cover first + subsequent** — create the instrument inline on the
    first buy; average-cost into an existing position on later buys. _(Exists.)_
-3. **Dividend / distribution** — income with **no units bought** (cash to the
-   funding account) OR **reinvested** (units up, no external cash). A distinct
-   trade mode; without it users mis-record income as a Buy or a plain transfer.
+3. **Dividend / distribution** — a distinct mode with TWO shapes, both universal
+   across brokers/funds (NOT Bibit-specific — see the Broker-agnostic principle):
+   - **Cash payout**: income with **no units and no position-value change** —
+     cash credited to a **user-chosen destination account** (often a DIFFERENT
+     account than the holding, e.g. a pension/cash pot), back-datable, and
+     provenance-linked to the source holding for reporting. The holdings account
+     is NOT mutated.
+   - **Reinvest**: **units up** at the reinvest price, **no external cash**; cost
+     basis increases by the reinvested amount (like an internally-funded Buy).
+     Real case (creator, BNI-AM Ardhani): 3 CASH dividends (2025-06-11 12,151 ·
+     2025-12-08 17,268 · 2026-06-08 595) auto-deposited to a _separate_ "Dana
+     Pensiun" account; units flat. So the destination is user-selectable and the
+     date is user-set — do not assume same-account or today.
 4. **Fees** — purchase / redemption / management fees reduce cash or NAV value;
    a fee that isn't modeled gets mis-booked as a mystery value drop.
 5. **Switch** (fund A → fund B) — an atomic sell-A + buy-B in one account, the
@@ -89,6 +106,13 @@ guards that must ALL exist for the model to be coherent (not just Buy/Sell):
     migration (creator's call).
 12. **Precision + idempotency** — fractional units (scaled bigint) and an
     idempotency key on every trade (retry-safe), same contract as the ledger.
+13. **Move a position between accounts (in-kind portfolio move)** — a broker lets
+    you move a fund/position from one portfolio to another WITHOUT selling (Bibit
+    "pindah portofolio", and its analogues everywhere). Model as an in-kind move:
+    the holding (units + cost basis) leaves account A and lands in account B; both
+    accounts' Σ(units × price) re-materialize; NO cash leg, NO realized gain (cost
+    basis carries over). Distinct from Sell-then-Buy (which realizes gain + moves
+    cash). Withdraw stays Sell.
 
 ### Non-goals (this ADR)
 
@@ -113,4 +137,6 @@ FIFO-vs-average election beyond the current average-cost model — later.
 - **Slice 3 — Fees** (purchase / redemption / management).
 - **Slice 4 — Switch** (atomic sell-A + buy-B).
 - **Slice 5 — Edit/correct a trade** (reverse + re-record, audited).
-- Cross-cutting: multi-currency trade + FX rides ADR-0052 Slice C/D.
+- **Slice 6 — Move a position between accounts** (in-kind, no cash, cost basis carries).
+- Cross-cutting: multi-currency trade + FX rides ADR-0052 Slice C/D; everything
+  broker/country-agnostic (Broker-agnostic principle above).

--- a/src/components/blocks/distribution-dialog.tsx
+++ b/src/components/blocks/distribution-dialog.tsx
@@ -1,0 +1,333 @@
+import * as React from "react"
+import { Coins, Repeat } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { MoneyInput } from "@/components/blocks/money-input"
+import { formatCurrency } from "@/lib/currency"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { QUANTITY_SCALE, scaledToQuantityString } from "@/lib/holdings"
+import { parseMoneyInput } from "@/lib/money"
+import { cn } from "@/lib/utils"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
+import { recordDistributionFn } from "@/server/holdings"
+
+// PER-259 Slice 2 / ADR-0054 — Dividend / distribution dialog.
+// Broker/country-agnostic: a holding pays a distribution and the user picks one
+// of two universal shapes. The heavy lifting (income posting, cost-basis blend,
+// Σ-holdings anchor, audit, idempotency) is SERVER-side (`recordDistributionFn`);
+// this dialog only collects inputs. NO "Bibit"/vendor wording.
+//
+//   Cash payout — income to a user-chosen destination cash account; the source
+//     holding's units + value are unchanged; back-datable.
+//   Reinvest    — units up on the source holding at the reinvest price; cost
+//     basis += amount; no external cash.
+
+export interface DistributionDestinationAccount {
+  id: string
+  name: string
+  currency: string
+}
+
+export type DistributionDialogState = { holding?: HoldingRecord }
+
+type Mode = "cash" | "reinvest"
+
+function toDateInputValue(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+export function DistributionDialog({
+  state,
+  investmentAccountId,
+  currency,
+  holdings,
+  destinationAccounts,
+  onClose,
+  onSaved,
+}: {
+  state: DistributionDialogState
+  investmentAccountId: string
+  currency: string
+  holdings: ReadonlyArray<HoldingRecord>
+  destinationAccounts: ReadonlyArray<DistributionDestinationAccount>
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const currencyCode = currency as CurrencyCode
+
+  const [mode, setMode] = React.useState<Mode>("cash")
+  const [holdingId, setHoldingId] = React.useState<string>(
+    state.holding?.id ?? holdings[0]?.id ?? ""
+  )
+  const [amount, setAmount] = React.useState<string>("")
+  const [date, setDate] = React.useState<string>(toDateInputValue(new Date()))
+  const [destinationAccountId, setDestinationAccountId] =
+    React.useState<string>(destinationAccounts[0]?.id ?? "")
+  const [unitPrice, setUnitPrice] = React.useState<string>("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const isCash = mode === "cash"
+
+  // Parsed amount (minor units) — authoritative for both the income row and the
+  // reinvested cost basis.
+  const amountMinor = React.useMemo<bigint | null>(() => {
+    if (amount.trim() === "") return null
+    const parsed = parseMoneyInput(amount, currencyCode)
+    return parsed !== null && parsed > 0n ? parsed : null
+  }, [amount, currencyCode])
+
+  // Live derived units for reinvest = amount ÷ unitPrice, round-half-up, via the
+  // same scale the server uses — pure derivation, no effect.
+  const unitsPreview = React.useMemo<
+    { kind: "empty" } | { kind: "invalid" } | { kind: "valid"; text: string }
+  >(() => {
+    if (isCash) return { kind: "empty" }
+    if (amountMinor === null || unitPrice.trim() === "")
+      return { kind: "empty" }
+    const price = parseMoneyInput(unitPrice, currencyCode)
+    if (price === null || price <= 0n) return { kind: "invalid" }
+    const scaled = (amountMinor * QUANTITY_SCALE + price / 2n) / price
+    if (scaled <= 0n) return { kind: "invalid" }
+    return { kind: "valid", text: scaledToQuantityString(scaled) }
+  }, [isCash, amountMinor, unitPrice, currencyCode])
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+    if (amountMinor === null) {
+      setError("Enter a valid distribution amount.")
+      return
+    }
+    if (holdingId === "") {
+      setError("Choose the holding that paid the distribution.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const shared = {
+        investmentAccountId,
+        holdingId,
+        amount: amountMinor.toString(),
+        date,
+        idempotencyKey: createUuidV7(),
+      }
+      if (isCash) {
+        if (destinationAccountId === "") {
+          setError("Choose a destination account for the cash payout.")
+          setSubmitting(false)
+          return
+        }
+        await recordDistributionFn({
+          data: { ...shared, mode: "cash", destinationAccountId },
+        })
+      } else {
+        const price = parseMoneyInput(unitPrice, currencyCode)
+        if (price === null || price <= 0n) {
+          setError("Enter a valid reinvest unit price.")
+          setSubmitting(false)
+          return
+        }
+        await recordDistributionFn({
+          data: { ...shared, mode: "reinvest", unitPrice: price.toString() },
+        })
+      }
+      await onSaved()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught))
+      setSubmitting(false)
+    }
+  }
+
+  const submitDisabled =
+    submitting ||
+    amountMinor === null ||
+    holdingId === "" ||
+    (isCash && destinationAccountId === "") ||
+    (!isCash && unitsPreview.kind !== "valid")
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {isCash ? (
+                <Coins className="size-4 text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <Repeat className="size-4 text-sky-600 dark:text-sky-400" />
+              )}
+              Dividend / distribution
+            </DialogTitle>
+            <DialogDescription>
+              {isCash
+                ? "A cash payout lands in another account; the position is unchanged."
+                : "Reinvest buys more units of this holding; no external cash moves."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label>Type</Label>
+              <Select
+                value={mode}
+                onValueChange={(value) => setMode(value as Mode)}
+              >
+                <SelectTrigger aria-label="Distribution type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="cash">Cash payout</SelectItem>
+                  <SelectItem value="reinvest">Reinvest</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label>Holding</Label>
+              <Select value={holdingId} onValueChange={setHoldingId}>
+                <SelectTrigger aria-label="Source holding">
+                  <SelectValue placeholder="Choose holding" />
+                </SelectTrigger>
+                <SelectContent>
+                  {holdings.map((holding) => (
+                    <SelectItem key={holding.id} value={holding.id}>
+                      {holding.instrument.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="distribution-amount">Amount ({currency})</Label>
+              <MoneyInput
+                id="distribution-amount"
+                currency={currencyCode}
+                value={amount}
+                onChange={setAmount}
+                placeholder="0"
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="distribution-date">Date</Label>
+              <Input
+                id="distribution-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          {isCash ? (
+            <div className="flex flex-col gap-2">
+              <Label>Deposit into</Label>
+              <Select
+                value={destinationAccountId}
+                onValueChange={setDestinationAccountId}
+              >
+                <SelectTrigger aria-label="Destination account">
+                  <SelectValue placeholder="Choose account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {destinationAccounts.map((account) => (
+                    <SelectItem key={account.id} value={account.id}>
+                      {account.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {destinationAccounts.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  No same-currency cash account to receive the payout.
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="distribution-unit-price">
+                Reinvest unit price ({currency})
+              </Label>
+              <MoneyInput
+                id="distribution-unit-price"
+                currency={currencyCode}
+                value={unitPrice}
+                onChange={setUnitPrice}
+                placeholder="0"
+                required
+              />
+              <div
+                className={cn(
+                  "flex items-center justify-between rounded-md border p-3 text-sm",
+                  unitsPreview.kind === "valid"
+                    ? "bg-muted/50"
+                    : "text-muted-foreground"
+                )}
+              >
+                <span className="text-muted-foreground">Units added</span>
+                <span className="font-semibold tabular-nums">
+                  {unitsPreview.kind === "valid" ? unitsPreview.text : "—"}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {isCash && amountMinor !== null ? (
+            <div className="flex items-center justify-between rounded-md border bg-muted/50 p-3 text-sm">
+              <span className="text-muted-foreground">Cash in</span>
+              <span className="font-semibold tabular-nums">
+                {formatCurrency(amountMinor.toString(), currency)}
+              </span>
+            </div>
+          ) : null}
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {submitting
+                ? "Recording…"
+                : isCash
+                  ? "Record payout"
+                  : "Record reinvest"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -2,6 +2,7 @@ import {
   ArrowDownLeft,
   ArrowUpRight,
   Coins,
+  Gift,
   PiggyBank,
   Plus,
   RefreshCw,
@@ -89,6 +90,8 @@ export function HoldingsPanel({
   onSell,
   onBuyHolding,
   onSellHolding,
+  onDividend,
+  onDividendHolding,
   onRefreshPrices,
   refreshingPrices,
 }: Readonly<{
@@ -102,6 +105,8 @@ export function HoldingsPanel({
   onSell: () => void
   onBuyHolding: (holding: HoldingRecord) => void
   onSellHolding: (holding: HoldingRecord) => void
+  onDividend: () => void
+  onDividendHolding: (holding: HoldingRecord) => void
   onRefreshPrices: () => void
   refreshingPrices: boolean
 }>) {
@@ -141,6 +146,12 @@ export function HoldingsPanel({
             <Button size="sm" variant="outline" onClick={onSell}>
               <ArrowUpRight className="size-4" />
               Sell
+            </Button>
+          ) : null}
+          {holdings.length > 0 ? (
+            <Button size="sm" variant="outline" onClick={onDividend}>
+              <Gift className="size-4" />
+              Dividend
             </Button>
           ) : null}
           <Button size="sm" variant="outline" onClick={onAdd}>
@@ -222,6 +233,16 @@ export function HoldingsPanel({
                     >
                       <ArrowUpRight className="size-3.5" />
                       Sell
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => onDividendHolding(holding)}
+                    >
+                      <Gift className="size-3.5" />
+                      Dividend
                     </Button>
                     <Button
                       type="button"

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -52,6 +52,10 @@ import {
   TradeDialog,
   type TradeDialogState,
 } from "@/components/blocks/trade-dialog"
+import {
+  DistributionDialog,
+  type DistributionDialogState,
+} from "@/components/blocks/distribution-dialog"
 import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
@@ -177,6 +181,9 @@ function AccountDetailPage() {
   const [tradeDialog, setTradeDialog] = React.useState<TradeDialogState | null>(
     null
   )
+  // PER-259 Slice 2 — dividend / distribution dialog (cash payout or reinvest).
+  const [distributionDialog, setDistributionDialog] =
+    React.useState<DistributionDialogState | null>(null)
   // PER-241 — the per-account statement now shares the /transactions row, so it
   // gets the same singleton edit modal + inline delete.
   const [editingTrx, setEditingTrx] =
@@ -718,6 +725,10 @@ function AccountDetailPage() {
               onSellHolding={(holding) =>
                 setTradeDialog({ side: "sell", holding })
               }
+              onDividend={() => setDistributionDialog({})}
+              onDividendHolding={(holding) =>
+                setDistributionDialog({ holding })
+              }
               onRefreshPrices={handleRefreshPrices}
               refreshingPrices={refreshingPrices}
             />
@@ -967,6 +978,27 @@ function AccountDetailPage() {
           onSaved={async () => {
             await refreshHoldings()
             setTradeDialog(null)
+          }}
+        />
+      ) : null}
+
+      {distributionDialog ? (
+        <DistributionDialog
+          // Remount per open so the form re-initializes cleanly.
+          key={
+            distributionDialog.holding
+              ? `distribution-${distributionDialog.holding.id}`
+              : "distribution"
+          }
+          state={distributionDialog}
+          investmentAccountId={accountId}
+          currency={currency}
+          holdings={holdingsView?.holdings ?? []}
+          destinationAccounts={fundingAccounts}
+          onClose={() => setDistributionDialog(null)}
+          onSaved={async () => {
+            await refreshHoldings()
+            setDistributionDialog(null)
           }}
         />
       ) : null}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -23,6 +23,7 @@ import {
   holdingGainMinor,
   holdingReturnPct,
   holdingValueMinor,
+  QUANTITY_SCALE,
   quantityToScaled,
   scaledToQuantityString,
   sumHoldingValuesMinor,
@@ -34,6 +35,7 @@ import {
 import { toMinorUnits } from "@/lib/money"
 import { getFamilyBaseCurrency } from "./fx"
 import {
+  postIncomeTransactionWithinTx,
   postValuationLinkedTransferLegs,
   type ValuationLinkedTransferLeg,
 } from "./transactions"
@@ -1461,6 +1463,484 @@ export const recordTradeFn = createServerFn({ method: "POST" })
   )
   .handler(async ({ data, context }) => {
     return await recordTradeForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// =============================================================================
+// DIVIDEND / DISTRIBUTION — cash payout OR reinvest (PER-259 Slice 2 / ADR-0054)
+// =============================================================================
+//
+// A distribution is money paid out BY a holding. Broker/country-agnostic (NOT
+// vendor-specific): a fund/stock/metal pays a distribution and the user picks
+// one of TWO universal shapes:
+//
+//   CASH PAYOUT — income, with NO change to the source holding's units or
+//     position value. Cash lands on a USER-CHOSEN destination cash account
+//     (often a DIFFERENT account than the holding — a pension/cash pot). Modeled
+//     as a normal INCOME `Transaction` on that destination (reusing the family's
+//     "Investment Income" income category), back-datable, provenance-linked to
+//     the source holding/instrument in the description, notes and audit payload.
+//     The holdings account is NOT mutated (no anchor recompute).
+//
+//   REINVEST — units UP on the source holding at the reinvest price (units =
+//     amount ÷ unitPrice, or user-entered units), cost basis += amount, and NO
+//     external cash. Structurally BUY minus the funding-account cash leg: the
+//     Σ-holdings anchor re-materializes via the source="holdings" path (the ONLY
+//     value-write the PER-259 guard allows on a holdings account).
+//
+// Both modes run the full ledger mutation contract (CLAUDE.md §5A): interactive
+// tenant transaction + RLS GUC, tenant-owned reference validation, endpoint-
+// scoped idempotency, and append-only AuditLog rows in the same transaction.
+// Same-currency this slice (destination/holding share the account currency).
+
+const RECORD_DISTRIBUTION_ENDPOINT = "recordDistributionFn"
+
+// The income category a CASH payout is booked under. Reused (find-or-create by
+// case-insensitive name, matching the `merchant_category_name_dedup` index) so a
+// family's existing "Investment Income" category is honored, never duplicated.
+const INVESTMENT_INCOME_CATEGORY_NAME = "Investment Income"
+
+const distributionModeSchema = z.enum(["cash", "reinvest"])
+
+export const recordDistributionInputSchema = z
+  .object({
+    investmentAccountId: z.string().min(1),
+    // The source holding paying the distribution.
+    holdingId: z.string().min(1),
+    mode: distributionModeSchema,
+    // Distribution amount in MINOR units (digit-string), strictly positive.
+    amount: positiveMinorDigitsSchema,
+    // Back-datable (real dividends land on a broker-set date, not "today").
+    date: z.coerce.date().optional(),
+    // CASH mode — the cash-like account the payout is deposited into (may differ
+    // from the holding's account). REQUIRED for cash, forbidden for reinvest.
+    destinationAccountId: z.string().min(1).optional(),
+    // CASH mode — optional income category override; defaults to the family's
+    // "Investment Income" category (find-or-create).
+    categoryId: z.string().min(1).optional(),
+    // REINVEST mode — the reinvest price per unit (minor units) used to derive
+    // the units credited, OR an explicit unit quantity. At least one required.
+    unitPrice: positiveMinorDigitsSchema.optional(),
+    quantity: decimalStringSchema.optional(),
+    idempotencyKey: uuidV7Schema,
+  })
+  .superRefine((data, ctx) => {
+    if (data.mode === "cash") {
+      if (!data.destinationAccountId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["destinationAccountId"],
+          message: "A cash payout requires a destination account",
+        })
+      }
+    } else {
+      if (!data.unitPrice && !data.quantity) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["unitPrice"],
+          message: "Reinvest requires a unit price or an explicit quantity",
+        })
+      }
+      if (data.destinationAccountId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["destinationAccountId"],
+          message:
+            "Reinvest does not move external cash (no destination account)",
+        })
+      }
+    }
+  })
+
+type RecordDistributionInput = z.infer<typeof recordDistributionInputSchema>
+
+export interface RecordDistributionResult {
+  mode: "cash" | "reinvest"
+  investmentAccountId: string
+  holdingId: string
+  instrumentId: string
+  /** Distribution amount, minor units (digit-string). */
+  amountMinor: string
+  // ---- CASH payout ----
+  /** Destination cash account the income landed on (cash mode), else null. */
+  destinationAccountId: string | null
+  /** The income Transaction posted on the destination (cash mode), else null. */
+  incomeTransaction: Awaited<
+    ReturnType<typeof postIncomeTransactionWithinTx>
+  > | null
+  /** Destination account balance after the income (cash mode), else null. */
+  destinationBalanceAfterMinor: string | null
+  // ---- REINVEST ----
+  /** Resulting position after reinvest (reinvest mode), else null. */
+  holding: SerializedHolding | null
+  /** Cost basis added to the source holding (reinvest mode), else null. */
+  costBasisDeltaMinor: string | null
+  /** Investment account value after re-materializing Σ holdings (reinvest), else null. */
+  investmentValueAfterMinor: string | null
+}
+
+// Find-or-create the family's income category for distributions. Case-insensitive
+// name match (the dedup index key) so an existing "Investment Income" is reused
+// and never duplicated; a freshly-created one is audited in the same tx.
+async function resolveDistributionIncomeCategory(
+  tx: TenantTransactionClient,
+  familyId: string,
+  auditCtx: AuditContext
+): Promise<string> {
+  const existing = await tx.category.findFirst({
+    where: {
+      familyId,
+      name: { equals: INVESTMENT_INCOME_CATEGORY_NAME, mode: "insensitive" },
+    },
+    select: { id: true },
+  })
+  if (existing) return existing.id
+
+  const created = await tx.category.create({
+    data: {
+      familyId,
+      name: INVESTMENT_INCOME_CATEGORY_NAME,
+      type: "income",
+      isSystem: false,
+    },
+  })
+  await auditLog(tx, auditCtx, {
+    action: "create",
+    entityType: "Category",
+    entityId: created.id,
+    after: { id: created.id, name: created.name, type: created.type },
+  })
+  return created.id
+}
+
+export async function recordDistributionForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordDistributionInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<RecordDistributionResult> {
+  const data: RecordDistributionInput =
+    recordDistributionInputSchema.parse(rawData)
+
+  const requestHash = await hashCanonicalPayload({
+    amount: data.amount,
+    categoryId: data.categoryId ?? null,
+    date: data.date?.toISOString() ?? null,
+    destinationAccountId: data.destinationAccountId ?? null,
+    holdingId: data.holdingId,
+    investmentAccountId: data.investmentAccountId,
+    mode: data.mode,
+    quantity: data.quantity ?? null,
+    unitPrice: data.unitPrice ?? null,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+  const amountMinor = BigInt(data.amount)
+  const date = data.date ?? new Date()
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay =
+        await replayIdempotentEndpointResponse<RecordDistributionResult>(tx, {
+          endpoint: RECORD_DISTRIBUTION_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        })
+      if (replay) return replay
+
+      // The investment (holdings) account + the source holding are common to
+      // both modes. Tenant ownership is RLS-scoped and belt-and-braces checked.
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.investmentAccountId,
+      })
+      const investmentAccount = await fetchActiveAccount(
+        tx,
+        familyId,
+        data.investmentAccountId,
+        "Investment"
+      )
+      if (investmentAccount.balanceSource !== "valuation") {
+        throw new HoldingError(
+          `Investment account ${investmentAccount.id} must be a valuation-tracked account (balanceSource="valuation"); it is "${investmentAccount.balanceSource}"`
+        )
+      }
+      const currency = assertKnownCurrency(investmentAccount.currency)
+
+      const holding = await loadHoldingWithInstrument(
+        tx,
+        familyId,
+        data.holdingId
+      )
+      if (holding.accountId !== investmentAccount.id) {
+        throw new HoldingError(
+          `Holding ${data.holdingId} does not belong to account ${data.investmentAccountId}`
+        )
+      }
+      const instrument = holding.instrument
+      const provenance = `${instrument.name}${instrument.symbol ? ` (${instrument.symbol})` : ""}`
+
+      let response: RecordDistributionResult
+
+      if (data.mode === "cash") {
+        // CASH PAYOUT — income on a user-chosen destination cash account; the
+        // source holding is NOT touched (units + position value unchanged).
+        const destinationAccountId = data.destinationAccountId
+        if (!destinationAccountId) {
+          // Unreachable (schema superRefine), keeps types honest.
+          throw new HoldingError("A cash payout requires a destination account")
+        }
+        await validateTenantReferences(tx, familyId, {
+          accountId: destinationAccountId,
+          categoryId: data.categoryId,
+        })
+        const destination = await fetchActiveAccount(
+          tx,
+          familyId,
+          destinationAccountId,
+          "Destination"
+        )
+        if (destination.balanceSource !== "transaction_flow") {
+          throw new HoldingError(
+            `Destination account ${destination.id} must be a cash-like account (balanceSource="transaction_flow"); it is "${destination.balanceSource}"`
+          )
+        }
+        if (destination.currency !== currency) {
+          throw new HoldingError(
+            `Cross-currency distributions are not supported this slice (holding ${currency}, destination ${destination.currency})`
+          )
+        }
+
+        // Reuse the family's "Investment Income" category (or an explicit
+        // income category the caller chose, validated to be income-typed).
+        let categoryId: string
+        if (data.categoryId) {
+          const category = await tx.category.findFirst({
+            where: { id: data.categoryId, familyId },
+            select: { id: true, type: true },
+          })
+          if (!category) {
+            throw new HoldingError(
+              `Category ${data.categoryId} not found for this family`
+            )
+          }
+          if (category.type !== "income") {
+            throw new HoldingError(
+              `Category ${data.categoryId} must be an income category for a cash distribution`
+            )
+          }
+          categoryId = category.id
+        } else {
+          categoryId = await resolveDistributionIncomeCategory(
+            tx,
+            familyId,
+            auditCtx
+          )
+        }
+
+        const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+        const incomeTransaction = await postIncomeTransactionWithinTx(tx, {
+          account: destination,
+          amount: amountMinor,
+          date,
+          description: `Dividend — ${instrument.name}`,
+          notes: `Distribution from ${provenance} · holding ${holding.id} in ${investmentAccount.name}`,
+          categoryId,
+          familyId,
+          user,
+          auditCtx,
+          baseCurrency,
+          idempotencyKey: data.idempotencyKey,
+          status: "CLEARED",
+        })
+
+        // Explicit provenance audit row — the durable, queryable link from the
+        // income transaction back to the source holding/instrument (no schema
+        // FK migration this slice; description + notes + this row carry it).
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Distribution",
+          entityId: incomeTransaction.id,
+          after: {
+            mode: "cash",
+            amountMinor: amountMinor.toString(),
+            investmentAccountId: investmentAccount.id,
+            holdingId: holding.id,
+            instrumentId: instrument.id,
+            instrumentName: instrument.name,
+            destinationAccountId: destination.id,
+            transactionId: incomeTransaction.id,
+          },
+        })
+
+        const destinationAfter = await tx.account.findUniqueOrThrow({
+          where: { id: destination.id },
+          select: { balance: true },
+        })
+
+        response = {
+          mode: "cash",
+          investmentAccountId: investmentAccount.id,
+          holdingId: holding.id,
+          instrumentId: instrument.id,
+          amountMinor: amountMinor.toString(),
+          destinationAccountId: destination.id,
+          incomeTransaction,
+          destinationBalanceAfterMinor: destinationAfter.balance.toString(),
+          holding: null,
+          costBasisDeltaMinor: null,
+          investmentValueAfterMinor: null,
+        }
+      } else {
+        // REINVEST — units up + cost basis up on the SOURCE holding, no external
+        // cash. Structurally BUY minus the funding cash leg: the reinvested
+        // `amount` is authoritative for cost; the units come from an explicit
+        // `quantity`, else derived from `unitPrice` (round-half-up).
+        let addedUnitsScaled: bigint
+        if (data.quantity) {
+          try {
+            addedUnitsScaled = quantityToScaled(data.quantity)
+          } catch (error) {
+            throw new HoldingError(
+              `quantity is not a valid amount: ${error instanceof Error ? error.message : String(error)}`
+            )
+          }
+        } else {
+          // data.unitPrice is guaranteed present here (schema superRefine).
+          const unitPrice = BigInt(data.unitPrice ?? "0")
+          if (unitPrice <= 0n) {
+            throw new HoldingError(
+              "Reinvest unit price must be greater than zero"
+            )
+          }
+          // units = amount / unitPrice; scaled = amount × SCALE / unitPrice.
+          addedUnitsScaled =
+            (amountMinor * QUANTITY_SCALE + unitPrice / 2n) / unitPrice
+        }
+        if (addedUnitsScaled <= 0n) {
+          throw new HoldingError(
+            "Reinvest results in zero units; increase the amount or lower the unit price"
+          )
+        }
+
+        const oldUnitsScaled = quantityToScaled(holding.quantity.toFixed(8))
+        const oldCost = holdingCostMinor(
+          oldUnitsScaled,
+          holding.avgUnitCostMinor
+        )
+        const newUnitsScaled = oldUnitsScaled + addedUnitsScaled
+        const newAvg = averageUnitCostMinor(
+          oldCost + amountMinor,
+          newUnitsScaled
+        )
+        const updated = await tx.holding.update({
+          where: { id: holding.id },
+          data: {
+            quantity: scaledToQuantityString(newUnitsScaled),
+            avgUnitCostMinor: newAvg,
+          },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Holding",
+          entityId: updated.id,
+          before: serializeHolding(holding),
+          after: serializeHolding(updated),
+        })
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Distribution",
+          entityId: updated.id,
+          after: {
+            mode: "reinvest",
+            amountMinor: amountMinor.toString(),
+            investmentAccountId: investmentAccount.id,
+            holdingId: holding.id,
+            instrumentId: instrument.id,
+            instrumentName: instrument.name,
+            unitsAddedScaled: addedUnitsScaled.toString(),
+          },
+        })
+
+        // Re-materialize the Σ-holdings anchor (source="holdings" — the only
+        // value-write the PER-259 guard allows on a holdings account).
+        await recomputeAccountValueAnchorWithinTx(
+          tx,
+          familyId,
+          investmentAccount.id,
+          investmentAccount.currency,
+          user,
+          auditCtx
+        )
+
+        const finalHolding = serializeHolding(
+          await loadHoldingWithInstrument(tx, familyId, updated.id)
+        )
+        const investmentAfter = await tx.account.findUniqueOrThrow({
+          where: { id: investmentAccount.id },
+          select: { balance: true },
+        })
+
+        response = {
+          mode: "reinvest",
+          investmentAccountId: investmentAccount.id,
+          holdingId: holding.id,
+          instrumentId: instrument.id,
+          amountMinor: amountMinor.toString(),
+          destinationAccountId: null,
+          incomeTransaction: null,
+          destinationBalanceAfterMinor: null,
+          holding: finalHolding,
+          costBasisDeltaMinor: amountMinor.toString(),
+          investmentValueAfterMinor: investmentAfter.balance.toString(),
+        }
+      }
+
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: RECORD_DISTRIBUTION_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<RecordDistributionResult>(tx, {
+        endpoint: RECORD_DISTRIBUTION_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const recordDistributionFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordDistributionInputSchema>) =>
+    recordDistributionInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordDistributionForFamily({
       data,
       familyId: context.familyId,
       user: context.user,

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -2131,6 +2131,105 @@ export async function postValuationLinkedTransferLegs(
   })
 }
 
+// PER-259 / ADR-0054 — a within-transaction primitive that posts ONE standard
+// INCOME `Transaction` on a cash-like account, guarded + base-projected +
+// audited, and returns it serialized. Factored out of `createTransactionForFamily`'s
+// standard income branch so a non-transfer caller (a holdings dividend CASH
+// payout — cash lands on a user-chosen destination account, the source holding
+// untouched) can post the exact same canonical income row without re-opening a
+// transaction or duplicating the balance/projection/audit contract. The +amount
+// delta rides the guarded `applyAccountBalanceDelta` path, so a destination that
+// is itself a valuation/holdings account is rejected fail-loud (ADR-0048 §3 /
+// ADR-0054) — a cash dividend cannot land on a holdings account. Currency is
+// derived from the account, never the caller (PER-147). The caller owns
+// idempotency (endpoint-scoped) and any provenance audit.
+export async function postIncomeTransactionWithinTx(
+  tx: TenantTransactionClient,
+  {
+    account,
+    amount,
+    date,
+    description,
+    notes = null,
+    categoryId = null,
+    familyId,
+    user,
+    auditCtx,
+    baseCurrency,
+    idempotencyKey,
+    status,
+  }: {
+    account: Account
+    amount: bigint
+    date: Date
+    description: string
+    notes?: string | null
+    categoryId?: string | null
+    familyId: string
+    user: { id: string }
+    auditCtx: AuditContext
+    baseCurrency: string
+    idempotencyKey: string
+    status: string
+  }
+) {
+  const inflow = absMoney(amount)
+
+  const [oldAccount, accountMutation] =
+    await runTenantTransactionQueriesInOrder([
+      () => tx.account.findUniqueOrThrow({ where: { id: account.id } }),
+      () =>
+        applyAccountBalanceDelta(tx, {
+          accountId: account.id,
+          delta: inflow,
+          familyId,
+          notFoundMessage: "Destination account not found or access denied!",
+        }),
+    ] as const)
+  const accountBalanceAfter = accountMutation.after.balance
+
+  const projection = await computeBaseProjectionForAmount(tx, familyId, {
+    amount: inflow,
+    currency: account.currency,
+    date,
+    baseCurrency,
+  })
+
+  const created = await tx.transaction.create({
+    data: {
+      type: "income",
+      kind: "standard",
+      amount: inflow,
+      currency: account.currency,
+      description,
+      date,
+      notes: notes || null,
+      accountId: account.id,
+      categoryId: categoryId || null,
+      userId: user.id,
+      familyId,
+      status,
+      baseAmount: projection.baseAmount,
+      baseCurrency: projection.baseCurrency,
+      fxRateScaled: projection.fxRateScaled,
+      fxRateSnapshotId: projection.fxRateSnapshotId,
+      accountBalanceAfter,
+      idempotencyKey,
+    },
+  })
+
+  const newAccount = await tx.account.findUniqueOrThrow({
+    where: { id: account.id },
+  })
+
+  await auditLogs(tx, auditCtx, [
+    ...accountBalanceAuditEntries([oldAccount], [newAccount]),
+    ...createdAuditEntries("Transaction", [created]),
+  ])
+
+  return serializeTransaction({ ...created, amount: absMoney(created.amount) })
+}
+
 async function createValuationLinkedTransferWithinTx(
   tx: TenantTransactionClient,
   {

--- a/tests/e2e/dividend-distribution.e2e.ts
+++ b/tests/e2e/dividend-distribution.e2e.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-259 Slice 2 / ADR-0054 — Dividend / distribution UI (broker-agnostic).
+// Onboard → create a cash account + a Tracked Asset (valuation-tracked) account
+// → add a holding → open the Dividend dialog and exercise BOTH universal shapes:
+//   Cash payout — income lands on a SEPARATE destination account; the source
+//     holding's value is unchanged (the real BNI-AM Ardhani case).
+//   Reinvest    — units up on the source holding; no external cash.
+//
+// \s (not literal spaces) — formatCurrency uses a non-breaking space.
+
+test.describe("dividend / distribution UI (PER-259 Slice 2)", () => {
+  test("cash payout lands on a separate account; source holding unchanged", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const pensionName = `Dana Pensiun ${suffix}`
+    const portfolioName = `Portfolio ${suffix}`
+
+    // --- Destination cash account (opening balance 0) ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(pensionName)
+    await page.getByLabel("Opening balance").fill("0")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Tracked Asset account ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // --- Seed a holding: 2 units @ 1,000,000 (value = cost = 2,000,000). ---
+    await page.getByRole("button", { name: "Add holding" }).click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Instrument name").fill("Gold")
+    await dialog.getByRole("combobox", { name: "Instrument kind" }).click()
+    await page.getByRole("option", { name: "Metal" }).click()
+    await dialog.getByLabel("Quantity").fill("2")
+    await dialog.getByLabel(/Average unit cost/i).fill("1000000")
+    await dialog.getByRole("button", { name: "Add holding" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(/Rp\s2,000,000\.00/).first()).toBeVisible()
+
+    // --- Cash payout of Rp 12,151 into the pension account. ---
+    await page.getByRole("button", { name: "Dividend" }).first().click()
+    dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByRole("heading", { name: "Dividend / distribution" })
+    ).toBeVisible()
+    // Type defaults to "Cash payout".
+    await dialog.getByLabel(/^Amount/).fill("12151")
+    await dialog.getByRole("combobox", { name: "Destination account" }).click()
+    await page.getByRole("option", { name: pensionName }).click()
+    await dialog.getByRole("button", { name: "Record payout" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Source holding UNCHANGED — value still Rp 2,000,000.00, and the account
+    // hero still re-materializes to Rp 2,000,000.00 (>= 2 occurrences: holding
+    // value, total, hero). A cash payout never touches the position.
+    expect(
+      await page.getByText(/Rp\s2,000,000\.00/).count()
+    ).toBeGreaterThanOrEqual(2)
+
+    // The income landed on the pension account: open it and see the credit.
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: `Open ${pensionName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+    await expect(page.getByText(/Dividend . Gold/).first()).toBeVisible()
+    await expect(page.getByText(/Rp\s12,151\.00/).first()).toBeVisible()
+  })
+
+  test("reinvest grows the source position; no external cash", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const portfolioName = `Portfolio ${suffix}`
+
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // Seed 2 units @ 1,000,000 (value = cost = 2,000,000).
+    await page.getByRole("button", { name: "Add holding" }).click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Instrument name").fill("Gold")
+    await dialog.getByRole("combobox", { name: "Instrument kind" }).click()
+    await page.getByRole("option", { name: "Metal" }).click()
+    await dialog.getByLabel("Quantity").fill("2")
+    await dialog.getByLabel(/Average unit cost/i).fill("1000000")
+    await dialog.getByRole("button", { name: "Add holding" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Reinvest Rp 1,000,000 at Rp 1,000,000/unit → +1 unit; cost 3,000,000.
+    await page.getByRole("button", { name: "Dividend" }).first().click()
+    dialog = page.getByRole("dialog")
+    await dialog.getByRole("combobox", { name: "Distribution type" }).click()
+    await page.getByRole("option", { name: "Reinvest" }).click()
+    await dialog.getByLabel(/^Amount/).fill("1000000")
+    await dialog.getByLabel(/Reinvest unit price/i).fill("1000000")
+    // The derived units preview updates.
+    await expect(dialog.getByText("1.00000000")).toBeVisible()
+    await dialog.getByRole("button", { name: "Record reinvest" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Position grew: cost Rp 3,000,000.00, value Rp 3,000,000.00, hero
+    // re-materialized (>= 2 occurrences of the value).
+    await expect(page.getByText(/Rp\s3,000,000\.00/).first()).toBeVisible()
+    expect(
+      await page.getByText(/Rp\s3,000,000\.00/).count()
+    ).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/tests/integration/distributions.integration.ts
+++ b/tests/integration/distributions.integration.ts
@@ -1,0 +1,435 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  HoldingError,
+  recordDistributionForFamily,
+  recordTradeForFamily,
+} from "@/server/holdings"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-259 Slice 2 / ADR-0054 — Dividend / distribution (cash payout + reinvest).
+// Broker/country-agnostic. Money amounts are in MINOR units (IDR sen). Fixtures
+// use exact-division quantities/prices so conservation is provable to the sen.
+
+describe("dividend / distribution (PER-259 Slice 2 / ADR-0054)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const makeInvestmentAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Reksadana"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const makeCashAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Checking",
+    openingBalance = "150000"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const balanceOf = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const row = await tx.account.findUniqueOrThrow({
+        where: { id: accountId },
+        select: { balance: true },
+      })
+      return row.balance
+    })
+
+  const fundInline = {
+    kind: "mutual_fund" as const,
+    name: "BNI-AM Dana Pendapatan Tetap Syariah Ardhani",
+  }
+
+  // Establish a 100-unit @ 10,000/unit position (cost 1,000,000).
+  const seedPosition = async (
+    owner: AuthenticatedOnboardedUser,
+    investmentId: string,
+    fundingId: string
+  ) => {
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investmentId,
+        fundingAccountId: fundingId,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    return {
+      instrumentId: buy.holding?.instrumentId ?? "",
+      holdingId: buy.holding?.id ?? "",
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // CASH PAYOUT — income on a DIFFERENT account; source holding untouched.
+  // --------------------------------------------------------------------------
+  test("CASH: income lands on a separate destination, source holding unchanged, back-dated", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const pension = await makeCashAccount(owner, "Dana Pensiun", "0")
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    const investValueBefore = await balanceOf(owner, investment.id)
+    const cashBefore = await balanceOf(owner, cash.id)
+    const dividendDate = new Date("2025-06-11T00:00:00.000Z")
+
+    const result = await recordDistributionForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        mode: "cash",
+        amount: "12151", // Ardhani 2025-06-11 payout
+        date: dividendDate,
+        destinationAccountId: pension.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result.mode).toBe("cash")
+    expect(result.destinationAccountId).toBe(pension.id)
+    expect(result.incomeTransaction?.type).toBe("income")
+    expect(result.incomeTransaction?.amount).toBe("12151")
+    expect(result.destinationBalanceAfterMinor).toBe("12151")
+
+    // Pension credited; the funding (cash) account NOT touched by the dividend.
+    expect(await balanceOf(owner, pension.id)).toBe(12_151n)
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore)
+
+    // Source holding + investment value UNCHANGED (no units, no revaluation).
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(1)
+    expect(view.holdings[0]?.quantity).toBe("100.00000000")
+    expect(view.holdings[0]?.valueMinor).toBe("1000000")
+    expect(view.holdings[0]?.costMinor).toBe("1000000")
+    expect(await balanceOf(owner, investment.id)).toBe(investValueBefore)
+
+    // The income row: income/standard, income category, on the destination,
+    // back-dated, provenance in the notes. Category is the reused "Investment
+    // Income".
+    const posted = await harness.withFamily(owner.family.id, async (tx) => {
+      const txn = await tx.transaction.findUniqueOrThrow({
+        where: { id: result.incomeTransaction?.id ?? "" },
+        include: { category: true },
+      })
+      return txn
+    })
+    expect(posted.type).toBe("income")
+    expect(posted.kind).toBe("standard")
+    expect(posted.accountId).toBe(pension.id)
+    expect(posted.category?.name).toBe("Investment Income")
+    expect(posted.category?.type).toBe("income")
+    expect(posted.date.toISOString()).toBe(dividendDate.toISOString())
+    expect(posted.notes ?? "").toContain("Ardhani")
+  })
+
+  test("CASH: a Distribution provenance audit row links back to the source holding", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const pension = await makeCashAccount(owner, "Dana Pensiun", "0")
+    const { instrumentId, holdingId } = await seedPosition(
+      owner,
+      investment.id,
+      cash.id
+    )
+    const key = factories.createIdempotencyKey()
+
+    await recordDistributionForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        mode: "cash",
+        amount: "17268",
+        destinationAccountId: pension.id,
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const audit = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.findMany({
+        where: { familyId: owner.family.id, idempotencyKey: key },
+        select: { entityType: true, action: true, afterJson: true },
+      })
+    )
+    const entityTypes = new Set(audit.map((r) => r.entityType))
+    expect(entityTypes.has("Transaction")).toBe(true)
+    expect(entityTypes.has("Distribution")).toBe(true)
+
+    const provenance = audit.find((r) => r.entityType === "Distribution")
+    const after = provenance?.afterJson as Record<string, unknown> | null
+    expect(after?.mode).toBe("cash")
+    expect(after?.holdingId).toBe(holdingId)
+    expect(after?.instrumentId).toBe(instrumentId)
+    expect(after?.destinationAccountId).toBe(pension.id)
+  })
+
+  test("CASH: replaying the same key posts a single income", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const pension = await makeCashAccount(owner, "Dana Pensiun", "0")
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        mode: "cash" as const,
+        amount: "595",
+        destinationAccountId: pension.id,
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+
+    const first = await recordDistributionForFamily(payload)
+    const second = await recordDistributionForFamily(payload)
+    const normalize = (value: unknown): unknown =>
+      JSON.parse(JSON.stringify(value))
+    expect(normalize(second)).toEqual(normalize(first))
+
+    // Applied once: pension credited exactly 595, one income row.
+    expect(await balanceOf(owner, pension.id)).toBe(595n)
+    const counts = await harness.withFamily(owner.family.id, async (tx) => ({
+      income: await tx.transaction.count({
+        where: { accountId: pension.id, type: "income", deletedAt: null },
+      }),
+    }))
+    expect(counts.income).toBe(1)
+  })
+
+  test("CASH: rejects a destination that is not cash-like", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const otherInvestment = await makeInvestmentAccount(owner, "Reksadana 2")
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    await expect(
+      recordDistributionForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          holdingId,
+          mode: "cash",
+          amount: "12151",
+          destinationAccountId: otherInvestment.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  // --------------------------------------------------------------------------
+  // REINVEST — units up + cost basis up; no external cash.
+  // --------------------------------------------------------------------------
+  test("REINVEST: units up + cost basis up, no external cash, anchor re-materialized", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    // Reinvest 500,000 at 10,000/unit → +50 units, cost 1,500,000, avg 10,000.
+    const result = await recordDistributionForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        mode: "reinvest",
+        amount: "500000",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result.mode).toBe("reinvest")
+    expect(result.costBasisDeltaMinor).toBe("500000")
+    expect(result.holding?.quantity).toBe("150.00000000")
+    expect(result.holding?.avgUnitCostMinor).toBe("10000")
+    expect(result.holding?.costMinor).toBe("1500000")
+    expect(result.holding?.valueMinor).toBe("1500000")
+    expect(result.investmentValueAfterMinor).toBe("1500000")
+
+    // NO external cash moved.
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore)
+    // Investment value re-materialized from Σ holdings.
+    expect(await balanceOf(owner, investment.id)).toBe(1_500_000n)
+
+    // NO income transaction was created (reinvest is not a cash movement).
+    const income = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.transaction.count({
+        where: { familyId: owner.family.id, type: "income", deletedAt: null },
+      })
+    )
+    expect(income).toBe(0)
+
+    // The re-materialized anchor uses the guard-allowed source="holdings" path.
+    const latestValuation = await harness.withFamily(
+      owner.family.id,
+      async (tx) =>
+        tx.valuation.findFirst({
+          where: { accountId: investment.id },
+          orderBy: { createdAt: "desc" },
+          select: { source: true, value: true },
+        })
+    )
+    expect(latestValuation?.source).toBe("holdings")
+    expect(latestValuation?.value).toBe(1_500_000n)
+  })
+
+  test("REINVEST: derives units from amount ÷ unitPrice (fractional)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    // Reinvest 595 at 10,000/unit → 0.0595 units (595 × 1e8 / 10000 = 5,950,000).
+    const result = await recordDistributionForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        mode: "reinvest",
+        amount: "595",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(result.holding?.quantity).toBe("100.05950000")
+    expect(result.holding?.costMinor).toBe("1000595")
+  })
+
+  test("REINVEST: replaying the same key applies the units once", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        mode: "reinvest" as const,
+        amount: "500000",
+        unitPrice: "10000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+
+    await recordDistributionForFamily(payload)
+    await recordDistributionForFamily(payload)
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    // Applied exactly once — 150 units, not 200.
+    expect(view.holdings[0]?.quantity).toBe("150.00000000")
+    expect(await balanceOf(owner, investment.id)).toBe(1_500_000n)
+  })
+
+  // --------------------------------------------------------------------------
+  // Tenant isolation
+  // --------------------------------------------------------------------------
+  test("a distribution referencing another family's accounts is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const intruder = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const pension = await makeCashAccount(owner, "Dana Pensiun", "0")
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    await expect(
+      recordDistributionForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          holdingId,
+          mode: "cash",
+          amount: "12151",
+          destinationAccountId: pension.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+    ).rejects.toThrow()
+
+    // No income posted anywhere.
+    expect(await balanceOf(owner, pension.id)).toBe(0n)
+  })
+})


### PR DESCRIPTION
## PER-259 Slice 2 — Dividend / distribution (ADR-0054 cascade item 3)

A holdings-tracked account distributes money via **two universal shapes**, broker/country-agnostic (no "Bibit"/vendor wording — the ADR-0054 Broker-agnostic principle). Includes the updated **ADR-0054** in this PR.

### The two shapes
**1. Cash payout** — income, with **NO change to the source holding's units or position value**. Cash lands on a **user-chosen destination cash account** (any `transaction_flow` account, often *different* from the holding — a pension/cash pot). Modeled as a normal INCOME `Transaction` on that destination, reusing the family's existing **"Investment Income"** income category (find-or-create, case-insensitive — never duplicated). **Back-datable.** The holdings account is **not** touched.

**2. Reinvest** — **units up** on the source holding at the reinvest price (`units = amount ÷ unitPrice`, or an explicit quantity), **cost basis += amount**, **no external cash**. The Σ-holdings anchor re-materializes through the `source="holdings"` path — the only value-write the PER-259 guard allows on a holdings account (Slice 1 unaffected). Structurally BUY minus the funding cash leg.

### Provenance model
No heavy migration. Provenance (source holding + instrument) is carried in the income row's **description** (`Dividend — <instrument>`), **notes**, and an explicit append-only **`Distribution` AuditLog row** (`mode`, `holdingId`, `instrumentId`, `destinationAccountId`, amount). Queryable, durable, no schema FK churn this slice.

### Destination-account model
The cash payout's destination is **user-selectable** (any active, same-currency, cash-like `transaction_flow` account) and **date is user-set** — it does not assume same-account or today. A non-cash destination is rejected fail-loud; a cash dividend can never land on a holdings account (the new income primitive rides the guarded `applyAccountBalanceDelta` path).

### Contract
```
recordDistributionFn({ investmentAccountId, holdingId, mode: "cash"|"reinvest",
  amount, date?, destinationAccountId? (cash), categoryId? (cash),
  unitPrice?/quantity? (reinvest), idempotencyKey })
```
Full ledger mutation contract per mode: one ACID `prisma.$transaction`, endpoint-scoped idempotency, tenant-owned reference validation + RLS GUC, append-only AuditLog, fractional-unit precision, same-currency this slice. Cash mode reuses a new within-tx primitive `postIncomeTransactionWithinTx` factored out of `createTransactionForFamily`'s standard income branch (additive; existing paths unchanged).

### UI
Broker-agnostic **Dividend / distribution** dialog (Cash payout / Reinvest) with a live units/cash preview; panel-level **Dividend** button + a per-holding Dividend action on the `HoldingsPanel`.

### Real acceptance case (BNI-AM Ardhani)
The 3 cash dividends (2025-06-11 Rp 12,151 · 2025-12-08 Rp 17,268 · 2026-06-08 Rp 595) each deposit to a **separate "Dana Pensiun" cash account** with the fund's units flat — exactly what the cash-payout flow does (destination-selectable + back-dated + source untouched). Covered directly in the integration + e2e tests (no special-casing).

### Test evidence (real Postgres, PER-86 harness)
- `distributions.integration.ts` — **8 passed**: cash income on a DIFFERENT destination (source holding units + value unchanged, back-dated, "Investment Income" category); Distribution provenance audit row; cash idempotent replay; non-cash destination rejected; reinvest units↑ + cost↑ + no external cash + `source="holdings"` anchor re-materialized; fractional units from amount÷price; reinvest idempotent replay; tenant isolation.
- Slice 1 unbroken — `trades` + `holdings` + `holdings-move-coherence`: **33 passed**; `transaction-idempotency` + `transfer-purpose-fee`: **16 passed**.
- e2e `dividend-distribution.e2e.ts` — **2 passed** (cash payout lands on a separate account with source unchanged; reinvest grows the position).
- Gates: `vp fmt`, `vp check`, `vp build` (server/client fence), `vp test` (714 unit) — all green.

Confirms **ADR-0048** and **Slice 1** invariants unbroken (the `source="holdings"` / guard path is the only value-write on a holdings account; NAV refresh untouched).

Do **not** merge — lead review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1
