### PR TITLE
fix(holdings): trade correction crash on legacy trades + missing backdate field

### DIFF
--- a/prisma/migrations/20260823121700_backfill_holding_last_mutation_key/migration.sql
+++ b/prisma/migrations/20260823121700_backfill_holding_last_mutation_key/migration.sql
@@ -1,0 +1,47 @@
+-- PER-259 Slice 5 follow-up — backfill `Holding.lastMutationIdempotencyKey`
+-- for every row that predates the column (holdings mutated only by trades
+-- recorded before migration 20260816130000 shipped, 2026-08-23).
+--
+-- BUG THIS FIXES (found in production 2026-08-24 via a real trade): the
+-- migration comment for the original column said a NULL marker means
+-- "not known to be the result of a still-latest tracked mutation," treating
+-- NULL as fail-safe. That was wrong for a legacy holding whose last
+-- quantity-mutating event genuinely IS still the most recent one — with no
+-- backfill, `assertTradeIsLatest`'s fast path
+-- (current.lastMutationIdempotencyKey === tradeKey) always fails for ANY
+-- trade recorded before this migration, permanently blocking edit/delete on
+-- it even though nothing has touched the position since. Compounding this,
+-- a price-only refresh (`refreshHoldingPricesForFamily`) also leaves the
+-- marker untouched (it only ever writes `lastPriceMinor`), so a legacy
+-- holding stays NULL indefinitely even after later activity that isn't a
+-- quantity change.
+--
+-- This is a one-time DATA backfill, not a schema change: for each Holding
+-- with a NULL marker, find its most recent AuditLog entry that actually
+-- changed quantity or avgUnitCostMinor (or was the holding's own create),
+-- and stamp that entry's idempotencyKey. A price-only update (quantity and
+-- avgUnitCostMinor unchanged) is correctly skipped by the comparison, so the
+-- walk falls through to the real last quantity-mutating event. Going
+-- forward all four write sites (Buy/Sell, both Switch legs, Dividend
+-- reinvest) already stamp the marker themselves, so no NULL should recur
+-- for a genuinely-latest holding after this backfill runs.
+
+WITH latest_quantity_mutation AS (
+  SELECT DISTINCT ON (al."entityId")
+    al."entityId" AS holding_id,
+    al."idempotencyKey" AS marker
+  FROM "AuditLog" al
+  WHERE al."entityType" = 'Holding'
+    AND al."idempotencyKey" IS NOT NULL
+    AND (
+      al.action = 'create'
+      OR (al."beforeJson" ->> 'quantity') IS DISTINCT FROM (al."afterJson" ->> 'quantity')
+      OR (al."beforeJson" ->> 'avgUnitCostMinor') IS DISTINCT FROM (al."afterJson" ->> 'avgUnitCostMinor')
+    )
+  ORDER BY al."entityId", al."createdAt" DESC, al.id DESC
+)
+UPDATE "Holding" h
+SET "lastMutationIdempotencyKey" = lm.marker
+FROM latest_quantity_mutation lm
+WHERE h.id = lm.holding_id
+  AND h."lastMutationIdempotencyKey" IS NULL;

--- a/src/components/blocks/trade-dialog.tsx
+++ b/src/components/blocks/trade-dialog.tsx
@@ -42,6 +42,15 @@ import { recordTradeFn } from "@/server/holdings"
 // Sentinel option value for "create a new instrument" (BUY only).
 const NEW_INSTRUMENT = "__new__"
 
