### PR TITLE
feat(holdings): PER-259 Slice 4 — Switch (atomic sell-A + buy-B, broker-agnostic)

### DIFF
--- a/src/components/blocks/switch-dialog.tsx
+++ b/src/components/blocks/switch-dialog.tsx
@@ -1,0 +1,533 @@
+import * as React from "react"
+import { ArrowRightLeft } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { MoneyInput } from "@/components/blocks/money-input"
+import { formatCurrency } from "@/lib/currency"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import {
+  holdingCostMinor,
+  holdingValueMinor,
+  QUANTITY_SCALE,
+  quantityToScaled,
+} from "@/lib/holdings"
+import { INSTRUMENT_KIND_OPTIONS, type InstrumentKind } from "@/lib/instruments"
+import { parseMoneyInput, toDecimalString } from "@/lib/money"
+import { cn } from "@/lib/utils"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import type { HoldingRecord } from "@/routes/_protected/-account-holdings"
+import { recordSwitchFn } from "@/server/holdings"
+
+// PER-259 Slice 4 / ADR-0054 — Switch dialog (atomic sell-A + buy-B, ONE account).
+// Broker/country-agnostic: the universal "switch"/"exchange" action (Bibit
+// "pindah", Vanguard/Fidelity "exchange") — NOT vendor wording. Within this ONE
+// holdings account, fund A is sold and fund B is bought with the proceeds; there
+// is NO external cash and NO funding account. The heavy lifting (average-cost
+// blend on both sides, realized gain, Σ-holdings anchor, provenance audit,
+// idempotency) is SERVER-side (`recordSwitchFn`); this dialog only collects
+// inputs and previews the derived numbers via the SAME pure helpers the server
+// uses, so nothing shown here can disagree with what actually posts.
+//
+// A separately-charged switch fee is out of scope (record it via the Fee
+// dialog) — see ADR-0054 §"Out of scope".
+
+const NEW_INSTRUMENT = "__new__"
+
+export type SwitchDialogState = { holding?: HoldingRecord }
+
+type Basis = "quantity" | "amount"
+
+function toDateInputValue(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+// units = amount / unitPrice, scaled, round-half-up — the SAME fold
+// `recordSwitchForFamily` uses server-side, so the client preview matches
+// exactly what will post.
+function unitsFromAmountScaled(
+  amountMinor: bigint,
+  unitPriceMinor: bigint
+): bigint {
+  if (unitPriceMinor <= 0n) return 0n
+  return (amountMinor * QUANTITY_SCALE + unitPriceMinor / 2n) / unitPriceMinor
+}
+
+type SwitchPreview =
+  | { kind: "empty" }
+  | { kind: "invalid"; reason: string }
+  | {
+      kind: "valid"
+      proceedsMinor: bigint
+      realizedGainMinor: bigint
+      toUnitsScaled: bigint | null
+    }
+
+export function SwitchDialog({
+  state,
+  investmentAccountId,
+  currency,
+  holdings,
+  onClose,
+  onSaved,
+}: {
+  state: SwitchDialogState
+  investmentAccountId: string
+  currency: string
+  holdings: ReadonlyArray<HoldingRecord>
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const currencyCode = currency as CurrencyCode
+
+  const [fromHoldingId, setFromHoldingId] = React.useState<string>(
+    state.holding?.id ?? holdings[0]?.id ?? ""
+  )
+  const fromHolding = holdings.find((h) => h.id === fromHoldingId) ?? null
+
+  // Destination options exclude the source holding's instrument — a switch
+  // moves into a DIFFERENT fund (server-enforced too; this just keeps the UI
+  // from offering an option that would fail).
+  const toHoldingOptions = holdings.filter(
+    (h) => h.instrument.id !== fromHolding?.instrument.id
+  )
+
+  const [basis, setBasis] = React.useState<Basis>("quantity")
+  const [quantity, setQuantity] = React.useState<string>("")
+  const [amount, setAmount] = React.useState<string>("")
+  const [fromUnitPrice, setFromUnitPrice] = React.useState<string>("")
+  const [toInstrumentChoice, setToInstrumentChoice] = React.useState<string>(
+    toHoldingOptions[0]?.instrument.id ?? NEW_INSTRUMENT
+  )
+  const [newName, setNewName] = React.useState<string>("")
+  const [newKind, setNewKind] = React.useState<InstrumentKind>("mutual_fund")
+  const [toUnitPrice, setToUnitPrice] = React.useState<string>("")
+  const [date, setDate] = React.useState<string>(toDateInputValue(new Date()))
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const isQuantityBasis = basis === "quantity"
+  const creatingInstrument = toInstrumentChoice === NEW_INSTRUMENT
+
+  // A's current price, for the "use current price" hint — the same fallback
+  // the server/holdings list uses (manual last price, else average cost).
+  const fromHoldingPriceHintMinor = fromHolding
+    ? BigInt(fromHolding.lastPriceMinor ?? fromHolding.avgUnitCostMinor)
+    : null
+
+  const fromUnitPriceMinor = React.useMemo<bigint | null>(() => {
+    if (fromUnitPrice.trim() === "") return null
+    const parsed = parseMoneyInput(fromUnitPrice, currencyCode)
+    return parsed !== null && parsed > 0n ? parsed : null
+  }, [fromUnitPrice, currencyCode])
+
+  const toUnitPriceMinor = React.useMemo<bigint | null>(() => {
+    if (toUnitPrice.trim() === "") return null
+    const parsed = parseMoneyInput(toUnitPrice, currencyCode)
+    return parsed !== null && parsed > 0n ? parsed : null
+  }, [toUnitPrice, currencyCode])
+
+  const amountMinor = React.useMemo<bigint | null>(() => {
+    if (isQuantityBasis) return null
+    if (amount.trim() === "") return null
+    const parsed = parseMoneyInput(amount, currencyCode)
+    return parsed !== null && parsed > 0n ? parsed : null
+  }, [isQuantityBasis, amount, currencyCode])
+
+  // Live preview of the switch: proceeds + realized gain (A side) and units
+  // acquired (B side) — pure derivation, no effect. Mirrors exactly what
+  // `recordSwitchForFamily` computes server-side.
+  const preview = React.useMemo<SwitchPreview>(() => {
+    if (!fromHolding || fromUnitPriceMinor === null) return { kind: "empty" }
+
+    let fromUnitsScaled: bigint
+    let proceedsMinor: bigint
+    if (isQuantityBasis) {
+      if (quantity.trim() === "") return { kind: "empty" }
+      try {
+        fromUnitsScaled = quantityToScaled(quantity.trim())
+      } catch {
+        return { kind: "invalid", reason: "Enter a valid quantity." }
+      }
+      if (fromUnitsScaled <= 0n) {
+        return {
+          kind: "invalid",
+          reason: "Quantity must be greater than zero.",
+        }
+      }
+      proceedsMinor = holdingValueMinor(fromUnitsScaled, fromUnitPriceMinor)
+    } else {
+      if (amountMinor === null) return { kind: "empty" }
+      proceedsMinor = amountMinor
+      fromUnitsScaled = unitsFromAmountScaled(proceedsMinor, fromUnitPriceMinor)
+      if (fromUnitsScaled <= 0n) {
+        return {
+          kind: "invalid",
+          reason: "Amount is too small to switch any units.",
+        }
+      }
+    }
+
+    const heldScaled = quantityToScaled(fromHolding.quantity)
+    if (fromUnitsScaled > heldScaled) {
+      return {
+        kind: "invalid",
+        reason: `Only ${fromHolding.quantity} ${fromHolding.instrument.name} held.`,
+      }
+    }
+
+    const costRemoved = holdingCostMinor(
+      fromUnitsScaled,
+      BigInt(fromHolding.avgUnitCostMinor)
+    )
+    const realizedGainMinor = proceedsMinor - costRemoved
+
+    const toUnitsScaled =
+      toUnitPriceMinor === null
+        ? null
+        : unitsFromAmountScaled(proceedsMinor, toUnitPriceMinor)
+    if (toUnitsScaled !== null && toUnitsScaled <= 0n) {
+      return {
+        kind: "invalid",
+        reason: "Destination unit price is too high for these proceeds.",
+      }
+    }
+
+    return { kind: "valid", proceedsMinor, realizedGainMinor, toUnitsScaled }
+  }, [
+    fromHolding,
+    fromUnitPriceMinor,
+    isQuantityBasis,
+    quantity,
+    amountMinor,
+    toUnitPriceMinor,
+  ])
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+    if (fromHolding === null) {
+      setError("Choose the holding to switch out of.")
+      return
+    }
+    if (fromUnitPriceMinor === null) {
+      setError("Enter A's current unit price.")
+      return
+    }
+    if (toUnitPriceMinor === null) {
+      setError("Enter the destination fund's unit price.")
+      return
+    }
+    if (preview.kind !== "valid") {
+      setError(
+        preview.kind === "invalid"
+          ? preview.reason
+          : "Enter a valid quantity or amount to switch."
+      )
+      return
+    }
+    if (creatingInstrument && newName.trim() === "") {
+      setError("Name the new destination fund.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const shared = {
+        investmentAccountId,
+        fromHoldingId: fromHolding.id,
+        fromUnitPrice: fromUnitPriceMinor.toString(),
+        toUnitPrice: toUnitPriceMinor.toString(),
+        date,
+        idempotencyKey: createUuidV7(),
+        ...(isQuantityBasis
+          ? { quantity: quantity.trim() }
+          : { amount: (amountMinor as bigint).toString() }),
+      }
+      if (creatingInstrument) {
+        await recordSwitchFn({
+          data: {
+            ...shared,
+            toInstrument: { kind: newKind, name: newName.trim() },
+          },
+        })
+      } else {
+        await recordSwitchFn({
+          data: { ...shared, toInstrumentId: toInstrumentChoice },
+        })
+      }
+      await onSaved()
+    } catch (caught) {
+      // The HoldingError message survives the RPC boundary and surfaces here.
+      setError(caught instanceof Error ? caught.message : String(caught))
+      setSubmitting(false)
+    }
+  }
+
+  const submitDisabled =
+    submitting ||
+    fromHolding === null ||
+    fromUnitPriceMinor === null ||
+    toUnitPriceMinor === null ||
+    preview.kind !== "valid" ||
+    (creatingInstrument && newName.trim() === "")
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <ArrowRightLeft className="size-4 text-violet-600 dark:text-violet-400" />
+              Switch fund
+            </DialogTitle>
+            <DialogDescription>
+              Move from one fund into another within this account. No external
+              cash moves; only the market-price difference realizes as gain or
+              loss.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-2">
+              <Label>From</Label>
+              <Select value={fromHoldingId} onValueChange={setFromHoldingId}>
+                <SelectTrigger aria-label="Source holding">
+                  <SelectValue placeholder="Choose holding" />
+                </SelectTrigger>
+                <SelectContent>
+                  {holdings.map((holding) => (
+                    <SelectItem key={holding.id} value={holding.id}>
+                      {holding.instrument.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="switch-date">Date</Label>
+              <Input
+                id="switch-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>To</Label>
+            <Select
+              value={toInstrumentChoice}
+              onValueChange={setToInstrumentChoice}
+            >
+              <SelectTrigger aria-label="Destination fund">
+                <SelectValue placeholder="Choose destination fund" />
+              </SelectTrigger>
+              <SelectContent>
+                {toHoldingOptions.map((holding) => (
+                  <SelectItem
+                    key={holding.instrument.id}
+                    value={holding.instrument.id}
+                  >
+                    {holding.instrument.name}
+                  </SelectItem>
+                ))}
+                <SelectItem value={NEW_INSTRUMENT}>New fund…</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {creatingInstrument ? (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="switch-new-name">Fund name</Label>
+                <Input
+                  id="switch-new-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="e.g. Sucorinvest Money Market"
+                  required
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label>Kind</Label>
+                <Select
+                  value={newKind}
+                  onValueChange={(value) => setNewKind(value as InstrumentKind)}
+                >
+                  <SelectTrigger aria-label="New fund kind">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INSTRUMENT_KIND_OPTIONS.map((k) => (
+                      <SelectItem key={k.value} value={k.value}>
+                        {k.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-2">
+            <Label>Switch by</Label>
+            <Select
+              value={basis}
+              onValueChange={(value) => setBasis(value as Basis)}
+            >
+              <SelectTrigger aria-label="Switch basis">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="quantity">Quantity of A</SelectItem>
+                <SelectItem value="amount">Amount (proceeds)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            {isQuantityBasis ? (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="switch-quantity">Quantity</Label>
+                <Input
+                  id="switch-quantity"
+                  inputMode="decimal"
+                  value={quantity}
+                  onChange={(e) => setQuantity(e.target.value)}
+                  placeholder="e.g. 2.018"
+                  required
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="switch-amount">Amount ({currency})</Label>
+                <MoneyInput
+                  id="switch-amount"
+                  currency={currencyCode}
+                  value={amount}
+                  onChange={setAmount}
+                  placeholder="0"
+                  required
+                />
+              </div>
+            )}
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="switch-from-price">A's price ({currency})</Label>
+              <MoneyInput
+                id="switch-from-price"
+                currency={currencyCode}
+                value={fromUnitPrice}
+                onChange={setFromUnitPrice}
+                placeholder="0"
+                required
+              />
+              {fromHoldingPriceHintMinor !== null ? (
+                <button
+                  type="button"
+                  className="w-fit text-xs text-muted-foreground underline-offset-2 hover:underline"
+                  onClick={() =>
+                    setFromUnitPrice(
+                      toDecimalString(fromHoldingPriceHintMinor, currencyCode)
+                    )
+                  }
+                >
+                  Use current:{" "}
+                  {formatCurrency(fromHoldingPriceHintMinor, currency)}
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="switch-to-price">B's price ({currency})</Label>
+            <MoneyInput
+              id="switch-to-price"
+              currency={currencyCode}
+              value={toUnitPrice}
+              onChange={setToUnitPrice}
+              placeholder="0"
+              required
+            />
+          </div>
+
+          <div
+            className={cn(
+              "flex flex-col gap-1.5 rounded-md border p-3 text-sm",
+              preview.kind === "valid" ? "bg-muted/50" : "text-muted-foreground"
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Proceeds moved</span>
+              <span className="font-semibold tabular-nums">
+                {preview.kind === "valid"
+                  ? formatCurrency(preview.proceedsMinor, currency)
+                  : "—"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Realized gain/loss</span>
+              <span
+                className={cn(
+                  "font-semibold tabular-nums",
+                  preview.kind === "valid" && preview.realizedGainMinor > 0n
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : preview.kind === "valid" && preview.realizedGainMinor < 0n
+                      ? "text-destructive"
+                      : ""
+                )}
+              >
+                {preview.kind === "valid"
+                  ? formatCurrency(preview.realizedGainMinor, currency)
+                  : "—"}
+              </span>
+            </div>
+          </div>
+
+          {preview.kind === "invalid" ? (
+            <p className="text-sm text-destructive" role="alert">
+              {preview.reason}
+            </p>
+          ) : null}
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {submitting ? "Switching…" : "Record switch"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/_protected/-account-holdings.tsx
+++ b/src/routes/_protected/-account-holdings.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowDownLeft,
+  ArrowRightLeft,
   ArrowUpRight,
   Coins,
   Gift,
@@ -95,6 +96,8 @@ export function HoldingsPanel({
   onDividendHolding,
   onFee,
   onFeeHolding,
+  onSwitch,
+  onSwitchHolding,
   onRefreshPrices,
   refreshingPrices,
 }: Readonly<{
@@ -112,6 +115,8 @@ export function HoldingsPanel({
   onDividendHolding: (holding: HoldingRecord) => void
   onFee: () => void
   onFeeHolding: (holding: HoldingRecord) => void
+  onSwitch: () => void
+  onSwitchHolding: (holding: HoldingRecord) => void
   onRefreshPrices: () => void
   refreshingPrices: boolean
 }>) {
@@ -123,12 +128,12 @@ export function HoldingsPanel({
 
   return (
     <div className="rounded-2xl border p-4">
-      <div className="mb-3 flex items-center justify-between gap-2">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <h2 className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
           <PiggyBank className="size-3.5" aria-hidden />
           Holdings
         </h2>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {hasLinkedHolding ? (
             <Button
               size="sm"
@@ -163,6 +168,12 @@ export function HoldingsPanel({
             <Button size="sm" variant="outline" onClick={onFee}>
               <Receipt className="size-4" />
               Fee
+            </Button>
+          ) : null}
+          {holdings.length > 0 ? (
+            <Button size="sm" variant="outline" onClick={onSwitch}>
+              <ArrowRightLeft className="size-4" />
+              Switch
             </Button>
           ) : null}
           <Button size="sm" variant="outline" onClick={onAdd}>
@@ -264,6 +275,16 @@ export function HoldingsPanel({
                     >
                       <Receipt className="size-3.5" />
                       Fee
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => onSwitchHolding(holding)}
+                    >
+                      <ArrowRightLeft className="size-3.5" />
+                      Switch
                     </Button>
                     <Button
                       type="button"

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -57,6 +57,10 @@ import {
   type DistributionDialogState,
 } from "@/components/blocks/distribution-dialog"
 import { FeeDialog, type FeeDialogState } from "@/components/blocks/fee-dialog"
+import {
+  SwitchDialog,
+  type SwitchDialogState,
+} from "@/components/blocks/switch-dialog"
 import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
@@ -186,6 +190,9 @@ function AccountDetailPage() {
   const [distributionDialog, setDistributionDialog] =
     React.useState<DistributionDialogState | null>(null)
   const [feeDialog, setFeeDialog] = React.useState<FeeDialogState | null>(null)
+  // PER-259 Slice 4 — switch dialog (atomic sell-A + buy-B, one account).
+  const [switchDialog, setSwitchDialog] =
+    React.useState<SwitchDialogState | null>(null)
   // PER-241 — the per-account statement now shares the /transactions row, so it
   // gets the same singleton edit modal + inline delete.
   const [editingTrx, setEditingTrx] =
@@ -733,6 +740,8 @@ function AccountDetailPage() {
               }
               onFee={() => setFeeDialog({})}
               onFeeHolding={(holding) => setFeeDialog({ holding })}
+              onSwitch={() => setSwitchDialog({})}
+              onSwitchHolding={(holding) => setSwitchDialog({ holding })}
               onRefreshPrices={handleRefreshPrices}
               refreshingPrices={refreshingPrices}
             />
@@ -1020,6 +1029,26 @@ function AccountDetailPage() {
           onSaved={async () => {
             await refreshHoldings()
             setFeeDialog(null)
+          }}
+        />
+      ) : null}
+
+      {switchDialog ? (
+        <SwitchDialog
+          // Remount per open so the form re-initializes cleanly.
+          key={
+            switchDialog.holding
+              ? `switch-${switchDialog.holding.id}`
+              : "switch"
+          }
+          state={switchDialog}
+          investmentAccountId={accountId}
+          currency={currency}
+          holdings={holdingsView?.holdings ?? []}
+          onClose={() => setSwitchDialog(null)}
+          onSaved={async () => {
+            await refreshHoldings()
+            setSwitchDialog(null)
           }}
         />
       ) : null}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -2260,6 +2260,470 @@ export const recordFeeFn = createServerFn({ method: "POST" })
   })
 
 // =============================================================================
+// SWITCH — atomic sell-A + buy-B in ONE holdings account (PER-259 Slice 4 / ADR-0054)
+// =============================================================================
+//
+// A switch is the single most common reksadana action after buy/sell: within ONE
+// holdings account, atomically SELL fund A and BUY fund B with the proceeds.
+// Broker/country-agnostic (NOT vendor-specific): Bibit "pindah/switch",
+// Vanguard/Fidelity "exchange", the universal "switch". Economically it is a
+// sell-A-then-buy-B collapsed into one indivisible ledger action — NO external
+// cash, NO funding account touched:
+//
+//   SELL side (A) — reduce A's units by the switched quantity; PROCEEDS = units ×
+//     A's current price (`fromUnitPrice`, authoritative for the internal value
+//     moved); REALIZED gain/loss = proceeds − (units × A's average unit cost);
+//     A's cost basis drops by that removed cost (average unit cost of the
+//     remaining units is unchanged). Switching ALL of A closes (deletes) the A
+//     position, mirroring a sell-to-zero.
+//   BUY side (B) — B receives the PROCEEDS as its buy amount: B units +=
+//     proceeds ÷ `toUnitPrice`; B cost basis += proceeds (average-cost blend). B
+//     may be an EXISTING holding in the same account (average-cost in) or a NEW
+//     instrument created inline (like a first Buy, honest cost basis, no
+//     fabricated market price).
+//
+// Both A and B are holdings in the SAME investment account; the account's
+// Σ-holdings anchor re-materializes ONCE via the source="holdings" path (the ONLY
+// value-write the PER-259 guard allows). There is no external cash leg, so net
+// account value changes only by the market price difference A↔B at execution —
+// exactly the realized gain when A carried no market last-price. Realized gain is
+// DERIVED and RETURNED, not posted as income (parity with SELL, Slice 1).
+//
+// This reuses the SAME pure trade math the Buy/Sell path uses (holdingCostMinor,
+// averageUnitCostMinor, holdingValueMinor from src/lib/holdings.ts, the units-
+// from-amount fold shared with reinvest); `recordTradeForFamily` is UNCHANGED.
+//
+// IN SCOPE: A→B (DIFFERENT funds), same account, same currency. OUT OF SCOPE:
+// moving the SAME fund A to a DIFFERENT account with no sell (an in-kind position
+// move — Slice 6), and a separately-charged SWITCH FEE (record it via Slice 3
+// Fee). Full ledger mutation contract (CLAUDE.md §5A): interactive tenant
+// transaction + RLS GUC, tenant-owned reference validation, endpoint-scoped
+// idempotency, and append-only AuditLog rows in the same transaction.
+
+const RECORD_SWITCH_ENDPOINT = "recordSwitchFn"
+
+export const recordSwitchInputSchema = z
+  .object({
+    investmentAccountId: z.string().min(1),
+    // The source holding (fund A) being switched OUT of. Must live in the account.
+    fromHoldingId: z.string().min(1),
+    // Destination instrument (fund B): an EXISTING tenant instrument OR an inline
+    // one to create. Exactly one — and it must differ from A.
+    toInstrumentId: z.string().min(1).optional(),
+    toInstrument: inlineInstrumentSchema.optional(),
+    // How much of A to switch: EITHER a quantity of A units OR the proceeds
+    // amount (minor units) to move. Exactly one — the other is derived.
+    quantity: decimalStringSchema.optional(),
+    amount: positiveMinorDigitsSchema.optional(),
+    // A's current price per unit (minor units) — authoritative for the proceeds.
+    fromUnitPrice: positiveMinorDigitsSchema,
+    // B's price per unit (minor units) — derives the B units the proceeds buy.
+    toUnitPrice: positiveMinorDigitsSchema,
+    // Back-datable (a switch executes on a broker-set date, not necessarily now).
+    date: z.coerce.date().optional(),
+    idempotencyKey: uuidV7Schema,
+  })
+  .superRefine((data, ctx) => {
+    if ((data.quantity !== undefined) === (data.amount !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["quantity"],
+        message:
+          "Provide exactly one of quantity (of A) or amount (proceeds to switch)",
+      })
+    }
+    if (Boolean(data.toInstrumentId) === Boolean(data.toInstrument)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["toInstrumentId"],
+        message:
+          "Provide exactly one of an existing toInstrumentId or an inline toInstrument to create",
+      })
+    }
+  })
+
+type RecordSwitchInput = z.infer<typeof recordSwitchInputSchema>
+
+export interface RecordSwitchResult {
+  investmentAccountId: string
+  // ---- SELL side (fund A) ----
+  fromHoldingId: string
+  fromInstrumentId: string
+  /** Resulting A position, or null when the switch closed it to zero. */
+  fromHolding: SerializedHolding | null
+  /** Units of A switched out, decimal string. */
+  fromQuantity: string
+  /** Proceeds = units switched × A's current price, minor units (digit-string). */
+  proceedsMinor: string
+  /** Realized gain/loss on the switched A units vs average cost, minor units, signed. */
+  realizedGainMinor: string
+  /** Cost basis removed from A by this switch, minor units. */
+  fromCostRemovedMinor: string
+  // ---- BUY side (fund B) ----
+  toHoldingId: string
+  toInstrumentId: string
+  /** Resulting B position after the switch (always present — B is bought). */
+  toHolding: SerializedHolding
+  /** Units of B acquired with the proceeds, decimal string. */
+  toQuantity: string
+  /** Cost basis added to B (== proceeds), minor units. */
+  toCostAddedMinor: string
+  /** Investment account value after re-materializing Σ holdings, minor units. */
+  investmentValueAfterMinor: string
+}
+
+// units = amount / unitPrice, scaled, round-half-up — the SAME fold the reinvest
+// and amount→quantity paths use (amount × SCALE / unitPrice). Both operands are
+// positive here (schema + guards), so the +unitPrice/2 numerator is exact half-up.
+function unitsFromAmountScaled(
+  amountMinor: bigint,
+  unitPriceMinor: bigint
+): bigint {
+  return (amountMinor * QUANTITY_SCALE + unitPriceMinor / 2n) / unitPriceMinor
+}
+
+export async function recordSwitchForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof recordSwitchInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<RecordSwitchResult> {
+  const data: RecordSwitchInput = recordSwitchInputSchema.parse(rawData)
+
+  const requestHash = await hashCanonicalPayload({
+    amount: data.amount ?? null,
+    date: data.date?.toISOString() ?? null,
+    fromHoldingId: data.fromHoldingId,
+    fromUnitPrice: data.fromUnitPrice,
+    investmentAccountId: data.investmentAccountId,
+    quantity: data.quantity ?? null,
+    toInstrument: data.toInstrument ?? null,
+    toInstrumentId: data.toInstrumentId ?? null,
+    toUnitPrice: data.toUnitPrice,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+  const date = data.date ?? new Date()
+  const fromUnitPrice = BigInt(data.fromUnitPrice)
+  const toUnitPrice = BigInt(data.toUnitPrice)
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<RecordSwitchResult>(
+        tx,
+        {
+          endpoint: RECORD_SWITCH_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      // Tenant ownership + eligibility of the holdings account (RLS-scoped,
+      // belt-and-braces). A switch never touches a cash/funding account.
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.investmentAccountId,
+      })
+      const investmentAccount = await fetchActiveAccount(
+        tx,
+        familyId,
+        data.investmentAccountId,
+        "Investment"
+      )
+      if (investmentAccount.balanceSource !== "valuation") {
+        throw new HoldingError(
+          `Investment account ${investmentAccount.id} must be a valuation-tracked account (balanceSource="valuation"); it is "${investmentAccount.balanceSource}"`
+        )
+      }
+      assertKnownCurrency(investmentAccount.currency)
+
+      // Fund A — the source holding, must belong to this account.
+      const fromHolding = await loadHoldingWithInstrument(
+        tx,
+        familyId,
+        data.fromHoldingId
+      )
+      if (fromHolding.accountId !== investmentAccount.id) {
+        throw new HoldingError(
+          `Holding ${data.fromHoldingId} does not belong to account ${data.investmentAccountId}`
+        )
+      }
+
+      // Fund B — resolve/create the destination instrument (same-currency,
+      // market-priced; reuses the shared resolver the Buy path uses). Must be a
+      // DIFFERENT instrument than A: a switch is A→B, not a same-position edit.
+      const toInstrument = await resolveInstrument(
+        tx,
+        familyId,
+        investmentAccount.currency,
+        { instrumentId: data.toInstrumentId, instrument: data.toInstrument },
+        auditCtx
+      )
+      if (toInstrument.id === fromHolding.instrumentId) {
+        throw new HoldingError(
+          "A switch moves into a DIFFERENT fund (A and B cannot be the same instrument); use Buy/Sell to change a single position"
+        )
+      }
+
+      // Derive the switched A units + proceeds. Proceeds are authoritative for
+      // the internal value moved and for B's cost basis (no external cash).
+      let fromUnitsScaled: bigint
+      let proceedsMinor: bigint
+      if (data.quantity !== undefined) {
+        try {
+          fromUnitsScaled = quantityToScaled(data.quantity)
+        } catch (error) {
+          throw new HoldingError(
+            `quantity is not a valid amount: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+        proceedsMinor = holdingValueMinor(fromUnitsScaled, fromUnitPrice)
+      } else {
+        // amount given (schema guarantees exactly one of quantity/amount).
+        proceedsMinor = BigInt(data.amount ?? "0")
+        fromUnitsScaled = unitsFromAmountScaled(proceedsMinor, fromUnitPrice)
+      }
+      if (fromUnitsScaled <= 0n) {
+        throw new HoldingError("Switch quantity must be greater than zero")
+      }
+      if (proceedsMinor <= 0n) {
+        throw new HoldingError("Switch proceeds must be greater than zero")
+      }
+
+      const oldFromUnitsScaled = quantityToScaled(
+        fromHolding.quantity.toFixed(8)
+      )
+      if (fromUnitsScaled > oldFromUnitsScaled) {
+        throw new HoldingError(
+          `Cannot switch ${scaledToQuantityString(fromUnitsScaled)} units; only ${fromHolding.quantity.toFixed(8)} held`
+        )
+      }
+
+      // ---- SELL side (A): average-cost method, realized gain vs average cost ----
+      const costRemoved = holdingCostMinor(
+        fromUnitsScaled,
+        fromHolding.avgUnitCostMinor
+      )
+      const realizedGainMinor = proceedsMinor - costRemoved
+      const remainingFromUnitsScaled = oldFromUnitsScaled - fromUnitsScaled
+
+      let fromHoldingId: string | null
+      if (remainingFromUnitsScaled === 0n) {
+        // Switched everything out of A — close (delete) the position, mirroring
+        // a sell-to-zero.
+        await tx.holding.delete({ where: { id: fromHolding.id } })
+        await auditLog(tx, auditCtx, {
+          action: "delete",
+          entityType: "Holding",
+          entityId: fromHolding.id,
+          before: serializeHolding(fromHolding),
+          after: null,
+        })
+        fromHoldingId = null
+      } else {
+        const updatedFrom = await tx.holding.update({
+          where: { id: fromHolding.id },
+          data: { quantity: scaledToQuantityString(remainingFromUnitsScaled) },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Holding",
+          entityId: updatedFrom.id,
+          before: serializeHolding(fromHolding),
+          after: serializeHolding(updatedFrom),
+        })
+        fromHoldingId = updatedFrom.id
+      }
+
+      // ---- BUY side (B): the proceeds buy B units, cost basis += proceeds ----
+      const addedToUnitsScaled = unitsFromAmountScaled(
+        proceedsMinor,
+        toUnitPrice
+      )
+      if (addedToUnitsScaled <= 0n) {
+        throw new HoldingError(
+          "Switch buys zero units of the destination fund; raise the amount or lower the destination unit price"
+        )
+      }
+
+      const existingTo = await tx.holding.findFirst({
+        where: {
+          familyId,
+          accountId: investmentAccount.id,
+          instrumentId: toInstrument.id,
+        },
+        include: { instrument: true },
+      })
+
+      let toHoldingId: string
+      if (existingTo) {
+        const oldToUnitsScaled = quantityToScaled(
+          existingTo.quantity.toFixed(8)
+        )
+        const oldToCost = holdingCostMinor(
+          oldToUnitsScaled,
+          existingTo.avgUnitCostMinor
+        )
+        const newToUnitsScaled = oldToUnitsScaled + addedToUnitsScaled
+        const newToAvg = averageUnitCostMinor(
+          oldToCost + proceedsMinor,
+          newToUnitsScaled
+        )
+        const updatedTo = await tx.holding.update({
+          where: { id: existingTo.id },
+          data: {
+            quantity: scaledToQuantityString(newToUnitsScaled),
+            avgUnitCostMinor: newToAvg,
+          },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "update",
+          entityType: "Holding",
+          entityId: updatedTo.id,
+          before: serializeHolding(existingTo),
+          after: serializeHolding(updatedTo),
+        })
+        toHoldingId = updatedTo.id
+      } else {
+        const newToAvg = averageUnitCostMinor(proceedsMinor, addedToUnitsScaled)
+        const createdTo = await tx.holding.create({
+          data: {
+            familyId,
+            accountId: investmentAccount.id,
+            instrumentId: toInstrument.id,
+            quantity: scaledToQuantityString(addedToUnitsScaled),
+            avgUnitCostMinor: newToAvg,
+            lastPriceMinor: null,
+          },
+          include: { instrument: true },
+        })
+        await auditLog(tx, auditCtx, {
+          action: "create",
+          entityType: "Holding",
+          entityId: createdTo.id,
+          after: serializeHolding(createdTo),
+        })
+        toHoldingId = createdTo.id
+      }
+
+      // Provenance audit row — the durable, queryable record of the switch
+      // linking both sides + proceeds + realized gain (mirrors Slice 2/3's
+      // Distribution/Fee provenance rows). Anchored on the source holding id.
+      await auditLog(tx, auditCtx, {
+        action: "create",
+        entityType: "Switch",
+        entityId: fromHolding.id,
+        after: {
+          date: date.toISOString(),
+          investmentAccountId: investmentAccount.id,
+          fromHoldingId: fromHolding.id,
+          fromInstrumentId: fromHolding.instrumentId,
+          fromInstrumentName: fromHolding.instrument.name,
+          fromUnitsScaled: fromUnitsScaled.toString(),
+          fromUnitPriceMinor: fromUnitPrice.toString(),
+          toHoldingId,
+          toInstrumentId: toInstrument.id,
+          toInstrumentName: toInstrument.name,
+          toUnitsScaled: addedToUnitsScaled.toString(),
+          toUnitPriceMinor: toUnitPrice.toString(),
+          proceedsMinor: proceedsMinor.toString(),
+          costRemovedMinor: costRemoved.toString(),
+          realizedGainMinor: realizedGainMinor.toString(),
+        },
+      })
+
+      // Re-materialize the Σ-holdings anchor ONCE (source="holdings" — the only
+      // value-write the PER-259 guard allows on a holdings account).
+      await recomputeAccountValueAnchorWithinTx(
+        tx,
+        familyId,
+        investmentAccount.id,
+        investmentAccount.currency,
+        user,
+        auditCtx
+      )
+
+      const finalFrom =
+        fromHoldingId === null
+          ? null
+          : serializeHolding(
+              await loadHoldingWithInstrument(tx, familyId, fromHoldingId)
+            )
+      const finalTo = serializeHolding(
+        await loadHoldingWithInstrument(tx, familyId, toHoldingId)
+      )
+      const investmentAfter = await tx.account.findUniqueOrThrow({
+        where: { id: investmentAccount.id },
+        select: { balance: true },
+      })
+
+      const response: RecordSwitchResult = {
+        investmentAccountId: investmentAccount.id,
+        fromHoldingId: fromHolding.id,
+        fromInstrumentId: fromHolding.instrumentId,
+        fromHolding: finalFrom,
+        fromQuantity: scaledToQuantityString(fromUnitsScaled),
+        proceedsMinor: proceedsMinor.toString(),
+        realizedGainMinor: realizedGainMinor.toString(),
+        fromCostRemovedMinor: costRemoved.toString(),
+        toHoldingId,
+        toInstrumentId: toInstrument.id,
+        toHolding: finalTo,
+        toQuantity: scaledToQuantityString(addedToUnitsScaled),
+        toCostAddedMinor: proceedsMinor.toString(),
+        investmentValueAfterMinor: investmentAfter.balance.toString(),
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: RECORD_SWITCH_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<RecordSwitchResult>(tx, {
+        endpoint: RECORD_SWITCH_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const recordSwitchFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof recordSwitchInputSchema>) =>
+    recordSwitchInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await recordSwitchForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// =============================================================================
 // MARKET-DATA PRICE LINK + AUTO-REVALUATION (PER-238 / ADR-0050 + ADR-0051)
 // =============================================================================
 //

--- a/tests/e2e/holdings-ui.e2e.ts
+++ b/tests/e2e/holdings-ui.e2e.ts
@@ -34,7 +34,10 @@ test.describe("holdings UI (PER-232)", () => {
     await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
 
     // Holdings panel renders with its empty state for a fresh tracked account.
-    await expect(page.getByText("Holdings")).toBeVisible()
+    // Scoped to the heading role — plain getByText("Holdings") case-insensitively
+    // substring-matches the empty-state copy too ("No holdings yet…"), which is
+    // a strict-mode violation once both are on screen together.
+    await expect(page.getByRole("heading", { name: "Holdings" })).toBeVisible()
     await expect(page.getByText(/No holdings yet/i)).toBeVisible()
 
     // --- Add a holding ---

--- a/tests/e2e/switch-fund.e2e.ts
+++ b/tests/e2e/switch-fund.e2e.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-259 Slice 4 / ADR-0054 — Switch UI (broker-agnostic; atomic sell-A +
+// buy-B, ONE account, NO external cash). Onboard → create a Tracked Asset
+// (valuation-tracked) account → add a holding (fund A) → open the Switch
+// dialog and switch ALL of A into a brand-new fund B. A's row disappears
+// (its position closed), B's row appears with the proceeds' worth of units,
+// and — since A's switch price equals its average cost here — the account's
+// total value is unchanged (no realized gain, no external cash).
+//
+// \s (not literal spaces) — formatCurrency uses a non-breaking space.
+
+test.describe("switch fund UI (PER-259 Slice 4)", () => {
+  test("switching ALL of A into a new fund B closes A and grows B; account value stays sane", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const portfolioName = `Portfolio ${suffix}`
+    const fundAName = `Fund A ${suffix}`
+    const fundBName = `Fund B ${suffix}`
+
+    // --- Tracked Asset account ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // --- Seed fund A: 2 units @ 1,000,000 (value = cost = 2,000,000). ---
+    await page.getByRole("button", { name: "Add holding" }).click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Instrument name").fill(fundAName)
+    await dialog.getByRole("combobox", { name: "Instrument kind" }).click()
+    await page.getByRole("option", { name: "Mutual fund" }).click()
+    await dialog.getByLabel("Quantity").fill("2")
+    await dialog.getByLabel(/Average unit cost/i).fill("1000000")
+    await dialog.getByRole("button", { name: "Add holding" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(/Rp\s2,000,000\.00/).first()).toBeVisible()
+
+    // --- Switch ALL of A into a brand-new fund B. ---
+    await page.getByRole("button", { name: "Switch" }).first().click()
+    dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByRole("heading", { name: "Switch fund" })
+    ).toBeVisible()
+
+    // Only one holding exists, so the destination already defaults to "New
+    // fund..." — fill the inline instrument fields directly.
+    await dialog.getByLabel("Fund name").fill(fundBName)
+
+    // Switch by quantity (the default basis) — all 2 units of A.
+    await dialog.getByLabel("Quantity").fill("2")
+
+    // Use A's current price (its average cost, 1,000,000/unit) so this switch
+    // realizes NO gain — proceeds equal A's removed cost basis exactly.
+    await dialog.getByRole("button", { name: /Use current/ }).click()
+
+    // B's price: 500,000/unit -> proceeds 2,000,000 buys exactly 4 units.
+    await dialog.getByLabel(/^B's price/).fill("500000")
+
+    await dialog.getByRole("button", { name: "Record switch" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // A's position closed — its row is gone.
+    await expect(page.getByText(fundAName)).toHaveCount(0)
+
+    // B's row appeared with the switched-in units (proceeds 2,000,000 / B's
+    // price 500,000 = 4 units).
+    await expect(page.getByText(fundBName).first()).toBeVisible()
+    await expect(page.getByText(/4\.00000000/).first()).toBeVisible()
+
+    // No realized gain (A's price == its average cost), so the account's
+    // total value is unchanged at Rp 2,000,000.00 (B's row value + the
+    // panel total, at least 2 occurrences).
+    expect(
+      await page.getByText(/Rp\s2,000,000\.00/).count()
+    ).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/tests/integration/switches.integration.ts
+++ b/tests/integration/switches.integration.ts
@@ -1,0 +1,572 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  getAccountHoldingsForFamily,
+  HoldingError,
+  recordSwitchForFamily,
+  recordTradeForFamily,
+} from "@/server/holdings"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-259 Slice 4 / ADR-0054 — Switch (atomic sell-A + buy-B, ONE holdings
+// account, NO external cash). Broker/country-agnostic (Bibit "pindah/switch",
+// Vanguard/Fidelity "exchange"). Amounts are in MINOR units (IDR sen). Fixtures
+// use exact-division quantities/prices so conservation is provable to the sen —
+// the account's Σ-holdings value must move by EXACTLY the realized gain, since
+// neither side carries a separate "current market price" beyond average cost.
+
+describe("switch (PER-259 Slice 4 / ADR-0054)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const makeInvestmentAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Reksadana"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const makeCashAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Checking",
+    openingBalance = "2000000"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const balanceOf = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const row = await tx.account.findUniqueOrThrow({
+        where: { id: accountId },
+        select: { balance: true },
+      })
+      return row.balance
+    })
+
+  // Buys `quantity` units of `instrument` @ `unitPrice` in `investmentId`,
+  // funded from `fundingId`. Returns the resulting holding + instrument id.
+  const seedPosition = async (
+    owner: AuthenticatedOnboardedUser,
+    investmentId: string,
+    fundingId: string,
+    instrument: { kind: "mutual_fund"; name: string },
+    quantity: string,
+    unitPrice: string
+  ) => {
+    const cashAmount = (BigInt(quantity) * BigInt(unitPrice)).toString()
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investmentId,
+        fundingAccountId: fundingId,
+        instrument,
+        side: "buy",
+        cashAmount,
+        quantity,
+        unitPrice,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    return {
+      instrumentId: buy.holding?.instrumentId ?? "",
+      holdingId: buy.holding?.id ?? "",
+    }
+  }
+
+  const fundA = { kind: "mutual_fund" as const, name: "BNI-AM Dana Ardhani" }
+  const fundB = {
+    kind: "mutual_fund" as const,
+    name: "Sucorinvest Money Market",
+  }
+
+  // --------------------------------------------------------------------------
+  // Partial switch A -> existing B: average-cost blends on B; A keeps its
+  // (unchanged) average cost on the remaining units; the account's total value
+  // moves by EXACTLY the realized gain (proven to the sen).
+  // --------------------------------------------------------------------------
+  test("partial switch into an existing holding blends average cost; account value moves only by the realized gain", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+    const b = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundB,
+      "50",
+      "8000"
+    )
+
+    const investBefore = await balanceOf(owner, investment.id) // 1,000,000 + 400,000 = 1,400,000
+    expect(investBefore).toBe(1_400_000n)
+
+    const key = factories.createIdempotencyKey()
+    const result = await recordSwitchForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fromHoldingId: a.holdingId,
+        toInstrumentId: b.instrumentId,
+        quantity: "40",
+        fromUnitPrice: "12000", // A appreciated from its 10,000 avg cost
+        toUnitPrice: "8000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Proceeds = 40 x 12,000 = 480,000. Cost removed = 40 x 10,000 = 400,000.
+    // Realized gain = 80,000.
+    expect(result.proceedsMinor).toBe("480000")
+    expect(result.fromCostRemovedMinor).toBe("400000")
+    expect(result.realizedGainMinor).toBe("80000")
+    expect(result.fromQuantity).toBe("40.00000000")
+
+    // A: 60 units remain, average cost UNCHANGED at 10,000/unit.
+    expect(result.fromHolding).not.toBeNull()
+    expect(result.fromHolding?.quantity).toBe("60.00000000")
+    expect(result.fromHolding?.avgUnitCostMinor).toBe("10000")
+
+    // B: 50 + 60 = 110 units; blended avg cost = (400,000 + 480,000) / 110 =
+    // 8,000/unit exactly.
+    expect(result.toQuantity).toBe("60.00000000")
+    expect(result.toCostAddedMinor).toBe("480000")
+    expect(result.toHolding.quantity).toBe("110.00000000")
+    expect(result.toHolding.avgUnitCostMinor).toBe("8000")
+
+    // Account total value: A (60 x 10,000 = 600,000) + B (110 x 8,000 =
+    // 880,000) = 1,480,000 -- exactly investBefore + the realized gain.
+    const investAfter = await balanceOf(owner, investment.id)
+    expect(investAfter).toBe(1_480_000n)
+    expect(investAfter - investBefore).toBe(80_000n)
+    expect(result.investmentValueAfterMinor).toBe(investAfter.toString())
+
+    // Provenance audit row links both sides + proceeds + realized gain.
+    const audit = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.findMany({
+        where: { familyId: owner.family.id, idempotencyKey: key },
+        select: { entityType: true, afterJson: true },
+      })
+    )
+    const provenance = audit.find((r) => r.entityType === "Switch")
+    expect(provenance).toBeDefined()
+    const after = provenance?.afterJson as Record<string, unknown> | null
+    expect(after?.fromHoldingId).toBe(a.holdingId)
+    expect(after?.toInstrumentId).toBe(b.instrumentId)
+    expect(after?.proceedsMinor).toBe("480000")
+    expect(after?.realizedGainMinor).toBe("80000")
+
+    // Only holdings mutate — no Transaction/cash leg is posted by a switch.
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(2)
+  })
+
+  // --------------------------------------------------------------------------
+  // Switch-all into a brand-new instrument: closes (deletes) A's position and
+  // creates B inline, like a first Buy.
+  // --------------------------------------------------------------------------
+  test("switching ALL of A into a new inline fund closes A's position and creates B", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+
+    const result = await recordSwitchForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fromHoldingId: a.holdingId,
+        toInstrument: fundB,
+        quantity: "100", // switch ALL of A
+        fromUnitPrice: "10500",
+        toUnitPrice: "1000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Proceeds = 100 x 10,500 = 1,050,000. Cost removed = 1,000,000. Realized
+    // gain = 50,000.
+    expect(result.proceedsMinor).toBe("1050000")
+    expect(result.realizedGainMinor).toBe("50000")
+
+    // A closed — no remaining holding.
+    expect(result.fromHolding).toBeNull()
+
+    // B created inline: 1,050,000 / 1,000 = 1,050 units @ avg cost 1,000/unit.
+    expect(result.toHolding.instrument.name).toBe(fundB.name)
+    expect(result.toHolding.quantity).toBe("1050.00000000")
+    expect(result.toHolding.avgUnitCostMinor).toBe("1000")
+
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(1)
+    expect(view.holdings[0]?.instrument.name).toBe(fundB.name)
+
+    const remainingA = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findFirst({ where: { id: a.holdingId } })
+    )
+    expect(remainingA).toBeNull()
+  })
+
+  // --------------------------------------------------------------------------
+  // Quantity-based and amount-based switches are equivalent when the amount
+  // equals the quantity-derived proceeds exactly.
+  // --------------------------------------------------------------------------
+  test("a quantity-based switch and an equivalent amount-based switch produce the same result", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await makeCashAccount(owner, "Checking", "10000000")
+
+    const investmentQty = await makeInvestmentAccount(owner, "By quantity")
+    const aQty = await seedPosition(
+      owner,
+      investmentQty.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+    const bQty = await seedPosition(
+      owner,
+      investmentQty.id,
+      cash.id,
+      fundB,
+      "50",
+      "8000"
+    )
+    const byQuantity = await recordSwitchForFamily({
+      data: {
+        investmentAccountId: investmentQty.id,
+        fromHoldingId: aQty.holdingId,
+        toInstrumentId: bQty.instrumentId,
+        quantity: "40",
+        fromUnitPrice: "12000",
+        toUnitPrice: "8000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    const investmentAmt = await makeInvestmentAccount(owner, "By amount")
+    const aAmt = await seedPosition(
+      owner,
+      investmentAmt.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+    const bAmt = await seedPosition(
+      owner,
+      investmentAmt.id,
+      cash.id,
+      fundB,
+      "50",
+      "8000"
+    )
+    const byAmount = await recordSwitchForFamily({
+      data: {
+        investmentAccountId: investmentAmt.id,
+        fromHoldingId: aAmt.holdingId,
+        toInstrumentId: bAmt.instrumentId,
+        // Exactly the proceeds the quantity-based switch derived (40 x 12,000).
+        amount: "480000",
+        fromUnitPrice: "12000",
+        toUnitPrice: "8000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(byAmount.fromQuantity).toBe(byQuantity.fromQuantity)
+    expect(byAmount.proceedsMinor).toBe(byQuantity.proceedsMinor)
+    expect(byAmount.realizedGainMinor).toBe(byQuantity.realizedGainMinor)
+    expect(byAmount.toQuantity).toBe(byQuantity.toQuantity)
+    expect(byAmount.toHolding.avgUnitCostMinor).toBe(
+      byQuantity.toHolding.avgUnitCostMinor
+    )
+    expect(byAmount.fromHolding?.quantity).toBe(
+      byQuantity.fromHolding?.quantity
+    )
+  })
+
+  // --------------------------------------------------------------------------
+  // Guard rejections
+  // --------------------------------------------------------------------------
+  test("rejects switching into the SAME instrument (A === B)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+
+    await expect(
+      recordSwitchForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          fromHoldingId: a.holdingId,
+          toInstrumentId: a.instrumentId,
+          quantity: "10",
+          fromUnitPrice: "10000",
+          toUnitPrice: "10000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  test("rejects switching more units than held", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+
+    await expect(
+      recordSwitchForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          fromHoldingId: a.holdingId,
+          toInstrument: fundB,
+          quantity: "150", // only 100 held
+          fromUnitPrice: "10000",
+          toUnitPrice: "1000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+
+    // A untouched by the rejected attempt.
+    const stillA = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findUniqueOrThrow({ where: { id: a.holdingId } })
+    )
+    expect(stillA.quantity.toFixed(8)).toBe("100.00000000")
+  })
+
+  test("rejects a non-holdings account (balanceSource != valuation)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+
+    await expect(
+      recordSwitchForFamily({
+        data: {
+          // A cash-like (transaction_flow) account is not a holdings account.
+          investmentAccountId: cash.id,
+          fromHoldingId: a.holdingId,
+          toInstrument: fundB,
+          quantity: "10",
+          fromUnitPrice: "10000",
+          toUnitPrice: "1000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  test("a switch referencing another family's holding/account is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const intruder = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+
+    await expect(
+      recordSwitchForFamily({
+        data: {
+          investmentAccountId: investment.id,
+          fromHoldingId: a.holdingId,
+          toInstrument: fundB,
+          quantity: "10",
+          fromUnitPrice: "10000",
+          toUnitPrice: "1000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+    ).rejects.toThrow()
+
+    // The owner's position is untouched by the rejected cross-tenant attempt.
+    const stillA = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findUniqueOrThrow({ where: { id: a.holdingId } })
+    )
+    expect(stillA.quantity.toFixed(8)).toBe("100.00000000")
+  })
+
+  // --------------------------------------------------------------------------
+  // Idempotency
+  // --------------------------------------------------------------------------
+  test("replaying the same key returns the same result and does not double-mutate", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const a = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundA,
+      "100",
+      "10000"
+    )
+    const b = await seedPosition(
+      owner,
+      investment.id,
+      cash.id,
+      fundB,
+      "50",
+      "8000"
+    )
+
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        investmentAccountId: investment.id,
+        fromHoldingId: a.holdingId,
+        toInstrumentId: b.instrumentId,
+        quantity: "40",
+        fromUnitPrice: "12000",
+        toUnitPrice: "8000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+
+    const first = await recordSwitchForFamily(payload)
+    const second = await recordSwitchForFamily(payload)
+    const normalize = (value: unknown): unknown =>
+      JSON.parse(JSON.stringify(value))
+    expect(normalize(second)).toEqual(normalize(first))
+
+    // Applied exactly once: A at 60 (not 20), B at 110 (not 170).
+    const finalA = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findUniqueOrThrow({ where: { id: a.holdingId } })
+    )
+    expect(finalA.quantity.toFixed(8)).toBe("60.00000000")
+    const finalB = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findUniqueOrThrow({ where: { id: b.holdingId } })
+    )
+    expect(finalB.quantity.toFixed(8)).toBe("110.00000000")
+
+    const investAfter = await balanceOf(owner, investment.id)
+    expect(investAfter).toBe(1_480_000n)
+
+    // Exactly one Switch provenance audit row for this key (replay short-
+    // circuits before the second write, never appending a duplicate).
+    const count = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.count({
+        where: {
+          familyId: owner.family.id,
+          idempotencyKey: key,
+          entityType: "Switch",
+        },
+      })
+    )
+    expect(count).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds **Switch**: within one holdings account, atomically sell fund A and buy fund B using A's proceeds — no external cash, no funding account. Realized gain computed on the sell side (average-cost method); buy side average-costs into an existing B or creates B inline. Switching all of A closes its position. Single `source="holdings"` anchor recompute, per the PER-259/ADR-0054 guard.
- Broker/country-agnostic per ADR-0054 (Bibit "pindah/switch", Vanguard/Fidelity "exchange" — never vendor-specific wording).
- Additive only: `recordSwitchForFamily`/`recordSwitchFn` in `holdings.ts`; `recordTradeForFamily`/`createTransactionForFamily` untouched.
- UI: panel-level + per-row "Switch" button on `HoldingsPanel`, new `SwitchDialog` with quantity/amount toggle and a live client-side preview that reuses the exact pure helpers the server uses (so the preview can never disagree with what posts).
- Two real bugs found and fixed during review: (1) the Holdings panel's header button row overflowed onto the Transactions panel below without `flex-wrap`, causing a click-interception; (2) the "use current price" hint fed a raw minor-unit value into a human-facing `MoneyInput`, inflating the price 100× on re-parse — fixed to use `toDecimalString`, matching the existing convention in `holding-form-dialog.tsx`.

## Test plan
- [x] `vp check` — clean (format + lint + types, 301 files)
- [x] `vp build` — clean, no server/client boundary leaks
- [x] `vp test run` (unit) — 714/714 passed
- [x] Real-Postgres integration (`tests/integration/switches.integration.ts`) — 8/8 passed: average-cost blend on partial switch, switch-all closes A + creates B inline, quantity-vs-amount basis equivalence, reject same-instrument A===B, reject over-quantity, reject non-holdings account, reject cross-tenant reference, idempotency replay (no double-mutation)
- [x] E2E (`tests/e2e/switch-fund.e2e.ts`) — 1/1 passed: seed a holding, switch all of it into a new fund via the dialog, verify A's row disappears, B's row appears with correct units, account value stays sane

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1