### PR TITLE
feat(holdings): PER-259 Slice 5 — edit/correct and delete a Buy/Sell trade

### DIFF
--- a/docs/adr/0054-holdings-account-operational-coherence.md
+++ b/docs/adr/0054-holdings-account-operational-coherence.md
@@ -153,62 +153,52 @@ FIFO-vs-average election beyond the current average-cost model — later.
     ratios) are already inside the NAV/price, so the Σ-holdings value already
     reflects them — NOT recorded separately. Slice 3 adds only the standalone fee.
 - **Slice 4 — Switch** (atomic sell-A + buy-B).
-- **Slice 5 — Edit/correct a trade** (reverse + re-record, audited). **Scope
-  decision (creator, 2026-08-16):** a Buy/Sell trade is editable/deletable
-  **only when it is still the LATEST quantity-mutating event on that
-  (account, instrument) position** — no other Buy/Sell/Switch has touched the
-  same holding since. Rationale: `Holding.avgUnitCostMinor` is blended
-  CURRENT STATE, not a per-lot ledger; reversing a non-latest trade would
-  require replaying the full subsequent trade history to stay exact, which is
-  explicitly OUT OF SCOPE here (flagged as a possible future extension, not
-  built). Attempting to correct a non-latest trade fails loud with an
-  actionable message (record a correcting trade instead) — it must never
-  silently produce a wrong average cost.
-  - **"Latest" is an explicit identity invariant, not a value diff.** Add a
-    durable marker on `Holding` naming the idempotency key of whichever
-    operation (Buy/Sell in `recordTradeForFamily`, either leg of
-    `recordSwitchForFamily`, reinvest in `recordDistributionForFamily`) last
-    changed its quantity/avgUnitCostMinor. Comparing CURRENT vs. a snapshot's
-    raw field values is insufficient — a later Sell-then-rebuy-at-the-same-
-    price could coincidentally match the original values and falsely appear
-    "still latest." Every holdings-quantity-mutating write path must set this
-    marker consistently (an additive migration + a small touch to each
-    existing write path — do not let any of them fall out of sync).
-  - **Reversal reuses the existing valuation-linked-transfer delete path.**
-    `softDeleteValuationLinkedTransferWithinTx` (transactions.ts) already
-    reverses a trade's cash leg + tombstones the Valuation/Transfer/Transaction
-    correctly, but today deliberately REFUSES (`HoldingsTradeDeleteUnsupportedError`)
-    when `Valuation.source === "holdings"`, because it has no way to also
-    reverse the paired Holding — see the guard's own comment (PER-198/ADR-0051)
-    for why that refusal exists and must stay the default for every OTHER
-    caller. Extend it (e.g. an optional holdings-reversal hook) so the new
-    Slice 5 code path can supply the Holding-side reversal atomically in the
-    same transaction, while every other caller keeps getting the existing
-    hard refusal unchanged.
-  - **Holding reversal uses the trade's own captured AuditLog snapshot**
-    (`before`/`after` on the `entityType: "Holding"` row keyed by the trade's
-    idempotencyKey — the same mechanism Slice 2-4's provenance rows already
-    use), not a recomputed inverse — exact by construction, no re-derived
-    rounding.
-  - **Edit = reversal + reapply, one atomic transaction.** Reapply must reuse
-    `recordTradeForFamily`'s own Buy/Sell math rather than duplicate it — this
-    requires extracting its existing body into a `*_WithinTx` core (the same
-    shape as `postIncomeTransactionWithinTx`/`postExpenseTransactionWithinTx`)
-    callable from both the public entry point (opens its own transaction, ZERO
-    behavior change — prove it with the full existing Buy/Sell integration
-    suite before/after) and the new correction path (composes reversal +
-    reapply in one transaction). The corrected trade gets a NEW transaction id
-    (reversal-and-replace, the same pattern `replaceTransactionWithinTenantTransaction`
-    already uses for classic transfers) — the old rows are tombstoned
-    (`deletedAt`), never hard-deleted (no ledger history is erased).
-  - **Delete = reversal only**, same guard, same reversal primitive, no reapply.
-  - Build DELETE first (simpler, fully provable), verify completely, THEN add
-    EDIT on top of the same reversal primitive.
-  - UI: the per-account statement's Edit/Delete on a Buy/Sell row route here
-    (not the generic transaction-edit modal) when the row is a holdings
-    trade; on rejection, surface the server's actionable message rather than
-    proactively graying out the buttons (no extra "is this editable" query
-    this slice — acceptable v1 UX, note as a possible follow-up polish).
+- **Slice 5 — Edit/correct a trade** — DONE (PER-259 Slice 5). A mis-entered
+  Buy/Sell can now be **corrected or deleted**, not just created. Scope
+  (locked with the creator): a trade is editable/deletable ONLY when it is
+  still the **latest quantity-mutating event** on its (account, instrument)
+  position — no other Buy/Sell, Switch leg, or Dividend reinvest has touched
+  that same Holding since. No full historical-replay engine; attempting to
+  correct a non-latest trade fails loud with an actionable message ("record a
+  correcting trade instead of editing this one"), never silently produces wrong
+  numbers.
+  - **"Latest" is an IDENTITY check** (`Holding.lastMutationIdempotencyKey`
+    marker — PER-259 migration `20260816130000_holding_last_mutation_key`) vs
+    the trade's own idempotencyKey, never a value diff: a later Sell-then-
+    rebuy-at-the-same-price could coincidentally reproduce the original
+    quantity/cost and falsely look "unchanged".
+  - **DELETE** reuses the EXISTING valuation-linked-transfer delete path
+    (`softDeleteValuationLinkedTransferWithinTx`, transactions.ts) via its new
+    `onHoldingsTradeReversal` hook — the SAME cash-leg/valuation/transfer
+    reversal every other valuation-linked delete uses, plus the hook restoring
+    the paired Holding from its captured AuditLog before/after snapshot (never
+    recomputing an inverse via math) and re-materializing the Σ-holdings anchor.
+  - **EDIT** is reversal-and-replace, ONE atomic transaction: reverse the OLD
+    trade exactly like DELETE, then REAPPLY the corrected params as a brand-new
+    trade via `recordTradeWithinTx` (the SAME core `recordTradeForFamily` uses
+    — no duplicated math). The old Transaction/Transfer/Valuation are
+    tombstoned (never hard-deleted); the corrected trade gets a NEW transaction
+    id — the exact "reversal-and-replace" pattern
+    `replaceTransactionWithinTenantTransaction` already uses for classic
+    transfer edits (CLAUDE.md §5A).
+  - **SIDE FLIP** (buy→sell or vice versa) is supported with NO special-casing:
+    the reversal restores the position to its exact pre-trade state, and the
+    reapply re-runs `recordTradeWithinTx`'s OWN validation against that
+    restored state — a flip that doesn't make sense (e.g. selling a position
+    the reversal just deleted) fails with the SAME actionable error
+    `recordTradeForFamily` already gives ("No <fund> position to sell"), never
+    silent misbehavior.
+  - **Known limitation** (explicitly "not a full historical-replay engine"): a
+    reopen-THEN-reclose cascade, or an unrelated manual `deleteHoldingForFamily`
+    call, both leave no CURRENT Holding row and are not distinguishable from
+    "still latest" by the fallback check alone — the one documented residual
+    gap in the Slice 5 guard.
+  - Server `deleteTradeForFamily` / `deleteTradeFn`, `correctTradeForFamily` /
+    `correctTradeFn`, `getTradeForCorrectionForFamily` /
+    `getTradeForCorrectionFn`; UI `trade-correction-dialog.tsx`; real-PG
+    integration suite `tests/integration/trade-corrections.integration.ts` +
+    e2e `tests/e2e/trade-correction.e2e.ts`. Full §5A contract (tenant
+    transaction, RLS, idempotency, audit).
 - **Slice 6 — Move a position between accounts** (in-kind, no cash, cost basis carries).
 - Cross-cutting: multi-currency trade + FX rides ADR-0052 Slice C/D; everything
   broker/country-agnostic (Broker-agnostic principle above).