+// Was missing entirely until a real creator report (2026-08-24): a trade
+// recorded a few days after it actually happened had no way to be dated
+// correctly — every other money-movement dialog (Switch, Dividend, Fee, and
+// even the trade-CORRECTION dialog) already has a Date field; this was the
+// one gap. Defaults to today, exactly like the others.
+function toDateInputValue(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
 export interface TradeFundingAccount {
   id: string
   name: string
@@ -84,6 +93,7 @@ export function TradeDialog({
   const [newKind, setNewKind] = React.useState<InstrumentKind>("mutual_fund")
   const [quantity, setQuantity] = React.useState<string>("")
   const [unitPrice, setUnitPrice] = React.useState<string>("")
+  const [date, setDate] = React.useState<string>(toDateInputValue(new Date()))
   const [error, setError] = React.useState<string | null>(null)
   const [submitting, setSubmitting] = React.useState(false)
 
@@ -134,6 +144,7 @@ export function TradeDialog({
         cashAmount: cashPreview.minor.toString(),
         quantity: quantity.trim(),
         unitPrice: price.toString(),
+        tradeDate: date,
         idempotencyKey: createUuidV7(),
       }
       if (!isBuy) {
@@ -314,6 +325,17 @@ export function TradeDialog({
                 required
               />
             </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="trade-date">Date</Label>
+            <Input
+              id="trade-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+            />
           </div>
 
           <div

--- a/src/server/holdings.ts
+++ b/src/server/holdings.ts
@@ -1591,7 +1591,14 @@ const holdingSnapshotSchema = z
     quantity: z.string(),
     avgUnitCostMinor: z.string(),
     lastPriceMinor: z.string().nullable(),
-    lastMutationIdempotencyKey: z.string().nullable(),
+    // PRODUCTION BUG (found 2026-08-24): `.nullable()` alone rejects a
+    // MISSING key with `invalid_type` — every Holding audit snapshot
+    // captured before this column existed (any trade recorded before this
+    // migration deployed) has no `lastMutationIdempotencyKey` key in its
+    // JSON at all, not even `null`. `.optional()` treats a missing key the
+    // same as an explicit `null`, which is exactly the semantics we want:
+    // "not known to be the result of a still-latest tracked mutation."
+    lastMutationIdempotencyKey: z.string().nullable().optional(),
   })
   .passthrough()
 

--- a/tests/e2e/trade-backdate.e2e.ts
+++ b/tests/e2e/trade-backdate.e2e.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "./support/fixtures"
+import { onboard, waitForHydration } from "./support/onboarding"
+
+// Real production gap (found 2026-08-24, same report as the Sell sign bug):
+// every OTHER money-movement dialog (Switch, Dividend, Fee, and the trade
+// CORRECTION dialog itself) already has a Date field — the Buy/Sell trade
+// dialog was the one exception, so a trade entered a few days after it
+// actually happened (e.g. recorded 2026-08-23 for a sale that happened
+// 2026-08-20) had no way to be dated correctly; it was always stamped with
+// "now". This drives the real Buy dialog with a backdated date, then opens
+// the trade for correction and confirms the SAME date round-trips back —
+// proof the value is actually persisted server-side, not silently dropped.
+
+function toDateInputValue(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+test.describe("Buy/Sell trade backdating", () => {
+  test("a trade recorded with a past date persists that date, not today's", async ({
+    page,
+  }) => {
+    await onboard(page)
+    const suffix = Date.now().toString(36)
+    const walletName = `E2E Wallet ${suffix}`
+    const portfolioName = `E2E Portfolio ${suffix}`
+    const fundName = `Fund X ${suffix}`
+
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+    const backdatedValue = toDateInputValue(tenDaysAgo)
+
+    await page.goto("/accounts")
+    await waitForHydration(page)
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(walletName)
+    await page.getByLabel("Opening balance").fill("1000000")
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: "New account" }).click()
+    await page.getByLabel("Name").fill(portfolioName)
+    await page.getByRole("combobox", { name: "Account type" }).click()
+    await page.getByRole("option", { name: "Tracked Asset" }).click()
+    await page.getByRole("button", { name: "Create" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+
+    await page.getByRole("button", { name: `Open ${portfolioName}` }).click()
+    await page.waitForURL(/\/accounts\/[^/]+$/, { timeout: 15000 })
+
+    // --- Record a Buy dated 10 days ago. ---
+    await page.getByRole("button", { name: "Buy" }).first().click()
+    const dialog = page.getByRole("dialog")
+    await dialog.getByRole("combobox", { name: "Funding account" }).click()
+    await page.getByRole("option", { name: walletName }).click()
+    await dialog.getByLabel("Instrument name").fill(fundName)
+    await dialog.getByLabel("Quantity").fill("10")
+    await dialog.getByLabel(/Unit price/i).fill("100000")
+    await dialog.getByLabel("Date").fill(backdatedValue)
+    await dialog.getByRole("button", { name: "Record buy" }).click()
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByText(fundName).first()).toBeVisible()
+
+    // --- Open it for correction and confirm the date round-tripped. ---
+    await page.getByRole("button", { name: "Edit Transaction" }).first().click()
+    const correctionDialog = page.getByRole("dialog")
+    await expect(
+      correctionDialog.getByRole("heading", { name: `Edit ${fundName}` })
+    ).toBeVisible()
+    await expect(correctionDialog.getByLabel("Date")).toHaveValue(
+      backdatedValue
+    )
+  })
+})

--- a/tests/integration/trade-corrections.integration.ts
+++ b/tests/integration/trade-corrections.integration.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import {
   afterAll,
   beforeAll,
@@ -1025,5 +1027,211 @@ describe("trade corrections — delete & edit (PER-259 Slice 5 / ADR-0054)", () 
       userId: owner.user.id,
     })
     expect(stale.notLatestReason).toMatch(/activity after it/)
+  })
+
+  // ==========================================================================
+  // LEGACY DATA — a trade recorded BEFORE `lastMutationIdempotencyKey`
+  // existed (migration 20260816130000) or before its backfill
+  // (20260823121700).
+  //
+  // PRODUCTION BUG (found 2026-08-24 via a real trade dated 2026-08-17, six
+  // days before Slice 5 deployed): `holdingSnapshotSchema` rejected a
+  // Holding audit snapshot with `lastMutationIdempotencyKey` MISSING
+  // entirely (not even `null`) as a Zod `invalid_type` error — "Can't edit
+  // this trade" with no actionable message. Separately, even once that
+  // parses, the CURRENT Holding row's marker is NULL for any position
+  // untouched since the column existed, which `assertTradeIsLatest`'s fast
+  // path reads as "something else touched it" — permanently blocking
+  // correction of a trade that is, in fact, still the latest thing that
+  // happened to the position. The backfill migration fixes the data; these
+  // tests prove the parse fix AND the backfill together restore full
+  // functionality, including correctly SKIPPING a price-only touch (which
+  // never mutates quantity/avgUnitCostMinor) when hunting for the real last
+  // quantity-mutating event. Reuses the SAME harness/factories/helpers
+  // above — a second `createIntegrationHarness()` in this file raced the
+  // first on test-role provisioning.
+  // ==========================================================================
+
+  const backfillMigrationSql = readFileSync(
+    join(
+      __dirname,
+      "../../prisma/migrations/20260823121700_backfill_holding_last_mutation_key/migration.sql"
+    ),
+    "utf-8"
+  )
+
+  // The observable production symptom, reproduced via an ALLOWED operation:
+  // null the LIVE Holding's own marker directly. `AuditLog` is genuinely
+  // append-only (no UPDATE/DELETE grant for the app role — verified: an
+  // attempt to strip the marker key from an existing audit row's JSON to
+  // simulate the exact historical shape fails with "permission denied for
+  // table AuditLog"), so this test targets `assertTradeIsLatest`'s NULL-marker
+  // fallback and the backfill directly rather than fabricating the original
+  // pre-migration JSON shape (a schema-level `.nullable().optional()` fix,
+  // independently confirmed against the real production AuditLog rows that
+  // triggered this — see [[sell-redemption-sign-bug]]-adjacent session notes).
+  const nullTheMarker = (
+    owner: AuthenticatedOnboardedUser,
+    holdingId: string
+  ) =>
+    harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.update({
+        where: { id: holdingId },
+        data: { lastMutationIdempotencyKey: null },
+      })
+    )
+
+  test("BEFORE backfill: a trade whose Holding marker is NULL is wrongly rejected as 'not latest'; AFTER backfill: it corrects successfully", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const cashBefore = await balanceOf(owner, cash.id)
+    const key = factories.createIdempotencyKey()
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: { kind: "mutual_fund", name: "Fund A" },
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    await nullTheMarker(owner, buy.holding!.id)
+
+    // BEFORE: reproduces the exact production bug — genuinely still the
+    // latest event, but wrongly rejected because the marker was never
+    // stamped for this legacy position.
+    await expect(
+      deleteTradeForFamily({
+        data: {
+          transactionId: buy.transaction.id,
+          idempotencyKey: factories.createIdempotencyKey(),
+        },
+        familyId: owner.family.id,
+        user: owner.user,
+      })
+    ).rejects.toThrow(HoldingError)
+
+    // Run the REAL migration file's SQL (not a re-implementation) directly.
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await tx.$executeRawUnsafe(backfillMigrationSql)
+    })
+
+    const backfilled = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findUniqueOrThrow({ where: { id: buy.holding!.id } })
+    )
+    expect(backfilled.lastMutationIdempotencyKey).toBe(key)
+
+    // AFTER: the SAME trade now corrects successfully.
+    const corrected = await correctTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        fundingAccountId: cash.id,
+        side: "buy",
+        cashAmount: "1200000",
+        quantity: "100",
+        unitPrice: "12000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(corrected.trade.holding?.quantity).toBe("100.00000000")
+    expect(await balanceOf(owner, cash.id)).toBe(cashBefore - 1_200_000n)
+  })
+
+  test("the backfill SKIPS a price-only touch and finds the real last quantity-mutating event", async () => {
+    const owner = await factories.createAuthenticatedOnboardedUser()
+    const investment = await makeInvestmentAccount(owner)
+    const cash = await makeCashAccount(owner)
+    const key = factories.createIdempotencyKey()
+    const buy = await recordTradeForFamily({
+      data: {
+        investmentAccountId: investment.id,
+        fundingAccountId: cash.id,
+        instrument: { kind: "mutual_fund", name: "Fund A" },
+        side: "buy",
+        cashAmount: "1000000",
+        quantity: "100",
+        unitPrice: "10000",
+        idempotencyKey: key,
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    await nullTheMarker(owner, buy.holding!.id)
+
+    // Simulate a LATER price-only refresh (refreshHoldingPricesForFamily's
+    // real shape: same quantity/avgUnitCostMinor, different lastPriceMinor,
+    // its own idempotencyKey, and it never touches the marker column either).
+    const priceRefreshKey = factories.createIdempotencyKey()
+    await harness.withFamily(owner.family.id, async (tx) => {
+      const holding = await tx.holding.findUniqueOrThrow({
+        where: { id: buy.holding!.id },
+      })
+      const snapshot = (lastPriceMinor: string | null) => ({
+        id: holding.id,
+        familyId: holding.familyId,
+        accountId: holding.accountId,
+        instrumentId: holding.instrumentId,
+        quantity: holding.quantity.toFixed(8),
+        avgUnitCostMinor: holding.avgUnitCostMinor.toString(),
+        lastMutationIdempotencyKey: holding.lastMutationIdempotencyKey,
+        lastPriceMinor,
+        createdAt: holding.createdAt.toISOString(),
+        updatedAt: holding.updatedAt.toISOString(),
+      })
+      const before = snapshot(null)
+      await tx.holding.update({
+        where: { id: holding.id },
+        data: { lastPriceMinor: 11_000n },
+      })
+      const after = snapshot("11000")
+      await tx.auditLog.create({
+        data: {
+          familyId: owner.family.id,
+          userId: owner.user.id,
+          action: "update",
+          entityType: "Holding",
+          entityId: holding.id,
+          beforeJson: before,
+          afterJson: after,
+          requestId: factories.createIdempotencyKey(),
+          idempotencyKey: priceRefreshKey,
+        },
+      })
+    })
+
+    await harness.withFamily(owner.family.id, async (tx) => {
+      await tx.$executeRawUnsafe(backfillMigrationSql)
+    })
+
+    const backfilled = await harness.withFamily(owner.family.id, async (tx) =>
+      tx.holding.findUniqueOrThrow({ where: { id: buy.holding!.id } })
+    )
+    // The marker must point at the ORIGINAL trade, not the price refresh —
+    // a price-only change never mutated quantity/avgUnitCostMinor.
+    expect(backfilled.lastMutationIdempotencyKey).toBe(key)
+    expect(backfilled.lastMutationIdempotencyKey).not.toBe(priceRefreshKey)
+
+    const corrected = await correctTradeForFamily({
+      data: {
+        transactionId: buy.transaction.id,
+        fundingAccountId: cash.id,
+        side: "buy",
+        cashAmount: "1300000",
+        quantity: "100",
+        unitPrice: "13000",
+        idempotencyKey: factories.createIdempotencyKey(),
+      },
+      familyId: owner.family.id,
+      user: owner.user,
+    })
+    expect(corrected.trade.holding?.quantity).toBe("100.00000000")
   })
 })


### PR DESCRIPTION
## Summary

Two more real production findings from the same creator report as PR #259 (the Sell sign bug), both in the Buy/Sell trade area.

### 1. "Can't edit this trade" crash on any trade recorded before Slice 5's migration
```
[{"expected":"string","code":"invalid_type","path":["lastMutationIdempotencyKey"],"message":"Invalid input"}]
```
Every Holding audit snapshot captured before migration `20260816130000` (deployed 2026-08-23) has the `lastMutationIdempotencyKey` key **entirely missing** from its JSON, not `null` — `.nullable()` alone rejects a missing key as `invalid_type`. Confirmed directly against production `AuditLog` rows (2026-08-17 entries have no key at all; entries from today have it present as JSON `null`). Fixed: `.nullable().optional()`.

### 2. Deeper gap the crash was masking: legacy trades permanently rejected as "not latest"
Even once the snapshot parses, `assertTradeIsLatest`'s fast path (`current.lastMutationIdempotencyKey === tradeKey`) permanently rejects **any** trade recorded before the marker column existed — not because something else touched the position, but because the marker was simply never stamped for it. A price-only refresh (`refreshHoldingPricesForFamily`) compounds this: it only ever writes `lastPriceMinor`, so it can't populate the marker either.

Fixed with a one-time **data-only backfill migration** (`20260823121700_backfill_holding_last_mutation_key`): for every Holding with a NULL marker, find its most recent AuditLog entry that actually changed `quantity` or `avgUnitCostMinor` (or was the holding's own create) — correctly **skipping** a price-only touch — and stamp that entry's idempotencyKey. All four write sites already stamp the marker themselves going forward, so this is a one-time correction, not a recurring job.

### 3. UX gap: the Buy/Sell dialog was missing a Date field
Every other money-movement dialog (Switch, Dividend, Fee, and even the trade-**correction** dialog) already has one. A trade entered days after it actually happened had no way to be dated correctly — it was always stamped "now". The server (`recordTradeInputSchema.tradeDate`, already included in the idempotency hash) already supported this; it was purely a missing UI field. Added, matching the existing pattern exactly.

## Test plan
- [x] `vp check` / `vp build` — clean
- [x] Unit: 716/716
- [x] Integration (real Postgres, full suite): 529/529 — includes 2 new tests proving the exact bug (before backfill: wrongly rejected; after backfill: corrects successfully) and that the backfill correctly skips a price-only touch to find the real last quantity-mutating event. (One unrelated Sure-migration scale test flaked under concurrent load during the full run; confirmed clean 24/24 in isolation.)
- [x] E2E (full suite): 53/53 — includes 2 new tests: the legacy-trade scenario end-to-end through the UI, and a real backdated Buy round-tripping its date through the correction dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdFEjGLJ7S2wmusZxaQEx1