### PR TITLE
feat(holdings): PER-259 Slice 3 — investment fees (standalone expense, broker-agnostic)

### DIFF
--- a/docs/adr/0054-holdings-account-operational-coherence.md
+++ b/docs/adr/0054-holdings-account-operational-coherence.md
@@ -134,7 +134,24 @@ FIFO-vs-average election beyond the current average-cost model — later.
   hide/redirect "Add transaction" transfer + "Update value" on holdings accounts;
   server + DB invariant with an actionable "use Buy/Sell" message; real-PG + e2e.
 - **Slice 2 — Dividend / distribution** trade mode (cash-out or reinvest).
-- **Slice 3 — Fees** (purchase / redemption / management).
+- **Slice 3 — Fees** (standalone) — DONE (PER-259 Slice 3). A **standalone fee**
+  tied to an investment (platform / annual / one-off transaction / redemption fee
+  charged _separately_) is modelled as an **EXPENSE** on a **user-chosen cash
+  account** (`transaction_flow`), reducing its balance via the guarded delta (so
+  a fee can never land on a holdings/valuation account), back-datable,
+  categorised with a family **"Investment Fee"** expense category (find-or-create,
+  case-insensitive — the Slice 2 pattern), and provenance-linked to the source
+  holding/instrument (description + notes + an append-only `Fee` AuditLog row).
+  **The source holding is NOT mutated.** Server `recordFeeFn` / `recordFeeForFamily`;
+  within-tx primitive `postExpenseTransactionWithinTx` (the EXPENSE sibling of
+  Slice 2's `postIncomeTransactionWithinTx`; `createTransactionForFamily`
+  untouched). Same-currency this slice.
+  - **Out of scope — already captured, never double-counted:** a fee **embedded
+    in a Buy/Sell** (purchase / redemption load) is already in the trade —
+    `cashAmount` is authoritative, the load is part of the cash actually
+    paid/received. And **NAV-embedded management fees** (reksadana / ETF expense
+    ratios) are already inside the NAV/price, so the Σ-holdings value already
+    reflects them — NOT recorded separately. Slice 3 adds only the standalone fee.
 - **Slice 4 — Switch** (atomic sell-A + buy-B).
 - **Slice 5 — Edit/correct a trade** (reverse + re-record, audited).
 - **Slice 6 — Move a position between accounts** (in-kind, no cash, cost basis carries).