--- a/prisma/migrations/20260816130000_holding_last_mutation_key/migration.sql
+++ b/prisma/migrations/20260816130000_holding_last_mutation_key/migration.sql
@@ -1,0 +1,24 @@
+-- PER-259 Slice 5 / ADR-0054 — "latest quantity-mutating event" identity marker.
+--
+-- Correcting (edit/delete) a Buy/Sell trade is only safe when nothing else has
+-- touched the SAME (account, instrument) position since — a Switch leg, a
+-- Dividend reinvest, or a later Buy/Sell. Comparing current quantity/cost VALUES
+-- against the trade's captured before/after snapshot is not sound: a later
+-- Sell-then-rebuy-at-the-same-price can coincidentally reproduce the original
+-- values and falsely look "unchanged". This column is an IDENTITY marker
+-- instead — the idempotencyKey of whichever operation last changed this row's
+-- quantity/avgUnitCostMinor — so the correction guard compares identity, never
+-- a value diff.
+--
+-- Every holdings-quantity-mutating write path stamps it: recordTradeForFamily's
+-- Buy AND Sell branches, both legs of recordSwitchForFamily, the reinvest
+-- branch of recordDistributionForFamily, and it is explicitly CLEARED (set
+-- back to NULL) by upsertHoldingForFamily's manual raw-edit branch — a manual
+-- edit invalidates any earlier trade's claim to being "still latest" (src/server/holdings.ts).
+--
+-- ADDITIVE ONLY — one nullable column, no default, no backfill needed (every
+-- existing holding predates trade-correction and is correctly NULL = "not
+-- known to be the result of a still-latest tracked mutation"; the first trade
+-- recorded against it going forward stamps the marker).
+
+ALTER TABLE "Holding" ADD COLUMN "lastMutationIdempotencyKey" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1021,6 +1021,18 @@ model Holding {
   // enters a price (value then falls back to cost basis, gain 0). CHECK null or >= 0.
   lastPriceMinor BigInt?
 
+  // PER-259 Slice 5 / ADR-0054 — the "latest quantity-mutating event" IDENTITY
+  // marker: the idempotencyKey of whichever operation last changed quantity /
+  // avgUnitCostMinor on this row (a Buy/Sell trade, a Switch leg, or a
+  // Dividend reinvest — see src/server/holdings.ts). A trade-correction/delete
+  // is only permitted when this equals the target trade's own idempotencyKey
+  // — an IDENTITY comparison, never a value diff (two trades can coincidentally
+  // produce the same quantity/cost). NULL means "never touched by a tracked
+  // mutation" (a freshly-created holding) OR "manually raw-edited since"
+  // (upsertHoldingForFamily's update branch clears it — a manual edit
+  // invalidates any earlier trade's claim to being "still latest").
+  lastMutationIdempotencyKey String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 

--- a/src/components/blocks/trade-correction-dialog.tsx
+++ b/src/components/blocks/trade-correction-dialog.tsx
@@ -1,0 +1,346 @@
+import * as React from "react"
+import { useQuery } from "@tanstack/react-query"
+import { ArrowDownLeft, ArrowUpRight, Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { MoneyInput } from "@/components/blocks/money-input"
+import { formatCurrency } from "@/lib/currency"
+import type { CurrencyCode } from "@/lib/data/currencies"
+import {
+  averageUnitCostMinor,
+  holdingCostMinor,
+  quantityToScaled,
+} from "@/lib/holdings"
+import { parseMoneyInput, toDecimalString } from "@/lib/money"
+import { cn } from "@/lib/utils"
+import { createUuidV7 } from "@/lib/uuid-v7"
+import {
+  correctTradeFn,
+  getTradeForCorrectionFn,
+  type TradeForCorrectionView,
+} from "@/server/holdings"
+
+// PER-259 Slice 5 / ADR-0054 — "Edit/correct a trade" dialog. Styled and
+// structured like `TradeDialog` (side + funding account + quantity + unit
+// price, cash total derived live via the SAME pure helper), but for an
+// EXISTING trade: the instrument is fixed (resolved server-side from
+// history — not editable, moving a position between instruments/accounts is
+// out of scope), and submission is reversal-and-replace
+// (`correctTradeFn`) rather than a fresh trade.
+
+function toDateInputValue(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+export interface TradeCorrectionFundingAccount {
+  id: string
+  name: string
+  currency: string
+}
+
+export function TradeCorrectionDialog({
+  transactionId,
+  fundingAccounts,
+  onClose,
+  onSaved,
+}: {
+  transactionId: string
+  fundingAccounts: ReadonlyArray<TradeCorrectionFundingAccount>
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const {
+    data: details,
+    isLoading,
+    error: loadError,
+  } = useQuery({
+    queryKey: ["trade_for_correction", transactionId],
+    queryFn: async () =>
+      await getTradeForCorrectionFn({ data: { transactionId } }),
+  })
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            Loading trade…
+          </div>
+        ) : loadError || !details ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Can&apos;t edit this trade</DialogTitle>
+            </DialogHeader>
+            <p className="text-sm text-destructive" role="alert">
+              {loadError instanceof Error
+                ? loadError.message
+                : "This transaction could not be loaded."}
+            </p>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={onClose}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <TradeCorrectionForm
+            details={details}
+            fundingAccounts={fundingAccounts}
+            onClose={onClose}
+            onSaved={onSaved}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// Split into its own component so `useState`'s initializers seed from
+// `details` on the ONE render this mounts (details are already resolved by
+// the time the parent renders it) — no useEffect, no "sync state from a
+// prop" hook needed.
+function TradeCorrectionForm({
+  details,
+  fundingAccounts,
+  onClose,
+  onSaved,
+}: {
+  details: TradeForCorrectionView
+  fundingAccounts: ReadonlyArray<TradeCorrectionFundingAccount>
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const currencyCode = details.currency as CurrencyCode
+
+  const initialUnitPriceMinor = averageUnitCostMinor(
+    BigInt(details.cashAmountMinor),
+    quantityToScaled(details.quantity)
+  )
+
+  const [side, setSide] = React.useState<"buy" | "sell">(details.side)
+  const [fundingAccountId, setFundingAccountId] = React.useState<string>(
+    details.fundingAccountId
+  )
+  const [quantity, setQuantity] = React.useState<string>(details.quantity)
+  const [unitPrice, setUnitPrice] = React.useState<string>(
+    toDecimalString(initialUnitPriceMinor, currencyCode)
+  )
+  const [date, setDate] = React.useState<string>(
+    toDateInputValue(details.tradeDate)
+  )
+  const [error, setError] = React.useState<string | null>(
+    details.notLatestReason
+  )
+  const [submitting, setSubmitting] = React.useState(false)
+
+  // Live cash total = quantity × unit price, via the SAME pure helper the
+  // server uses for cost basis — pure derivation, no effect.
+  const cashPreview = React.useMemo<
+    { kind: "empty" } | { kind: "invalid" } | { kind: "valid"; minor: bigint }
+  >(() => {
+    if (quantity.trim() === "" || unitPrice.trim() === "") {
+      return { kind: "empty" }
+    }
+    const price = parseMoneyInput(unitPrice, currencyCode)
+    if (price === null || price <= 0n) return { kind: "invalid" }
+    try {
+      const scaled = quantityToScaled(quantity.trim())
+      if (scaled <= 0n) return { kind: "invalid" }
+      return { kind: "valid", minor: holdingCostMinor(scaled, price) }
+    } catch {
+      return { kind: "invalid" }
+    }
+  }, [quantity, unitPrice, currencyCode])
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+    if (cashPreview.kind !== "valid") {
+      setError("Enter a valid quantity and unit price.")
+      return
+    }
+    const price = parseMoneyInput(unitPrice, currencyCode)
+    if (price === null) {
+      setError("Enter a valid unit price.")
+      return
+    }
+    setSubmitting(true)
+    try {
+      await correctTradeFn({
+        data: {
+          transactionId: details.transactionId,
+          fundingAccountId,
+          side,
+          cashAmount: cashPreview.minor.toString(),
+          quantity: quantity.trim(),
+          unitPrice: price.toString(),
+          tradeDate: new Date(date),
+          idempotencyKey: createUuidV7(),
+        },
+      })
+      await onSaved()
+    } catch (caught) {
+      // The HoldingError message (e.g. "this trade has activity after it…")
+      // survives the RPC boundary and surfaces here verbatim.
+      setError(caught instanceof Error ? caught.message : String(caught))
+      setSubmitting(false)
+    }
+  }
+
+  const submitDisabled =
+    submitting ||
+    fundingAccountId === "" ||
+    quantity.trim() === "" ||
+    unitPrice.trim() === "" ||
+    cashPreview.kind !== "valid" ||
+    details.notLatestReason !== null
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          {side === "buy" ? (
+            <ArrowDownLeft className="size-4 text-emerald-600 dark:text-emerald-400" />
+          ) : (
+            <ArrowUpRight className="size-4 text-destructive" />
+          )}
+          Edit {details.instrumentName}
+        </DialogTitle>
+        <DialogDescription>
+          Correcting this trade reverses it and records a new one with the
+          corrected details. The old entry stays in your history, tombstoned.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <Label>Side</Label>
+          <Select
+            value={side}
+            onValueChange={(value) => setSide(value as "buy" | "sell")}
+            disabled={details.notLatestReason !== null}
+          >
+            <SelectTrigger aria-label="Trade side">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="buy">Buy</SelectItem>
+              <SelectItem value="sell">Sell</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label>Funding account</Label>
+          <Select
+            value={fundingAccountId}
+            onValueChange={setFundingAccountId}
+            disabled={details.notLatestReason !== null}
+          >
+            <SelectTrigger aria-label="Funding account">
+              <SelectValue placeholder="Choose account" />
+            </SelectTrigger>
+            <SelectContent>
+              {fundingAccounts.map((account) => (
+                <SelectItem key={account.id} value={account.id}>
+                  {account.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="trade-correction-quantity">Quantity</Label>
+          <Input
+            id="trade-correction-quantity"
+            inputMode="decimal"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+            disabled={details.notLatestReason !== null}
+            required
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="trade-correction-unit-price">
+            Unit price ({details.currency})
+          </Label>
+          <MoneyInput
+            id="trade-correction-unit-price"
+            currency={currencyCode}
+            value={unitPrice}
+            onChange={setUnitPrice}
+            disabled={details.notLatestReason !== null}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="trade-correction-date">Date</Label>
+        <Input
+          id="trade-correction-date"
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          disabled={details.notLatestReason !== null}
+        />
+      </div>
+
+      <div
+        className={cn(
+          "flex items-center justify-between rounded-md border p-3 text-sm",
+          cashPreview.kind === "valid" ? "bg-muted/50" : "text-muted-foreground"
+        )}
+      >
+        <span className="text-muted-foreground">
+          {side === "buy" ? "Cash out" : "Cash in"}
+        </span>
+        <span className="font-semibold tabular-nums">
+          {cashPreview.kind === "valid"
+            ? formatCurrency(cashPreview.minor.toString(), details.currency)
+            : "—"}
+        </span>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+          disabled={submitting}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={submitDisabled}>
+          {submitting ? "Saving…" : "Save correction"}
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}

--- a/src/routes/_protected/accounts.$accountId.tsx
+++ b/src/routes/_protected/accounts.$accountId.tsx
@@ -61,6 +61,7 @@ import {
   SwitchDialog,
   type SwitchDialogState,
 } from "@/components/blocks/switch-dialog"
+import { TradeCorrectionDialog } from "@/components/blocks/trade-correction-dialog"
 import { TransactionFormModal } from "@/components/transaction-form-modal"
 import {
   accountCollection,
@@ -95,6 +96,7 @@ import { enableHoldingsTrackingFn } from "@/server/accounts"
 import { canEnableHoldingsTracking } from "@/lib/accounts"
 import {
   deleteHoldingFn,
+  deleteTradeFn,
   getAccountHoldingsFn,
   refreshHoldingPricesFn,
   syncMarketPricesFn,
@@ -197,6 +199,10 @@ function AccountDetailPage() {
   // gets the same singleton edit modal + inline delete.
   const [editingTrx, setEditingTrx] =
     React.useState<TransactionEditData | null>(null)
+  // PER-259 Slice 5 — Buy/Sell trade correction dialog (reversal + reapply).
+  const [tradeCorrectionDialog, setTradeCorrectionDialog] = React.useState<{
+    transactionId: string
+  } | null>(null)
   // PER-241 — persisted compact ↔ comfortable density, shared with the ledger.
   const [density, setDensity] = useTransactionDensity()
 
@@ -569,6 +575,58 @@ function AccountDetailPage() {
     }
   }
 
+  // PER-259 Slice 5 / ADR-0054 — a Buy/Sell trade's cash leg is a `transfer`
+  // Transaction whose canonical Transfer purpose is auto-labeled "Invest" /
+  // "Withdraw" (PER-247's `resolveTransferPurpose`) — a cheap, ALREADY-loaded
+  // client-side signal for "this row is LIKELY a holdings trade", so Edit/
+  // Delete can route to the dedicated trade-correction flow instead of the
+  // generic transaction modal. This is a heuristic, not the source of truth:
+  // a non-holdings valuation account's plain valuation-linked transfer gets
+  // the SAME purpose label, and a liability-funded trade (rare) would NOT
+  // match it. Either way the SERVER is the law — `deleteTradeFn`/
+  // `correctTradeFn` reject anything that is not actually a Buy/Sell trade
+  // with an actionable message, which the dialog/toast surfaces verbatim; no
+  // proactive per-row "is this editable" query runs for the other rows.
+  function isTradeRow(trx: TransactionRecord): boolean {
+    return (
+      trx.type === "transfer" &&
+      (trx.transferPurpose === "investment_contribution" ||
+        trx.transferPurpose === "investment_withdrawal")
+    )
+  }
+
+  function handleRowEdit(
+    trx: TransactionRecord,
+    editData: TransactionEditData
+  ) {
+    if (isTradeRow(trx)) {
+      setTradeCorrectionDialog({ transactionId: trx.id })
+      return
+    }
+    setEditingTrx(editData)
+  }
+
+  async function handleRowDelete(trx: TransactionRecord) {
+    if (!isTradeRow(trx)) {
+      await handleStatementDelete(trx.id)
+      return
+    }
+    const confirmed = confirm(
+      "Delete this trade? Its cash and position are reversed, and the change stays in your history."
+    )
+    if (!confirmed) return
+    try {
+      await deleteTradeFn({
+        data: { transactionId: trx.id, idempotencyKey: createUuidV7() },
+      })
+      await refreshHoldings()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete trade"
+      )
+    }
+  }
+
   // PER-224 — account health: fold runway + reserve buffer + balance-drift into
   // one transparent score. Cash-like only (the signals don't apply to tracked
   // assets / term liabilities).
@@ -918,8 +976,10 @@ function AccountDetailPage() {
                                   }
                                 : null
                             }
-                            onEdit={setEditingTrx}
-                            onDelete={handleStatementDelete}
+                            onEdit={(editData) =>
+                              handleRowEdit(row.trx, editData)
+                            }
+                            onDelete={() => handleRowDelete(row.trx)}
                           />
                         )}
                       </div>
@@ -1049,6 +1109,21 @@ function AccountDetailPage() {
           onSaved={async () => {
             await refreshHoldings()
             setSwitchDialog(null)
+          }}
+        />
+      ) : null}
+
+      {tradeCorrectionDialog ? (
+        <TradeCorrectionDialog
+          // Remount per trade so the form re-initializes from freshly-loaded
+          // correction details (the singleton edit pattern, §5C).
+          key={`trade-correction-${tradeCorrectionDialog.transactionId}`}
+          transactionId={tradeCorrectionDialog.transactionId}
+          fundingAccounts={fundingAccounts}
+          onClose={() => setTradeCorrectionDialog(null)}
+          onSaved={async () => {
+            await refreshHoldings()
+            setTradeCorrectionDialog(null)
           }}
         />
       ) : null}

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -35,11 +35,15 @@ import {
 import { toMinorUnits } from "@/lib/money"
 import { getFamilyBaseCurrency } from "./fx"
 import {
+  findTransactionAuditGraph,
   postExpenseTransactionWithinTx,
   postIncomeTransactionWithinTx,
   postValuationLinkedTransferLegs,
+  softDeleteValuationLinkedTransferWithinTx,
+  TransactionGoneError,
   type ValuationLinkedTransferLeg,
 } from "./transactions"
+import { createUuidV7 } from "@/lib/uuid-v7"
 import {
   auditLog,
   createAuditContext,
@@ -219,6 +223,14 @@ export interface SerializedHolding {
   /** Unrealized return as a fraction, or null when cost is 0. */
   returnPct: number | null
   /**
+   * PER-259 Slice 5 / ADR-0054 — identity marker: the idempotencyKey of
+   * whichever operation last changed `quantity`/`avgUnitCostMinor` on this
+   * row (a trade, a Switch leg, or a Dividend reinvest), or null when never
+   * touched by a tracked mutation / cleared by a manual raw edit. Part of the
+   * "before" snapshot a trade-correction restores verbatim — never recomputed.
+   */
+  lastMutationIdempotencyKey: string | null
+  /**
    * PER-238 — as-of of the latest MarketQuote for the linked MarketInstrument
    * (ISO string), or null when the holding is not linked / has no quote yet.
    * Populated by the read view (getAccountHoldingsForFamily); a bare
@@ -284,6 +296,7 @@ function serializeHolding(holding: HoldingWithInstrument): SerializedHolding {
     costMinor: cost.toString(),
     gainMinor: gain.toString(),
     returnPct: holdingReturnPct(value, cost),
+    lastMutationIdempotencyKey: holding.lastMutationIdempotencyKey,
     latestMarketQuoteAsOf: null,
     createdAt: holding.createdAt.toISOString(),
     updatedAt: holding.updatedAt.toISOString(),
@@ -642,6 +655,12 @@ export async function upsertHoldingForFamily({
             quantity: data.quantity,
             avgUnitCostMinor,
             lastPriceMinor,
+            // PER-259 Slice 5 — a manual raw edit is NOT a tracked mutation
+            // (trade / switch leg / reinvest); clear the "latest" identity
+            // marker so a stale trade can never be mistaken for still being
+            // latest after this out-of-band edit. See the marker's doc
+            // comment on `SerializedHolding` / the migration header.
+            lastMutationIdempotencyKey: null,
           },
           include: { instrument: true },
         })
@@ -1103,6 +1122,329 @@ async function fetchActiveAccount(
   return account
 }
 
+// PER-259 Slice 5 / ADR-0054 — the within-transaction CORE of a Buy/Sell trade,
+// extracted verbatim (zero behavior change) from `recordTradeForFamily` so a
+// second caller can compose it: the trade-CORRECTION path (`correctTradeForFamily`
+// below) reverses the old trade, then calls this SAME core to reapply the
+// corrected params as a brand-new trade in the SAME transaction — reusing the
+// exact math (average cost, realized gain, the "latest" marker stamp) instead
+// of duplicating it. Mirrors `postIncomeTransactionWithinTx` /
+// `postExpenseTransactionWithinTx`'s shape: this does NOT replay-check or
+// persist an IdempotencyRecord — the caller owns that (its own endpoint for
+// `recordTradeForFamily`, or the correction endpoint's for the reapply).
+async function recordTradeWithinTx(
+  tx: TenantTransactionClient,
+  {
+    data,
+    familyId,
+    user,
+    auditCtx,
+  }: {
+    data: RecordTradeInput
+    familyId: string
+    user: ServerActor
+    auditCtx: AuditContext
+  }
+): Promise<RecordTradeResult> {
+  const isBuy = data.side === "buy"
+
+  // Tenant ownership of BOTH accounts (RLS-scoped, composite-FK backed).
+  await validateTenantReferences(tx, familyId, {
+    accountId: data.fundingAccountId,
+    toAccountId: data.investmentAccountId,
+  })
+
+  const fundingAccount = await fetchActiveAccount(
+    tx,
+    familyId,
+    data.fundingAccountId,
+    "Funding"
+  )
+  if (fundingAccount.balanceSource !== "transaction_flow") {
+    throw new HoldingError(
+      `Funding account ${fundingAccount.id} must be a cash-like account (balanceSource="transaction_flow"); it is "${fundingAccount.balanceSource}"`
+    )
+  }
+
+  const investmentAccount = await fetchActiveAccount(
+    tx,
+    familyId,
+    data.investmentAccountId,
+    "Investment"
+  )
+  if (investmentAccount.balanceSource !== "valuation") {
+    throw new HoldingError(
+      `Investment account ${investmentAccount.id} must be a valuation-tracked account (balanceSource="valuation"); it is "${investmentAccount.balanceSource}"`
+    )
+  }
+
+  // Single-currency slice: the cash leg and the position share one currency.
+  if (fundingAccount.currency !== investmentAccount.currency) {
+    throw new HoldingError(
+      `Cross-currency trades are not supported this slice (funding ${fundingAccount.currency}, investment ${investmentAccount.currency})`
+    )
+  }
+  // Validate the currency is one we support (throws a typed HoldingError).
+  assertKnownCurrency(investmentAccount.currency)
+
+  const cashAmount = BigInt(data.cashAmount)
+  let quantityScaled: bigint
+  try {
+    quantityScaled = quantityToScaled(data.quantity)
+  } catch (error) {
+    throw new HoldingError(
+      `quantity is not a valid amount: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  if (quantityScaled <= 0n) {
+    throw new HoldingError("quantity must be greater than zero")
+  }
+
+  // Resolve the instrument. A BUY may create one inline; a SELL must name an
+  // existing instrument (you cannot sell a position you do not hold).
+  if (!isBuy && (data.instrument || !data.instrumentId)) {
+    throw new HoldingError(
+      "A sell must reference an existing instrumentId (you can only sell a position you hold)"
+    )
+  }
+  const instrument = await resolveInstrument(
+    tx,
+    familyId,
+    investmentAccount.currency,
+    { instrumentId: data.instrumentId, instrument: data.instrument },
+    auditCtx
+  )
+
+  // Side-channel outputs captured from the position mutation (which runs
+  // inside resolveValuation, after the cash leg posts). An object (not bare
+  // primitives) so closure assignments keep their declared union type.
+  const tradeOut: {
+    holdingId: string | null
+    realizedGainMinor: bigint | null
+    costBasisDeltaMinor: bigint
+  } = { holdingId: null, realizedGainMinor: null, costBasisDeltaMinor: 0n }
+
+  const existing = await tx.holding.findFirst({
+    where: {
+      familyId,
+      accountId: investmentAccount.id,
+      instrumentId: instrument.id,
+    },
+    include: { instrument: true },
+  })
+
+  // Direction + kind mirror the DB trigger exactly (source→destination):
+  //   BUY  = contribution (funding → investment)
+  //   SELL = redemption   (investment → funding)
+  const direction = isBuy ? "contribution" : "redemption"
+  const kind = isBuy
+    ? deriveTransferKindForAccounts({
+        fromAccountType: parseAccountType(fundingAccount.accountType),
+        toAccountType: parseAccountType(investmentAccount.accountType),
+      })
+    : deriveTransferKindForAccounts({
+        fromAccountType: parseAccountType(investmentAccount.accountType),
+        toAccountType: parseAccountType(fundingAccount.accountType),
+      })
+
+  const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
+  const tradeDate = data.tradeDate ?? new Date()
+  const description = `${isBuy ? "Buy" : "Sell"} ${instrument.name}`
+
+  const leg: ValuationLinkedTransferLeg = {
+    amount: cashAmount,
+    date: tradeDate,
+    description,
+    notes: null,
+    status: "CLEARED",
+    idempotencyKey: data.idempotencyKey,
+  }
+
+  const serializedTransaction = await postValuationLinkedTransferLegs(tx, {
+    cashAccount: fundingAccount,
+    trackedAccount: investmentAccount,
+    direction,
+    kind,
+    // PER-247: a Buy IS an investment contribution (Sell a withdrawal) —
+    // label the canonical Transfer so per-account rendering is
+    // contextual. Only on funds_movement (a liability-funded trade keeps
+    // its liability_draw meaning; purpose is forbidden there).
+    purpose:
+      kind === "funds_movement"
+        ? isBuy
+          ? "investment_contribution"
+          : "investment_withdrawal"
+        : null,
+    leg,
+    familyId,
+    user,
+    auditCtx,
+    baseCurrency,
+    resolveValuation: async (t) => {
+      if (isBuy) {
+        if (existing) {
+          const oldUnitsScaled = quantityToScaled(existing.quantity.toFixed(8))
+          const oldCost = holdingCostMinor(
+            oldUnitsScaled,
+            existing.avgUnitCostMinor
+          )
+          const newUnitsScaled = oldUnitsScaled + quantityScaled
+          const newAvg = averageUnitCostMinor(
+            oldCost + cashAmount,
+            newUnitsScaled
+          )
+          const updated = await t.holding.update({
+            where: { id: existing.id },
+            data: {
+              quantity: scaledToQuantityString(newUnitsScaled),
+              avgUnitCostMinor: newAvg,
+              // PER-259 Slice 5 — stamp the "latest" identity marker with
+              // THIS trade's own idempotencyKey (see marker doc comment).
+              lastMutationIdempotencyKey: data.idempotencyKey,
+            },
+            include: { instrument: true },
+          })
+          await auditLog(t, auditCtx, {
+            action: "update",
+            entityType: "Holding",
+            entityId: updated.id,
+            before: serializeHolding(existing),
+            after: serializeHolding(updated),
+          })
+          tradeOut.holdingId = updated.id
+        } else {
+          const newAvg = averageUnitCostMinor(cashAmount, quantityScaled)
+          const created = await t.holding.create({
+            data: {
+              familyId,
+              accountId: investmentAccount.id,
+              instrumentId: instrument.id,
+              quantity: scaledToQuantityString(quantityScaled),
+              avgUnitCostMinor: newAvg,
+              lastPriceMinor: null,
+              // PER-259 Slice 5 — this trade is the FIRST mutation ever
+              // on this position; stamp it immediately.
+              lastMutationIdempotencyKey: data.idempotencyKey,
+            },
+            include: { instrument: true },
+          })
+          await auditLog(t, auditCtx, {
+            action: "create",
+            entityType: "Holding",
+            entityId: created.id,
+            after: serializeHolding(created),
+          })
+          tradeOut.holdingId = created.id
+        }
+        tradeOut.costBasisDeltaMinor = cashAmount
+      } else {
+        // SELL — must have an existing position with enough units.
+        if (!existing) {
+          throw new HoldingError(
+            `No ${instrument.name} position to sell in this account`
+          )
+        }
+        const oldUnitsScaled = quantityToScaled(existing.quantity.toFixed(8))
+        if (quantityScaled > oldUnitsScaled) {
+          throw new HoldingError(
+            `Cannot sell ${data.quantity} units; only ${existing.quantity.toFixed(8)} held`
+          )
+        }
+        // Average-cost method: cost removed = units sold × average unit cost;
+        // the average unit cost of the remaining units is unchanged.
+        const costRemoved = holdingCostMinor(
+          quantityScaled,
+          existing.avgUnitCostMinor
+        )
+        tradeOut.costBasisDeltaMinor = costRemoved
+        tradeOut.realizedGainMinor = cashAmount - costRemoved
+        const newUnitsScaled = oldUnitsScaled - quantityScaled
+        if (newUnitsScaled === 0n) {
+          // Sold to zero — close (delete) the position, mirroring
+          // deleteHoldingForFamily's hard delete of the position row.
+          await t.holding.delete({ where: { id: existing.id } })
+          await auditLog(t, auditCtx, {
+            action: "delete",
+            entityType: "Holding",
+            entityId: existing.id,
+            before: serializeHolding(existing),
+            after: null,
+          })
+          tradeOut.holdingId = null
+        } else {
+          const updated = await t.holding.update({
+            where: { id: existing.id },
+            data: {
+              quantity: scaledToQuantityString(newUnitsScaled),
+              // PER-259 Slice 5 — stamp the "latest" identity marker.
+              lastMutationIdempotencyKey: data.idempotencyKey,
+            },
+            include: { instrument: true },
+          })
+          await auditLog(t, auditCtx, {
+            action: "update",
+            entityType: "Holding",
+            entityId: updated.id,
+            before: serializeHolding(existing),
+            after: serializeHolding(updated),
+          })
+          tradeOut.holdingId = updated.id
+        }
+      }
+
+      // Re-materialize the investment account value = Σ holdings, written as
+      // the valuation anchor that pairs with the cash leg under one Transfer.
+      const valuation = await recomputeAccountValueAnchorWithinTx(
+        t,
+        familyId,
+        investmentAccount.id,
+        investmentAccount.currency,
+        user,
+        auditCtx
+      )
+      return { valuation }
+    },
+  })
+
+  const finalHolding =
+    tradeOut.holdingId === null
+      ? null
+      : serializeHolding(
+          await loadHoldingWithInstrument(tx, familyId, tradeOut.holdingId)
+        )
+
+  const [fundingAfter, investmentAfter] = await Promise.all([
+    tx.account.findUniqueOrThrow({
+      where: { id: fundingAccount.id },
+      select: { balance: true },
+    }),
+    tx.account.findUniqueOrThrow({
+      where: { id: investmentAccount.id },
+      select: { balance: true },
+    }),
+  ])
+
+  const response: RecordTradeResult = {
+    side: data.side,
+    investmentAccountId: investmentAccount.id,
+    fundingAccountId: fundingAccount.id,
+    transaction: serializedTransaction,
+    holding: finalHolding,
+    realizedGainMinor:
+      tradeOut.realizedGainMinor === null
+        ? null
+        : tradeOut.realizedGainMinor.toString(),
+    costBasisDeltaMinor: tradeOut.costBasisDeltaMinor.toString(),
+    fundingBalanceAfterMinor: fundingAfter.balance.toString(),
+    investmentValueAfterMinor: investmentAfter.balance.toString(),
+  }
+  return response
+}
+
+// The public endpoint. A THIN wrapper around `recordTradeWithinTx`: parse +
+// hash + replay-check + persist — a PURE extraction, zero behavior change
+// from before Slice 5 (verified by re-running the full Buy/Sell integration
+// suite before and after this refactor — see PER-259 Slice 5 report).
 export async function recordTradeForFamily({
   data: rawData,
   familyId,
@@ -1115,7 +1457,6 @@ export async function recordTradeForFamily({
   runInTenantTransaction?: RunInTenantTransaction
 }): Promise<RecordTradeResult> {
   const data: RecordTradeInput = recordTradeInputSchema.parse(rawData)
-  const isBuy = data.side === "buy"
 
   const requestHash = await hashCanonicalPayload({
     cashAmount: data.cashAmount,
@@ -1146,290 +1487,13 @@ export async function recordTradeForFamily({
       )
       if (replay) return replay
 
-      // Tenant ownership of BOTH accounts (RLS-scoped, composite-FK backed).
-      await validateTenantReferences(tx, familyId, {
-        accountId: data.fundingAccountId,
-        toAccountId: data.investmentAccountId,
-      })
-
-      const fundingAccount = await fetchActiveAccount(
-        tx,
-        familyId,
-        data.fundingAccountId,
-        "Funding"
-      )
-      if (fundingAccount.balanceSource !== "transaction_flow") {
-        throw new HoldingError(
-          `Funding account ${fundingAccount.id} must be a cash-like account (balanceSource="transaction_flow"); it is "${fundingAccount.balanceSource}"`
-        )
-      }
-
-      const investmentAccount = await fetchActiveAccount(
-        tx,
-        familyId,
-        data.investmentAccountId,
-        "Investment"
-      )
-      if (investmentAccount.balanceSource !== "valuation") {
-        throw new HoldingError(
-          `Investment account ${investmentAccount.id} must be a valuation-tracked account (balanceSource="valuation"); it is "${investmentAccount.balanceSource}"`
-        )
-      }
-
-      // Single-currency slice: the cash leg and the position share one currency.
-      if (fundingAccount.currency !== investmentAccount.currency) {
-        throw new HoldingError(
-          `Cross-currency trades are not supported this slice (funding ${fundingAccount.currency}, investment ${investmentAccount.currency})`
-        )
-      }
-      // Validate the currency is one we support (throws a typed HoldingError).
-      assertKnownCurrency(investmentAccount.currency)
-
-      const cashAmount = BigInt(data.cashAmount)
-      let quantityScaled: bigint
-      try {
-        quantityScaled = quantityToScaled(data.quantity)
-      } catch (error) {
-        throw new HoldingError(
-          `quantity is not a valid amount: ${error instanceof Error ? error.message : String(error)}`
-        )
-      }
-      if (quantityScaled <= 0n) {
-        throw new HoldingError("quantity must be greater than zero")
-      }
-
-      // Resolve the instrument. A BUY may create one inline; a SELL must name an
-      // existing instrument (you cannot sell a position you do not hold).
-      if (!isBuy && (data.instrument || !data.instrumentId)) {
-        throw new HoldingError(
-          "A sell must reference an existing instrumentId (you can only sell a position you hold)"
-        )
-      }
-      const instrument = await resolveInstrument(
-        tx,
-        familyId,
-        investmentAccount.currency,
-        { instrumentId: data.instrumentId, instrument: data.instrument },
-        auditCtx
-      )
-
-      // Side-channel outputs captured from the position mutation (which runs
-      // inside resolveValuation, after the cash leg posts). An object (not bare
-      // primitives) so closure assignments keep their declared union type.
-      const tradeOut: {
-        holdingId: string | null
-        realizedGainMinor: bigint | null
-        costBasisDeltaMinor: bigint
-      } = { holdingId: null, realizedGainMinor: null, costBasisDeltaMinor: 0n }
-
-      const existing = await tx.holding.findFirst({
-        where: {
-          familyId,
-          accountId: investmentAccount.id,
-          instrumentId: instrument.id,
-        },
-        include: { instrument: true },
-      })
-
-      // Direction + kind mirror the DB trigger exactly (source→destination):
-      //   BUY  = contribution (funding → investment)
-      //   SELL = redemption   (investment → funding)
-      const direction = isBuy ? "contribution" : "redemption"
-      const kind = isBuy
-        ? deriveTransferKindForAccounts({
-            fromAccountType: parseAccountType(fundingAccount.accountType),
-            toAccountType: parseAccountType(investmentAccount.accountType),
-          })
-        : deriveTransferKindForAccounts({
-            fromAccountType: parseAccountType(investmentAccount.accountType),
-            toAccountType: parseAccountType(fundingAccount.accountType),
-          })
-
-      const baseCurrency = await getFamilyBaseCurrency(tx, familyId)
-      const tradeDate = data.tradeDate ?? new Date()
-      const description = `${isBuy ? "Buy" : "Sell"} ${instrument.name}`
-
-      const leg: ValuationLinkedTransferLeg = {
-        amount: cashAmount,
-        date: tradeDate,
-        description,
-        notes: null,
-        status: "CLEARED",
-        idempotencyKey: data.idempotencyKey,
-      }
-
-      const serializedTransaction = await postValuationLinkedTransferLegs(tx, {
-        cashAccount: fundingAccount,
-        trackedAccount: investmentAccount,
-        direction,
-        kind,
-        // PER-247: a Buy IS an investment contribution (Sell a withdrawal) —
-        // label the canonical Transfer so per-account rendering is
-        // contextual. Only on funds_movement (a liability-funded trade keeps
-        // its liability_draw meaning; purpose is forbidden there).
-        purpose:
-          kind === "funds_movement"
-            ? isBuy
-              ? "investment_contribution"
-              : "investment_withdrawal"
-            : null,
-        leg,
+      const response = await recordTradeWithinTx(tx, {
+        data,
         familyId,
         user,
         auditCtx,
-        baseCurrency,
-        resolveValuation: async (t) => {
-          if (isBuy) {
-            if (existing) {
-              const oldUnitsScaled = quantityToScaled(
-                existing.quantity.toFixed(8)
-              )
-              const oldCost = holdingCostMinor(
-                oldUnitsScaled,
-                existing.avgUnitCostMinor
-              )
-              const newUnitsScaled = oldUnitsScaled + quantityScaled
-              const newAvg = averageUnitCostMinor(
-                oldCost + cashAmount,
-                newUnitsScaled
-              )
-              const updated = await t.holding.update({
-                where: { id: existing.id },
-                data: {
-                  quantity: scaledToQuantityString(newUnitsScaled),
-                  avgUnitCostMinor: newAvg,
-                },
-                include: { instrument: true },
-              })
-              await auditLog(t, auditCtx, {
-                action: "update",
-                entityType: "Holding",
-                entityId: updated.id,
-                before: serializeHolding(existing),
-                after: serializeHolding(updated),
-              })
-              tradeOut.holdingId = updated.id
-            } else {
-              const newAvg = averageUnitCostMinor(cashAmount, quantityScaled)
-              const created = await t.holding.create({
-                data: {
-                  familyId,
-                  accountId: investmentAccount.id,
-                  instrumentId: instrument.id,
-                  quantity: scaledToQuantityString(quantityScaled),
-                  avgUnitCostMinor: newAvg,
-                  lastPriceMinor: null,
-                },
-                include: { instrument: true },
-              })
-              await auditLog(t, auditCtx, {
-                action: "create",
-                entityType: "Holding",
-                entityId: created.id,
-                after: serializeHolding(created),
-              })
-              tradeOut.holdingId = created.id
-            }
-            tradeOut.costBasisDeltaMinor = cashAmount
-          } else {
-            // SELL — must have an existing position with enough units.
-            if (!existing) {
-              throw new HoldingError(
-                `No ${instrument.name} position to sell in this account`
-              )
-            }
-            const oldUnitsScaled = quantityToScaled(
-              existing.quantity.toFixed(8)
-            )
-            if (quantityScaled > oldUnitsScaled) {
-              throw new HoldingError(
-                `Cannot sell ${data.quantity} units; only ${existing.quantity.toFixed(8)} held`
-              )
-            }
-            // Average-cost method: cost removed = units sold × average unit cost;
-            // the average unit cost of the remaining units is unchanged.
-            const costRemoved = holdingCostMinor(
-              quantityScaled,
-              existing.avgUnitCostMinor
-            )
-            tradeOut.costBasisDeltaMinor = costRemoved
-            tradeOut.realizedGainMinor = cashAmount - costRemoved
-            const newUnitsScaled = oldUnitsScaled - quantityScaled
-            if (newUnitsScaled === 0n) {
-              // Sold to zero — close (delete) the position, mirroring
-              // deleteHoldingForFamily's hard delete of the position row.
-              await t.holding.delete({ where: { id: existing.id } })
-              await auditLog(t, auditCtx, {
-                action: "delete",
-                entityType: "Holding",
-                entityId: existing.id,
-                before: serializeHolding(existing),
-                after: null,
-              })
-              tradeOut.holdingId = null
-            } else {
-              const updated = await t.holding.update({
-                where: { id: existing.id },
-                data: { quantity: scaledToQuantityString(newUnitsScaled) },
-                include: { instrument: true },
-              })
-              await auditLog(t, auditCtx, {
-                action: "update",
-                entityType: "Holding",
-                entityId: updated.id,
-                before: serializeHolding(existing),
-                after: serializeHolding(updated),
-              })
-              tradeOut.holdingId = updated.id
-            }
-          }
-
-          // Re-materialize the investment account value = Σ holdings, written as
-          // the valuation anchor that pairs with the cash leg under one Transfer.
-          const valuation = await recomputeAccountValueAnchorWithinTx(
-            t,
-            familyId,
-            investmentAccount.id,
-            investmentAccount.currency,
-            user,
-            auditCtx
-          )
-          return { valuation }
-        },
       })
 
-      const finalHolding =
-        tradeOut.holdingId === null
-          ? null
-          : serializeHolding(
-              await loadHoldingWithInstrument(tx, familyId, tradeOut.holdingId)
-            )
-
-      const [fundingAfter, investmentAfter] = await Promise.all([
-        tx.account.findUniqueOrThrow({
-          where: { id: fundingAccount.id },
-          select: { balance: true },
-        }),
-        tx.account.findUniqueOrThrow({
-          where: { id: investmentAccount.id },
-          select: { balance: true },
-        }),
-      ])
-
-      const response: RecordTradeResult = {
-        side: data.side,
-        investmentAccountId: investmentAccount.id,
-        fundingAccountId: fundingAccount.id,
-        transaction: serializedTransaction,
-        holding: finalHolding,
-        realizedGainMinor:
-          tradeOut.realizedGainMinor === null
-            ? null
-            : tradeOut.realizedGainMinor.toString(),
-        costBasisDeltaMinor: tradeOut.costBasisDeltaMinor.toString(),
-        fundingBalanceAfterMinor: fundingAfter.balance.toString(),
-        investmentValueAfterMinor: investmentAfter.balance.toString(),
-      }
       await persistIdempotentEndpointResponse(tx, {
         endpoint: RECORD_TRADE_ENDPOINT,
         familyId,
@@ -1467,6 +1531,763 @@ export const recordTradeFn = createServerFn({ method: "POST" })
       data,
       familyId: context.familyId,
       user: context.user,
+    })
+  })
+
+// =============================================================================
+// EDIT / DELETE / CORRECT A TRADE (PER-259 Slice 5 / ADR-0054)
+// =============================================================================
+//
+// A mis-entered Buy/Sell must be correctable — the last hole in ADR-0054's
+// "on a holdings account, you trade" model (Slice 8 in the ADR's cascade).
+// SCOPE (locked, grilled with the creator — see ADR-0054 "Slice 5"): a trade
+// is editable/deletable ONLY when it is still the LATEST quantity-mutating
+// event on its (account, instrument) position — no other Buy/Sell/Switch/
+// Dividend-reinvest has touched that same Holding since. This is NOT a full
+// historical-replay engine; attempting to correct a non-latest trade fails
+// loud with an actionable message, never silently produces wrong numbers.
+//
+// "Latest" is an IDENTITY check (the `Holding.lastMutationIdempotencyKey`
+// marker — see the migration + `SerializedHolding` doc comments), never a
+// value diff: a later Sell-then-rebuy-at-the-same-price could coincidentally
+// reproduce the original quantity/cost and falsely look "unchanged".
+//
+// DELETE reuses the EXISTING valuation-linked-transfer delete path
+// (`softDeleteValuationLinkedTransferWithinTx`, transactions.ts) via its new
+// `onHoldingsTradeReversal` hook — the SAME cash-leg/valuation/transfer
+// reversal every other valuation-linked delete uses, plus the hook restoring
+// the paired Holding from its captured AuditLog before/after snapshot (never
+// recomputing an inverse via math) and re-materializing the Σ-holdings anchor.
+//
+// EDIT is reversal-and-replace, ONE atomic transaction: reverse the OLD trade
+// exactly like DELETE, then REAPPLY the corrected params as a brand-new trade
+// via `recordTradeWithinTx` (the SAME core `recordTradeForFamily` uses — no
+// duplicated math). The old Transaction/Transfer/Valuation are tombstoned
+// (never hard-deleted); the corrected trade gets a NEW transaction id — the
+// exact "reversal-and-replace" pattern `replaceTransactionWithinTenantTransaction`
+// already uses for classic transfer edits (CLAUDE.md §5A).
+//
+// SIDE FLIP (buy→sell or vice versa) is supported with NO special-casing: the
+// reversal restores the position to its exact pre-trade state, and the
+// reapply re-runs `recordTradeWithinTx`'s OWN validation against that
+// restored state — a flip that doesn't make sense (e.g. selling a position
+// the reversal just deleted) fails with the SAME actionable error
+// `recordTradeForFamily` already gives ("No <fund> position to sell"), never
+// silent misbehavior.
+
+const DELETE_TRADE_ENDPOINT = "deleteTradeFn"
+const CORRECT_TRADE_ENDPOINT = "correctTradeFn"
+
+// The raw row fields a trade-correction needs to restore a Holding EXACTLY
+// (never recomputed via math) — a strict subset of `serializeHolding`'s full
+// output (which also carries derived/display-only fields like `valueMinor`).
+// `.passthrough()` so the full serialized snapshot in AuditLog parses fine.
+const holdingSnapshotSchema = z
+  .object({
+    id: z.string(),
+    accountId: z.string(),
+    instrumentId: z.string(),
+    familyId: z.string(),
+    quantity: z.string(),
+    avgUnitCostMinor: z.string(),
+    lastPriceMinor: z.string().nullable(),
+    lastMutationIdempotencyKey: z.string().nullable(),
+  })
+  .passthrough()
+
+type HoldingSnapshot = z.infer<typeof holdingSnapshotSchema>
+
+// AuditLog's `beforeJson`/`afterJson` are stored as SQL NULL (via `Prisma.DbNull`
+// on `undefined`, or plain JS `null` on an explicit `null`) for a "create" /
+// "delete" action's missing half — both read back as JS `null`. Anything else
+// is validated (never trusted blindly) against the shape above.
+function parseHoldingSnapshot(json: unknown): HoldingSnapshot | null {
+  if (json === null || json === undefined) return null
+  return holdingSnapshotSchema.parse(json)
+}
+
+interface ResolvedTradeForCorrection {
+  cashTx: NonNullable<Awaited<ReturnType<typeof findTransactionAuditGraph>>>
+  investmentAccount: Awaited<ReturnType<typeof fetchActiveAccount>>
+  tradeKey: string
+  holdingId: string
+  holdingBefore: HoldingSnapshot | null
+  holdingAfter: HoldingSnapshot | null
+}
+
+// Resolve a trade's full identity from the ONE thing the UI actually has: the
+// cash-leg Transaction id shown on the per-account statement. Fails loud (a
+// typed HoldingError / TransactionGoneError) for anything that is not a
+// still-alive Buy/Sell trade — never guesses.
+async function resolveTradeForCorrection(
+  tx: TenantTransactionClient,
+  familyId: string,
+  transactionId: string
+): Promise<ResolvedTradeForCorrection> {
+  const cashTx = await findTransactionAuditGraph(tx, transactionId)
+  if (!cashTx || cashTx.familyId !== familyId) {
+    throw new HoldingError(
+      `Transaction ${transactionId} not found for this family`
+    )
+  }
+  if (cashTx.deletedAt !== null) {
+    throw new TransactionGoneError()
+  }
+  if (cashTx.type !== "transfer") {
+    throw new HoldingError("This transaction is not a Buy/Sell trade")
+  }
+  const transfer = cashTx.transferOut ?? cashTx.transferIn
+  if (!transfer || transfer.valuationId === null) {
+    throw new HoldingError("This transaction is not a Buy/Sell trade")
+  }
+  if (transfer.deletedAt !== null) {
+    throw new TransactionGoneError()
+  }
+  const valuation = await tx.valuation.findUniqueOrThrow({
+    where: { id: transfer.valuationId },
+  })
+  if (valuation.source !== HOLDINGS_VALUATION_SOURCE) {
+    throw new HoldingError("This transaction is not a Buy/Sell trade")
+  }
+  const tradeKey = cashTx.idempotencyKey
+  if (!tradeKey) {
+    throw new HoldingError(
+      "This trade has no recorded idempotency key and cannot be corrected"
+    )
+  }
+
+  const investmentAccount = await fetchActiveAccount(
+    tx,
+    familyId,
+    valuation.accountId,
+    "Investment"
+  )
+  if (investmentAccount.balanceSource !== "valuation") {
+    // Defensive — a holdings anchor can only ever target such an account.
+    throw new HoldingError(
+      `Investment account ${investmentAccount.id} is not valuation-tracked`
+    )
+  }
+
+  // Every trade mutates EXACTLY one Holding under its own idempotencyKey (a
+  // Switch/Dividend never creates a Transaction, so no cross-endpoint
+  // collision is possible here — see the section header).
+  const holdingRows = await tx.auditLog.findMany({
+    where: { familyId, entityType: "Holding", idempotencyKey: tradeKey },
+  })
+  if (holdingRows.length !== 1) {
+    throw new HoldingError(
+      `Could not uniquely resolve the position change for this trade (found ${holdingRows.length} matching audit rows); it cannot be corrected automatically.`
+    )
+  }
+  const holdingRow = holdingRows[0]!
+  const holdingBefore = parseHoldingSnapshot(holdingRow.beforeJson)
+  const holdingAfter = parseHoldingSnapshot(holdingRow.afterJson)
+  if (!holdingBefore && !holdingAfter) {
+    throw new Error(
+      `Holding audit row ${holdingRow.id} has neither a before nor an after snapshot`
+    )
+  }
+
+  return {
+    cashTx,
+    investmentAccount,
+    tradeKey,
+    holdingId: holdingRow.entityId,
+    holdingBefore,
+    holdingAfter,
+  }
+}
+
+// The "latest quantity-mutating event" guard (ADR-0054 Slice 5 scope). See the
+// section header for the identity-vs-value-diff rationale and the one
+// documented residual gap (reopen-then-reclose after a sell-to-zero).
+async function assertTradeIsLatest(
+  tx: TenantTransactionClient,
+  familyId: string,
+  resolved: ResolvedTradeForCorrection
+): Promise<void> {
+  const current = await tx.holding.findFirst({
+    where: { id: resolved.holdingId, familyId },
+  })
+  if (current) {
+    if (current.lastMutationIdempotencyKey !== resolved.tradeKey) {
+      throw new HoldingError(
+        "This trade has activity after it (a later Buy/Sell, Switch, or Dividend reinvest touched this position) — record a correcting trade instead of editing this one."
+      )
+    }
+    return
+  }
+  // The Holding row no longer exists. The common, expected case: THIS trade
+  // itself was a SELL that closed the position to zero (a hard delete, same
+  // as `recordTradeForFamily`'s close-to-zero branch) — safe to correct as
+  // long as nothing has REOPENED the same (account, instrument) position
+  // since (a fresh Holding row would exist if a later Buy/Switch did so).
+  //
+  // KNOWN LIMITATION (ADR-0054 — explicitly "not a full historical-replay
+  // engine"): a reopen-THEN-reclose cascade, or an unrelated manual
+  // `deleteHoldingForFamily` call, both leave no CURRENT Holding row either,
+  // and are not distinguishable from "still latest" by this fallback alone.
+  // This is the one documented residual gap in the Slice 5 guard.
+  const identity = resolved.holdingBefore ?? resolved.holdingAfter
+  if (!identity) {
+    throw new Error("Cannot determine the position identity for this trade")
+  }
+  const reopened = await tx.holding.findFirst({
+    where: {
+      familyId,
+      accountId: identity.accountId,
+      instrumentId: identity.instrumentId,
+    },
+  })
+  if (reopened) {
+    throw new HoldingError(
+      "This trade has activity after it (the position was reopened since) — record a correcting trade instead of editing this one."
+    )
+  }
+}
+
+// The `onHoldingsTradeReversal` hook body: restore the Holding EXACTLY to its
+// captured "before" snapshot (delete it if "before" was null — this trade
+// created it from scratch), then re-materialize the Σ-holdings anchor. Never
+// recomputes an inverse via math — item 4 of the locked Slice 5 design.
+async function reverseHoldingForTrade(
+  tx: TenantTransactionClient,
+  {
+    familyId,
+    holdingId,
+    holdingBefore,
+    account,
+    user,
+    auditCtx,
+  }: {
+    familyId: string
+    holdingId: string
+    holdingBefore: HoldingSnapshot | null
+    account: { id: string; currency: string }
+    user: ServerActor
+    auditCtx: AuditContext
+  }
+): Promise<void> {
+  const current = await tx.holding.findFirst({
+    where: { id: holdingId, familyId },
+    include: { instrument: true },
+  })
+
+  if (holdingBefore === null) {
+    // This trade created the Holding from scratch — reversing it deletes it.
+    if (current) {
+      await tx.holding.delete({ where: { id: current.id } })
+      await auditLog(tx, auditCtx, {
+        action: "delete",
+        entityType: "Holding",
+        entityId: current.id,
+        before: serializeHolding(current),
+        after: null,
+      })
+    }
+  } else if (current) {
+    const updated = await tx.holding.update({
+      where: { id: current.id },
+      data: {
+        quantity: holdingBefore.quantity,
+        avgUnitCostMinor: BigInt(holdingBefore.avgUnitCostMinor),
+        lastPriceMinor:
+          holdingBefore.lastPriceMinor === null
+            ? null
+            : BigInt(holdingBefore.lastPriceMinor),
+        lastMutationIdempotencyKey: holdingBefore.lastMutationIdempotencyKey,
+      },
+      include: { instrument: true },
+    })
+    await auditLog(tx, auditCtx, {
+      action: "update",
+      entityType: "Holding",
+      entityId: updated.id,
+      before: serializeHolding(current),
+      after: serializeHolding(updated),
+    })
+  } else {
+    // The trade closed the position to zero (a SELL-to-zero) — recreate it
+    // EXACTLY at its "before" snapshot, preserving the original row id so
+    // historical references (e.g. prior Distribution/Fee audit rows) still
+    // resolve.
+    const created = await tx.holding.create({
+      data: {
+        id: holdingBefore.id,
+        familyId,
+        accountId: holdingBefore.accountId,
+        instrumentId: holdingBefore.instrumentId,
+        quantity: holdingBefore.quantity,
+        avgUnitCostMinor: BigInt(holdingBefore.avgUnitCostMinor),
+        lastPriceMinor:
+          holdingBefore.lastPriceMinor === null
+            ? null
+            : BigInt(holdingBefore.lastPriceMinor),
+        lastMutationIdempotencyKey: holdingBefore.lastMutationIdempotencyKey,
+      },
+      include: { instrument: true },
+    })
+    await auditLog(tx, auditCtx, {
+      action: "create",
+      entityType: "Holding",
+      entityId: created.id,
+      after: serializeHolding(created),
+    })
+  }
+
+  // Re-materialize the Σ-holdings anchor AFTER the surgical reversal. This
+  // becomes the account's new latest valuation (fresh valuationDate = now),
+  // correctly reflecting the reversed position alongside any OTHER holding's
+  // untouched, possibly-later activity in the same account — NEVER picking
+  // "whatever anchor is now latest" (which is what the generic
+  // `rebuildWithinTx` step this hook replaces would have done).
+  await recomputeAccountValueAnchorWithinTx(
+    tx,
+    familyId,
+    account.id,
+    account.currency,
+    user,
+    auditCtx
+  )
+}
+
+// -----------------------------------------------------------------------------
+// DELETE — reversal only. Built and verified FIRST (simpler, provable) before
+// EDIT, which composes this same reversal with a reapply.
+// -----------------------------------------------------------------------------
+
+export const deleteTradeInputSchema = z.object({
+  transactionId: z.string().min(1),
+  idempotencyKey: uuidV7Schema,
+})
+
+type DeleteTradeInput = z.infer<typeof deleteTradeInputSchema>
+
+export interface DeleteTradeResult {
+  transactionId: string
+  reversed: true
+}
+
+export async function deleteTradeForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof deleteTradeInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<DeleteTradeResult> {
+  const data: DeleteTradeInput = deleteTradeInputSchema.parse(rawData)
+  const requestHash = await hashCanonicalPayload({
+    transactionId: data.transactionId,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<DeleteTradeResult>(
+        tx,
+        {
+          endpoint: DELETE_TRADE_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      const resolved = await resolveTradeForCorrection(
+        tx,
+        familyId,
+        data.transactionId
+      )
+      await assertTradeIsLatest(tx, familyId, resolved)
+
+      await softDeleteValuationLinkedTransferWithinTx(tx, {
+        auditCtx,
+        familyId,
+        cashTx: resolved.cashTx,
+        onHoldingsTradeReversal: async (tx2, hookArgs) => {
+          await reverseHoldingForTrade(tx2, {
+            familyId: hookArgs.familyId,
+            holdingId: resolved.holdingId,
+            holdingBefore: resolved.holdingBefore,
+            account: resolved.investmentAccount,
+            user,
+            auditCtx: hookArgs.auditCtx,
+          })
+        },
+      })
+
+      await auditLog(tx, auditCtx, {
+        action: "delete",
+        entityType: "TradeCorrection",
+        entityId: resolved.cashTx.id,
+        before: {
+          transactionId: resolved.cashTx.id,
+          fundingAccountId: resolved.cashTx.accountId,
+          amountMinor: resolved.cashTx.amount,
+          date: resolved.cashTx.date,
+          holdingBefore: resolved.holdingBefore,
+          holdingAfter: resolved.holdingAfter,
+        },
+        after: null,
+      })
+
+      const response: DeleteTradeResult = {
+        transactionId: data.transactionId,
+        reversed: true,
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: DELETE_TRADE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<DeleteTradeResult>(tx, {
+        endpoint: DELETE_TRADE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const deleteTradeFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof deleteTradeInputSchema>) =>
+    deleteTradeInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await deleteTradeForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// -----------------------------------------------------------------------------
+// EDIT / CORRECT — reversal + reapply, ONE atomic transaction.
+// -----------------------------------------------------------------------------
+
+export const correctTradeInputSchema = z.object({
+  transactionId: z.string().min(1),
+  fundingAccountId: z.string().min(1),
+  side: tradeSideSchema,
+  cashAmount: positiveMinorDigitsSchema,
+  quantity: decimalStringSchema,
+  unitPrice: positiveMinorDigitsSchema.optional(),
+  tradeDate: z.coerce.date().optional(),
+  idempotencyKey: uuidV7Schema,
+})
+
+type CorrectTradeInput = z.infer<typeof correctTradeInputSchema>
+
+export interface CorrectTradeResult {
+  oldTransactionId: string
+  trade: RecordTradeResult
+}
+
+export async function correctTradeForFamily({
+  data: rawData,
+  familyId,
+  user,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.input<typeof correctTradeInputSchema>
+  familyId: string
+  user: ServerActor
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<CorrectTradeResult> {
+  const data: CorrectTradeInput = correctTradeInputSchema.parse(rawData)
+  const requestHash = await hashCanonicalPayload({
+    cashAmount: data.cashAmount,
+    fundingAccountId: data.fundingAccountId,
+    quantity: data.quantity,
+    side: data.side,
+    tradeDate: data.tradeDate?.toISOString() ?? null,
+    transactionId: data.transactionId,
+    unitPrice: data.unitPrice ?? null,
+  })
+  const auditCtx = await createAuditContext(
+    { user: { id: user.id, familyId } },
+    data.idempotencyKey
+  )
+
+  const runOnce = async () =>
+    await runInTenantTransaction(familyId, user.id, async (tx) => {
+      const replay = await replayIdempotentEndpointResponse<CorrectTradeResult>(
+        tx,
+        {
+          endpoint: CORRECT_TRADE_ENDPOINT,
+          familyId,
+          key: data.idempotencyKey,
+          requestHash,
+        }
+      )
+      if (replay) return replay
+
+      const resolved = await resolveTradeForCorrection(
+        tx,
+        familyId,
+        data.transactionId
+      )
+      await assertTradeIsLatest(tx, familyId, resolved)
+
+      // Tenant ownership of the (possibly changed) funding account.
+      await validateTenantReferences(tx, familyId, {
+        accountId: data.fundingAccountId,
+      })
+
+      // The instrument is FIXED (resolved from history), never editable here —
+      // moving a position to a different instrument/account is out of this
+      // slice's scope (Slice 6 territory). At least one of before/after is
+      // guaranteed by `resolveTradeForCorrection`.
+      const instrumentId = (resolved.holdingBefore ?? resolved.holdingAfter)!
+        .instrumentId
+
+      // 1. Reverse the OLD trade (cash + valuation + Holding), in this SAME tx.
+      await softDeleteValuationLinkedTransferWithinTx(tx, {
+        auditCtx,
+        familyId,
+        cashTx: resolved.cashTx,
+        onHoldingsTradeReversal: async (tx2, hookArgs) => {
+          await reverseHoldingForTrade(tx2, {
+            familyId: hookArgs.familyId,
+            holdingId: resolved.holdingId,
+            holdingBefore: resolved.holdingBefore,
+            account: resolved.investmentAccount,
+            user,
+            auditCtx: hookArgs.auditCtx,
+          })
+        },
+      })
+
+      // 2. Reapply the CORRECTED params as a brand-new trade, in the SAME tx,
+      // via the exact core `recordTradeForFamily` uses (no duplicated math). A
+      // fresh, server-minted internal key — never the edit's own key (which
+      // would collide across corrections of the SAME trade) and never the old
+      // trade's key (already consumed by the tombstoned Transaction — the
+      // family-unique `tx_family_idempotency` index does not exempt deleted
+      // rows). The corrected trade gets a NEW transaction id; the old one
+      // stays tombstoned, never hard-deleted.
+      const reapplyKey = createUuidV7()
+      const reapplyAuditCtx = await createAuditContext(
+        { user: { id: user.id, familyId } },
+        reapplyKey
+      )
+      const newTradeData: RecordTradeInput = recordTradeInputSchema.parse({
+        cashAmount: data.cashAmount,
+        fundingAccountId: data.fundingAccountId,
+        idempotencyKey: reapplyKey,
+        instrumentId,
+        investmentAccountId: resolved.investmentAccount.id,
+        quantity: data.quantity,
+        side: data.side,
+        tradeDate: data.tradeDate,
+        unitPrice: data.unitPrice,
+      })
+      const trade = await recordTradeWithinTx(tx, {
+        data: newTradeData,
+        familyId,
+        user,
+        auditCtx: reapplyAuditCtx,
+      })
+
+      // Provenance: document the correction old → new (mirrors Slice 2-4's
+      // Distribution/Fee/Switch audit rows) under the EDIT operation's OWN key.
+      await auditLog(tx, auditCtx, {
+        action: "update",
+        entityType: "TradeCorrection",
+        entityId: resolved.cashTx.id,
+        before: {
+          transactionId: resolved.cashTx.id,
+          fundingAccountId: resolved.cashTx.accountId,
+          amountMinor: resolved.cashTx.amount,
+          date: resolved.cashTx.date,
+          holdingBefore: resolved.holdingBefore,
+          holdingAfter: resolved.holdingAfter,
+        },
+        after: {
+          cashAmount: data.cashAmount,
+          fundingAccountId: data.fundingAccountId,
+          quantity: data.quantity,
+          side: data.side,
+          tradeDate: (data.tradeDate ?? new Date()).toISOString(),
+          transactionId: trade.transaction.id,
+          unitPrice: data.unitPrice ?? null,
+        },
+      })
+
+      const response: CorrectTradeResult = {
+        oldTransactionId: resolved.cashTx.id,
+        trade,
+      }
+      await persistIdempotentEndpointResponse(tx, {
+        endpoint: CORRECT_TRADE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+        response,
+      })
+      return response
+    })
+
+  try {
+    return await runOnce()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    const replay = await scopedTenantTransaction(familyId, user.id, (tx) =>
+      replayIdempotentEndpointResponse<CorrectTradeResult>(tx, {
+        endpoint: CORRECT_TRADE_ENDPOINT,
+        familyId,
+        key: data.idempotencyKey,
+        requestHash,
+      })
+    )
+    if (replay) return replay
+    throw error
+  }
+}
+
+export const correctTradeFn = createServerFn({ method: "POST" })
+  .middleware([requireCapability("ledger:write")])
+  .inputValidator((data: z.input<typeof correctTradeInputSchema>) =>
+    correctTradeInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await correctTradeForFamily({
+      data,
+      familyId: context.familyId,
+      user: context.user,
+    })
+  })
+
+// -----------------------------------------------------------------------------
+// READ — prefill data for the trade-correction dialog. A `Transaction` id is
+// the only thing the per-account statement's row actually has; this resolves
+// it to the trade's editable fields (side/quantity/cashAmount/fundingAccount/
+// date), reusing the SAME `resolveTradeForCorrection` the mutation endpoints
+// use so the two can never disagree. Called ONLY when a user opens the edit
+// dialog for a row the client already suspects is a trade (never proactively
+// for every statement row this slice — see the section header).
+// -----------------------------------------------------------------------------
+
+export const getTradeForCorrectionInputSchema = z.object({
+  transactionId: z.string().min(1),
+})
+
+export interface TradeForCorrectionView {
+  transactionId: string
+  side: "buy" | "sell"
+  fundingAccountId: string
+  investmentAccountId: string
+  instrumentId: string
+  instrumentName: string
+  currency: string
+  /** Cash amount that moved, minor units (digit-string, always positive). */
+  cashAmountMinor: string
+  /** This trade's own quantity delta, decimal string (always positive). */
+  quantity: string
+  tradeDate: string
+  /** Non-null when this trade is NOT the latest event on its position — the
+   * SAME message `deleteTradeFn`/`correctTradeFn` would reject with. Shown
+   * inline immediately rather than only on submit; the mutation endpoints
+   * remain the authoritative check either way. */
+  notLatestReason: string | null
+}
+
+export async function getTradeForCorrectionForFamily({
+  data,
+  familyId,
+  userId,
+  runInTenantTransaction = scopedTenantTransaction,
+}: {
+  data: z.infer<typeof getTradeForCorrectionInputSchema>
+  familyId: string
+  userId: string
+  runInTenantTransaction?: RunInTenantTransaction
+}): Promise<TradeForCorrectionView> {
+  return await runInTenantTransaction(familyId, userId, async (tx) => {
+    const resolved = await resolveTradeForCorrection(
+      tx,
+      familyId,
+      data.transactionId
+    )
+
+    let notLatestReason: string | null = null
+    try {
+      await assertTradeIsLatest(tx, familyId, resolved)
+    } catch (error) {
+      notLatestReason = error instanceof Error ? error.message : String(error)
+    }
+
+    // BUY debits the funding (cash) account — cashTx.amount is negative
+    // (mirrors `direction = isBuy ? "contribution" : "redemption"` exactly).
+    const isBuy = resolved.cashTx.amount < 0n
+    const beforeScaled = resolved.holdingBefore
+      ? quantityToScaled(resolved.holdingBefore.quantity)
+      : 0n
+    const afterScaled = resolved.holdingAfter
+      ? quantityToScaled(resolved.holdingAfter.quantity)
+      : 0n
+    const deltaScaled = isBuy
+      ? afterScaled - beforeScaled
+      : beforeScaled - afterScaled
+
+    const instrumentId = (resolved.holdingBefore ?? resolved.holdingAfter)!
+      .instrumentId
+    const instrument = await tx.instrument.findUniqueOrThrow({
+      where: { id: instrumentId },
+    })
+
+    return {
+      transactionId: resolved.cashTx.id,
+      side: isBuy ? "buy" : "sell",
+      fundingAccountId: resolved.cashTx.accountId,
+      investmentAccountId: resolved.investmentAccount.id,
+      instrumentId: instrument.id,
+      instrumentName: instrument.name,
+      currency: resolved.investmentAccount.currency,
+      cashAmountMinor: (resolved.cashTx.amount < 0n
+        ? -resolved.cashTx.amount
+        : resolved.cashTx.amount
+      ).toString(),
+      quantity: scaledToQuantityString(deltaScaled),
+      tradeDate: resolved.cashTx.date.toISOString(),
+      notLatestReason,
+    }
+  })
+}
+
+export const getTradeForCorrectionFn = createServerFn({ method: "GET" })
+  .middleware([familyMiddleware])
+  .inputValidator((data: z.infer<typeof getTradeForCorrectionInputSchema>) =>
+    getTradeForCorrectionInputSchema.parse(data)
+  )
+  .handler(async ({ data, context }) => {
+    return await getTradeForCorrectionForFamily({
+      data,
+      familyId: context.familyId,
+      userId: context.user.id,
     })
   })
 
@@ -1849,6 +2670,9 @@ export async function recordDistributionForFamily({
           data: {
             quantity: scaledToQuantityString(newUnitsScaled),
             avgUnitCostMinor: newAvg,
+            // PER-259 Slice 5 — stamp the "latest" identity marker with THIS
+            // reinvest's own idempotencyKey (see marker doc comment).
+            lastMutationIdempotencyKey: data.idempotencyKey,
           },
           include: { instrument: true },
         })
@@ -2531,7 +3355,11 @@ export async function recordSwitchForFamily({
       } else {
         const updatedFrom = await tx.holding.update({
           where: { id: fromHolding.id },
-          data: { quantity: scaledToQuantityString(remainingFromUnitsScaled) },
+          data: {
+            quantity: scaledToQuantityString(remainingFromUnitsScaled),
+            // PER-259 Slice 5 — stamp the "latest" identity marker (sell side).
+            lastMutationIdempotencyKey: data.idempotencyKey,
+          },
           include: { instrument: true },
         })
         await auditLog(tx, auditCtx, {
@@ -2583,6 +3411,8 @@ export async function recordSwitchForFamily({
           data: {
             quantity: scaledToQuantityString(newToUnitsScaled),
             avgUnitCostMinor: newToAvg,
+            // PER-259 Slice 5 — stamp the "latest" identity marker (buy side).
+            lastMutationIdempotencyKey: data.idempotencyKey,
           },
           include: { instrument: true },
         })
@@ -2604,6 +3434,9 @@ export async function recordSwitchForFamily({
             quantity: scaledToQuantityString(addedToUnitsScaled),
             avgUnitCostMinor: newToAvg,
             lastPriceMinor: null,
+            // PER-259 Slice 5 — this switch is the FIRST mutation ever on the
+            // destination position; stamp it immediately.
+            lastMutationIdempotencyKey: data.idempotencyKey,
           },
           include: { instrument: true },
         })

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -313,7 +313,7 @@ async function findOptionalTransactionWithSplitEntries(
   return { ...transaction, splitEntries }
 }
 
-async function findTransactionAuditGraph(
+export async function findTransactionAuditGraph(
   tx: TenantTransactionClient,
   id: string
 ) {
@@ -2893,16 +2893,40 @@ export const createTransactionFn = createServerFn({ method: "POST" })
 // Transfer row itself. Every step is idempotent at the call-site level via
 // deleteTransactionForFamily's IdempotencyRecord and the `deletedAt: null`
 // guard on each updateMany below (a replayed delete cannot double-reverse).
-async function softDeleteValuationLinkedTransferWithinTx(
+// PER-259 Slice 5 / ADR-0054 — the escape hatch `softDeleteValuationLinkedTransferWithinTx`
+// takes when the tracked-side leg IS a holdings anchor (source === HOLDINGS_VALUATION_SOURCE).
+// The DEFAULT behavior (no hook supplied) is UNCHANGED from PER-198/ADR-0051: throw
+// `HoldingsTradeDeleteUnsupportedError` before any write, exactly as before — this keeps
+// every existing caller (the generic `deleteTransactionFn` path, bulk delete, etc.) fail-safe.
+// ONLY the new Slice 5 trade-correction path (`src/server/holdings.ts`) supplies this hook,
+// which must reverse the paired `Holding` row (from its captured AuditLog before/after
+// snapshot — never recompute an inverse via math) and re-materialize the investment
+// account's Σ-holdings anchor (`recomputeAccountValueAnchorWithinTx`) in the SAME
+// transaction, in place of the generic `rebuildWithinTx` step below (which would pick
+// "whatever valuation is now latest" — WRONG when a different holding in the same account
+// had activity after this trade; see the call site for the full rationale).
+export type HoldingsTradeReversalHook = (
+  tx: TenantTransactionClient,
+  args: {
+    familyId: string
+    auditCtx: AuditContext
+    valuation: Valuation
+    cashTx: NonNullable<Awaited<ReturnType<typeof findTransactionAuditGraph>>>
+  }
+) => Promise<void>
+
+export async function softDeleteValuationLinkedTransferWithinTx(
   tx: TenantTransactionClient,
   {
     auditCtx,
     familyId,
     cashTx,
+    onHoldingsTradeReversal,
   }: {
     auditCtx: AuditContext
     familyId: string
     cashTx: NonNullable<Awaited<ReturnType<typeof findTransactionAuditGraph>>>
+    onHoldingsTradeReversal?: HoldingsTradeReversalHook
   }
 ): Promise<void> {
   const transfer = cashTx.transferOut ?? cashTx.transferIn
@@ -2924,8 +2948,13 @@ async function softDeleteValuationLinkedTransferWithinTx(
   // transfer graph and would NOT be reversed here, silently drifting the account
   // off Σ holdings. Block the delete before mutating anything (the surrounding
   // transaction rolls back, so no balance/tombstone is written). A plain
-  // valuation-linked transfer (source !== "holdings") is unaffected.
-  if (oldValuation.source === HOLDINGS_VALUATION_SOURCE) {
+  // valuation-linked transfer (source !== "holdings") is unaffected. PER-259
+  // Slice 5: a caller MAY supply `onHoldingsTradeReversal` to lift this guard —
+  // every OTHER caller (no hook) keeps today's exact fail-safe behavior.
+  if (
+    oldValuation.source === HOLDINGS_VALUATION_SOURCE &&
+    !onHoldingsTradeReversal
+  ) {
     throw new HoldingsTradeDeleteUnsupportedError()
   }
 
@@ -2967,10 +2996,27 @@ async function softDeleteValuationLinkedTransferWithinTx(
   })
   if (valuationUpdate.count !== 1) throw new TransactionGoneError()
 
-  // 4. Re-materialize the tracked account from whatever Valuation is now the
-  // latest non-deleted one (rebuildWithinTx writes its own Account audit
-  // entry when the balance actually changes).
-  await rebuildWithinTx(tx, familyId, trackedAccountFacts, auditCtx)
+  // 4. Re-materialize the tracked account. PLAIN valuation-linked transfer
+  // (no hook): whatever Valuation is now the latest non-deleted one
+  // (rebuildWithinTx writes its own Account audit entry when the balance
+  // actually changes) — unchanged from before Slice 5. HOLDINGS trade (hook
+  // supplied): the hook reverses the paired Holding from its captured
+  // before/after snapshot and re-materializes the Σ-holdings anchor itself —
+  // NEVER rebuildWithinTx here, which would pick "whatever valuation is now
+  // latest" and could silently pick up a LATER anchor written by a
+  // DIFFERENT holding's subsequent trade in the same account, clobbering
+  // that unrelated activity instead of reflecting the surgical, per-holding
+  // reversal this trade's correction/delete actually performed.
+  if (onHoldingsTradeReversal) {
+    await onHoldingsTradeReversal(tx, {
+      familyId,
+      auditCtx,
+      valuation: oldValuation,
+      cashTx,
+    })
+  } else {
+    await rebuildWithinTx(tx, familyId, trackedAccountFacts, auditCtx)
+  }
 
   // 5. Tombstone the Transfer row itself.
   const transferUpdate = await tx.transfer.updateMany({

--- a/tests/e2e/trade-correction.e2e.ts
+++ b/tests/e2e/trade-correction.e2e.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// PER-259 Slice 5 / ADR-0054 — Edit/correct + delete a Buy/Sell trade, driven
+// through the real per-account statement row (not a direct server-fn call).
+// Record a Buy via the Trade dialog, correct its quantity through the
+// dedicated TradeCorrectionDialog (proving the statement row's Edit button
+// routes a trade to the CORRECTION flow, not the generic transaction modal),
+// then delete the corrected trade and verify the position/cash fully
+// reverse — the same "reversal-and-replace" / "reversal-only" the server
+// tests already prove, now proven end to end through the browser.
+//
+// \s (not literal spaces) — formatCurrency uses a non-breaking space.
+
+test.describe("trade correction UI (PER-259 Slice 5)", () => {
+  test("editing a trade corrects quantity/cash via the dedicated dialog; deleting it fully reverses the position", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const walletName = `E2E Wallet ${suffix}`
+    const portfolioName = `E2E Portfolio ${suffix}`
+    const fundName = `Fund X ${suffix}`
+
+    // --- Cash (funding) account ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(walletName)
+    await page.getByLabel("Opening balance").fill("10000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Tracked Asset (valuation-tracked) investment account ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // --- Record a Buy: 10 units @ 100,000 = 1,000,000 cash out. ---
+    await page.getByRole("button", { name: "Buy" }).first().click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByRole("combobox", { name: "Funding account" }).click()
+    await page.getByRole("option", { name: walletName }).click()
+    await dialog.getByLabel("Instrument name").fill(fundName)
+    await dialog.getByLabel("Quantity").fill("10")
+    await dialog.getByLabel(/Unit price/i).fill("100000")
+    await dialog.getByRole("button", { name: "Record buy" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await expect(page.getByText(fundName).first()).toBeVisible()
+    await expect(page.getByText(/Rp\s1,000,000\.00/).first()).toBeVisible()
+
+    // --- Edit the trade: statement row's Edit button routes a trade to the
+    // dedicated correction dialog (not the generic transaction modal). ---
+    await page.getByRole("button", { name: "Edit Transaction" }).first().click()
+    dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByRole("heading", { name: `Edit ${fundName}` })
+    ).toBeVisible()
+
+    // Correct the quantity down to 8 units (same price) — cash moves to
+    // 800,000, and the position becomes 8.00000000 units.
+    await dialog.getByLabel("Quantity").fill("8")
+    await dialog.getByRole("button", { name: "Save correction" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // Position corrected: 8 units, value 800,000. The wallet kept 200,000 of
+    // the original 1,000,000 debit (10,000,000 - 800,000 = 9,200,000).
+    await expect(page.getByText(/8\.00000000/).first()).toBeVisible()
+    await expect(page.getByText(/Rp\s800,000\.00/).first()).toBeVisible()
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText(/Rp\s9,200,000\.00/).first()).toBeVisible()
+
+    // --- Delete the (corrected) trade: position + cash fully reverse. ---
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+    page.once("dialog", (d) => void d.accept())
+    await page
+      .getByRole("button", { name: "Delete Transaction" })
+      .first()
+      .click()
+    await expect(page.getByText(fundName)).toHaveCount(0)
+
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText(/Rp\s10,000,000\.00/).first()).toBeVisible()
+    await expect(page.getByText("Balance drift")).toHaveCount(0)
+  })
+})

--- a/tests/integration/holdings-move-coherence.integration.ts
+++ b/tests/integration/holdings-move-coherence.integration.ts
@@ -42,7 +42,14 @@ import {
 // Legacy rows that predate holdings are grandfathered: rebuild/drift never
 // re-reject them.
 
-const TEST_DATE = new Date("2026-08-16T00:00:00.000Z")
+// Always "tomorrow" relative to whenever the suite actually runs — never a
+// hardcoded calendar literal. A fixed past literal here rots: once wall-clock
+// "now" passes it, an account's opening-balance anchor (valuationDate = now,
+// see `createAccountForFamily`) legitimately outranks it under PER-201's
+// createdAt-aware canonical-balance rule (latest by date OR createdAt), so a
+// test valuation/transfer dated here would silently fail to become canonical
+// — not a product bug, a stale test fixture.
+const TEST_DATE = new Date(Date.now() + 24 * 60 * 60 * 1000)
 
 describe("PER-259 / ADR-0054 — holdings-account money-movement coherence", () => {
   let harness: IntegrationHarness

--- a/tests/integration/trade-corrections.integration.ts
+++ b/tests/integration/trade-corrections.integration.ts
@@ -1,0 +1,1029 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vite-plus/test"
+import type { AccountType } from "@/lib/accounts"
+import { createAccountForFamily } from "@/server/accounts"
+import {
+  correctTradeForFamily,
+  deleteTradeForFamily,
+  getAccountHoldingsForFamily,
+  getTradeForCorrectionForFamily,
+  HoldingError,
+  recordDistributionForFamily,
+  recordSwitchForFamily,
+  recordTradeForFamily,
+  upsertHoldingForFamily,
+} from "@/server/holdings"
+import { IdempotencyConflictError } from "@/server/idempotency"
+import {
+  createTransactionForFamily,
+  TransactionGoneError,
+} from "@/server/transactions"
+import {
+  createIntegrationHarness,
+  type IntegrationHarness,
+} from "./support/database"
+import {
+  createTestFactories,
+  type AuthenticatedOnboardedUser,
+  type TestFactories,
+} from "./support/factories"
+
+// PER-259 Slice 5 / ADR-0054 — edit / delete (correct) a Buy/Sell trade.
+//
+// The locked scope: a trade is correctable ONLY while it is still the LATEST
+// quantity-mutating event on its (account, instrument) position — an IDENTITY
+// check on `Holding.lastMutationIdempotencyKey`, never a value diff. Delete =
+// reversal only; Edit = reversal + reapply in ONE atomic transaction, the
+// corrected trade getting a NEW transaction id (reversal-and-replace; the old
+// rows stay tombstoned, never hard-deleted). The Holding side of the reversal
+// restores the trade's captured AuditLog before/after snapshot — never a
+// recomputed inverse.
+//
+// Money amounts are in MINOR units (IDR sen). Fixtures use exact-division
+// quantities/prices so conservation is provable to the sen.
+
+describe("trade corrections — delete & edit (PER-259 Slice 5 / ADR-0054)", () => {
+  let harness: IntegrationHarness
+  let factories: TestFactories
+
+  beforeAll(async () => {
+    harness = await createIntegrationHarness()
+    factories = createTestFactories(harness)
+  })
+
+  beforeEach(async () => {
+    await harness.reset()
+  })
+
+  afterAll(async () => {
+    await harness.teardown()
+  })
+
+  const TEST_DATE = new Date("2026-08-10T00:00:00.000Z")
+
+  const makeInvestmentAccount = async (owner: AuthenticatedOnboardedUser) =>
+    await createAccountForFamily({
+      data: {
+        name: "Bibit",
+        accountType: "TRACKED_ASSET" as AccountType,
+        accountSubtype: "brokerage",
+        openingBalance: "0",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  // Opening balance 150,000 major = 15,000,000 sen.
+  const makeCashAccount = async (
+    owner: AuthenticatedOnboardedUser,
+    name = "Checking"
+  ) =>
+    await createAccountForFamily({
+      data: {
+        name,
+        accountType: "DEPOSITORY" as AccountType,
+        openingBalance: "150000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const balanceOf = (owner: AuthenticatedOnboardedUser, accountId: string) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const row = await tx.account.findUniqueOrThrow({
+        where: { id: accountId },
+        select: { balance: true },
+      })
+      return row.balance
+    })
+
+  const fundInline = { kind: "mutual_fund" as const, name: "Fund A" }
+
+  const buyFund = async (
+    owner: AuthenticatedOnboardedUser,
+    investmentAccountId: string,
+    fundingAccountId: string,
+    overrides: {
+      instrumentId?: string
+      quantity?: string
+      unitPrice?: string
+      cashAmount?: string
+      idempotencyKey?: string
+    } = {}
+  ) =>
+    await recordTradeForFamily({
+      data: {
+        investmentAccountId,
+        fundingAccountId,
+        instrument: overrides.instrumentId ? undefined : fundInline,
+        instrumentId: overrides.instrumentId,
+        side: "buy",
+        cashAmount: overrides.cashAmount ?? "1000000",
+        quantity: overrides.quantity ?? "100",
+        unitPrice: overrides.unitPrice ?? "10000",
+        idempotencyKey:
+          overrides.idempotencyKey ?? factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+  const holdingRow = (owner: AuthenticatedOnboardedUser, holdingId: string) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findFirst({
+        where: { id: holdingId, familyId: owner.family.id },
+      })
+    )
+
+  const tombstones = (
+    owner: AuthenticatedOnboardedUser,
+    transactionId: string
+  ) =>
+    harness.withFamily(owner.family.id, async (tx) => {
+      const transaction = await tx.transaction.findUnique({
+        where: { id: transactionId },
+        select: { deletedAt: true },
+      })
+      const transfer = await tx.transfer.findFirst({
+        where: {
+          OR: [
+            { outflowTransactionId: transactionId },
+            { inflowTransactionId: transactionId },
+          ],
+        },
+        select: { deletedAt: true, valuationId: true },
+      })
+      const valuation = transfer?.valuationId
+        ? await tx.valuation.findUnique({
+            where: { id: transfer.valuationId },
+            select: { deletedAt: true },
+          })
+        : null
+      return {
+        transactionDeleted: transaction?.deletedAt !== null,
+        transferDeleted: transfer?.deletedAt !== null,
+        valuationDeleted: valuation ? valuation.deletedAt !== null : null,
+      }
+    })
+
+  // ==========================================================================
+  // DELETE — reversal only
+  // ==========================================================================
+
+  test("DELETE a BUY: cash, position, anchor all reversed; rows tombstoned; audit written", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    expect(await balanceOf(owner, investment.id)).toBe(1_000_000n)
+
+    const result = await deleteTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(result.reversed).toBe(true)
+
+    // Cash fully restored; the position this trade created from scratch is
+    // gone; the Σ-holdings anchor re-materialized back to zero.
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore)
+    expect(await balanceOf(owner, investment.id)).toBe(0n)
+    const view = await getAccountHoldingsForFamily({
+      accountId: investment.id,
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.holdings).toHaveLength(0)
+
+    // Tombstoned, never hard-deleted.
+    const t = await tombstones(owner, buy.transaction.id)
+    expect(t.transactionDeleted).toBe(true)
+    expect(t.transferDeleted).toBe(true)
+    expect(t.valuationDeleted).toBe(true)
+
+    // The TradeCorrection provenance row exists (delete action, snapshot
+    // payload) keyed by the DELETE's own idempotency key.
+    const audit = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.findMany({
+        where: { familyId: owner.family.id, entityType: "TradeCorrection" },
+        select: { action: true, entityId: true },
+      })
+    )
+    expect(audit).toHaveLength(1)
+    expect(audit[0]?.action).toBe("delete")
+    expect(audit[0]?.entityId).toBe(buy.transaction.id)
+  })
+
+  test("DELETE a partial SELL restores the position exactly from its snapshot (incl. the marker)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy1 = await buyFund(owner, investment.id, cash.id)
+    const secondBuyKey = factories.createIdempotencyKey()
+    const buy2 = await buyFund(owner, investment.id, cash.id, {
+      instrumentId: buy1.holding?.instrumentId ?? undefined,
+      cashAmount: "2000000",
+      quantity: "100",
+      unitPrice: "20000",
+      idempotencyKey: secondBuyKey,
+    })
+    // Position: 200 units @ avg 15,000 (cost 3,000,000). Sell 50 @ 25,000.
+    const sell = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId: buy2.holding?.instrumentId ?? undefined,
+        side: "sell",
+        cashAmount: "1250000",
+        quantity: "50",
+        unitPrice: "25000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    const cashAfterSell = await balanceOf(owner, cash.id)
+    expect(await balanceOf(owner, investment.id)).toBe(2_250_000n)
+
+    await deleteTradeForFamily({
+      data: {
+        transactionId: sell.transaction.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Exact snapshot restore: 200 @ 15,000, and the "latest" marker rolled
+    // back to the second buy's key (the mutation that was latest BEFORE the
+    // reversed sell).
+    const holding = await holdingRow(owner, buy2.holding?.id ?? "")
+    expect(holding?.quantity.toFixed(8)).toBe("200.00000000")
+    expect(holding?.avgUnitCostMinor).toBe(15_000n)
+    expect(holding?.lastMutationIdempotencyKey).toBe(secondBuyKey)
+    expect(await balanceOf(owner, investment.id)).toBe(3_000_000n)
+    expect(await balanceOf(owner, cash.id)).toBe(cashAfterSell - 1_250_000n)
+  })
+
+  test("DELETE a sell-to-zero recreates the closed position with its original id", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const holdingId = buy.holding?.id ?? ""
+    const instrumentId = buy.holding?.instrumentId ?? undefined
+    const cashAfterBuy = await balanceOf(owner, cash.id)
+
+    const sell = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "sell",
+        cashAmount: "1500000",
+        quantity: "100",
+        unitPrice: "15000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(sell.holding).toBeNull() // closed to zero
+    expect(await balanceOf(owner, investment.id)).toBe(0n)
+
+    await deleteTradeForFamily({
+      data: {
+        transactionId: sell.transaction.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // The closed position is recreated EXACTLY at its before-snapshot, keeping
+    // the original row id so historical references still resolve.
+    const holding = await holdingRow(owner, holdingId)
+    expect(holding).not.toBeNull()
+    expect(holding?.quantity.toFixed(8)).toBe("100.00000000")
+    expect(holding?.avgUnitCostMinor).toBe(10_000n)
+    expect(await balanceOf(owner, investment.id)).toBe(1_000_000n)
+    expect(await balanceOf(owner, cash.id)).toBe(cashAfterBuy)
+  })
+
+  test("DELETE replay with the same key reverses exactly once", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: { transactionId: buy.transaction.id, idempotencyKey: key },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+    const first = await deleteTradeForFamily(payload)
+    const second = await deleteTradeForFamily(payload)
+    expect(second).toEqual(first)
+
+    // Still exactly one tombstone set; cash moved exactly once.
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore)
+    const counts = await harness.withFamily(owner.family.id, async (tx) => ({
+      liveTxns: await tx.transaction.count({
+        where: { accountId: cash.id, type: "transfer", deletedAt: null },
+      }),
+      tombstonedTxns: await tx.transaction.count({
+        where: {
+          accountId: cash.id,
+          type: "transfer",
+          deletedAt: { not: null },
+        },
+      }),
+    }))
+    expect(counts.liveTxns).toBe(0)
+    expect(counts.tombstonedTxns).toBe(1)
+  })
+
+  test("DELETE with a reused key but a different payload conflicts", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const key = factories.createIdempotencyKey()
+    await deleteTradeForFamily({
+      data: { transactionId: buy.transaction.id, idempotencyKey: key },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: "some-other-transaction-id",
+          idempotencyKey: key,
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(IdempotencyConflictError)
+  })
+
+  test("DELETE an already-deleted trade (fresh key) fails without double reversal", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    await deleteTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(TransactionGoneError)
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore)
+  })
+
+  test("DELETE rejected when a later BUY touched the position", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const first = await buyFund(owner, investment.id, cash.id)
+    await buyFund(owner, investment.id, cash.id, {
+      instrumentId: first.holding?.instrumentId ?? undefined,
+      cashAmount: "2000000",
+      quantity: "100",
+      unitPrice: "20000",
+    })
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: first.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/activity after it/)
+  })
+
+  test("DELETE rejected even when values coincidentally match (IDENTITY, not a value diff)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    // Buy 100 @ 10,000 → sell 50 @ 10,000 → rebuy 50 @ 10,000. The position
+    // is back to EXACTLY the values the first buy left (100 @ 10,000) — a
+    // value-diff guard would wrongly consider the first buy "still latest".
+    const first = await buyFund(owner, investment.id, cash.id)
+    const instrumentId = first.holding?.instrumentId ?? undefined
+    await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "sell",
+        cashAmount: "500000",
+        quantity: "50",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    await buyFund(owner, investment.id, cash.id, {
+      instrumentId,
+      cashAmount: "500000",
+      quantity: "50",
+      unitPrice: "10000",
+    })
+    const holding = await holdingRow(owner, first.holding?.id ?? "")
+    expect(holding?.quantity.toFixed(8)).toBe("100.00000000")
+    expect(holding?.avgUnitCostMinor).toBe(10_000n)
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: first.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/activity after it/)
+  })
+
+  test("DELETE rejected after a Switch leg touched the position", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    await recordSwitchForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fromHoldingId: buy.holding?.id ?? "",
+        toInstrument: { kind: "mutual_fund" as const, name: "Fund B" },
+        quantity: "40",
+        fromUnitPrice: "10000",
+        toUnitPrice: "8000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/activity after it/)
+  })
+
+  test("DELETE rejected after a Dividend reinvest touched the position", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    await recordDistributionForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        holdingId: buy.holding?.id ?? "",
+        mode: "reinvest",
+        amount: "500000",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/activity after it/)
+  })
+
+  test("DELETE rejected after a manual raw edit cleared the marker", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    // A manual raw edit (upsert update branch) is NOT a tracked mutation — it
+    // clears the marker, invalidating the trade's "still latest" claim.
+    await upsertHoldingForFamily({
+      data: {
+        accountId: investment.id,
+        holdingId: buy.holding?.id ?? "",
+        instrument: fundInline,
+        quantity: "100",
+        avgUnitCost: "10500",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/activity after it/)
+  })
+
+  test("DELETE a non-trade transaction is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const cash = await makeCashAccount(owner)
+    const category = await factories.createCategory({
+      familyId: owner.family.id,
+    })
+
+    const expense = await createTransactionForFamily({
+      data: {
+        id: factories.createIdempotencyKey(),
+        idempotencyKey: factories.createIdempotencyKey(),
+        accountId: cash.id,
+        amount: 20_000n,
+        categoryId: category.id,
+        date: TEST_DATE,
+        description: "Coffee",
+        type: "expense" as const,
+      },
+      familyId: owner.family.id,
+      runInTenantTransaction: harness.withMember,
+      user: owner.user,
+    })
+
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: expense.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(HoldingError)
+  })
+
+  test("DELETE cross-tenant is rejected; nothing is tombstoned", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const intruder = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+    ).rejects.toThrow()
+
+    const t = await tombstones(owner, buy.transaction.id)
+    expect(t.transactionDeleted).toBe(false)
+    expect(t.transferDeleted).toBe(false)
+    expect(await balanceOf(owner, investment.id)).toBe(1_000_000n)
+  })
+
+  // ==========================================================================
+  // CORRECT / EDIT — reversal + reapply, one atomic transaction
+  // ==========================================================================
+
+  test("CORRECT a BUY: old tombstoned, corrected trade live under a NEW id, marker follows", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const result = await correctTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        fundingAccountId: cash.id,
+        side: "buy",
+        cashAmount: "1200000", // corrected: 100 units @ 12,000
+        quantity: "100",
+        unitPrice: "12000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    expect(result.oldTransactionId).toBe(buy.transaction.id)
+    expect(result.trade.transaction.id).not.toBe(buy.transaction.id)
+    expect(result.trade.holding?.quantity).toBe("100.00000000")
+    expect(result.trade.holding?.avgUnitCostMinor).toBe("12000")
+
+    // Balances reflect ONLY the corrected trade.
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 1_200_000n)
+    expect(await balanceOf(owner, investment.id)).toBe(1_200_000n)
+
+    // Old rows tombstoned; the position's "latest" marker is the NEW trade's
+    // own key (server-minted), so the corrected trade is itself correctable.
+    const t = await tombstones(owner, buy.transaction.id)
+    expect(t.transactionDeleted).toBe(true)
+    const state = await harness.withFamily(owner.family.id, async (tx) => {
+      const newTx = await tx.transaction.findUniqueOrThrow({
+        where: { id: result.trade.transaction.id },
+        select: { idempotencyKey: true, deletedAt: true },
+      })
+      const holding = await tx.holding.findFirstOrThrow({
+        where: { familyId: owner.family.id, accountId: investment.id },
+      })
+      return { newTx, marker: holding.lastMutationIdempotencyKey }
+    })
+    expect(state.newTx.deletedAt).toBeNull()
+    expect(state.marker).toBe(state.newTx.idempotencyKey)
+
+    // Provenance: one TradeCorrection update row linking old → new.
+    const audit = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.auditLog.findMany({
+        where: { familyId: owner.family.id, entityType: "TradeCorrection" },
+        select: { action: true, entityId: true },
+      })
+    )
+    expect(audit).toHaveLength(1)
+    expect(audit[0]?.action).toBe("update")
+    expect(audit[0]?.entityId).toBe(buy.transaction.id)
+  })
+
+  test("CORRECT replay with the same key corrects exactly once", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const key = factories.createIdempotencyKey()
+    const payload = {
+      data: {
+        transactionId: buy.transaction.id,
+        fundingAccountId: cash.id,
+        side: "buy" as const,
+        cashAmount: "1200000",
+        quantity: "100",
+        unitPrice: "12000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    }
+    const first = await correctTradeForFamily(payload)
+    const second = await correctTradeForFamily(payload)
+    const normalize = (value: unknown): unknown =>
+      JSON.parse(JSON.stringify(value))
+    expect(normalize(second)).toEqual(normalize(first))
+
+    // One tombstoned (old) + one live (corrected) transfer transaction.
+    const counts = await harness.withFamily(owner.family.id, async (tx) => ({
+      live: await tx.transaction.count({
+        where: { accountId: cash.id, type: "transfer", deletedAt: null },
+      }),
+      tombstoned: await tx.transaction.count({
+        where: {
+          accountId: cash.id,
+          type: "transfer",
+          deletedAt: { not: null },
+        },
+      }),
+    }))
+    expect(counts.live).toBe(1)
+    expect(counts.tombstoned).toBe(1)
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 1_200_000n)
+  })
+
+  test("CORRECT with a reused key but a different payload conflicts", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const key = factories.createIdempotencyKey()
+    await correctTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        fundingAccountId: cash.id,
+        side: "buy",
+        cashAmount: "1200000",
+        quantity: "100",
+        unitPrice: "12000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    await expect(
+      correctTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          fundingAccountId: cash.id,
+          side: "buy",
+          cashAmount: "1300000", // different payload, same key
+          quantity: "100",
+          unitPrice: "13000",
+          idempotencyKey: key,
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toBeInstanceOf(IdempotencyConflictError)
+  })
+
+  test("CORRECT rejected when the trade is not the latest event", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const first = await buyFund(owner, investment.id, cash.id)
+    await buyFund(owner, investment.id, cash.id, {
+      instrumentId: first.holding?.instrumentId ?? undefined,
+      cashAmount: "2000000",
+      quantity: "100",
+      unitPrice: "20000",
+    })
+
+    await expect(
+      correctTradeForFamily({
+        data: {
+          transactionId: first.transaction.id,
+          fundingAccountId: cash.id,
+          side: "buy",
+          cashAmount: "1200000",
+          quantity: "100",
+          unitPrice: "12000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/activity after it/)
+  })
+
+  test("CORRECT can move the trade to a DIFFERENT funding account", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash1 = await makeCashAccount(owner, "Checking")
+    const cash2 = await makeCashAccount(owner, "Savings")
+    const cash1Before = await balanceOf(owner, cash1.id)
+    const cash2Before = await balanceOf(owner, cash2.id)
+
+    const buy = await buyFund(owner, investment.id, cash1.id)
+    await correctTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        fundingAccountId: cash2.id, // corrected: funded from Savings
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Original funding account fully restored; the new one carries the debit.
+    expect(await balanceOf(owner, cash1.id)).toBe(cash1Before)
+    expect(await balanceOf(owner, cash2.id)).toBe(cash2Before - 1_000_000n)
+    expect(await balanceOf(owner, investment.id)).toBe(1_000_000n)
+  })
+
+  test("CORRECT side flip BUY → SELL keeps the books exact", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    // A side flip needs a PRE-EXISTING position to sell from (the reversed
+    // trade's own units are rolled back with it): establish 100 @ 10,000,
+    // then a second buy of 100 @ 10,000 — and correct THAT second buy into
+    // a sell of 40 @ 11,000.
+    const first = await buyFund(owner, investment.id, cash.id)
+    const second = await buyFund(owner, investment.id, cash.id, {
+      instrumentId: first.holding?.instrumentId ?? undefined,
+    })
+    const result = await correctTradeForFamily({
+      data: {
+        transactionId: second.transaction.id,
+        fundingAccountId: cash.id,
+        side: "sell", // corrected: actually SOLD 40 @ 11,000
+        cashAmount: "440000",
+        quantity: "40",
+        unitPrice: "11000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Reversal restored the pre-second-buy position (100 @ 10,000), then the
+    // sell took 40 @ avg cost: realized gain = 440,000 − (40 × 10,000).
+    expect(result.trade.realizedGainMinor).toBe("40000")
+    expect(result.trade.holding?.quantity).toBe("60.00000000")
+    expect(result.trade.holding?.avgUnitCostMinor).toBe("10000")
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 560_000n)
+    expect(await balanceOf(owner, investment.id)).toBe(600_000n)
+  })
+
+  test("CORRECT a position-creating BUY into a SELL fails loud (nothing to sell)", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    // The ONLY trade on the position: flipping it to a sell is financially
+    // incoherent (reversal removes the very units the sell would need) — the
+    // correction must fail loud and roll back ATOMICALLY (original trade
+    // untouched, balances unchanged).
+    const buy = await buyFund(owner, investment.id, cash.id)
+    await expect(
+      correctTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          fundingAccountId: cash.id,
+          side: "sell",
+          cashAmount: "440000",
+          quantity: "40",
+          unitPrice: "11000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(/No Fund A position to sell/)
+
+    // Atomicity: the original trade is still live, balances exactly as after
+    // the buy — the failed correction left no partial state behind.
+    const t = await tombstones(owner, buy.transaction.id)
+    expect(t.transactionDeleted).toBe(false)
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 1_000_000n)
+    expect(await balanceOf(owner, investment.id)).toBe(1_000_000n)
+  })
+
+  test("CORRECT side flip SELL → BUY keeps the books exact", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const instrumentId = buy.holding?.instrumentId ?? undefined
+    const sell = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrumentId,
+        side: "sell",
+        cashAmount: "480000", // 40 @ 12,000
+        quantity: "40",
+        unitPrice: "12000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Correct the SELL into a BUY of 50 @ 10,000.
+    const result = await correctTradeForFamily({
+      data: {
+        transactionId: sell.transaction.id,
+        fundingAccountId: cash.id,
+        side: "buy",
+        cashAmount: "500000",
+        quantity: "50",
+        unitPrice: "10000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+
+    // Reversal restored the pre-sell position (100 @ 10,000), then the buy
+    // added 50 @ 10,000 → 150 @ 10,000.
+    expect(result.trade.holding?.quantity).toBe("150.00000000")
+    expect(result.trade.holding?.avgUnitCostMinor).toBe("10000")
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 1_500_000n)
+    expect(await balanceOf(owner, investment.id)).toBe(1_500_000n)
+  })
+
+  test("CORRECT cross-tenant is rejected", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const intruder = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    await expect(
+      correctTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          fundingAccountId: cash.id,
+          side: "buy",
+          cashAmount: "1200000",
+          quantity: "100",
+          unitPrice: "12000",
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: intruder.family.id,
+        user: intruder.user,
+      })
+    ).rejects.toThrow()
+
+    const t = await tombstones(owner, buy.transaction.id)
+    expect(t.transactionDeleted).toBe(false)
+  })
+
+  // ==========================================================================
+  // READ — prefill for the correction dialog
+  // ==========================================================================
+
+  test("getTradeForCorrection prefills a latest trade and flags a non-latest one", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+
+    const buy = await buyFund(owner, investment.id, cash.id)
+    const view = await getTradeForCorrectionForFamily({
+      data: { transactionId: buy.transaction.id },
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(view.side).toBe("buy")
+    expect(view.quantity).toBe("100.00000000")
+    expect(view.cashAmountMinor).toBe("1000000")
+    expect(view.fundingAccountId).toBe(cash.id)
+    expect(view.investmentAccountId).toBe(investment.id)
+    expect(view.instrumentName).toBe("Fund A")
+    expect(view.notLatestReason).toBeNull()
+
+    // A second buy makes the FIRST non-latest; the read surfaces the same
+    // actionable message the mutations would reject with.
+    await buyFund(owner, investment.id, cash.id, {
+      instrumentId: view.instrumentId,
+      cashAmount: "2000000",
+      quantity: "100",
+      unitPrice: "20000",
+    })
+    const stale = await getTradeForCorrectionForFamily({
+      data: { transactionId: buy.transaction.id },
+      familyId: owner.family.id,
+      userId: owner.user.id,
+    })
+    expect(stale.notLatestReason).toMatch(/activity after it/)
+  })
+})


### PR DESCRIPTION
## Summary
- Closes the last operational-coherence gap in ADR-0054: a mis-entered Buy/Sell trade on a holdings-tracked account can now be **corrected or deleted**, not just created.
- Scope (locked with the creator, see ADR-0054 "Slice 5"): a trade is editable/deletable ONLY when it is still the **latest quantity-mutating event** on its (account, instrument) position — no full historical-replay engine. A later Buy/Sell, Switch leg, or Dividend reinvest on the same position blocks the correction with an actionable message.
- New `Holding.lastMutationIdempotencyKey` — an additive, nullable **identity marker** (never a value diff: a later sell-then-rebuy-at-the-same-price could coincidentally reproduce the original numbers) naming the idempotencyKey of whichever operation last mutated a Holding's quantity/avgUnitCostMinor. Stamped at all four write sites (Buy/Sell, both Switch legs, Dividend reinvest); cleared on a manual raw edit.
- `softDeleteValuationLinkedTransferWithinTx` gains an opt-in `onHoldingsTradeReversal` hook — every existing caller keeps today's exact fail-safe behavior (default still throws `HoldingsTradeDeleteUnsupportedError`). Only the new trade-correction path supplies the hook.
- `recordTradeForFamily`'s core logic is extracted into `recordTradeWithinTx` with **zero behavior change** (the full pre-existing Buy/Sell integration suite passes unchanged), so `correctTradeFn` can reapply it after reversal.
- `deleteTradeFn`: reversal-only — restores the Holding from its captured AuditLog before/after snapshot (never recomputed via math) and re-materializes the Σ-holdings anchor.
- `correctTradeFn`: reversal + reapply in **one atomic transaction** (reversal-and-replace: old rows tombstoned, corrected trade gets a new transaction id).
- `TradeCorrectionDialog` + statement-row wiring: a trade row's Edit/Delete now routes to the dedicated correction flow instead of the generic transaction modal.

### Bonus fix (unrelated, found while verifying this slice)
`holdings-move-coherence.integration.ts` hardcoded a calendar-literal `TEST_DATE` that had rotted into the past relative to wall-clock test time, which made two pre-existing ADR-0048 tests fail. Not a product bug — PER-201's createdAt-aware canonical-balance rule was correctly refusing to let an older-dated valuation outrank a newer opening-balance anchor. Fixed to compute relative to test-run time so it can't rot again.

## Test plan
- [x] `vp check` — clean
- [x] `vp build` — clean, no server/client boundary leak
- [x] Unit: 714/714
- [x] Integration (real Postgres, full suite): 527/527 — includes 23 new tests in `trade-corrections.integration.ts` (delete/edit happy paths, partial-sell/sell-to-zero snapshot restore, idempotency replay + conflict, "latest" guard rejection incl. coincidental-value-match, cross-tenant rejection, side flips, funding-account change) plus full regression across trades/switches/distributions/fees/holdings
- [x] E2E (full suite): 51/51 — includes new `trade-correction.e2e.ts` (edit via dedicated dialog, then delete, driven through the real per-account statement row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1