### PR TITLE
fix(ledger): a Sell/redemption's proceeds showed as negative on the receiving cash account

### DIFF
--- a/src/components/blocks/trade-correction-dialog.tsx
+++ b/src/components/blocks/trade-correction-dialog.tsx
@@ -248,13 +248,22 @@ function TradeCorrectionForm({
           </Select>
         </div>
         <div className="flex flex-col gap-2">
-          <Label>Funding account</Label>
+          {/* A Buy PAYS from this account; a Sell RECEIVES proceeds into it —
+              "Funding account" reads backwards for a Sell (see the same fix
+              in trade-dialog.tsx). */}
+          <Label>
+            {side === "buy" ? "Funding account" : "Destination account"}
+          </Label>
           <Select
             value={fundingAccountId}
             onValueChange={setFundingAccountId}
             disabled={details.notLatestReason !== null}
           >
-            <SelectTrigger aria-label="Funding account">
+            <SelectTrigger
+              aria-label={
+                side === "buy" ? "Funding account" : "Destination account"
+              }
+            >
               <SelectValue placeholder="Choose account" />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/blocks/trade-dialog.tsx
+++ b/src/components/blocks/trade-dialog.tsx
@@ -186,7 +186,7 @@ export function TradeDialog({
             <DialogDescription>
               {isBuy
                 ? "Move cash into this account and grow a position. Net worth stays the same."
-                : "Sell a position; cash returns to your funding account. Realized gain is shown after."}
+                : "Sell a position; cash lands in the account you choose below. Realized gain is shown after."}
             </DialogDescription>
           </DialogHeader>
 
@@ -207,12 +207,20 @@ export function TradeDialog({
               </Select>
             </div>
             <div className="flex flex-col gap-2">
-              <Label>Funding account</Label>
+              {/* A Buy PAYS from this account; a Sell RECEIVES proceeds into
+                  it — same field, opposite direction of money. Labeling it
+                  "Funding account" for a Sell reads backwards (a user
+                  reported exactly this confusion after a real Sell — the
+                  cash correctly landed here, but the label implied it was
+                  the source, not the destination). */}
+              <Label>{isBuy ? "Funding account" : "Destination account"}</Label>
               <Select
                 value={fundingAccountId}
                 onValueChange={setFundingAccountId}
               >
-                <SelectTrigger aria-label="Funding account">
+                <SelectTrigger
+                  aria-label={isBuy ? "Funding account" : "Destination account"}
+                >
                   <SelectValue placeholder="Choose account" />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/blocks/transaction-list-row.tsx
+++ b/src/components/blocks/transaction-list-row.tsx
@@ -162,13 +162,21 @@ export function TransactionListRow({
   // `toAccountId` is INCOMING — flip its sign/colour to read as a credit. The
   // whole-book (unfiltered) ledger passes no viewed accounts, so it stays
   // neutral. (Used only on the non-perspective, whole-book path.)
+  //
+  // `signedDeltaForAccount(trx, viewedId) >= 0n` is the general, correct test
+  // (it accounts for `isAccountCredit`, not just `toAccountId`, see its doc
+  // comment — a valuation-linked Sell's cash leg is owned by the account that
+  // GAINS money, which `toAccountId` alone can't tell you). Multi-account
+  // filters are rare in practice, so checking each viewed id individually
+  // here is fine.
   const isIncomingTransfer =
     trx.type === "transfer" &&
     viewedAccountIds != null &&
     viewedAccountIds.length > 0 &&
-    trx.toAccountId != null &&
-    viewedAccountIds.includes(trx.toAccountId) &&
-    !viewedAccountIds.includes(trx.accountId)
+    !viewedAccountIds.includes(trx.accountId) &&
+    viewedAccountIds.some(
+      (id) => trx.toAccountId === id && signedDeltaForAccount(trx, id) >= 0n
+    )
 
   const rowActions =
     onEdit || onDelete ? (

--- a/src/lib/account-analytics.test.ts
+++ b/src/lib/account-analytics.test.ts
@@ -26,26 +26,58 @@ function txn(partial: Partial<AnalyticsTxn>): AnalyticsTxn {
 
 describe("signedDeltaForAccount", () => {
   it("income is positive, expense negative", () => {
-    expect(signedDeltaForAccount({ type: "income", amount: 100n }, ID)).toBe(
-      100n
-    )
-    expect(signedDeltaForAccount({ type: "expense", amount: 100n }, ID)).toBe(
-      -100n
-    )
-  })
-  it("transfer is + when this account is the destination, − when source", () => {
     expect(
-      signedDeltaForAccount(
-        { type: "transfer", amount: 100n, toAccountId: ID },
-        ID
-      )
+      signedDeltaForAccount({ type: "income", amount: 100n, accountId: ID }, ID)
     ).toBe(100n)
     expect(
       signedDeltaForAccount(
-        { type: "transfer", amount: 100n, toAccountId: "other" },
+        { type: "expense", amount: 100n, accountId: ID },
         ID
       )
     ).toBe(-100n)
+  })
+
+  it("plain funds_movement transfer: + for the destination, − for the source", () => {
+    // A plain transfer's one visible row is owned by the PAYING account
+    // (transferIncoming: false) — this is the shape createTransactionForFamily
+    // produces for a normal Jago → GoPay top-up.
+    const outflowRow = {
+      type: "transfer",
+      amount: 100n,
+      accountId: "source",
+      toAccountId: "dest",
+      transferIncoming: false,
+    }
+    expect(signedDeltaForAccount(outflowRow, "source")).toBe(-100n)
+    expect(signedDeltaForAccount(outflowRow, "dest")).toBe(100n)
+  })
+
+  it("valuation-linked SELL/redemption: the CASH account is credited, not debited (regression — a Sell's proceeds showed as a negative 'Withdraw' on the receiving cash account in production)", () => {
+    // postValuationLinkedTransferLegs always owns the row on the CASH
+    // account regardless of direction — accountId=Bank Jago, toAccountId=the
+    // investment account, EVEN THOUGH this leg is an inflow for Jago. Only
+    // `transferIncoming` (not `toAccountId === accountId`) tells us that.
+    const sellCashLeg = {
+      type: "transfer",
+      amount: 180_000n,
+      accountId: "bank-jago",
+      toAccountId: "hasil-jualan",
+      transferIncoming: true,
+    }
+    expect(signedDeltaForAccount(sellCashLeg, "bank-jago")).toBe(180_000n)
+    expect(signedDeltaForAccount(sellCashLeg, "hasil-jualan")).toBe(-180_000n)
+  })
+
+  it("valuation-linked BUY/contribution: the CASH account is debited", () => {
+    const buyCashLeg = {
+      type: "transfer",
+      amount: 180_000n,
+      accountId: "bank-jago",
+      toAccountId: "hasil-jualan",
+      transferIncoming: false,
+    }
+    expect(signedDeltaForAccount(buyCashLeg, "bank-jago")).toBe(-180_000n)
+    expect(signedDeltaForAccount(buyCashLeg, "hasil-jualan")).toBe(180_000n)
   })
 })
 
@@ -71,6 +103,10 @@ describe("buildBalanceSeries", () => {
       date: "2026-03-20",
       type: "transfer",
       amount: 50_000n,
+      // A transfer INTO ID: owned by the OTHER account (a self-referencing
+      // accountId === toAccountId would be nonsensical — `txn()` defaults
+      // accountId to ID, so this must be overridden for an inflow fixture).
+      accountId: "other",
       toAccountId: ID,
     }),
   ]

--- a/src/lib/account-analytics.ts
+++ b/src/lib/account-analytics.ts
@@ -29,7 +29,7 @@ export const ACCOUNT_RANGES: ReadonlyArray<{
 export interface AnalyticsTxn {
   date: Date | string
   createdAt?: Date | string
-  amount: bigint // absolute magnitude (sign lives in `type`)
+  amount: bigint // absolute magnitude (sign lives in `type`, or `transferIncoming` for a transfer)
   type: string // "income" | "expense" | "transfer"
   // PER-247: the transaction kind (funds_movement / cc_payment / loan_payment /
   // liability_draw / …) and the funds_movement purpose. Together they give a
@@ -38,6 +38,15 @@ export interface AnalyticsTxn {
   transferPurpose?: string | null
   accountId: string
   toAccountId?: string | null
+  // PER-247: does this row's OWN `accountId` RECEIVE money (toAccount →
+  // account), rather than send it out? Server-computed from the authoritative
+  // `Transfer.inflowTransactionId` pairing (see server/transactions.ts) — a
+  // plain funds_movement transfer's one visible row is always the outflow
+  // (false), but a valuation-linked trade/redemption cash leg
+  // (postValuationLinkedTransferLegs) sits in the inflow slot for a
+  // Sell/redemption despite `accountId` being the CASH account either way.
+  // false/undefined for income/expense (their sign lives in `type` alone).
+  transferIncoming?: boolean | null
   category?: { name: string; color?: string | null } | null
   merchant?: { name: string } | null
   isSplit?: boolean
@@ -45,17 +54,41 @@ export interface AnalyticsTxn {
 
 /**
  * Signed movement of a transaction FROM this account's perspective.
- * income → +, expense → −, transfer → + when this account is the destination
- * leg, − when it is the source. Exactly one leg touches the account, so summing
- * this over the ledger never double-counts (mirrors PER-202).
+ * income → +, expense → −.
+ *
+ * A transfer's sign is NOT reliably inferable from `toAccountId === accountId`
+ * alone: that holds for a plain funds_movement transfer (its one visible row
+ * is always owned by the PAYING account — `accountId` = source, `toAccountId`
+ * = destination), but NOT for a valuation-linked trade/redemption cash leg
+ * (`postValuationLinkedTransferLegs`), whose row is always owned by the CASH
+ * account regardless of direction — a Buy/contribution debits it, a
+ * Sell/redemption CREDITS it. Using `toAccountId === accountId` there would
+ * wrongly read a Sell's cash-in leg as an outflow (confirmed in production:
+ * a Sell's proceeds showed as a negative "Withdraw to <fund>" on the
+ * receiving cash account's own statement, when the underlying ledger amount
+ * was correctly positive).
+ *
+ * The correct, general rule: `transferIncoming` (the SAME authoritative,
+ * DB-backed signal PER-247 already computes to orient the account-column
+ * arrow — see transaction-list-row.tsx) tells us whether the row's OWNER
+ * (`trx.accountId`) gained or lost funds — that's true regardless of which
+ * account structurally happens to be `accountId` vs `toAccountId`. Viewing
+ * from the owner's own account uses that delta directly; viewing from the
+ * counterparty (surfaced via `toAccountId`) flips it. Exactly one leg touches
+ * a given account's statement, so summing this over the ledger never
+ * double-counts (mirrors PER-202).
  */
 export function signedDeltaForAccount(
-  trx: Pick<AnalyticsTxn, "type" | "amount" | "toAccountId">,
+  trx: Pick<
+    AnalyticsTxn,
+    "type" | "amount" | "accountId" | "toAccountId" | "transferIncoming"
+  >,
   accountId: string
 ): bigint {
   if (trx.type === "income") return trx.amount
   if (trx.type === "expense") return -trx.amount
-  return trx.toAccountId === accountId ? trx.amount : -trx.amount
+  const ownerDelta = trx.transferIncoming ? trx.amount : -trx.amount
+  return trx.accountId === accountId ? ownerDelta : -ownerDelta
 }
 
 /** Start-of-window cutoff for a range, or null for "ALL". */

--- a/src/lib/account-performance.test.ts
+++ b/src/lib/account-performance.test.ts
@@ -4,7 +4,16 @@ import { type AnalyticsTxn } from "./account-analytics"
 
 const ACC = "inv-1"
 
-/** A transfer INTO the account (a buy / contribution). */
+// The REAL shape `postValuationLinkedTransferLegs` produces: the Transaction
+// row is always owned by the CASH account (`accountId`), never the tracked
+// account, regardless of direction — a contribution debits the cash account
+// (transferIncoming: false), a redemption credits it (transferIncoming: true).
+// `signedDeltaForAccount` needs `transferIncoming`, not `toAccountId`, to
+// derive the correct sign for this shape (see its doc comment) — a fixture
+// with `accountId: ACC` directly (the account under test OWNING the row)
+// would silently test the WRONG structural shape and miss regressions.
+
+/** A transfer INTO the account (a buy / contribution): cash pays out. */
 function buy(amount: bigint): AnalyticsTxn {
   return {
     date: "2026-01-01",
@@ -12,16 +21,18 @@ function buy(amount: bigint): AnalyticsTxn {
     type: "transfer",
     accountId: "bank",
     toAccountId: ACC,
+    transferIncoming: false,
   }
 }
-/** A transfer OUT of the account (a sell / withdrawal). */
+/** A transfer OUT of the account (a sell / withdrawal): cash is credited. */
 function sell(amount: bigint): AnalyticsTxn {
   return {
     date: "2026-02-01",
     amount,
     type: "transfer",
-    accountId: ACC,
-    toAccountId: "bank",
+    accountId: "bank",
+    toAccountId: ACC,
+    transferIncoming: true,
   }
 }
 

--- a/src/lib/transaction-list.test.ts
+++ b/src/lib/transaction-list.test.ts
@@ -10,15 +10,38 @@ import { toMoney } from "./money"
 type Txn = {
   type: string
   amount: bigint
+  accountId: string
   toAccountId?: string | null
+  transferIncoming?: boolean | null
 }
 
-const income = (amount: bigint): Txn => ({ type: "income", amount })
-const expense = (amount: bigint): Txn => ({ type: "expense", amount })
-const transferTo = (amount: bigint, toAccountId: string): Txn => ({
+// Income/expense never read `accountId` in signedDeltaForAccount (sign lives
+// in `type` alone), but the real shape always carries one — this placeholder
+// keeps the fixture type-honest without being semantically meaningful here.
+const income = (amount: bigint): Txn => ({
+  type: "income",
+  amount,
+  accountId: "any",
+})
+const expense = (amount: bigint): Txn => ({
+  type: "expense",
+  amount,
+  accountId: "any",
+})
+// Models a plain funds_movement transfer's one visible row: always owned by
+// the PAYING account (transferIncoming: false — see signedDeltaForAccount's
+// doc comment for why this matters for a valuation-linked leg, which this
+// helper does NOT model).
+const transferTo = (
+  amount: bigint,
+  accountId: string,
+  toAccountId: string
+): Txn => ({
   type: "transfer",
   amount,
+  accountId,
   toAccountId,
+  transferIncoming: false,
 })
 
 describe("dailyNet — global perspective", () => {
@@ -28,7 +51,7 @@ describe("dailyNet — global perspective", () => {
   })
 
   it("excludes transfers (internal moves are a wash across the whole book)", () => {
-    const rows = [income(10_000n), transferTo(4_000n, "acc-x")]
+    const rows = [income(10_000n), transferTo(4_000n, "acc-y", "acc-x")]
     expect(dailyNet(rows, { kind: "global" })).toBe(10_000n)
   })
 
@@ -46,12 +69,12 @@ describe("dailyNet — account perspective", () => {
   })
 
   it("counts a transfer INTO the account as positive", () => {
-    const rows = [transferTo(6_000n, A)]
+    const rows = [transferTo(6_000n, "other", A)]
     expect(dailyNet(rows, { kind: "account", accountId: A })).toBe(6_000n)
   })
 
   it("counts a transfer OUT of the account (destination is elsewhere) as negative", () => {
-    const rows = [transferTo(6_000n, "acc-other")]
+    const rows = [transferTo(6_000n, A, "acc-other")]
     expect(dailyNet(rows, { kind: "account", accountId: A })).toBe(-6_000n)
   })
 
@@ -59,8 +82,8 @@ describe("dailyNet — account perspective", () => {
     const rows = [
       income(10_000n),
       expense(1_000n),
-      transferTo(3_000n, A), // +3,000 into A
-      transferTo(2_000n, "acc-other"), // −2,000 out of A
+      transferTo(3_000n, "other", A), // +3,000 into A
+      transferTo(2_000n, A, "acc-other"), // −2,000 out of A
     ]
     expect(dailyNet(rows, { kind: "account", accountId: A })).toBe(10_000n)
   })
@@ -77,7 +100,7 @@ describe("computeRunningBalances", () => {
     const rows: IdTxn[] = [
       row("r1", income(3_000n)), // newest: +3,000 into A
       row("r2", expense(2_000n)), // −2,000 from A
-      row("r3", transferTo(1_000n, A)), // oldest: +1,000 into A
+      row("r3", transferTo(1_000n, "other", A)), // oldest: +1,000 into A
     ]
     const balances = computeRunningBalances(rows, A, toMoney(10_000n))
     // after r1 = current
@@ -92,7 +115,7 @@ describe("computeRunningBalances", () => {
     const rows: IdTxn[] = [
       row("r1", income(3_000n)),
       row("r2", expense(2_000n)),
-      row("r3", transferTo(1_000n, A)),
+      row("r3", transferTo(1_000n, "other", A)),
     ]
     const current = 10_000n
     const balances = computeRunningBalances(rows, A, toMoney(current))
@@ -106,7 +129,7 @@ describe("computeRunningBalances", () => {
   })
 
   it("treats a transfer OUT (destination elsewhere) as a debit", () => {
-    const rows: IdTxn[] = [row("r1", transferTo(4_000n, "acc-other"))]
+    const rows: IdTxn[] = [row("r1", transferTo(4_000n, A, "acc-other"))]
     const balances = computeRunningBalances(rows, A, toMoney(6_000n))
     // The only row moved 4,000 OUT of A, so before it the balance was 10,000.
     expect(balances.get("r1")).toBe(6_000n)

--- a/src/lib/transaction-list.ts
+++ b/src/lib/transaction-list.ts
@@ -33,7 +33,12 @@ export type LedgerPerspective =
  * currency. Pure — the date grouping happens at the call site.
  */
 export function dailyNet(
-  txns: ReadonlyArray<Pick<AnalyticsTxn, "type" | "amount" | "toAccountId">>,
+  txns: ReadonlyArray<
+    Pick<
+      AnalyticsTxn,
+      "type" | "amount" | "accountId" | "toAccountId" | "transferIncoming"
+    >
+  >,
   perspective: LedgerPerspective
 ): Money {
   let net: bigint = ZERO_MONEY
@@ -129,7 +134,7 @@ export function formatRelativeDay(
 /** A row carrying the identity + signed-delta inputs the register walk needs. */
 type RunningBalanceRow = { id: string } & Pick<
   AnalyticsTxn,
-  "type" | "amount" | "toAccountId"
+  "type" | "amount" | "accountId" | "toAccountId" | "transferIncoming"
 >
 
 /**

--- a/src/server/transactions.ts
+++ b/src/server/transactions.ts
@@ -3312,7 +3312,11 @@ export const getTransactionsFn = createServerFn({ method: "GET" })
 
         // The MAP logic: Ubah array yang didapat dari DB.
         // Amounts are stored signed (negative for expense) but the UI consumes
-        // them as positive magnitudes; sign is communicated via `type`.
+        // them as positive magnitudes; sign is communicated via `type` for
+        // income/expense, and via the already-computed `transferIncoming`
+        // (above) for a transfer — see `signedDeltaForAccount`'s doc comment
+        // for why `toAccountId === accountId` alone is NOT a reliable sign for
+        // a valuation-linked trade/redemption's cash leg.
         // Wire-encode bigint → string at this boundary; client revives via
         // TanStack DB collection `select` callback (see src/lib/collections.ts).
         return transactions.map((tx) =>

--- a/tests/e2e/sell-proceeds-sign.e2e.ts
+++ b/tests/e2e/sell-proceeds-sign.e2e.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// Real production bug (found 2026-08-24 via a live Sell — "Sell Majoris Pasar
+// Uang Syariah Indonesia", proceeds Rp 180,000): a Sell/redemption's cash leg
+// is always owned by the CASH account regardless of direction
+// (postValuationLinkedTransferLegs), unlike a plain funds_movement transfer
+// (always owned by the payer). The per-account statement's sign/label logic
+// (`signedDeltaForAccount` in src/lib/account-analytics.ts) inferred direction
+// from `toAccountId === accountId` alone, which is correct for a plain
+// transfer but WRONG for a Sell viewed on the receiving cash account's own
+// page: the proceeds showed as a NEGATIVE "Withdraw to <fund>" (red) when the
+// underlying signed ledger amount was correctly POSITIVE (verified directly
+// against the real production Transaction row: accountId=cash, amount=
+// +18,000,000). The fix reuses the ALREADY-EXISTING, DB-authoritative
+// `transferIncoming` field (PER-247, from Transfer.inflowTransactionId) that
+// was already computed correctly server-side but never consumed by the sign
+// logic — only by a separate "orient the account arrow" render.
+//
+// This test drives the WHOLE chain for real: Buy → Sell → view the cash
+// (funding) account's OWN statement page → the Sell's proceeds must render
+// POSITIVE/green with "... from <fund>", never negative/blue "to <fund>".
+//
+// \s (not literal spaces) — formatCurrency uses a non-breaking space.
+
+test.describe("Sell proceeds sign on the receiving cash account (production bug regression)", () => {
+  test("a Sell's cash-in leg shows positive/green 'from <fund>' on the funding account's own statement, not negative 'to <fund>'", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const walletName = `E2E Wallet ${suffix}`
+    const portfolioName = `E2E Portfolio ${suffix}`
+    const fundName = `Fund X ${suffix}`
+
+    // --- Cash (funding) account, opening balance 1,000,000. ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(walletName)
+    await page.getByLabel("Opening balance").fill("1000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- Tracked Asset (valuation-tracked) investment account. ---
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // --- Buy 10 units @ 100,000 = 1,000,000 cash out (wallet -> 0). ---
+    await page.getByRole("button", { name: "Buy" }).first().click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByRole("combobox", { name: "Funding account" }).click()
+    await page.getByRole("option", { name: walletName }).click()
+    await dialog.getByLabel("Instrument name").fill(fundName)
+    await dialog.getByLabel("Quantity").fill("10")
+    await dialog.getByLabel(/Unit price/i).fill("100000")
+    await dialog.getByRole("button", { name: "Record buy" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(fundName).first()).toBeVisible()
+
+    // --- Sell all 10 units @ 118,000 = 1,180,000 proceeds (redemption). ---
+    await page.getByRole("button", { name: "Sell" }).first().click()
+    dialog = page.getByRole("dialog")
+    await dialog.getByRole("combobox", { name: "Destination account" }).click()
+    await page.getByRole("option", { name: walletName }).click()
+    await dialog.getByLabel("Quantity").fill("10")
+    await dialog.getByLabel(/Unit price/i).fill("118000")
+    await dialog.getByRole("button", { name: "Record sell" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    // --- The proceeds must show POSITIVE on the WALLET's own page. ---
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: `Open ${walletName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // The Sell's cash-in leg: a credit reads "Withdraw from <portfolio>"
+    // (moneyMovementLabel("investment_withdrawal") = "Withdraw", + "from"
+    // since this leg is incoming) with a "+" amount. The original bug showed
+    // "Withdraw to <portfolio>" with a "−" amount instead — this exact string
+    // could ONLY come from the buggy direction, so its absence is conclusive.
+    await expect(page.getByText(`Withdraw from ${portfolioName}`)).toBeVisible()
+    await expect(page.getByText(`Withdraw to ${portfolioName}`)).toHaveCount(0)
+    await expect(page.getByText(/\+Rp\s1,180,000\.00/)).toBeVisible()
+
+    // The Buy's cash-out leg is UNCHANGED by this fix: still a debit, "Invest
+    // to <portfolio>" with a "−" amount (contribution direction was already
+    // correct before the fix — this guards against a regression the other way).
+    await expect(page.getByText(`Invest to ${portfolioName}`)).toBeVisible()
+    await expect(page.getByText(/−Rp\s1,000,000\.00/)).toBeVisible()
+
+    // Sanity: the wallet's real balance reflects the credit (1,000,000 -
+    // 1,000,000 buy + 1,180,000 sell = 1,180,000).
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await expect(page.getByText(/Rp\s1,180,000\.00/).first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Real production finding, reported by the creator: a "Sell Majoris Pasar Uang Syariah Indonesia" redemption's cash proceeds (Rp 180,000) showed up on the receiving Bank Jago account's own statement as **"Withdraw to Hasil Jualan, −Rp 180,000.00"** — a negative outflow — when the underlying signed ledger amount (verified directly against production Postgres) was correctly **positive**: Bank Jago's balance genuinely increased by Rp 180,000. The database and balance math were never wrong — only the client-side derived sign/label was.

### Root cause
`signedDeltaForAccount` (`src/lib/account-analytics.ts`) inferred a transfer's direction purely from `toAccountId === accountId`. That's correct for a plain funds_movement transfer (its one visible row is always owned by the PAYING account), but **wrong** for a valuation-linked trade/redemption cash leg (`postValuationLinkedTransferLegs`), whose row is always owned by the CASH account regardless of direction — a Buy debits it, a Sell **credits** it.

### The fix
Reuses `transferIncoming` — an already-existing, DB-authoritative field (PER-247, derived from `Transfer.inflowTransactionId`) that was already computed correctly server-side but only ever consumed to orient an account-arrow chip, never by the sign/label logic itself. **No new server field, no migration** — this is a pure client-side logic fix, plus test-fixture corrections that were modeling an unrealistic transaction shape.

### Blast radius (all fixed by correcting the one shared function)
- The per-account statement's sign, color, and "from/to" label for this transaction class.
- `computeRunningBalances`: the wrong sign was subtracted backward through history, corrupting every OLDER row's displayed running balance on the affected account by 2x the transaction amount.
- `computeAccountPerformance`'s ledger-contribution heuristic — a Sell was read as ADDING to cost basis instead of removing from it (masked by existing test fixtures that modeled an unrealistic transaction shape — fixed too).
- Net cash flow / spend-by-category netting, account runway, idle-cash (all consumers of `signedDeltaForAccount`).

Accounts that track holdings (like the reported case) get their cost-basis panel from the authoritative `Holdings` sum instead, so that specific panel was unaffected there — but the statement row sign/label bug was live for everyone.

## Test plan
- [x] `vp check` — clean
- [x] `vp build` — clean
- [x] Unit: 716/716, including new regression cases in `account-analytics.test.ts` for both directions (Sell credits, Buy debits) of a valuation-linked cash leg, plus corrected fixtures in `account-performance.test.ts` and `transaction-list.test.ts` that now model the real transaction shape
- [x] Full e2e suite: 52/52 (one pre-existing load-flake reproduced only under full-suite contention, confirmed clean in isolation, unrelated to this change), including a new dedicated `sell-proceeds-sign.e2e.ts` that drives Buy → Sell → the funding account's own statement through a real browser and asserts the exact positive/"from" rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1