--- a/src/components/blocks/fee-dialog.tsx
+++ b/src/components/blocks/fee-dialog.tsx
@@ -1,0 +1,239 @@
+import * as React from "react"
+import { Receipt } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { MoneyInput } from "@/components/blocks/money-input"
+import { formatCurrency } from "@/lib/currency"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import { parseMoneyInput } from "@/lib/money"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
+import { recordFeeFn } from "@/server/holdings"
+
+// PER-259 Slice 3 / ADR-0054 — Investment fee dialog.
+// Broker/country-agnostic: a STANDALONE fee tied to an investment (platform,
+// annual, one-off transaction/redemption fee charged separately). Modeled as an
+// EXPENSE on a user-chosen cash account; the source holding is untouched. The
+// heavy lifting (guarded expense posting, category find-or-create, provenance
+// audit, idempotency) is SERVER-side (`recordFeeFn`); this dialog only collects
+// inputs. NO vendor wording.
+//
+// Fees embedded in a Buy/Sell (purchase/redemption load) and NAV-embedded
+// management fees (expense ratios) are already captured elsewhere and are NOT
+// recorded here.
+
+export interface FeeSourceAccount {
+  id: string
+  name: string
+  currency: string
+}
+
+export type FeeDialogState = { holding?: HoldingRecord }
+
+function toDateInputValue(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+export function FeeDialog({
+  state,
+  investmentAccountId,
+  currency,
+  holdings,
+  sourceAccounts,
+  onClose,
+  onSaved,
+}: {
+  state: FeeDialogState
+  investmentAccountId: string
+  currency: string
+  holdings: ReadonlyArray<HoldingRecord>
+  sourceAccounts: ReadonlyArray<FeeSourceAccount>
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const currencyCode = currency as CurrencyCode
+
+  const [holdingId, setHoldingId] = React.useState<string>(
+    state.holding?.id ?? holdings[0]?.id ?? ""
+  )
+  const [amount, setAmount] = React.useState<string>("")
+  const [date, setDate] = React.useState<string>(toDateInputValue(new Date()))
+  const [sourceAccountId, setSourceAccountId] = React.useState<string>(
+    sourceAccounts[0]?.id ?? ""
+  )
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  // Parsed fee amount (minor units) — authoritative for the expense row.
+  const amountMinor = React.useMemo<bigint | null>(() => {
+    if (amount.trim() === "") return null
+    const parsed = parseMoneyInput(amount, currencyCode)
+    return parsed !== null && parsed > 0n ? parsed : null
+  }, [amount, currencyCode])
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+    if (amountMinor === null) {
+      setError("Enter a valid fee amount.")
+      return
+    }
+    if (holdingId === "") {
+      setError("Choose the holding this fee relates to.")
+      return
+    }
+    if (sourceAccountId === "") {
+      setError("Choose the account the fee is charged to.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      await recordFeeFn({
+        data: {
+          investmentAccountId,
+          holdingId,
+          amount: amountMinor.toString(),
+          date,
+          sourceAccountId,
+          idempotencyKey: createUuidV7(),
+        },
+      })
+      await onSaved()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught))
+      setSubmitting(false)
+    }
+  }
+
+  const submitDisabled =
+    submitting ||
+    amountMinor === null ||
+    holdingId === "" ||
+    sourceAccountId === ""
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Receipt className="size-4 text-amber-600 dark:text-amber-400" />
+              Investment fee
+            </DialogTitle>
+            <DialogDescription>
+              A standalone fee reduces the account it is charged to; the
+              position is unchanged.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label>Holding</Label>
+              <Select value={holdingId} onValueChange={setHoldingId}>
+                <SelectTrigger aria-label="Source holding">
+                  <SelectValue placeholder="Choose holding" />
+                </SelectTrigger>
+                <SelectContent>
+                  {holdings.map((holding) => (
+                    <SelectItem key={holding.id} value={holding.id}>
+                      {holding.instrument.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="fee-date">Date</Label>
+              <Input
+                id="fee-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="fee-amount">Amount ({currency})</Label>
+            <MoneyInput
+              id="fee-amount"
+              currency={currencyCode}
+              value={amount}
+              onChange={setAmount}
+              placeholder="0"
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Charge to</Label>
+            <Select value={sourceAccountId} onValueChange={setSourceAccountId}>
+              <SelectTrigger aria-label="Fee source account">
+                <SelectValue placeholder="Choose account" />
+              </SelectTrigger>
+              <SelectContent>
+                {sourceAccounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {account.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {sourceAccounts.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No same-currency cash account to charge the fee to.
+              </p>
+            ) : null}
+          </div>
+
+          {amountMinor !== null ? (
+            <div className="flex items-center justify-between rounded-md border bg-muted/50 p-3 text-sm">
+              <span className="text-muted-foreground">Cash out</span>
+              <span className="font-semibold tabular-nums">
+                {formatCurrency(amountMinor.toString(), currency)}
+              </span>
+            </div>
+          ) : null}
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {submitting ? "Recording…" : "Record fee"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -5,6 +5,7 @@ import {
   Gift,
   PiggyBank,
   Plus,
+  Receipt,
   RefreshCw,
   TrendingDown,
   TrendingUp,
@@ -92,6 +93,8 @@ export function HoldingsPanel({
   onSellHolding,
   onDividend,
   onDividendHolding,
+  onFee,
+  onFeeHolding,
   onRefreshPrices,
   refreshingPrices,
 }: Readonly<{
@@ -107,6 +110,8 @@ export function HoldingsPanel({
   onSellHolding: (holding: HoldingRecord) => void
   onDividend: () => void
   onDividendHolding: (holding: HoldingRecord) => void
+  onFee: () => void
+  onFeeHolding: (holding: HoldingRecord) => void
   onRefreshPrices: () => void
   refreshingPrices: boolean
 }>) {
@@ -152,6 +157,12 @@ export function HoldingsPanel({
             <Button size="sm" variant="outline" onClick={onDividend}>
               <Gift className="size-4" />
               Dividend
+            </Button>
+          ) : null}
+          {holdings.length > 0 ? (
+            <Button size="sm" variant="outline" onClick={onFee}>
+              <Receipt className="size-4" />
+              Fee
             </Button>
           ) : null}
           <Button size="sm" variant="outline" onClick={onAdd}>
@@ -243,6 +254,16 @@ export function HoldingsPanel({
                     >
                       <Gift className="size-3.5" />
                       Dividend
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => onFeeHolding(holding)}
+                    >
+                      <Receipt className="size-3.5" />
+                      Fee
                     </Button>
                     <Button
                       type="button"

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -56,6 +56,7 @@ import {
   DistributionDialog,
   type DistributionDialogState,
 } from "@/components/blocks/distribution-dialog"
+import { FeeDialog, type FeeDialogState } from "@/components/blocks/fee-dialog"
 import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
@@ -184,6 +185,7 @@ function AccountDetailPage() {
   // PER-259 Slice 2 — dividend / distribution dialog (cash payout or reinvest).
   const [distributionDialog, setDistributionDialog] =
     React.useState<DistributionDialogState | null>(null)
+  const [feeDialog, setFeeDialog] = React.useState<FeeDialogState | null>(null)
   // PER-241 — the per-account statement now shares the /transactions row, so it
   // gets the same singleton edit modal + inline delete.
   const [editingTrx, setEditingTrx] =
@@ -729,6 +731,8 @@ function AccountDetailPage() {
               onDividendHolding={(holding) =>
                 setDistributionDialog({ holding })
               }
+              onFee={() => setFeeDialog({})}
+              onFeeHolding={(holding) => setFeeDialog({ holding })}
               onRefreshPrices={handleRefreshPrices}
               refreshingPrices={refreshingPrices}
             />
@@ -999,6 +1003,23 @@ function AccountDetailPage() {
           onSaved={async () => {
             await refreshHoldings()
             setDistributionDialog(null)
+          }}
+        />
+      ) : null}
+
+      {feeDialog ? (
+        <FeeDialog
+          // Remount per open so the form re-initializes cleanly.
+          key={feeDialog.holding ? `fee-${feeDialog.holding.id}` : "fee"}
+          state={feeDialog}
+          investmentAccountId={accountId}
+          currency={currency}
+          holdings={holdingsView?.holdings ?? []}
+          sourceAccounts={fundingAccounts}
+          onClose={() => setFeeDialog(null)}
+          onSaved={async () => {
+            await refreshHoldings()
+            setFeeDialog(null)
           }}
         />
       ) : null}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -35,6 +35,7 @@ import {
 import { toMinorUnits } from "@/lib/money"
 import { getFamilyBaseCurrency } from "./fx"
 import {
+  postExpenseTransactionWithinTx,
   postIncomeTransactionWithinTx,
   postValuationLinkedTransferLegs,
   type ValuationLinkedTransferLeg,
@@ -1941,6 +1942,317 @@ export const recordDistributionFn = createServerFn({ method: "POST" })
   )
   .handler(async ({ data, context }) => {
     return await recordDistributionForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// =============================================================================
+// FEE — standalone investment fee as an EXPENSE (PER-259 Slice 3 / ADR-0054)
+// =============================================================================
+//
+// A fee is a cost tied to an investment. Broker/country-agnostic (NOT vendor-
+// specific): a platform fee, an annual/subscription fee, a one-off transaction/
+// redemption fee charged SEPARATELY. This slice models the STANDALONE fee — the
+// common, missing case — as a normal EXPENSE `Transaction` on a USER-CHOSEN cash
+// account (balanceSource="transaction_flow"), reducing its balance via the
+// guarded delta (so a fee can NEVER land on a holdings/valuation account), back-
+// datable, categorised with the family's "Investment Fee" expense category
+// (find-or-create, case-insensitive — same pattern as Slice 2's "Investment
+// Income"), and provenance-linked to the source holding/instrument (description +
+// notes + an append-only `Fee` AuditLog row carrying holdingId/instrumentId/
+// amount). The source holding is NOT mutated (no anchor recompute).
+//
+// OUT OF SCOPE — already captured elsewhere, never double-counted here:
+//   • Fees EMBEDDED in a Buy/Sell (purchase / redemption load) — `cashAmount`
+//     is authoritative, the load is part of the cash actually paid/received
+//     (recordTradeForFamily). Nothing extra to record.
+//   • NAV-embedded management fees (reksadana / ETF expense ratios) — already
+//     inside the NAV/price, so the Σ-holdings value already reflects them. NOT
+//     recorded as a separate row.
+//
+// Full ledger mutation contract (CLAUDE.md §5A): interactive tenant transaction
+// + RLS GUC, tenant-owned reference validation, endpoint-scoped idempotency, and
+// append-only AuditLog rows in the same transaction. Same-currency this slice
+// (the source cash account shares the holding/account currency).
+
+const RECORD_FEE_ENDPOINT = "recordFeeFn"
+
+// The expense category a standalone fee is booked under. Reused (find-or-create
+// by case-insensitive name, matching the `merchant_category_name_dedup` index)
+// so a family's existing "Investment Fee" category is honored, never duplicated.
+const INVESTMENT_FEE_CATEGORY_NAME = "Investment Fee"
+
+export const recordFeeInputSchema = z.object({
+  investmentAccountId: z.string().min(1),
+  // The source holding the fee is tied to (provenance). NOT mutated.
+  holdingId: z.string().min(1),
+  // Fee amount in MINOR units (digit-string), strictly positive.
+  amount: positiveMinorDigitsSchema,
+  // The cash-like account the fee is charged to (reduces its balance).
+  sourceAccountId: z.string().min(1),
+  // Back-datable (a fee lands on a broker-set date, not necessarily "today").
+  date: z.coerce.date().optional(),
+  // Optional expense category override; defaults to the family's "Investment
+  // Fee" category (find-or-create). Validated to be expense-typed + tenant-owned.
+  categoryId: z.string().min(1).optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+type RecordFeeInput = z.infer<typeof recordFeeInputSchema>
+
+export interface RecordFeeResult {
+  investmentAccountId: string
+  holdingId: string
+  instrumentId: string
+  /** Fee amount, minor units (digit-string). */
+  amountMinor: string
+  /** The cash account the fee was charged to. */
+  sourceAccountId: string
+  /** The expense Transaction posted on the source cash account. */
+  expenseTransaction: Awaited<ReturnType<typeof postExpenseTransactionWithinTx>>
+  /** Source account balance after the fee expense, minor units. */
+  sourceBalanceAfterMinor: string
+}
+
+// Find-or-create the family's expense category for fees. Case-insensitive name
+// match (the dedup index key) so an existing "Investment Fee" is reused and never
+// duplicated; a freshly-created one is audited in the same tx.
+async function resolveFeeExpenseCategory(
+  tx: TenantTransactionClient,
+  familyId: string,
+  auditCtx: AuditContext
+): Promise<string> {
+  const existing = await tx.category.findFirst({
+    where: {
+      familyId,
+      name: { equals: INVESTMENT_FEE_CATEGORY_NAME, mode: "insensitive" },
+    },
+    select: { id: true },
+  })
+  if (existing) return existing.id
+
+  const created = await tx.category.create({
+    data: {
+      familyId,
+      name: INVESTMENT_FEE_CATEGORY_NAME,
+      type: "expense",
+      isSystem: false,
+    },
+  })
+  await auditLog(tx, auditCtx, {
+    action: "create",
+    entityType: "Category",
+    entityId: created.id,
+    after: { id: created.id, name: created.name, type: created.type },
+  })
+  return created.id
+}
+
+export async function recordFeeForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordFeeInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<RecordFeeResult> {
+  const data: RecordFeeInput = recordFeeInputSchema.parse(rawData)
+
+  const requestHash = await hashCanonicalPayload({
+    amount: data.amount,
+    categoryId: data.categoryId ?? null,
+    date: data.date?.toISOString() ?? null,
+    holdingId: data.holdingId,
+    investmentAccountId: data.investmentAccountId,
+    sourceAccountId: data.sourceAccountId,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+  const amountMinor = BigInt(data.amount)
+  const date = data.date ?? new Date()
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<RecordFeeResult>(
+        tx,
+        {
+          endpoint: RECORD_FEE_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      // Tenant ownership of the investment account, source account, and (when
+      // provided) the category. RLS-scoped and belt-and-braces checked.
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.investmentAccountId,
+        categoryId: data.categoryId,
+      })
+      const investmentAccount = await fetchActiveAccount(
+        tx,
+        familyId,
+        data.investmentAccountId,
+        "Investment"
+      )
+      if (investmentAccount.balanceSource !== "valuation") {
+        throw new HoldingError(
+          `Investment account ${investmentAccount.id} must be a valuation-tracked account (balanceSource="valuation"); it is "${investmentAccount.balanceSource}"`
+        )
+      }
+      const currency = assertKnownCurrency(investmentAccount.currency)
+
+      // The source holding — provenance only; NOT mutated.
+      const holding = await loadHoldingWithInstrument(
+        tx,
+        familyId,
+        data.holdingId
+      )
+      if (holding.accountId !== investmentAccount.id) {
+        throw new HoldingError(
+          `Holding ${data.holdingId} does not belong to account ${data.investmentAccountId}`
+        )
+      }
+      const instrument = holding.instrument
+      const provenance = `${instrument.name}${instrument.symbol ? ` (${instrument.symbol})` : ""}`
+
+      // The cash account the fee is charged to. The guarded expense delta will
+      // ALSO reject a valuation/holdings account fail-loud (ADR-0048 §3); this
+      // check gives a clearer, earlier message for the common misuse.
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.sourceAccountId,
+      })
+      const source = await fetchActiveAccount(
+        tx,
+        familyId,
+        data.sourceAccountId,
+        "Source"
+      )
+      if (source.balanceSource !== "transaction_flow") {
+        throw new HoldingError(
+          `Source account ${source.id} must be a cash-like account (balanceSource="transaction_flow"); it is "${source.balanceSource}". A fee cannot be charged to a holdings account.`
+        )
+      }
+      if (source.currency !== currency) {
+        throw new HoldingError(
+          `Cross-currency fees are not supported this slice (holding ${currency}, source ${source.currency})`
+        )
+      }
+
+      // Reuse the family's "Investment Fee" category (or an explicit expense
+      // category the caller chose, validated to be expense-typed).
+      let categoryId: string
+      if (data.categoryId) {
+        const category = await tx.category.findFirst({
+          where: { id: data.categoryId, familyId },
+          select: { id: true, type: true },
+        })
+        if (!category) {
+          throw new HoldingError(
+            `Category ${data.categoryId} not found for this family`
+          )
+        }
+        if (category.type !== "expense") {
+          throw new HoldingError(
+            `Category ${data.categoryId} must be an expense category for a fee`
+          )
+        }
+        categoryId = category.id
+      } else {
+        categoryId = await resolveFeeExpenseCategory(tx, familyId, auditCtx)
+      }
+
+      const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+      const expenseTransaction = await postExpenseTransactionWithinTx(tx, {
+        account: source,
+        amount: amountMinor,
+        date,
+        description: `Fee — ${instrument.name}`,
+        notes: `Investment fee for ${provenance} · holding ${holding.id} in ${investmentAccount.name}`,
+        categoryId,
+        familyId,
+        user,
+        auditCtx,
+        baseCurrency,
+        idempotencyKey: data.idempotencyKey,
+        status: "CLEARED",
+      })
+
+      // Explicit provenance audit row — the durable, queryable link from the fee
+      // expense back to the source holding/instrument (no schema FK migration
+      // this slice; description + notes + this row carry it). Mirrors Slice 2's
+      // "Distribution" provenance row.
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "Fee",
+        entityId: expenseTransaction.id,
+        after: {
+          amountMinor: amountMinor.toString(),
+          investmentAccountId: investmentAccount.id,
+          holdingId: holding.id,
+          instrumentId: instrument.id,
+          instrumentName: instrument.name,
+          sourceAccountId: source.id,
+          transactionId: expenseTransaction.id,
+        },
+      })
+
+      const sourceAfter = await tx.account.findUniqueOrThrow({
+        where: { id: source.id },
+        select: { balance: true },
+      })
+
+      const response: RecordFeeResult = {
+        investmentAccountId: investmentAccount.id,
+        holdingId: holding.id,
+        instrumentId: instrument.id,
+        amountMinor: amountMinor.toString(),
+        sourceAccountId: source.id,
+        expenseTransaction,
+        sourceBalanceAfterMinor: sourceAfter.balance.toString(),
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: RECORD_FEE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<RecordFeeResult>(tx, {
+        endpoint: RECORD_FEE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const recordFeeFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordFeeInputSchema>) =>
+    recordFeeInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordFeeForFamily({
       data,
       familyId: context.familyId,
       user: context.user,

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -2230,6 +2230,107 @@ export async function postIncomeTransactionWithinTx(
   return serializeTransaction({ ...created, amount: absMoney(created.amount) })
 }
 
+// PER-259 Slice 3 / ADR-0054 — the EXPENSE sibling of `postIncomeTransactionWithinTx`.
+// Posts ONE standard EXPENSE `Transaction` on a cash-like account, guarded +
+// base-projected + audited, and returns it serialized. Factored out so a non-
+// transfer caller (a standalone investment FEE — a platform / annual /
+// transaction fee charged separately, reducing a user-chosen cash account, with
+// the source holding untouched) can post the exact same canonical expense row
+// without re-opening a transaction or duplicating the balance/projection/audit
+// contract. The −amount delta rides the guarded `applyAccountBalanceDelta` path,
+// so a source account that is itself a valuation/holdings account is rejected
+// fail-loud (ADR-0048 §3 / ADR-0054) — a fee can never land on a holdings
+// account. Currency is derived from the account, never the caller (PER-147). The
+// caller owns idempotency (endpoint-scoped) and any provenance audit.
+export async function postExpenseTransactionWithinTx(
+  tx: TenantTransactionClient,
+  {
+    account,
+    amount,
+    date,
+    description,
+    notes = null,
+    categoryId = null,
+    familyId,
+    user,
+    auditCtx,
+    baseCurrency,
+    idempotencyKey,
+    status,
+  }: {
+    account: Account
+    amount: bigint
+    date: Date
+    description: string
+    notes?: string | null
+    categoryId?: string | null
+    familyId: string
+    user: { id: string }
+    auditCtx: AuditContext
+    baseCurrency: string
+    idempotencyKey: string
+    status: string
+  }
+) {
+  // Signed convention (CLAUDE.md §5A): an expense is stored NEGATIVE and the
+  // account balance moves DOWN by exactly that amount.
+  const outflow = negateMoney(absMoney(amount))
+
+  const [oldAccount, accountMutation] =
+    await runTenantTransactionQueriesInOrder([
+      () => tx.account.findUniqueOrThrow({ where: { id: account.id } }),
+      () =>
+        applyAccountBalanceDelta(tx, {
+          accountId: account.id,
+          delta: outflow,
+          familyId,
+          notFoundMessage: "Source account not found or access denied!",
+        }),
+    ] as const)
+  const accountBalanceAfter = accountMutation.after.balance
+
+  const projection = await computeBaseProjectionForAmount(tx, familyId, {
+    amount: outflow,
+    currency: account.currency,
+    date,
+    baseCurrency,
+  })
+
+  const created = await tx.transaction.create({
+    data: {
+      type: "expense",
+      kind: "standard",
+      amount: outflow,
+      currency: account.currency,
+      description,
+      date,
+      notes: notes || null,
+      accountId: account.id,
+      categoryId: categoryId || null,
+      userId: user.id,
+      familyId,
+      status,
+      baseAmount: projection.baseAmount,
+      baseCurrency: projection.baseCurrency,
+      fxRateScaled: projection.fxRateScaled,
+      fxRateSnapshotId: projection.fxRateSnapshotId,
+      accountBalanceAfter,
+      idempotencyKey,
+    },
+  })
+
+  const newAccount = await tx.account.findUniqueOrThrow({
+    where: { id: account.id },
+  })
+
+  await auditLogs(tx, auditCtx, [
+    ...accountBalanceAuditEntries([oldAccount], [newAccount]),
+    ...createdAuditEntries("Transaction", [created]),
+  ])
+
+  return serializeTransaction({ ...created, amount: absMoney(created.amount) })
+}
+
 async function createValuationLinkedTransferWithinTx(
   tx: TenantTransactionClient,
   {

--- a/tests/e2e/investment-fee.e2e.ts
+++ b/tests/e2e/investment-fee.e2e.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-259 Slice 3 / ADR-0054 — Investment fee UI (broker-agnostic).
+// Onboard → create a cash account + a Tracked Asset (valuation-tracked) account
+// → add a holding → open the Fee dialog and record a STANDALONE fee. The fee is
+// an EXPENSE on the chosen cash account; the source holding is unchanged.
+//
+// \s (not literal spaces) — formatCurrency uses a non-breaking space.
+
+test.describe("investment fee UI (PER-259 Slice 3)", () => {
+  test("a standalone fee reduces the chosen cash account; source holding unchanged", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const walletName = `Wallet ${suffix}`
+    const portfolioName = `Portfolio ${suffix}`
+
+    // --- Cash account the fee is charged to (opening balance 1,000,000) ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(walletName)
+    await page.getByLabel("Opening balance").fill("1000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Tracked Asset account ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // --- Seed a holding: 2 units @ 1,000,000 (value = cost = 2,000,000). ---
+    await page.getByRole("button", { name: "Add holding" }).click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Instrument name").fill("Gold")
+    await dialog.getByRole("combobox", { name: "Instrument kind" }).click()
+    await page.getByRole("option", { name: "Metal" }).click()
+    await dialog.getByLabel("Quantity").fill("2")
+    await dialog.getByLabel(/Average unit cost/i).fill("1000000")
+    await dialog.getByRole("button", { name: "Add holding" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(/Rp\s2,000,000\.00/).first()).toBeVisible()
+
+    // --- Record a Rp 25,000 fee charged to the wallet. ---
+    await page.getByRole("button", { name: "Fee" }).first().click()
+    dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByRole("heading", { name: "Investment fee" })
+    ).toBeVisible()
+    await dialog.getByLabel(/^Amount/).fill("25000")
+    await dialog.getByRole("combobox", { name: "Fee source account" }).click()
+    await page.getByRole("option", { name: walletName }).click()
+    await dialog.getByRole("button", { name: "Record fee" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Source holding UNCHANGED — value still Rp 2,000,000.00, and the account
+    // hero still re-materializes to Rp 2,000,000.00 (>= 2 occurrences). A fee
+    // never touches the position.
+    expect(
+      await page.getByText(/Rp\s2,000,000\.00/).count()
+    ).toBeGreaterThanOrEqual(2)
+
+    // The fee expense landed on the wallet: open it and see the debit + row.
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: `Open ${walletName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+    await expect(page.getByText(/Fee . Gold/).first()).toBeVisible()
+    // Wallet balance is now 1,000,000 − 25,000 = 975,000.
+    await expect(page.getByText(/Rp\s975,000\.00/).first()).toBeVisible()
+  })
+})

--- a/tests/integration/fees.integration.ts
+++ b/tests/integration/fees.integration.ts
@@ -1,0 +1,361 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  HoldingError,
+  recordFeeForFamily,
+  recordTradeForFamily,
+} from "@/server/holdings"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-259 Slice 3 / ADR-0054 — Standalone investment fee (EXPENSE).
+// Broker/country-agnostic. Amounts are in MINOR units (IDR sen). A fee reduces a
+// user-chosen cash account, leaves the source holding untouched, and is booked
+// under a find-or-create "Investment Fee" expense category with a provenance
+// audit row.
+
+describe("investment fee (PER-259 Slice 3 / ADR-0054)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const makeInvestmentAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Reksadana"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const makeCashAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Checking",
+    openingBalance = "2000000"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const balanceOf = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const row = await tx.account.findUniqueOrThrow({
+        where: { id: accountId },
+        select: { balance: true },
+      })
+      return row.balance
+    })
+
+  const fundInline = {
+    kind: "mutual_fund" as const,
+    name: "BNI-AM Dana Pendapatan Tetap Syariah Ardhani",
+  }
+
+  // Establish a 100-unit @ 10,000/unit position (cost 1,000,000).
+  const seedPosition = async (
+    owner: AuthenticatedOnboardedUser,
+    investmentId: string,
+    fundingId: string
+  ) => {
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investmentId,
+        fundingAccountId: fundingId,
+        instrument: fundInline,
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    return {
+      instrumentId: buy.holding?.instrumentId ?? "",
+      holdingId: buy.holding?.id ?? "",
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Standalone fee — expense on a chosen cash account; holding untouched.
+  // --------------------------------------------------------------------------
+  test("posts an expense on the chosen cash account; source holding unchanged; back-dated; Investment Fee category", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const wallet = await makeCashAccount(owner, "Wallet", "500000")
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    const investValueBefore = await balanceOf(owner, investment.id)
+    const walletBefore = await balanceOf(owner, wallet.id)
+    const feeDate = new Date("2025-07-01T00:00:00.000Z")
+
+    const result = await recordFeeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        amount: "25000", // platform fee
+        date: feeDate,
+        sourceAccountId: wallet.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result.sourceAccountId).toBe(wallet.id)
+    expect(result.amountMinor).toBe("25000")
+    expect(result.expenseTransaction.type).toBe("expense")
+    expect(result.expenseTransaction.amount).toBe("25000")
+    expect(result.sourceBalanceAfterMinor).toBe(
+      (walletBefore - 25_000n).toString()
+    )
+
+    // Chosen account debited by exactly the fee; the buy funding account NOT
+    // touched by the fee.
+    expect(await balanceOf(owner, wallet.id)).toBe(walletBefore - 25_000n)
+
+    // Source holding + investment value UNCHANGED (no units, no revaluation).
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(1)
+    expect(view.holdings[0]?.quantity).toBe("100.00000000")
+    expect(view.holdings[0]?.valueMinor).toBe("1000000")
+    expect(view.holdings[0]?.costMinor).toBe("1000000")
+    expect(await balanceOf(owner, investment.id)).toBe(investValueBefore)
+
+    // The expense row: expense/standard, expense category, on the chosen
+    // account, back-dated, provenance in the notes. Amount stored SIGNED
+    // (negative). Category is the find-or-create "Investment Fee".
+    const posted = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.transaction.findUniqueOrThrow({
+        where: { id: result.expenseTransaction.id },
+        include: { category: true },
+      })
+    )
+    expect(posted.type).toBe("expense")
+    expect(posted.kind).toBe("standard")
+    expect(posted.accountId).toBe(wallet.id)
+    expect(posted.amount).toBe(-25_000n)
+    expect(posted.category?.name).toBe("Investment Fee")
+    expect(posted.category?.type).toBe("expense")
+    expect(posted.date.toISOString()).toBe(feeDate.toISOString())
+    expect(posted.notes ?? "").toContain("Ardhani")
+  })
+
+  test("a Fee provenance audit row links back to the source holding", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { instrumentId, holdingId } = await seedPosition(
+      owner,
+      investment.id,
+      cash.id
+    )
+    const key = factories.createIdempotencyKey()
+
+    await recordFeeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        amount: "17268",
+        sourceAccountId: cash.id,
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const audit = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.findMany({
+        where: { familyId: owner.family.id, idempotencyKey: key },
+        select: { entityType: true, action: true, afterJson: true },
+      })
+    )
+    const entityTypes = new Set(audit.map((r) => r.entityType))
+    expect(entityTypes.has("Transaction")).toBe(true)
+    expect(entityTypes.has("Fee")).toBe(true)
+
+    const provenance = audit.find((r) => r.entityType === "Fee")
+    const after = provenance?.afterJson as Record<string, unknown> | null
+    expect(after?.holdingId).toBe(holdingId)
+    expect(after?.instrumentId).toBe(instrumentId)
+    expect(after?.sourceAccountId).toBe(cash.id)
+    expect(after?.amountMinor).toBe("17268")
+  })
+
+  test("replaying the same key posts a single expense", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+    const cashAfterSeed = await balanceOf(owner, cash.id)
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        investmentAccountId: investment.id,
+        holdingId,
+        amount: "595",
+        sourceAccountId: cash.id,
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+
+    const first = await recordFeeForFamily(payload)
+    const second = await recordFeeForFamily(payload)
+    const normalize = (value: unknown): unknown =>
+      JSON.parse(JSON.stringify(value))
+    expect(normalize(second)).toEqual(normalize(first))
+
+    // Applied once: cash debited exactly 595, one expense row.
+    expect(await balanceOf(owner, cash.id)).toBe(cashAfterSeed - 595n)
+    const count = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.transaction.count({
+        where: { accountId: cash.id, type: "expense", deletedAt: null },
+      })
+    )
+    expect(count).toBe(1)
+  })
+
+  // --------------------------------------------------------------------------
+  // The guard: a fee can never land on a holdings/valuation account.
+  // --------------------------------------------------------------------------
+  test("rejects a source account that is not cash-like (the holdings account itself)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    const investValueBefore = await balanceOf(owner, investment.id)
+
+    await expect(
+      recordFeeForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          holdingId,
+          amount: "25000",
+          // Charge the fee to the holdings/valuation account itself — rejected.
+          sourceAccountId: investment.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+
+    // The holdings account value is untouched by the rejected attempt.
+    expect(await balanceOf(owner, investment.id)).toBe(investValueBefore)
+  })
+
+  test("rejects a non-expense category override", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+
+    const incomeCategory = await harness.withFamily(
+      owner.family.id,
+      async (tx) =>
+        tx.category.create({
+          data: {
+            familyId: owner.family.id,
+            name: "Some Income",
+            type: "income",
+            isSystem: false,
+          },
+        })
+    )
+
+    await expect(
+      recordFeeForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          holdingId,
+          amount: "25000",
+          sourceAccountId: cash.id,
+          categoryId: incomeCategory.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  // --------------------------------------------------------------------------
+  // Tenant isolation
+  // --------------------------------------------------------------------------
+  test("a fee referencing another family's accounts is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const intruder = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const { holdingId } = await seedPosition(owner, investment.id, cash.id)
+    const cashAfterSeed = await balanceOf(owner, cash.id)
+
+    await expect(
+      recordFeeForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          holdingId,
+          amount: "25000",
+          sourceAccountId: cash.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+    ).rejects.toThrow()
+
+    // No expense posted on the owner's account.
+    expect(await balanceOf(owner, cash.id)).toBe(cashAfterSeed)
+  })
+})


### PR DESCRIPTION
## What a fee IS (broker/country-agnostic)

A cost tied to an investment. This slice adds the **standalone fee** — the common, missing case: a platform fee, an annual/subscription fee, or a one-off transaction/redemption fee charged **separately**. It is modeled as:

- an **EXPENSE `Transaction`** on a **user-chosen cash account** (`transaction_flow`), reducing its balance via the **guarded** `applyAccountBalanceDelta` (so a fee can **never** land on a holdings/valuation account — ADR-0048 §3 fail-loud);
- **back-datable** (a fee lands on a broker-set date, not necessarily "today");
- categorised with a family **"Investment Fee"** expense category (find-or-create, case-insensitive — the same pattern Slice 2 used for "Investment Income");
- **provenance-linked** to the source holding/instrument (description + notes + an append-only `Fee` AuditLog row carrying `holdingId` / `instrumentId` / `amount`).

The **source holding is NOT mutated** (no anchor recompute).

### In-scope vs. already-captured fees

| Fee kind | Handling |
| --- | --- |
| **Standalone** fee (platform / annual / one-off txn/redemption) | **This slice** — expense on a chosen cash account. |
| Fee **embedded in a Buy/Sell** (purchase / redemption load) | **Already captured** — `cashAmount` is authoritative in `recordTradeForFamily`; the load is part of the cash paid/received. Nothing extra. |
| **NAV-embedded** management fee (reksadana / ETF expense ratio) | **Already captured** — inside the NAV/price, so Σ-holdings value already reflects it. Not recorded separately. |

## Build

- **`postExpenseTransactionWithinTx`** (transactions.ts) — the EXPENSE sibling of `postIncomeTransactionWithinTx`: guarded delta + base projection + audit; `type="expense"`, `kind="standard"`, amount stored **signed negative**. **`createTransactionForFamily` is untouched (0 deletions in transactions.ts — purely additive).**
- **`recordFeeFn` / `recordFeeForFamily`** (holdings.ts) — `{ investmentAccountId, holdingId, amount, date?, sourceAccountId, categoryId?, idempotencyKey }`. ACID tenant transaction + RLS GUC, endpoint-scoped idempotency, tenant-validated references, "Investment Fee" find-or-create (or a validated expense-typed category override), append-only `Fee` provenance audit row. Same-currency this slice.
- **UI** — a **Fee** action on the Holdings panel header and per-holding row, plus a new broker-agnostic **FeeDialog** (no vendor wording).
- Respects the PER-259 guard + ADR-0048; Slices 1-2 not regressed.

## Provenance

No schema/FK migration this slice. The link from the fee expense back to the source position is carried by: the transaction **description** (`Fee — <instrument>`), **notes** (`Investment fee for <instrument> · holding <id> in <account>`), and an append-only **`Fee` AuditLog** row (`holdingId`, `instrumentId`, `amount`, `sourceAccountId`) — mirroring Slice 2's `Distribution` row.

## Test evidence (all real Postgres, PER-86 harness, PG :5433)

- **`tests/integration/fees.integration.ts` — 6 passed:** expense on a chosen cash account (balance down), source holding units + value **unchanged**, back-dated, `"Investment Fee"` category, amount stored signed-negative; `Fee` provenance audit row; idempotent replay (single expense); **guard rejection** (fee charged to the holdings/valuation account → `HoldingError`); non-expense category override rejected; tenant isolation rejected.
- **Slices 1-2 unbroken:** distributions + holdings + trades suites — **48 passed**.
- **Unit suite:** 714 passed. **e2e:** `investment-fee.e2e.ts` passed (fee reduces the chosen cash account; source holding unchanged).
- Gates: `vp check`, `vp build` (server/client fence), `vp fmt`, `vp test` — all green. No live network.

Confirmed: **Slices 1-2 and ADR-0048 invariants unbroken.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1